### PR TITLE
Fix config parser

### DIFF
--- a/packages/catalog-process/src/utilities/config.ts
+++ b/packages/catalog-process/src/utilities/config.ts
@@ -14,7 +14,15 @@ const FileManagerConfig = z
       MOCK_FILE_MANAGER: z.literal("true"),
     }),
     z.object({
-      MOCK_FILE_MANAGER: z.literal("false").optional(),
+      MOCK_FILE_MANAGER: z.literal("false"),
+      S3_ACCESS_KEY_ID: z.string(),
+      S3_SECRET_ACCESS_KEY: z.string(),
+      S3_REGION: z.string(),
+      S3_BUCKET_NAME: z.string(),
+      ESERVICE_DOCS_PATH: z.string(),
+    }),
+    z.object({
+      MOCK_FILE_MANAGER: z.undefined(),
       S3_ACCESS_KEY_ID: z.string(),
       S3_SECRET_ACCESS_KEY: z.string(),
       S3_REGION: z.string(),


### PR DESCRIPTION
Zod `discriminatedUnion` has some issues and in the future will be deprecated in favor of a new API called `switch`.
https://github.com/colinhacks/zod/issues/2106

Our current configuration doesn't work for this reason https://github.com/colinhacks/zod/issues/2637

An easy solution is to duplicate the entry for each value, for this reason, I removed the `optional()` and added `MOCK_FILE_MANAGER: z.undefined()` which should behave the same way as before without the error.