### PR TITLE
Refactor protobuf enum mapping

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,6 +6,8 @@ module.exports = {
   },
   rules: {
     // Any project level custom rule
+    "@typescript-eslint/switch-exhaustiveness-check": "error",
+    "default-case": "off",
     "prefer-arrow/prefer-arrow-functions": "off",
     eqeqeq: ["error", "smart"],
     "@typescript-eslint/consistent-type-definitions": "off",

--- a/packages/agreement-consumer/src/model/converter.ts
+++ b/packages/agreement-consumer/src/model/converter.ts
@@ -11,7 +11,6 @@ import {
   StampsV1,
   StampV1,
 } from "pagopa-interop-models";
-import { match } from "ts-pattern";
 
 export const fromDocumentV1 = (
   input: AgreementDocumentV1
@@ -48,18 +47,26 @@ export const fromAgreementStamps = (
 
 export const fromAgreementState = (
   input: AgreementStateV1
-): PersistentAgreementState =>
-  match(input)
-    .with(AgreementStateV1.ACTIVE, () => persistentAgreementState.active)
-    .with(AgreementStateV1.SUSPENDED, () => persistentAgreementState.suspended)
-    .with(AgreementStateV1.ARCHIVED, () => persistentAgreementState.archived)
-    .with(AgreementStateV1.PENDING, () => persistentAgreementState.pending)
-    .with(
-      AgreementStateV1.MISSING_CERTIFIED_ATTRIBUTES,
-      () => persistentAgreementState.missingCertifiedAttributes
-    )
-    .with(AgreementStateV1.REJECTED, () => persistentAgreementState.rejected)
-    .otherwise(() => persistentAgreementState.draft);
+): PersistentAgreementState => {
+  switch (input) {
+    case AgreementStateV1.ACTIVE:
+      return persistentAgreementState.active;
+    case AgreementStateV1.SUSPENDED:
+      return persistentAgreementState.suspended;
+    case AgreementStateV1.ARCHIVED:
+      return persistentAgreementState.archived;
+    case AgreementStateV1.DRAFT:
+      return persistentAgreementState.draft;
+    case AgreementStateV1.PENDING:
+      return persistentAgreementState.pending;
+    case AgreementStateV1.MISSING_CERTIFIED_ATTRIBUTES:
+      return persistentAgreementState.missingCertifiedAttributes;
+    case AgreementStateV1.REJECTED:
+      return persistentAgreementState.rejected;
+    case AgreementStateV1.UNSPECIFIED$:
+      throw new Error("Unspecified agreement state");
+  }
+};
 
 export const fromAgreementV1 = (input: AgreementV1): PersistentAgreement => ({
   ...input,

--- a/packages/catalog-consumer/src/model/converter.ts
+++ b/packages/catalog-consumer/src/model/converter.ts
@@ -21,40 +21,52 @@ import { P, match } from "ts-pattern";
 
 export const fromAgreementApprovalPolicyV1 = (
   input: AgreementApprovalPolicyV1 | undefined
-): AgreementApprovalPolicy | undefined =>
-  match(input)
-    .with(AgreementApprovalPolicyV1.UNSPECIFIED$, () => undefined)
-    .with(
-      AgreementApprovalPolicyV1.MANUAL,
-      () => agreementApprovalPolicy.manual
-    )
-    .with(
-      AgreementApprovalPolicyV1.AUTOMATIC,
-      () => agreementApprovalPolicy.automatic
-    )
-    .otherwise(() => undefined);
+): AgreementApprovalPolicy | undefined => {
+  if (input == null) {
+    return undefined;
+  }
+
+  switch (input) {
+    case AgreementApprovalPolicyV1.MANUAL:
+      return agreementApprovalPolicy.manual;
+    case AgreementApprovalPolicyV1.AUTOMATIC:
+      return agreementApprovalPolicy.automatic;
+    case AgreementApprovalPolicyV1.UNSPECIFIED$:
+      throw new Error("Unspecified agreement approval policy");
+  }
+};
 
 export const fromEServiceDescriptorStateV1 = (
   input: EServiceDescriptorStateV1
-): DescriptorState =>
-  match(input)
-    .with(EServiceDescriptorStateV1.DRAFT, () => descriptorState.draft)
-    .with(EServiceDescriptorStateV1.SUSPENDED, () => descriptorState.suspended)
-    .with(EServiceDescriptorStateV1.ARCHIVED, () => descriptorState.archived)
-    .with(EServiceDescriptorStateV1.PUBLISHED, () => descriptorState.published)
-    .with(
-      EServiceDescriptorStateV1.DEPRECATED,
-      () => descriptorState.deprecated
-    )
-    .otherwise(() => descriptorState.draft);
+): DescriptorState => {
+  switch (input) {
+    case EServiceDescriptorStateV1.DRAFT:
+      return descriptorState.draft;
+    case EServiceDescriptorStateV1.SUSPENDED:
+      return descriptorState.suspended;
+    case EServiceDescriptorStateV1.ARCHIVED:
+      return descriptorState.archived;
+    case EServiceDescriptorStateV1.PUBLISHED:
+      return descriptorState.published;
+    case EServiceDescriptorStateV1.DEPRECATED:
+      return descriptorState.deprecated;
+    case EServiceDescriptorStateV1.UNSPECIFIED$:
+      throw new Error("Unspecified descriptor state");
+  }
+};
 
 export const fromEServiceTechnologyV1 = (
   input: EServiceTechnologyV1
-): Technology =>
-  match(input)
-    .with(EServiceTechnologyV1.REST, () => technology.rest)
-    .with(EServiceTechnologyV1.SOAP, () => technology.soap)
-    .otherwise(() => technology.rest);
+): Technology => {
+  switch (input) {
+    case EServiceTechnologyV1.REST:
+      return technology.rest;
+    case EServiceTechnologyV1.SOAP:
+      return technology.soap;
+    case EServiceTechnologyV1.UNSPECIFIED$:
+      throw new Error("Unspecified technology");
+  }
+};
 
 export const fromEServiceAttributeV1 = (
   input: EServiceAttributeV1


### PR DESCRIPTION
## Description
This PR removes `ts-pattern` for protobuf enum mapping because it's impossible to use `exhaustive` (https://github.com/gvergnaud/ts-pattern/issues/183).
I added a check on the exhaustiveness of the `switch` and used that instead.