### PR TITLE
Event consumer improvements

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,16 +15,12 @@ services:
 
   zookeeper:
     image: quay.io/debezium/zookeeper:2.3
-    ports:
-      - 2181:2181
-      - 2888:2888
-      - 3888:3888
   kafka:
     image: quay.io/debezium/kafka:2.3
     ports:
       - 9092:9092
       - 29092:29092
-    links:
+    depends_on:
       - zookeeper
     environment:
       ZOOKEEPER_CONNECT: zookeeper:2181
@@ -39,10 +35,10 @@ services:
     environment:
       BOOTSTRAP_SERVERS: kafka:29092
       GROUP_ID: 1
-      CONFIG_STORAGE_TOPIC: my_connect_configs
-      OFFSET_STORAGE_TOPIC: my_connect_offsets
-      STATUS_STORAGE_TOPIC: my_connect_statuses
-    links:
+      CONFIG_STORAGE_TOPIC: connect_configs
+      OFFSET_STORAGE_TOPIC: connect_offsets
+      STATUS_STORAGE_TOPIC: connect_statuses
+    depends_on:
       - kafka
   readmodel:
     image: mongo:6.0.7
@@ -88,4 +84,3 @@ services:
       chmod 600 /var/lib/pgadmin/storage/root_example.com/pgpass;
       /entrypoint.sh
       "
-

--- a/packages/event-consumer/register-catalog-postgres.json
+++ b/packages/event-consumer/register-catalog-postgres.json
@@ -3,12 +3,12 @@
     "config": {
         "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
         "tasks.max": "1",
-        "database.hostname": "host.docker.internal",
-        "database.port": "6001",
+        "database.hostname": "catalog-event-store",
+        "database.port": "5432",
         "database.user": "root",
         "database.password": "root",
         "database.dbname" : "root",
-        "topic.prefix": "dbserver1",
+        "topic.prefix": "catalog",
         "schema.include.list": "public",
         "plugin.name": "pgoutput"
     }

--- a/packages/event-consumer/scripts/infra-start.sh
+++ b/packages/event-consumer/scripts/infra-start.sh
@@ -18,7 +18,7 @@ function register_connector () {
   while true; do
     local response=$(curl -s -o /dev/null -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" -w "%{http_code}\n" -d "@$SCRIPT_DIR/$CONNECTOR_PATH" "$URL")
 
-    if [ "$response" -eq "200" ]; then
+    if [ "$response" -eq "201" ]; then
       echo "$SERVICE_NAME connector registered successfully"
       break
     elif [ "$response" -eq "409" ]; then

--- a/packages/event-consumer/src/index.ts
+++ b/packages/event-consumer/src/index.ts
@@ -26,7 +26,6 @@ await consumer.connect();
 
 await consumer.subscribe({
   topics: ["catalog.public.event"],
-  fromBeginning: true, // used now for testing, but I don't understand if it works, anyway should be false in real usage
 });
 
 const EServiceTechnology = z.enum(["REST", "SOAP"]);

--- a/packages/event-consumer/src/index.ts
+++ b/packages/event-consumer/src/index.ts
@@ -7,7 +7,7 @@ const mongoUri = "mongodb://root:example@localhost:27017";
 const client = new MongoClient(mongoUri);
 
 const db = client.db("readmodel");
-const catalog = db.collection("catalog");
+const catalog = db.collection("eservices");
 
 const kafka = new Kafka({
   clientId: "my-app",

--- a/packages/event-consumer/src/index.ts
+++ b/packages/event-consumer/src/index.ts
@@ -25,7 +25,7 @@ await consumer.connect();
 // });
 
 await consumer.subscribe({
-  topics: ["dbserver1.public.event"],
+  topics: ["catalog.public.event"],
   fromBeginning: true, // used now for testing, but I don't understand if it works, anyway should be false in real usage
 });
 

--- a/packages/event-consumer/src/index.ts
+++ b/packages/event-consumer/src/index.ts
@@ -17,12 +17,15 @@ const kafka = new Kafka({
 const consumer = kafka.consumer({ groupId: "my-group" });
 await consumer.connect();
 
-// process.on("SIGINT", function () {
-//   consumer.disconnect().then(
-//     () => console.log("Disconnected"),
-//     (err) => console.log(err)
-//   );
-// });
+function exitGracefully(): void {
+  consumer.disconnect().finally(() => {
+    logger.info("Consumer disconnected");
+    process.exit(0);
+  });
+}
+
+process.on("SIGINT", exitGracefully);
+process.on("SIGTERM", exitGracefully);
 
 await consumer.subscribe({
   topics: ["catalog.public.event"],


### PR DESCRIPTION
Minor improvements to the event consumer:

- fix Mongo collection name
- simplify some Docker networking stuff now that all infra is in the same Docker Compose file
- disconnect the consumer when terminated with Ctrl-C