### PR TITLE
Ppa 34 silent healthy status route logs

### DIFF
--- a/packages/catalog-process/scripts/db-start.sh
+++ b/packages/catalog-process/scripts/db-start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f ../../docker/docker-compose.yml up -d  catalog-event-store pg-admin
+docker compose -f ../../docker/docker-compose.yml up -d  catalog-event-store pg-admin readmodel

--- a/packages/catalog-process/scripts/db-stop.sh
+++ b/packages/catalog-process/scripts/db-stop.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f ../../docker/docker-compose.yml stop catalog-event-store pg-admin
+docker compose -f ../../docker/docker-compose.yml stop catalog-event-store pg-admin readmodel

--- a/packages/catalog-process/src/app.ts
+++ b/packages/catalog-process/src/app.ts
@@ -4,8 +4,8 @@ import { logger } from "pagopa-interop-commons";
 import { z } from "zod";
 import { authMiddleware } from "./authMiddleware.js";
 import { ctx } from "./context.js";
-import healthRouter from "./routers/HealthRouter.js";
 import eservicesRouter from "./routers/EServiceRouter.js";
+import healthRouter from "./routers/HealthRouter.js";
 import { config } from "./utilities/config.js";
 
 const zodiosCtx = zodiosContext(z.object({ ctx }));
@@ -24,6 +24,7 @@ app.use(
     metaField: null,
     requestWhitelist:
       config.logLevel === "debug" ? ["body", "headers", "query"] : [],
+    ignoredRoutes: ["/status"],
     responseWhitelist:
       config.logLevel === "debug"
         ? ["body", "statusCode", "statusMessage"]


### PR DESCRIPTION
Close [PPA-34](https://buildo.atlassian.net/browse/PPA-34?atlOrigin=eyJpIjoiZWQ5MzRhNzM1NzJhNDBlMDkwM2YxNzEwYjBjMWI2MWIiLCJwIjoiaiJ9)

This PR silent all logs for healthy check route `/status` 
Also add ReadModel image when start infra locally with scripts, this read model db is necessary to running catalog-process locally. 