### PR TITLE
Update node version in the CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - uses: pnpm/action-setup@v2
         with:
           run_install: true
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - uses: pnpm/action-setup@v2
         with:
           run_install: true
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - uses: pnpm/action-setup@v2
         with:
           run_install: true


### PR DESCRIPTION
We're using node 16 in the CI but requiring `>= 18`
<img width="809" alt="Screenshot 2023-08-01 at 17 39 59" src="https://github.com/pagopa/interop-be-monorepo/assets/5033362/a7c1bb49-bec8-45f0-8c70-a25128d8599a">
