### PR TITLE
Fix typo in docker-compose file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -85,7 +85,6 @@ services:
       chmod 600 /var/lib/pgadmin/storage/root_example.com/pgpass;
       /entrypoint.sh
       "
-      services:
   kafka-ui:
     container_name: kafka-ui
     image: provectuslabs/kafka-ui:latest


### PR DESCRIPTION
This pull request is for removing a not needed line from the `docker-compose` file. It was most likely a typo.