### PR TITLE
Fix contextDataMiddleware

### DIFF
--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -56,6 +56,6 @@ export const contextDataMiddleware = (
     };
 
     context.correlationId = headers?.correlationId;
-    next();
   }
+  next();
 };


### PR DESCRIPTION
## Description 
This PR fix ContextData middleware when `authentication` isn't provided, in case of `health status` authentication is not required.

**ERROR**: ContextData middleware inject x-correlation-id from headers in context data, if not provided next function are not invoked.

