### PR TITLE
IMN 111- Fix kafka group

### DIFF
--- a/packages/agreement-consumer/.env
+++ b/packages/agreement-consumer/.env
@@ -2,7 +2,7 @@ HOST=0.0.0.0
 PORT=3000
 LOG_LEVEL=info
 
-KAFKA_CLIENT_ID="my-app"
+KAFKA_CLIENT_ID="agreement"
 KAFKA_GROUP_ID="agreement-group"
 KAFKA_BROKERS="localhost:9092"
 KAFKA_DISABLE_AWS_IAM_AUTH="true"

--- a/packages/agreement-consumer/.env
+++ b/packages/agreement-consumer/.env
@@ -3,7 +3,7 @@ PORT=3000
 LOG_LEVEL=info
 
 KAFKA_CLIENT_ID="my-app"
-KAFKA_GROUP_ID="my-group"
+KAFKA_GROUP_ID="agreement-group"
 KAFKA_BROKERS="localhost:9092"
 KAFKA_DISABLE_AWS_IAM_AUTH="true"
 READMODEL_DB_HOST="localhost"

--- a/packages/catalog-consumer/.env
+++ b/packages/catalog-consumer/.env
@@ -2,7 +2,7 @@ HOST=0.0.0.0
 PORT=3000
 LOG_LEVEL=info
 
-KAFKA_CLIENT_ID="my-app"
+KAFKA_CLIENT_ID="catalog"
 KAFKA_GROUP_ID="catalog-group"
 KAFKA_BROKERS="localhost:9092"
 KAFKA_DISABLE_AWS_IAM_AUTH="true"

--- a/packages/catalog-consumer/.env
+++ b/packages/catalog-consumer/.env
@@ -3,7 +3,7 @@ PORT=3000
 LOG_LEVEL=info
 
 KAFKA_CLIENT_ID="my-app"
-KAFKA_GROUP_ID="my-group"
+KAFKA_GROUP_ID="catalog-group"
 KAFKA_BROKERS="localhost:9092"
 KAFKA_DISABLE_AWS_IAM_AUTH="true"
 READMODEL_DB_HOST="localhost"


### PR DESCRIPTION
## Description
This PR adds a dedicated Kafka group for each `consumer` to avoid situations in which a consumer id is idle even if is connected to a topic with enough partitions