### PR TITLE
IMN-82 SALS Kafka consumers authentication mechanism

### DIFF
--- a/packages/agreement-consumer/package.json
+++ b/packages/agreement-consumer/package.json
@@ -25,13 +25,13 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "@jm18457/kafkajs-msk-iam-authentication-mechanism": "^3.1.2",
     "@protobuf-ts/runtime": "^2.9.1",
     "connection-string": "^4.3.6",
     "dotenv-flow": "^3.2.0",
     "kafkajs": "^2.2.4",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
+    "kafka-iam-auth": "workspace:*",
     "ts-pattern": "^5.0.1",
     "zod": "^3.21.4"
   }

--- a/packages/agreement-consumer/src/index.ts
+++ b/packages/agreement-consumer/src/index.ts
@@ -16,6 +16,8 @@ async function processMessage(message: KafkaMessage): Promise<void> {
   }
 }
 
-await runConsumer(config, "event-store.agreement.events", processMessage).catch(
-  logger.error
-);
+await runConsumer(
+  config,
+  ["event-store.agreement.events"],
+  processMessage
+).catch(logger.error);

--- a/packages/agreement-consumer/src/index.ts
+++ b/packages/agreement-consumer/src/index.ts
@@ -1,42 +1,10 @@
-import { Kafka, KafkaMessage } from "kafkajs";
+import { KafkaMessage } from "kafkajs";
 import { consumerConfig, logger } from "pagopa-interop-commons";
-import { createMechanism } from "@jm18457/kafkajs-msk-iam-authentication-mechanism";
-
+import { runConsumer } from "kafka-iam-auth";
 import { decodeKafkaMessage } from "./model/models.js";
 import { handleMessage } from "./agreementConsumerService.js";
 
 const config = consumerConfig();
-const kafkaConfig = config.kafkaDisableAwsIamAuth
-  ? {
-      clientId: config.kafkaClientId,
-      brokers: [config.kafkaBrokers],
-      ssl: false,
-    }
-  : {
-      clientId: config.kafkaClientId,
-      brokers: [config.kafkaBrokers],
-      ssl: true,
-      sasl: createMechanism({ region: config.awsRegion }),
-    };
-
-const kafka = new Kafka(kafkaConfig);
-const consumer = kafka.consumer({ groupId: config.kafkaGroupId });
-await consumer.connect();
-
-function exitGracefully(): void {
-  consumer.disconnect().finally(() => {
-    logger.info("Consumer disconnected");
-    process.exit(0);
-  });
-}
-
-process.on("SIGINT", exitGracefully);
-process.on("SIGTERM", exitGracefully);
-
-await consumer.subscribe({
-  topics: ["event-store.agreement.events"],
-  fromBeginning: true,
-});
 
 async function processMessage(message: KafkaMessage): Promise<void> {
   try {
@@ -48,6 +16,6 @@ async function processMessage(message: KafkaMessage): Promise<void> {
   }
 }
 
-await consumer.run({
-  eachMessage: ({ message }) => processMessage(message),
-});
+await runConsumer(config, "event-store.agreement.events", processMessage).catch(
+  logger.error
+);

--- a/packages/catalog-consumer/package.json
+++ b/packages/catalog-consumer/package.json
@@ -32,6 +32,7 @@
     "kafkajs": "^2.2.4",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
+    "kafka-iam-auth": "workspace:*",
     "ts-pattern": "^5.0.1",
     "zod": "^3.21.4"
   }

--- a/packages/catalog-consumer/package.json
+++ b/packages/catalog-consumer/package.json
@@ -25,14 +25,13 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "@jm18457/kafkajs-msk-iam-authentication-mechanism": "^3.1.2",
     "@protobuf-ts/runtime": "^2.9.1",
     "connection-string": "^4.3.6",
     "dotenv-flow": "^3.2.0",
+    "kafka-iam-auth": "workspace:*",
     "kafkajs": "^2.2.4",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
-    "kafka-iam-auth": "workspace:*",
     "ts-pattern": "^5.0.1",
     "zod": "^3.21.4"
   }

--- a/packages/catalog-consumer/src/index.ts
+++ b/packages/catalog-consumer/src/index.ts
@@ -1,42 +1,8 @@
-import { Kafka, KafkaMessage } from "kafkajs";
+import { KafkaMessage } from "kafkajs";
 import { logger, consumerConfig } from "pagopa-interop-commons";
-import { createMechanism } from "@jm18457/kafkajs-msk-iam-authentication-mechanism";
+import { runConsumer } from "kafka-iam-auth";
 import { decodeKafkaMessage } from "./model/models.js";
 import { handleMessage } from "./consumerService.js";
-
-const config = consumerConfig();
-
-const kafkaConfig = config.kafkaDisableAwsIamAuth
-  ? {
-      clientId: config.kafkaClientId,
-      brokers: [config.kafkaBrokers],
-      ssl: false,
-    }
-  : {
-      clientId: config.kafkaClientId,
-      brokers: [config.kafkaBrokers],
-      ssl: true,
-      sasl: createMechanism({ region: config.awsRegion }),
-    };
-
-const kafka = new Kafka(kafkaConfig);
-const consumer = kafka.consumer({ groupId: config.kafkaGroupId });
-await consumer.connect();
-
-function exitGracefully(): void {
-  consumer.disconnect().finally(() => {
-    logger.info("Consumer disconnected");
-    process.exit(0);
-  });
-}
-
-process.on("SIGINT", exitGracefully);
-process.on("SIGTERM", exitGracefully);
-
-await consumer.subscribe({
-  topics: ["event-store.catalog.events"],
-  fromBeginning: true,
-});
 
 async function processMessage(message: KafkaMessage): Promise<void> {
   try {
@@ -48,6 +14,15 @@ async function processMessage(message: KafkaMessage): Promise<void> {
   }
 }
 
-await consumer.run({
-  eachMessage: ({ message }) => processMessage(message),
-});
+function exitGracefully(): void {
+  logger.info("Consumer exiting...");
+  process.exit(0);
+}
+process.on("SIGINT", exitGracefully);
+process.on("SIGTERM", exitGracefully);
+
+const config = consumerConfig();
+
+runConsumer(config, "event-store.catalog.events", processMessage).catch(
+  logger.error
+);

--- a/packages/catalog-consumer/src/index.ts
+++ b/packages/catalog-consumer/src/index.ts
@@ -7,22 +7,13 @@ import { handleMessage } from "./consumerService.js";
 async function processMessage(message: KafkaMessage): Promise<void> {
   try {
     await handleMessage(decodeKafkaMessage(message));
-
     logger.info("Read model was updated");
   } catch (e) {
     logger.error(`Error during message handling ${e}`);
   }
 }
 
-function exitGracefully(): void {
-  logger.info("Consumer exiting...");
-  process.exit(0);
-}
-process.on("SIGINT", exitGracefully);
-process.on("SIGTERM", exitGracefully);
-
 const config = consumerConfig();
-
-runConsumer(config, "event-store.catalog.events", processMessage).catch(
+await runConsumer(config, "event-store.catalog.events", processMessage).catch(
   logger.error
 );

--- a/packages/catalog-consumer/src/index.ts
+++ b/packages/catalog-consumer/src/index.ts
@@ -14,6 +14,6 @@ async function processMessage(message: KafkaMessage): Promise<void> {
 }
 
 const config = consumerConfig();
-await runConsumer(config, "event-store.catalog.events", processMessage).catch(
+await runConsumer(config, ["event-store.catalog.events"], processMessage).catch(
   logger.error
 );

--- a/packages/kafka-iam-auth/README.md
+++ b/packages/kafka-iam-auth/README.md
@@ -1,0 +1,23 @@
+# Description
+This package handles AWS IAM authentication for Kafka topic consumed by consumer's services, it creates a SASL configuration valid for KafakaJS authetication mechanism.
+
+## Usages   
+Import node module "pagopa-interop-kafka-iam-auth" 
+```
+import { createMechanism } from "@jm18457 kafkajs-msk-iam-authentication-mechanism";
+```
+
+createMechanism accept AWS region and return a SALS config valid for KafkaJS, your configuration should be something like this:
+```
+  const kafkaConfig = {
+    clientId: config.kafkaClientId,
+    brokers: [config.kafkaBrokers],
+    ssl: true,
+    sasl: createMechanism({ region: config.awsRegion })
+  };
+```
+
+
+## Credits
+This project uses code from the [Original Repository](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism), which is licensed under the MIT License. We are grateful to the original authors and contributors for their work.
+

--- a/packages/kafka-iam-auth/README.md
+++ b/packages/kafka-iam-auth/README.md
@@ -1,23 +1,32 @@
 # Description
-This package handles AWS IAM authentication for Kafka topic consumed by consumer's services, it creates a SASL configuration valid for KafakaJS authetication mechanism.
 
-## Usages   
-Import node module "pagopa-interop-kafka-iam-auth" 
-```
-import { createMechanism } from "@jm18457 kafkajs-msk-iam-authentication-mechanism";
+This package run consumer and handles AWS IAM authentication for Kafka topic consumed by consumer's services, it creates a SASL configuration valid for KafakaJS authetication mechanism.
+
+## Usages
+
+To run an authenticated consumer, you need to provide three parameters:
+
+- **Consumer's Config**: Contains all environment variables defined for the current consumer. You can get it with `const config = consumerConfig();`
+
+- **Topic Name**: The target topic for the consumer. It usually has a name like "event-store.{schema}.{table}".
+
+- **Message Handler**: A function that processes messages and contains business logic. The function signature should be `(message: KafkaMessage) => Promise<void>`.
+
+Here's an example of how to execute a consumer:
+
+```javascript
+import { runConsumer } from 'pagopa-interop-kafka-iam-auth';
+
+// Your config, topic name, and message handler
+const config = consumerConfig();
+const topicName = 'event-store.mySchema.myTable';
+const processMessageHandler = async (message: KafkaMessage) => {
+  // Your message processing logic here
+};
+
+await runConsumer(config, topicName, processMessageHandler);
 ```
 
-createMechanism accept AWS region and return a SALS config valid for KafkaJS, your configuration should be something like this:
-```
-  const kafkaConfig = {
-    clientId: config.kafkaClientId,
-    brokers: [config.kafkaBrokers],
-    ssl: true,
-    sasl: createMechanism({ region: config.awsRegion })
-  };
-```
 
-
-## Credits
+### Credits
 This project uses code from the [Original Repository](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism), which is licensed under the MIT License. We are grateful to the original authors and contributors for their work.
-

--- a/packages/kafka-iam-auth/README.md
+++ b/packages/kafka-iam-auth/README.md
@@ -1,16 +1,16 @@
 # Description
 
-This package run consumer and handles AWS IAM authentication for Kafka topic consumed by consumer's services, it creates a SASL configuration valid for KafakaJS authetication mechanism.
+This package runs consumer and handles AWS IAM authentication for Kafka topic consumed by consumer's services, it creates a SASL configuration valid for KafakaJS authentication mechanism.
 
 ## Usages
 
 To run an authenticated consumer, you need to provide three parameters:
 
-- **Consumer's Config**: Contains all environment variables defined for the current consumer. You can get it with `const config = consumerConfig();`
+- **Consumer's Config**: contains all environment variables defined for the current consumer. You can get it with `const config = consumerConfig();`
 
-- **Topic Name**: The target topic for the consumer. It usually has a name like "event-store.{schema}.{table}".
+- **Topic Name**: the target topic for the consumer. It usually has a name like "event-store.{schema}.{table}".
 
-- **Message Handler**: A function that processes messages and contains business logic. The function signature should be `(message: KafkaMessage) => Promise<void>`.
+- **Message Handler**: function that processes messages, contains your business logic. The function signature is `(message: KafkaMessage) => Promise<void>`.
 
 Here's an example of how to execute a consumer:
 
@@ -27,6 +27,22 @@ const processMessageHandler = async (message: KafkaMessage) => {
 await runConsumer(config, topicName, processMessageHandler);
 ```
 
+## Local Testing
+To simulate Kafaka topic consuming and executing a real SALS authentication with AWS, you need to connect your consumer to specific topic presents in dev environment.
+You must put the following variables in your consumer .env file to simulate the same credential provisioning executed by service in Kubernates pod:
 
-### Credits
+```bash
+AWS_WEB_IDENTITY_TOKEN_FILE="{TOKE_FILE_PATH}"
+AWS_ROLE_ARN="arn:aws:iam::{ID}:role/interop-be-{SERVICE}-consumer-refactor-dev"
+AWS_REGION="eu-central-1"
+AWS_STS_REGIONAL_ENDPOINTS="regional"
+AWS_DEFAULT_REGION="eu-central-1"
+```
+
+Replace all placeholders {...} with desired configurations.
+
+Token file should contains a valid token retrieved from AWS, by the way all of those variables can be found inspecting pod in dev cluster.
+
+
+## Credits
 This project uses code from the [Original Repository](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism), which is licensed under the MIT License. We are grateful to the original authors and contributors for their work.

--- a/packages/kafka-iam-auth/package.json
+++ b/packages/kafka-iam-auth/package.json
@@ -23,10 +23,10 @@
     "crypto": "^1.0.1",
     "kafkajs": "^2.2.4",
     "pagopa-interop-commons": "workspace:^",
-    "pagopa-interop-models": "workspace:*",
-    "typescript": "5.1.3"
+    "pagopa-interop-models": "workspace:*"
   },
   "devDependencies": {
-    "@aws-sdk/types": "^3.433.0"
+    "@aws-sdk/types": "^3.433.0",
+    "typescript": "5.1.3"
   }
 }

--- a/packages/kafka-iam-auth/package.json
+++ b/packages/kafka-iam-auth/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "kafka-iam-auth",
+  "private": true,
+  "version": "1.0.0",
+  "description": "PagoPA Interoperability KafkaJS AWS IAM Authetication module",
+  "main": "dist",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:autofix": "eslint . --ext .ts,.tsx --fix",
+    "format:check": "prettier --check src",
+    "format:write": "prettier --write src",
+    "build": "tsc"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@aws-crypto/sha256-js": "^5.2.0",
+    "@aws-sdk/credential-providers": "^3.441.0",
+    "@aws-sdk/signature-v4": "^3.374.0",
+    "crypto": "^1.0.1",
+    "kafkajs": "^2.2.4",
+    "pagopa-interop-commons": "workspace:^",
+    "pagopa-interop-models": "workspace:*",
+    "typescript": "5.1.3"
+  },
+  "devDependencies": {
+    "@aws-sdk/types": "^3.433.0"
+  }
+}

--- a/packages/kafka-iam-auth/src/constants.ts
+++ b/packages/kafka-iam-auth/src/constants.ts
@@ -1,0 +1,14 @@
+/** @internal */
+export const INT32_SIZE = 4;
+export const TYPE = "AWS_MSK_IAM";
+/** @internal */
+export const SERVICE = "kafka-cluster";
+/** @internal */
+export const SIGNED_HEADERS = "host";
+/** @internal */
+export const HASHED_PAYLOAD =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+/** @internal */
+export const ALGORITHM = "AWS4-HMAC-SHA256";
+/** @internal */
+export const ACTION = "kafka-cluster:Connect";

--- a/packages/kafka-iam-auth/src/create-authenticator.ts
+++ b/packages/kafka-iam-auth/src/create-authenticator.ts
@@ -1,0 +1,47 @@
+import { AuthenticationProviderArgs, Authenticator } from "kafkajs";
+import { authenticationSaslFailed } from "pagopa-interop-models";
+import { TYPE } from "./constants.js";
+import { Options } from "./create-mechanism.js";
+import { CreatePayload } from "./create-payload.js";
+import { createSaslAuthenticationRequest } from "./create-sasl-authentication-request.js";
+import { createSaslAuthenticationResponse } from "./create-sasl-authentication-response.js";
+
+export const createAuthenticator =
+  (options: Options) =>
+  (args: AuthenticationProviderArgs): Authenticator => ({
+    authenticate: async (): Promise<void> => {
+      const { host, port, logger, saslAuthenticate } = args;
+      const broker = `${host}:${port}`;
+      const payloadFactory = new CreatePayload(options);
+
+      try {
+        const payload = await payloadFactory.create({ brokerHost: host });
+        const authenticateResponse = await saslAuthenticate({
+          request: createSaslAuthenticationRequest(payload),
+          response: createSaslAuthenticationResponse,
+        });
+
+        logger.info("Authentication response", { authenticateResponse });
+
+        const isValidResponse =
+          authenticateResponse &&
+          typeof authenticateResponse === "object" &&
+          "version" in authenticateResponse &&
+          authenticateResponse.version;
+        if (!isValidResponse) {
+          throw authenticationSaslFailed("Invalid response from broker");
+        }
+
+        logger.info(`SASL ${TYPE} authentication successful`, { broker });
+      } catch (error) {
+        if (error instanceof Error) {
+          logger.error(error?.message, { broker });
+          throw authenticationSaslFailed(error?.message);
+        } else if (typeof error === "string") {
+          logger.error(error, { broker });
+          throw authenticationSaslFailed(error);
+        }
+        throw authenticationSaslFailed(`Unknow error : ${error}`);
+      }
+    },
+  });

--- a/packages/kafka-iam-auth/src/create-mechanism.ts
+++ b/packages/kafka-iam-auth/src/create-mechanism.ts
@@ -1,0 +1,35 @@
+import { Mechanism } from "kafkajs";
+import { AwsCredentialIdentity, Provider } from "@aws-sdk/types";
+import { TYPE } from "./constants.js";
+import { createAuthenticator } from "./create-authenticator.js";
+
+export type Options = {
+  /**
+   * The AWS region in which the Kafka broker exists.
+   */
+  region: string;
+  /**
+   * Provides the time period, in seconds, for which the generated presigned URL is valid.
+   *
+   * @default 900
+   */
+  ttl?: string;
+  /**
+   * Is a string passed in by the client library to describe the client.
+   *
+   * @default MSK_IAM
+   */
+  userAgent?: string;
+  /**
+   * @default fromNodeProviderChain()
+   */
+  credentials?: AwsCredentialIdentity | Provider<AwsCredentialIdentity>;
+};
+
+export const createMechanism = (
+  options: Options,
+  mechanism: string = TYPE
+): Mechanism => ({
+  mechanism,
+  authenticationProvider: createAuthenticator(options),
+});

--- a/packages/kafka-iam-auth/src/create-payload.ts
+++ b/packages/kafka-iam-auth/src/create-payload.ts
@@ -1,0 +1,186 @@
+/* eslint-disable functional/no-let */
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
+import { createHash } from "crypto";
+import { AwsCredentialIdentity, Provider } from "@aws-sdk/types";
+import { SignatureV4 } from "@aws-sdk/signature-v4";
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
+import { Sha256 } from "@aws-crypto/sha256-js";
+import {
+  ACTION,
+  ALGORITHM,
+  HASHED_PAYLOAD,
+  SERVICE,
+  SIGNED_HEADERS,
+} from "./constants.js";
+import { Options } from "./create-mechanism.js";
+
+/** @internal */
+export type DateLike = number | Date | string;
+
+/** @internal */
+export type Payload = {
+  version: string;
+  "user-agent": string;
+  host: string;
+  action: string;
+  "x-amz-credential": string;
+  "x-amz-algorithm": string;
+  "x-amz-date": string;
+  "x-amz-security-token"?: string;
+  "x-amz-signedheaders": string;
+  "x-amz-expires": string;
+  "x-amz-signature": string;
+};
+
+/** @internal */
+export class CreatePayload {
+  private readonly region: string;
+  private readonly ttl: string;
+  private readonly userAgent: string;
+  private readonly credentials:
+    | AwsCredentialIdentity
+    | Provider<AwsCredentialIdentity>;
+  private readonly signature: SignatureV4;
+
+  constructor(options: Options) {
+    const { region, ttl, userAgent, credentials } = options;
+    this.region = region;
+    this.ttl = ttl ?? "900";
+    this.userAgent = userAgent ?? "MSK_IAM";
+    this.credentials = credentials ?? fromNodeProviderChain();
+
+    this.signature = new SignatureV4({
+      credentials: this.credentials,
+      region: this.region,
+      service: SERVICE,
+      applyChecksum: false,
+      uriEscapePath: true,
+      sha256: Sha256,
+    });
+  }
+
+  timestampYYYYmmDDFormat(date: DateLike): string {
+    const d = new Date(date);
+    return this.timestampYYYYmmDDTHHMMSSZFormat(d).substring(0, 8);
+  }
+
+  timestampYYYYmmDDTHHMMSSZFormat(date: DateLike): string {
+    const d = new Date(date);
+    return d.toISOString().replace(/[-.:]/g, "").substring(0, 15).concat("Z");
+  }
+
+  generateCanonicalHeaders(brokerHost: string): string {
+    return `host:${brokerHost}\n`;
+  }
+
+  generateXAmzCredential(accessKeyId: string, date: string): string {
+    return `${accessKeyId}/${date}/${this.region}/${SERVICE}/aws4_request`;
+  }
+
+  generateStringToSign(date: DateLike, canonicalRequest: string): string {
+    return `${ALGORITHM}
+${this.timestampYYYYmmDDTHHMMSSZFormat(date)}
+${this.timestampYYYYmmDDFormat(date)}/${this.region}/${SERVICE}/aws4_request
+${createHash("sha256").update(canonicalRequest, "utf8").digest("hex")}`;
+  }
+
+  generateCanonicalQueryString(
+    date: string,
+    xAmzCredential: string,
+    sessionToken?: string
+  ): string {
+    let canonicalQueryString = "";
+    canonicalQueryString += `${encodeURIComponent(
+      "Action"
+    )}=${encodeURIComponent(ACTION)}&`;
+    canonicalQueryString += `${encodeURIComponent(
+      "X-Amz-Algorithm"
+    )}=${encodeURIComponent(ALGORITHM)}&`;
+    canonicalQueryString += `${encodeURIComponent(
+      "X-Amz-Credential"
+    )}=${encodeURIComponent(xAmzCredential)}&`;
+    canonicalQueryString += `${encodeURIComponent(
+      "X-Amz-Date"
+    )}=${encodeURIComponent(date)}&`;
+    canonicalQueryString += `${encodeURIComponent(
+      "X-Amz-Expires"
+    )}=${encodeURIComponent(this.ttl)}&`;
+
+    if (sessionToken !== undefined) {
+      canonicalQueryString += `${encodeURIComponent(
+        "X-Amz-Security-Token"
+      )}=${encodeURIComponent(sessionToken)}&`;
+    }
+
+    canonicalQueryString += `${encodeURIComponent(
+      "X-Amz-SignedHeaders"
+    )}=${encodeURIComponent(SIGNED_HEADERS)}`;
+
+    return canonicalQueryString;
+  }
+
+  generateCanonicalRequest(
+    canonicalQueryString: string,
+    canonicalHeaders: string,
+    signedHeaders: string,
+    hashedPayload: string
+  ): string {
+    return (
+      "GET\n" +
+      "/\n" +
+      canonicalQueryString +
+      "\n" +
+      canonicalHeaders +
+      "\n" +
+      signedHeaders +
+      "\n" +
+      hashedPayload
+    );
+  }
+
+  async create({ brokerHost }: { brokerHost: string }): Promise<Payload> {
+    if (!brokerHost) {
+      throw new Error("Missing values");
+    }
+    const { accessKeyId, sessionToken } =
+      typeof this.credentials === "function"
+        ? await this.credentials()
+        : this.credentials;
+    const now = Date.now();
+    const xAmzCredential = this.generateXAmzCredential(
+      accessKeyId,
+      this.timestampYYYYmmDDFormat(now)
+    );
+    const canonicalHeaders = this.generateCanonicalHeaders(brokerHost);
+    const canonicalQueryString = this.generateCanonicalQueryString(
+      this.timestampYYYYmmDDTHHMMSSZFormat(now),
+      xAmzCredential,
+      sessionToken
+    );
+    const canonicalRequest = this.generateCanonicalRequest(
+      canonicalQueryString,
+      canonicalHeaders,
+      SIGNED_HEADERS,
+      HASHED_PAYLOAD
+    ); //
+    const stringToSign = this.generateStringToSign(now, canonicalRequest);
+
+    const signature = await this.signature.sign(stringToSign, {
+      signingDate: new Date(now).toISOString(),
+    });
+
+    return {
+      version: "2020_10_22",
+      "user-agent": this.userAgent,
+      host: brokerHost,
+      action: ACTION,
+      "x-amz-credential": xAmzCredential,
+      "x-amz-algorithm": ALGORITHM,
+      "x-amz-date": this.timestampYYYYmmDDTHHMMSSZFormat(now),
+      "x-amz-security-token": sessionToken,
+      "x-amz-signedheaders": SIGNED_HEADERS,
+      "x-amz-expires": this.ttl,
+      "x-amz-signature": signature,
+    };
+  }
+}

--- a/packages/kafka-iam-auth/src/create-sasl-authentication-request.ts
+++ b/packages/kafka-iam-auth/src/create-sasl-authentication-request.ts
@@ -1,0 +1,17 @@
+import { SaslAuthenticationRequest } from "kafkajs";
+import { Payload } from "./create-payload.js";
+import { INT32_SIZE } from "./constants.js";
+
+/** @internal */
+export const createSaslAuthenticationRequest = (
+  payload: Payload
+): SaslAuthenticationRequest => ({
+  encode: (): Buffer => {
+    const stringifiedPayload = JSON.stringify(payload);
+    const byteLength = Buffer.byteLength(stringifiedPayload, "utf8");
+    const buf = Buffer.alloc(INT32_SIZE + byteLength);
+    buf.writeUInt32BE(byteLength, 0);
+    buf.write(stringifiedPayload, INT32_SIZE, byteLength, "utf8");
+    return buf;
+  },
+});

--- a/packages/kafka-iam-auth/src/create-sasl-authentication-response.ts
+++ b/packages/kafka-iam-auth/src/create-sasl-authentication-response.ts
@@ -1,0 +1,13 @@
+import { SaslAuthenticationResponse } from "kafkajs";
+import { INT32_SIZE } from "./constants.js";
+
+/** @internal */
+export const createSaslAuthenticationResponse: SaslAuthenticationResponse<unknown> =
+  {
+    decode: (rawData: Buffer) => {
+      const byteLength = rawData.readInt32BE(0);
+      return rawData.slice(INT32_SIZE, INT32_SIZE + byteLength);
+    },
+
+    parse: (data: Buffer) => JSON.parse(data.toString()),
+  };

--- a/packages/kafka-iam-auth/src/index.ts
+++ b/packages/kafka-iam-auth/src/index.ts
@@ -1,0 +1,64 @@
+export * from "./constants.js";
+export * from "./create-authenticator.js";
+export * from "./create-mechanism.js";
+export * from "./create-payload.js";
+export * from "./create-sasl-authentication-request.js";
+export * from "./create-sasl-authentication-response.js";
+import { Kafka, KafkaMessage } from "kafkajs";
+import { ConsumerConfig, logger } from "pagopa-interop-commons";
+import { createAuthenticator } from "./create-authenticator.js";
+import { createMechanism } from "./create-mechanism.js";
+
+export const awsIamAuthenticator = createAuthenticator;
+export const DEFAULT_AUTHENTICATION_TIMEOUT = 20;
+
+export const runConsumer = async (
+  config: ConsumerConfig,
+  topic: string,
+  consumerHandler: (message: KafkaMessage) => Promise<void>
+): Promise<void> => {
+  setInterval(async () => {
+    logger.debug(`Consumer connecting to topics [${config.kafkaBrokers}]...`);
+
+    const kafkaConfig = config.kafkaDisableAwsIamAuth
+      ? {
+          clientId: config.kafkaClientId,
+          brokers: [config.kafkaBrokers],
+          ssl: false,
+          authenticationTimeout: DEFAULT_AUTHENTICATION_TIMEOUT,
+        }
+      : {
+          clientId: config.kafkaClientId,
+          brokers: [config.kafkaBrokers],
+          ssl: true,
+          sasl: createMechanism({
+            region: config.awsRegion,
+            ttl: DEFAULT_AUTHENTICATION_TIMEOUT.toString(),
+          }),
+          authenticationTimeout: DEFAULT_AUTHENTICATION_TIMEOUT,
+        };
+
+    const kafka = new Kafka(kafkaConfig);
+    const consumer = kafka.consumer({
+      groupId: config.kafkaGroupId,
+      sessionTimeout: DEFAULT_AUTHENTICATION_TIMEOUT,
+      heartbeatInterval: 5,
+    });
+    await consumer.connect();
+    logger.info("Consumer connected");
+
+    await consumer.subscribe({
+      topics: [topic],
+      fromBeginning: true,
+    });
+
+    consumer.disconnect().finally(() => {
+      logger.info("Consumer disconnected");
+      process.exit(0);
+    });
+
+    await consumer.run({
+      eachMessage: ({ message }) => consumerHandler(message),
+    });
+  }, DEFAULT_AUTHENTICATION_TIMEOUT);
+};

--- a/packages/kafka-iam-auth/src/index.ts
+++ b/packages/kafka-iam-auth/src/index.ts
@@ -49,10 +49,10 @@ const handleExit = (consumer: Consumer): void => {
 
 const initConsumer = async (
   config: ConsumerConfig,
-  topic: string,
+  topics: string[],
   consumerHandler: (message: KafkaMessage) => Promise<void>
 ): Promise<Consumer> => {
-  logger.info(`Consumer connecting to topics [${config.kafkaBrokers}]`);
+  logger.info(`Consumer connecting to topics [${JSON.stringify(topics)}]`);
 
   const kafkaConfig = config.kafkaDisableAwsIamAuth
     ? {
@@ -79,7 +79,7 @@ const initConsumer = async (
   logger.info("Consumer connected");
 
   await consumer.subscribe({
-    topics: [topic],
+    topics,
     fromBeginning: true,
   });
 
@@ -91,7 +91,7 @@ const initConsumer = async (
 
 export const runConsumer = async (
   config: ConsumerConfig,
-  topic: string,
+  topic: string[],
   consumerHandler: (message: KafkaMessage) => Promise<void>
 ): Promise<void> => {
   let consumer = await initConsumer(config, topic, consumerHandler);

--- a/packages/kafka-iam-auth/src/index.ts
+++ b/packages/kafka-iam-auth/src/index.ts
@@ -50,7 +50,6 @@ const handleExit = (consumer: Consumer): void => {
 const initConsumer = async (
   config: ConsumerConfig,
   topic: string,
-  fromBeginning: boolean,
   consumerHandler: (message: KafkaMessage) => Promise<void>
 ): Promise<Consumer> => {
   logger.info(`Consumer connecting to topics [${config.kafkaBrokers}]`);
@@ -81,7 +80,7 @@ const initConsumer = async (
 
   await consumer.subscribe({
     topics: [topic],
-    fromBeginning,
+    fromBeginning: true,
   });
 
   await consumer.run({
@@ -95,14 +94,14 @@ export const runConsumer = async (
   topic: string,
   consumerHandler: (message: KafkaMessage) => Promise<void>
 ): Promise<void> => {
-  let consumer = await initConsumer(config, topic, true, consumerHandler);
+  let consumer = await initConsumer(config, topic, consumerHandler);
 
   do {
     await consumer.disconnect().finally(() => {
       logger.info("Consumer disconnected");
     });
 
-    consumer = await initConsumer(config, topic, false, consumerHandler);
+    consumer = await initConsumer(config, topic, consumerHandler);
 
     await new Promise((resolve) =>
       setTimeout(

--- a/packages/kafka-iam-auth/src/index.ts
+++ b/packages/kafka-iam-auth/src/index.ts
@@ -1,64 +1,114 @@
+/* eslint-disable functional/no-let */
+/* eslint-disable no-constant-condition */
 export * from "./constants.js";
 export * from "./create-authenticator.js";
 export * from "./create-mechanism.js";
 export * from "./create-payload.js";
 export * from "./create-sasl-authentication-request.js";
 export * from "./create-sasl-authentication-response.js";
-import { Kafka, KafkaMessage } from "kafkajs";
+import { Consumer, Kafka, KafkaMessage } from "kafkajs";
 import { ConsumerConfig, logger } from "pagopa-interop-commons";
-import { createAuthenticator } from "./create-authenticator.js";
 import { createMechanism } from "./create-mechanism.js";
 
-export const awsIamAuthenticator = createAuthenticator;
-export const DEFAULT_AUTHENTICATION_TIMEOUT = 20;
+export const DEFAULT_AUTHENTICATION_TIMEOUT = 60 * 60 * 1000;
+export const REAUTHENTICATION_THRESHOLD = 20 * 1000;
+
+const errorTypes = ["unhandledRejection", "uncaughtException"];
+const signalTraps = ["SIGTERM", "SIGINT", "SIGUSR2"];
+
+const handleExit = (consumer: Consumer): void => {
+  errorTypes.forEach((type) => {
+    process.on(type, async (e) => {
+      try {
+        logger.info(`process.on ${type}`);
+        logger.error(e);
+        await consumer.disconnect().finally(() => {
+          logger.info("Consumer disconnected");
+          process.exit(0);
+        });
+        process.exit(0);
+      } catch (_) {
+        process.exit(1);
+      }
+    });
+  });
+
+  signalTraps.forEach((type) => {
+    process.once(type, async () => {
+      try {
+        await consumer.disconnect().finally(() => {
+          logger.info("Consumer disconnected");
+          process.exit(0);
+        });
+      } finally {
+        process.kill(process.pid, type);
+      }
+    });
+  });
+};
+
+const initConsumer = async (
+  config: ConsumerConfig,
+  topic: string,
+  fromBeginning: boolean,
+  consumerHandler: (message: KafkaMessage) => Promise<void>
+): Promise<Consumer> => {
+  logger.info(`Consumer connecting to topics [${config.kafkaBrokers}]`);
+
+  const kafkaConfig = config.kafkaDisableAwsIamAuth
+    ? {
+        clientId: config.kafkaClientId,
+        brokers: [config.kafkaBrokers],
+        ssl: false,
+      }
+    : {
+        clientId: config.kafkaClientId,
+        brokers: [config.kafkaBrokers],
+        ssl: true,
+        sasl: createMechanism({
+          region: config.awsRegion,
+          ttl: DEFAULT_AUTHENTICATION_TIMEOUT.toString(),
+        }),
+      };
+
+  const kafka = new Kafka(kafkaConfig);
+  const consumer = kafka.consumer({ groupId: config.kafkaGroupId });
+
+  handleExit(consumer);
+
+  await consumer.connect();
+  logger.info("Consumer connected");
+
+  await consumer.subscribe({
+    topics: [topic],
+    fromBeginning,
+  });
+
+  await consumer.run({
+    eachMessage: ({ message }) => consumerHandler(message),
+  });
+  return consumer;
+};
 
 export const runConsumer = async (
   config: ConsumerConfig,
   topic: string,
   consumerHandler: (message: KafkaMessage) => Promise<void>
 ): Promise<void> => {
-  setInterval(async () => {
-    logger.debug(`Consumer connecting to topics [${config.kafkaBrokers}]...`);
+  let consumer = await initConsumer(config, topic, true, consumerHandler);
 
-    const kafkaConfig = config.kafkaDisableAwsIamAuth
-      ? {
-          clientId: config.kafkaClientId,
-          brokers: [config.kafkaBrokers],
-          ssl: false,
-          authenticationTimeout: DEFAULT_AUTHENTICATION_TIMEOUT,
-        }
-      : {
-          clientId: config.kafkaClientId,
-          brokers: [config.kafkaBrokers],
-          ssl: true,
-          sasl: createMechanism({
-            region: config.awsRegion,
-            ttl: DEFAULT_AUTHENTICATION_TIMEOUT.toString(),
-          }),
-          authenticationTimeout: DEFAULT_AUTHENTICATION_TIMEOUT,
-        };
-
-    const kafka = new Kafka(kafkaConfig);
-    const consumer = kafka.consumer({
-      groupId: config.kafkaGroupId,
-      sessionTimeout: DEFAULT_AUTHENTICATION_TIMEOUT,
-      heartbeatInterval: 5,
-    });
-    await consumer.connect();
-    logger.info("Consumer connected");
-
-    await consumer.subscribe({
-      topics: [topic],
-      fromBeginning: true,
-    });
-
-    consumer.disconnect().finally(() => {
+  do {
+    await consumer.disconnect().finally(() => {
       logger.info("Consumer disconnected");
-      process.exit(0);
     });
 
-    await consumer.run({
-      eachMessage: ({ message }) => consumerHandler(message),
-    });
-  }, DEFAULT_AUTHENTICATION_TIMEOUT);
+    consumer = await initConsumer(config, topic, false, consumerHandler);
+
+    await new Promise((resolve) =>
+      setTimeout(
+        resolve,
+        DEFAULT_AUTHENTICATION_TIMEOUT - REAUTHENTICATION_THRESHOLD
+      )
+    );
+  } while (true);
 };

--- a/packages/kafka-iam-auth/src/index.ts
+++ b/packages/kafka-iam-auth/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable functional/no-let */
 /* eslint-disable no-constant-condition */
 export * from "./constants.js";
 export * from "./create-authenticator.js";
@@ -94,14 +93,8 @@ export const runConsumer = async (
   topic: string[],
   consumerHandler: (message: KafkaMessage) => Promise<void>
 ): Promise<void> => {
-  let consumer = await initConsumer(config, topic, consumerHandler);
-
   do {
-    await consumer.disconnect().finally(() => {
-      logger.info("Consumer disconnected");
-    });
-
-    consumer = await initConsumer(config, topic, consumerHandler);
+    const consumer = await initConsumer(config, topic, consumerHandler);
 
     await new Promise((resolve) =>
       setTimeout(
@@ -109,5 +102,9 @@ export const runConsumer = async (
         DEFAULT_AUTHENTICATION_TIMEOUT - REAUTHENTICATION_THRESHOLD
       )
     );
+
+    await consumer.disconnect().finally(() => {
+      logger.info("Consumer disconnected");
+    });
   } while (true);
 };

--- a/packages/kafka-iam-auth/tsconfig.json
+++ b/packages/kafka-iam-auth/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -134,6 +134,11 @@ export const ErrorTypes = {
     httpStatus: 500,
     title: "Tenant not found",
   },
+  AuthenticationSaslFailed: {
+    code: "9000",
+    httpStatus: 500,
+    title: "SASL authentication fails",
+  },
 } as const;
 
 export type ErrorType = (typeof ErrorTypes)[keyof typeof ErrorTypes];
@@ -324,6 +329,13 @@ export function tenantIdNotFound(tenantId: string): AgreementProcessError {
   return new AgreementProcessError(
     `Tenant ${tenantId} not found`,
     ErrorTypes.TenantIdNotFound
+  );
+}
+
+export function authenticationSaslFailed(message: string): ProcessError {
+  return new ProcessError(
+    `SALS Authentication fails with this error : ${message}`,
+    ErrorTypes.AuthenticationSaslFailed
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
 
   packages/agreement-consumer:
     dependencies:
-      '@jm18457/kafkajs-msk-iam-authentication-mechanism':
-        specifier: ^3.1.2
-        version: 3.1.2
       '@protobuf-ts/runtime':
         specifier: ^2.9.1
         version: 2.9.1
@@ -29,6 +26,9 @@ importers:
       dotenv-flow:
         specifier: ^3.2.0
         version: 3.2.0
+      kafka-iam-auth:
+        specifier: workspace:*
+        version: link:../kafka-iam-auth
       kafkajs:
         specifier: ^2.2.4
         version: 2.2.4
@@ -124,9 +124,6 @@ importers:
 
   packages/catalog-consumer:
     dependencies:
-      '@jm18457/kafkajs-msk-iam-authentication-mechanism':
-        specifier: ^3.1.2
-        version: 3.1.2
       '@protobuf-ts/runtime':
         specifier: ^2.9.1
         version: 2.9.1
@@ -493,14 +490,6 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@aws-crypto/sha256-js@4.0.0:
-    resolution: {integrity: sha512-MHGJyjE7TX9aaqXj7zk2ppnFUOhaDs5sP+HtNS0evOxn72c+5njUmyJmpGd7TfyoDznZlHMmdo/xGUdu2NIjNQ==}
-    dependencies:
-      '@aws-crypto/util': 4.0.0
-      '@aws-sdk/types': 3.418.0
-      tslib: 1.14.1
-    dev: false
-
   /@aws-crypto/sha256-js@5.2.0:
     resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
     engines: {node: '>=16.0.0'}
@@ -518,14 +507,6 @@ packages:
 
   /@aws-crypto/util@3.0.0:
     resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
-    dependencies:
-      '@aws-sdk/types': 3.418.0
-      '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 1.14.1
-    dev: false
-
-  /@aws-crypto/util@4.0.0:
-    resolution: {integrity: sha512-2EnmPy2gsFZ6m8bwUQN4jq+IyXV3quHAcwPOS6ZA3k+geujiqI8aRokO2kFJe+idJ/P3v4qWI186rVMo0+zLDQ==}
     dependencies:
       '@aws-sdk/types': 3.418.0
       '@aws-sdk/util-utf8-browser': 3.259.0
@@ -1113,15 +1094,6 @@ packages:
       '@aws-sdk/chunked-blob-reader': 3.310.0
       '@aws-sdk/chunked-blob-reader-native': 3.310.0
       '@aws-sdk/types': 3.357.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/hash-node@3.374.0:
-    resolution: {integrity: sha512-5GmU64bwoQhkebMv7NzHa+Mw+p7ZmrKz9e3A6hKClxVGeZFE/+jME46gMuFYzO0iz3WqX4CCzUVOhNbS0x8EMQ==}
-    engines: {node: '>=14.0.0'}
-    deprecated: This package has moved to @smithy/hash-node
-    dependencies:
-      '@smithy/hash-node': 1.0.2
       tslib: 2.6.2
     dev: false
 
@@ -2063,17 +2035,6 @@ packages:
     dependencies:
       '@sinclair/typebox': 0.27.8
     dev: true
-
-  /@jm18457/kafkajs-msk-iam-authentication-mechanism@3.1.2:
-    resolution: {integrity: sha512-83mdXHMbu1HJDyldJRuJyjtI8MjfCDc10tG3uzRxuvOlgz3hJdqv5E7hYtPcLy26ceTqnRUSzw7rGwLI346bYw==}
-    dependencies:
-      '@aws-crypto/sha256-js': 4.0.0
-      '@aws-sdk/credential-providers': 3.441.0
-      '@aws-sdk/hash-node': 3.374.0
-      '@aws-sdk/signature-v4': 3.374.0
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       dotenv-flow:
         specifier: ^3.2.0
         version: 3.2.0
+      kafka-iam-auth:
+        specifier: workspace:*
+        version: link:../kafka-iam-auth
       kafkajs:
         specifier: ^2.2.4
         version: 2.2.4
@@ -314,6 +317,37 @@ importers:
         specifier: ^5.1.3
         version: 5.1.3
 
+  packages/kafka-iam-auth:
+    dependencies:
+      '@aws-crypto/sha256-js':
+        specifier: ^5.2.0
+        version: 5.2.0
+      '@aws-sdk/credential-providers':
+        specifier: ^3.441.0
+        version: 3.441.0
+      '@aws-sdk/signature-v4':
+        specifier: ^3.374.0
+        version: 3.374.0
+      crypto:
+        specifier: ^1.0.1
+        version: 1.0.1
+      kafkajs:
+        specifier: ^2.2.4
+        version: 2.2.4
+      pagopa-interop-commons:
+        specifier: workspace:^
+        version: link:../commons
+      pagopa-interop-models:
+        specifier: workspace:*
+        version: link:../models
+      typescript:
+        specifier: 5.1.3
+        version: 5.1.3
+    devDependencies:
+      '@aws-sdk/types':
+        specifier: ^3.433.0
+        version: 3.433.0
+
   packages/models:
     dependencies:
       '@protobuf-ts/plugin':
@@ -408,7 +442,7 @@ packages:
     resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.418.0
       tslib: 1.14.1
     dev: false
 
@@ -416,7 +450,7 @@ packages:
     resolution: {integrity: sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.418.0
       tslib: 1.14.1
     dev: false
 
@@ -432,7 +466,7 @@ packages:
       '@aws-crypto/ie11-detection': 3.0.0
       '@aws-crypto/supports-web-crypto': 3.0.0
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.418.0
       '@aws-sdk/util-locate-window': 3.310.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
@@ -463,8 +497,17 @@ packages:
     resolution: {integrity: sha512-MHGJyjE7TX9aaqXj7zk2ppnFUOhaDs5sP+HtNS0evOxn72c+5njUmyJmpGd7TfyoDznZlHMmdo/xGUdu2NIjNQ==}
     dependencies:
       '@aws-crypto/util': 4.0.0
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.418.0
       tslib: 1.14.1
+    dev: false
+
+  /@aws-crypto/sha256-js@5.2.0:
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.433.0
+      tslib: 2.6.2
     dev: false
 
   /@aws-crypto/supports-web-crypto@3.0.0:
@@ -476,7 +519,7 @@ packages:
   /@aws-crypto/util@3.0.0:
     resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
     dependencies:
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.418.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
     dev: false
@@ -484,9 +527,17 @@ packages:
   /@aws-crypto/util@4.0.0:
     resolution: {integrity: sha512-2EnmPy2gsFZ6m8bwUQN4jq+IyXV3quHAcwPOS6ZA3k+geujiqI8aRokO2kFJe+idJ/P3v4qWI186rVMo0+zLDQ==}
     dependencies:
-      '@aws-sdk/types': 3.357.0
+      '@aws-sdk/types': 3.418.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
+    dev: false
+
+  /@aws-crypto/util@5.2.0:
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+    dependencies:
+      '@aws-sdk/types': 3.433.0
+      '@smithy/util-utf8': 2.0.0
+      tslib: 2.6.2
     dev: false
 
   /@aws-sdk/chunked-blob-reader-native@3.310.0:
@@ -502,45 +553,47 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/client-cognito-identity@3.418.0:
-    resolution: {integrity: sha512-8Gib2gMbfCfxNz/FgSRijl47pnmV/rVvyRNoYtk24xndUydhyXKFTB0cqGVDpPv7eRb3wWQ9YZYVuaBDnEdZ1A==}
+  /@aws-sdk/client-cognito-identity@3.441.0:
+    resolution: {integrity: sha512-0BYe2YAoAIF2GdonU6IcrUb/r2pYJHICzqOCi85ixAiGKYokBSl53P7x17DkA7J2mjLWTv+S9nvuVa2RG/L7bA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.418.0
-      '@aws-sdk/credential-provider-node': 3.418.0
-      '@aws-sdk/middleware-host-header': 3.418.0
-      '@aws-sdk/middleware-logger': 3.418.0
-      '@aws-sdk/middleware-recursion-detection': 3.418.0
-      '@aws-sdk/middleware-signing': 3.418.0
-      '@aws-sdk/middleware-user-agent': 3.418.0
-      '@aws-sdk/region-config-resolver': 3.418.0
-      '@aws-sdk/types': 3.418.0
-      '@aws-sdk/util-endpoints': 3.418.0
-      '@aws-sdk/util-user-agent-browser': 3.418.0
-      '@aws-sdk/util-user-agent-node': 3.418.0
-      '@smithy/config-resolver': 2.0.10
-      '@smithy/fetch-http-handler': 2.1.5
-      '@smithy/hash-node': 2.0.9
-      '@smithy/invalid-dependency': 2.0.9
-      '@smithy/middleware-content-length': 2.0.11
-      '@smithy/middleware-endpoint': 2.0.9
-      '@smithy/middleware-retry': 2.0.12
-      '@smithy/middleware-serde': 2.0.9
-      '@smithy/middleware-stack': 2.0.3
-      '@smithy/node-config-provider': 2.0.12
-      '@smithy/node-http-handler': 2.1.5
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/smithy-client': 2.1.7
-      '@smithy/types': 2.3.3
-      '@smithy/url-parser': 2.0.9
+      '@aws-sdk/client-sts': 3.441.0
+      '@aws-sdk/core': 3.441.0
+      '@aws-sdk/credential-provider-node': 3.441.0
+      '@aws-sdk/middleware-host-header': 3.433.0
+      '@aws-sdk/middleware-logger': 3.433.0
+      '@aws-sdk/middleware-recursion-detection': 3.433.0
+      '@aws-sdk/middleware-signing': 3.433.0
+      '@aws-sdk/middleware-user-agent': 3.438.0
+      '@aws-sdk/region-config-resolver': 3.433.0
+      '@aws-sdk/types': 3.433.0
+      '@aws-sdk/util-endpoints': 3.438.0
+      '@aws-sdk/util-user-agent-browser': 3.433.0
+      '@aws-sdk/util-user-agent-node': 3.437.0
+      '@smithy/config-resolver': 2.0.16
+      '@smithy/fetch-http-handler': 2.2.4
+      '@smithy/hash-node': 2.0.12
+      '@smithy/invalid-dependency': 2.0.12
+      '@smithy/middleware-content-length': 2.0.14
+      '@smithy/middleware-endpoint': 2.1.3
+      '@smithy/middleware-retry': 2.0.18
+      '@smithy/middleware-serde': 2.0.12
+      '@smithy/middleware-stack': 2.0.6
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/node-http-handler': 2.1.8
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/smithy-client': 2.1.12
+      '@smithy/types': 2.4.0
+      '@smithy/url-parser': 2.0.12
       '@smithy/util-base64': 2.0.0
       '@smithy/util-body-length-browser': 2.0.0
       '@smithy/util-body-length-node': 2.1.0
-      '@smithy/util-defaults-mode-browser': 2.0.11
-      '@smithy/util-defaults-mode-node': 2.0.13
-      '@smithy/util-retry': 2.0.2
+      '@smithy/util-defaults-mode-browser': 2.0.16
+      '@smithy/util-defaults-mode-node': 2.0.21
+      '@smithy/util-endpoints': 1.0.2
+      '@smithy/util-retry': 2.0.5
       '@smithy/util-utf8': 2.0.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -692,42 +745,44 @@ packages:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-sso@3.418.0:
-    resolution: {integrity: sha512-fakz3YeSW/kCAOJ5w4ObrrQBxsYO8sU8i6WHLv6iWAsYZKAws2Mqa8g89P61+GitSH4z9waksdLouS6ep78/5A==}
+  /@aws-sdk/client-sso@3.441.0:
+    resolution: {integrity: sha512-gndGymu4cEIN7WWhQ67RO0JMda09EGBlay2L8IKCHBK/65Y34FHUX1tCNbO2qezEzsi6BPW5o2n53Rd9QqpHUw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/middleware-host-header': 3.418.0
-      '@aws-sdk/middleware-logger': 3.418.0
-      '@aws-sdk/middleware-recursion-detection': 3.418.0
-      '@aws-sdk/middleware-user-agent': 3.418.0
-      '@aws-sdk/region-config-resolver': 3.418.0
-      '@aws-sdk/types': 3.418.0
-      '@aws-sdk/util-endpoints': 3.418.0
-      '@aws-sdk/util-user-agent-browser': 3.418.0
-      '@aws-sdk/util-user-agent-node': 3.418.0
-      '@smithy/config-resolver': 2.0.10
-      '@smithy/fetch-http-handler': 2.1.5
-      '@smithy/hash-node': 2.0.9
-      '@smithy/invalid-dependency': 2.0.9
-      '@smithy/middleware-content-length': 2.0.11
-      '@smithy/middleware-endpoint': 2.0.9
-      '@smithy/middleware-retry': 2.0.12
-      '@smithy/middleware-serde': 2.0.9
-      '@smithy/middleware-stack': 2.0.3
-      '@smithy/node-config-provider': 2.0.12
-      '@smithy/node-http-handler': 2.1.5
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/smithy-client': 2.1.7
-      '@smithy/types': 2.3.3
-      '@smithy/url-parser': 2.0.9
+      '@aws-sdk/core': 3.441.0
+      '@aws-sdk/middleware-host-header': 3.433.0
+      '@aws-sdk/middleware-logger': 3.433.0
+      '@aws-sdk/middleware-recursion-detection': 3.433.0
+      '@aws-sdk/middleware-user-agent': 3.438.0
+      '@aws-sdk/region-config-resolver': 3.433.0
+      '@aws-sdk/types': 3.433.0
+      '@aws-sdk/util-endpoints': 3.438.0
+      '@aws-sdk/util-user-agent-browser': 3.433.0
+      '@aws-sdk/util-user-agent-node': 3.437.0
+      '@smithy/config-resolver': 2.0.16
+      '@smithy/fetch-http-handler': 2.2.4
+      '@smithy/hash-node': 2.0.12
+      '@smithy/invalid-dependency': 2.0.12
+      '@smithy/middleware-content-length': 2.0.14
+      '@smithy/middleware-endpoint': 2.1.3
+      '@smithy/middleware-retry': 2.0.18
+      '@smithy/middleware-serde': 2.0.12
+      '@smithy/middleware-stack': 2.0.6
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/node-http-handler': 2.1.8
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/smithy-client': 2.1.12
+      '@smithy/types': 2.4.0
+      '@smithy/url-parser': 2.0.12
       '@smithy/util-base64': 2.0.0
       '@smithy/util-body-length-browser': 2.0.0
       '@smithy/util-body-length-node': 2.1.0
-      '@smithy/util-defaults-mode-browser': 2.0.11
-      '@smithy/util-defaults-mode-node': 2.0.13
-      '@smithy/util-retry': 2.0.2
+      '@smithy/util-defaults-mode-browser': 2.0.16
+      '@smithy/util-defaults-mode-node': 2.0.21
+      '@smithy/util-endpoints': 1.0.2
+      '@smithy/util-retry': 2.0.5
       '@smithy/util-utf8': 2.0.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -779,45 +834,47 @@ packages:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-sts@3.418.0:
-    resolution: {integrity: sha512-L0n0Hw+Pm+BhXTN1bYZ0y4JAMArYgazdHf1nUSlEHndgZicCCuQtlMLxfo3i/IbtWi0dzfZcZ9d/MdAM8p4Jyw==}
+  /@aws-sdk/client-sts@3.441.0:
+    resolution: {integrity: sha512-GL0Cw2v7XL1cn0T+Sk5VHLlgBJoUdMsysXsHa1mFdk0l6XHMAAnwXVXiNnjmoDSPrG0psz7dL2AKzPVRXbIUjA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/credential-provider-node': 3.418.0
-      '@aws-sdk/middleware-host-header': 3.418.0
-      '@aws-sdk/middleware-logger': 3.418.0
-      '@aws-sdk/middleware-recursion-detection': 3.418.0
-      '@aws-sdk/middleware-sdk-sts': 3.418.0
-      '@aws-sdk/middleware-signing': 3.418.0
-      '@aws-sdk/middleware-user-agent': 3.418.0
-      '@aws-sdk/region-config-resolver': 3.418.0
-      '@aws-sdk/types': 3.418.0
-      '@aws-sdk/util-endpoints': 3.418.0
-      '@aws-sdk/util-user-agent-browser': 3.418.0
-      '@aws-sdk/util-user-agent-node': 3.418.0
-      '@smithy/config-resolver': 2.0.10
-      '@smithy/fetch-http-handler': 2.1.5
-      '@smithy/hash-node': 2.0.9
-      '@smithy/invalid-dependency': 2.0.9
-      '@smithy/middleware-content-length': 2.0.11
-      '@smithy/middleware-endpoint': 2.0.9
-      '@smithy/middleware-retry': 2.0.12
-      '@smithy/middleware-serde': 2.0.9
-      '@smithy/middleware-stack': 2.0.3
-      '@smithy/node-config-provider': 2.0.12
-      '@smithy/node-http-handler': 2.1.5
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/smithy-client': 2.1.7
-      '@smithy/types': 2.3.3
-      '@smithy/url-parser': 2.0.9
+      '@aws-sdk/core': 3.441.0
+      '@aws-sdk/credential-provider-node': 3.441.0
+      '@aws-sdk/middleware-host-header': 3.433.0
+      '@aws-sdk/middleware-logger': 3.433.0
+      '@aws-sdk/middleware-recursion-detection': 3.433.0
+      '@aws-sdk/middleware-sdk-sts': 3.433.0
+      '@aws-sdk/middleware-signing': 3.433.0
+      '@aws-sdk/middleware-user-agent': 3.438.0
+      '@aws-sdk/region-config-resolver': 3.433.0
+      '@aws-sdk/types': 3.433.0
+      '@aws-sdk/util-endpoints': 3.438.0
+      '@aws-sdk/util-user-agent-browser': 3.433.0
+      '@aws-sdk/util-user-agent-node': 3.437.0
+      '@smithy/config-resolver': 2.0.16
+      '@smithy/fetch-http-handler': 2.2.4
+      '@smithy/hash-node': 2.0.12
+      '@smithy/invalid-dependency': 2.0.12
+      '@smithy/middleware-content-length': 2.0.14
+      '@smithy/middleware-endpoint': 2.1.3
+      '@smithy/middleware-retry': 2.0.18
+      '@smithy/middleware-serde': 2.0.12
+      '@smithy/middleware-stack': 2.0.6
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/node-http-handler': 2.1.8
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/smithy-client': 2.1.12
+      '@smithy/types': 2.4.0
+      '@smithy/url-parser': 2.0.12
       '@smithy/util-base64': 2.0.0
       '@smithy/util-body-length-browser': 2.0.0
       '@smithy/util-body-length-node': 2.1.0
-      '@smithy/util-defaults-mode-browser': 2.0.11
-      '@smithy/util-defaults-mode-node': 2.0.13
-      '@smithy/util-retry': 2.0.2
+      '@smithy/util-defaults-mode-browser': 2.0.16
+      '@smithy/util-defaults-mode-node': 2.0.21
+      '@smithy/util-endpoints': 1.0.2
+      '@smithy/util-retry': 2.0.5
       '@smithy/util-utf8': 2.0.0
       fast-xml-parser: 4.2.5
       tslib: 2.6.2
@@ -825,14 +882,21 @@ packages:
       - aws-crt
     dev: false
 
-  /@aws-sdk/credential-provider-cognito-identity@3.418.0:
-    resolution: {integrity: sha512-MakYZsT7fkG1W9IgkBz7PTXG/e6YD2oSEk+hPgwfdMv0YX76qjTU02B2qbbKSGtXichX73MNUPOvygF5XAi6oA==}
+  /@aws-sdk/core@3.441.0:
+    resolution: {integrity: sha512-gV0eQwR0VnSPUYAbgDkbBtfXbSpZgl/K6UB13DP1IFFjQYbF/BxYwvcQe4jHoPOBifSgjEbl8MfOOeIyI7k9vg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.418.0
-      '@aws-sdk/types': 3.418.0
+      '@smithy/smithy-client': 2.1.12
+    dev: false
+
+  /@aws-sdk/credential-provider-cognito-identity@3.441.0:
+    resolution: {integrity: sha512-mIs5vI3zcN/iVyUwpVdEhmFsUFX0x95aGErVh1ratX7fHdtENdSt0X5Bn3yQowze1DRUJBahqsPZuxe35gUt8w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.441.0
+      '@aws-sdk/types': 3.433.0
       '@smithy/property-provider': 2.0.10
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -848,13 +912,28 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/credential-provider-env@3.418.0:
-    resolution: {integrity: sha512-e74sS+x63EZUBO+HaI8zor886YdtmULzwKdctsZp5/37Xho1CVUNtEC+fYa69nigBD9afoiH33I4JggaHgrekQ==}
+  /@aws-sdk/credential-provider-env@3.433.0:
+    resolution: {integrity: sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.418.0
+      '@aws-sdk/types': 3.433.0
       '@smithy/property-provider': 2.0.10
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/credential-provider-http@3.435.0:
+    resolution: {integrity: sha512-i07YSy3+IrXwAzp3goCMo2OYzAwqRGIWPNMUX5ziFgA1eMlRWNC2slnbqJzax6xHrU8HdpNESAfflnQvUVBqYQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.433.0
+      '@smithy/fetch-http-handler': 2.2.4
+      '@smithy/node-http-handler': 2.1.8
+      '@smithy/property-provider': 2.0.10
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/smithy-client': 2.1.12
+      '@smithy/types': 2.4.0
+      '@smithy/util-stream': 2.0.17
       tslib: 2.6.2
     dev: false
 
@@ -876,19 +955,19 @@ packages:
       - aws-crt
     dev: false
 
-  /@aws-sdk/credential-provider-ini@3.418.0:
-    resolution: {integrity: sha512-LTAeKKV85unlSqGNIeqEZ4N9gufaSoH+670n5YTUEk564zHCkUQW0PJomzLF5jKBco6Yfzv6rPBTukd+x9XWqw==}
+  /@aws-sdk/credential-provider-ini@3.441.0:
+    resolution: {integrity: sha512-SQipQYxYqDUuSOfIhDmaTdwPTcndGQotGZXWJl56mMWqAhU8MkwjK+oMf3VgRt/umJC0QwUCF5HUHIj7gSB1JA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.418.0
-      '@aws-sdk/credential-provider-process': 3.418.0
-      '@aws-sdk/credential-provider-sso': 3.418.0
-      '@aws-sdk/credential-provider-web-identity': 3.418.0
-      '@aws-sdk/types': 3.418.0
+      '@aws-sdk/credential-provider-env': 3.433.0
+      '@aws-sdk/credential-provider-process': 3.433.0
+      '@aws-sdk/credential-provider-sso': 3.441.0
+      '@aws-sdk/credential-provider-web-identity': 3.433.0
+      '@aws-sdk/types': 3.433.0
       '@smithy/credential-provider-imds': 2.0.12
       '@smithy/property-provider': 2.0.10
       '@smithy/shared-ini-file-loader': 2.0.11
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -913,20 +992,20 @@ packages:
       - aws-crt
     dev: false
 
-  /@aws-sdk/credential-provider-node@3.418.0:
-    resolution: {integrity: sha512-VveTjtSC6m8YXj3fQDkMKEZuHv+CR2Z4u/NAN51Fi4xOtIWUtOBj5rfZ8HmBYoBjRF0DtRlPXuMiNnXAzTctfQ==}
+  /@aws-sdk/credential-provider-node@3.441.0:
+    resolution: {integrity: sha512-WB9p37yHq6fGJt6Vll29ijHbkh9VDbPM/n5ns73bTAgFD7R0ht5kPmdmHGQA6m3RKjcHLPbymQ3lXykkMwWf/Q==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.418.0
-      '@aws-sdk/credential-provider-ini': 3.418.0
-      '@aws-sdk/credential-provider-process': 3.418.0
-      '@aws-sdk/credential-provider-sso': 3.418.0
-      '@aws-sdk/credential-provider-web-identity': 3.418.0
-      '@aws-sdk/types': 3.418.0
+      '@aws-sdk/credential-provider-env': 3.433.0
+      '@aws-sdk/credential-provider-ini': 3.441.0
+      '@aws-sdk/credential-provider-process': 3.433.0
+      '@aws-sdk/credential-provider-sso': 3.441.0
+      '@aws-sdk/credential-provider-web-identity': 3.433.0
+      '@aws-sdk/types': 3.433.0
       '@smithy/credential-provider-imds': 2.0.12
       '@smithy/property-provider': 2.0.10
       '@smithy/shared-ini-file-loader': 2.0.11
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -943,14 +1022,14 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/credential-provider-process@3.418.0:
-    resolution: {integrity: sha512-xPbdm2WKz1oH6pTkrJoUmr3OLuqvvcPYTQX0IIlc31tmDwDWPQjXGGFD/vwZGIZIkKaFpFxVMgAzfFScxox7dw==}
+  /@aws-sdk/credential-provider-process@3.433.0:
+    resolution: {integrity: sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.418.0
+      '@aws-sdk/types': 3.433.0
       '@smithy/property-provider': 2.0.10
       '@smithy/shared-ini-file-loader': 2.0.11
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -969,16 +1048,16 @@ packages:
       - aws-crt
     dev: false
 
-  /@aws-sdk/credential-provider-sso@3.418.0:
-    resolution: {integrity: sha512-tUF5Hg/HfaU5t+E7IuvohYlodSIlBXa28xAJPPFxhKrUnvP6AIoW6JLazOtCIQjQgJYEUILV29XX+ojUuITcaw==}
+  /@aws-sdk/credential-provider-sso@3.441.0:
+    resolution: {integrity: sha512-pTg16G+62mWCE8yGKuQnEBqPdpG5g71remf2jUqXaI1c7GCzbnkQDV9eD4DaAGOvzIs0wo9zAQnS2kVDPFlCYA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-sso': 3.418.0
-      '@aws-sdk/token-providers': 3.418.0
-      '@aws-sdk/types': 3.418.0
+      '@aws-sdk/client-sso': 3.441.0
+      '@aws-sdk/token-providers': 3.438.0
+      '@aws-sdk/types': 3.433.0
       '@smithy/property-provider': 2.0.10
       '@smithy/shared-ini-file-loader': 2.0.11
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -994,34 +1073,35 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/credential-provider-web-identity@3.418.0:
-    resolution: {integrity: sha512-do7ang565n9p3dS1JdsQY01rUfRx8vkxQqz5M8OlcEHBNiCdi2PvSjNwcBdrv/FKkyIxZb0TImOfBSt40hVdxQ==}
+  /@aws-sdk/credential-provider-web-identity@3.433.0:
+    resolution: {integrity: sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.418.0
+      '@aws-sdk/types': 3.433.0
       '@smithy/property-provider': 2.0.10
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/credential-providers@3.418.0:
-    resolution: {integrity: sha512-atEybTA0jvP9CpBCPKCoiPz1hjJ/lbRxf67r+fpAqPtfQKutGq/jZm78Yz5kV9F/NJEW2mK2GR/BslCAHc4H8g==}
+  /@aws-sdk/credential-providers@3.441.0:
+    resolution: {integrity: sha512-DLx7s9/YR1CwWSjVmDMKLhyWrBXOFY3RtDLXh7AD4CAEGjhNr9mYWILMk4E6RtXl1ZhRKTMlkrUQnxNTwmct1w==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.418.0
-      '@aws-sdk/client-sso': 3.418.0
-      '@aws-sdk/client-sts': 3.418.0
-      '@aws-sdk/credential-provider-cognito-identity': 3.418.0
-      '@aws-sdk/credential-provider-env': 3.418.0
-      '@aws-sdk/credential-provider-ini': 3.418.0
-      '@aws-sdk/credential-provider-node': 3.418.0
-      '@aws-sdk/credential-provider-process': 3.418.0
-      '@aws-sdk/credential-provider-sso': 3.418.0
-      '@aws-sdk/credential-provider-web-identity': 3.418.0
-      '@aws-sdk/types': 3.418.0
+      '@aws-sdk/client-cognito-identity': 3.441.0
+      '@aws-sdk/client-sso': 3.441.0
+      '@aws-sdk/client-sts': 3.441.0
+      '@aws-sdk/credential-provider-cognito-identity': 3.441.0
+      '@aws-sdk/credential-provider-env': 3.433.0
+      '@aws-sdk/credential-provider-http': 3.435.0
+      '@aws-sdk/credential-provider-ini': 3.441.0
+      '@aws-sdk/credential-provider-node': 3.441.0
+      '@aws-sdk/credential-provider-process': 3.433.0
+      '@aws-sdk/credential-provider-sso': 3.441.0
+      '@aws-sdk/credential-provider-web-identity': 3.433.0
+      '@aws-sdk/types': 3.433.0
       '@smithy/credential-provider-imds': 2.0.12
       '@smithy/property-provider': 2.0.10
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -1033,7 +1113,7 @@ packages:
       '@aws-sdk/chunked-blob-reader': 3.310.0
       '@aws-sdk/chunked-blob-reader-native': 3.310.0
       '@aws-sdk/types': 3.357.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@aws-sdk/hash-node@3.374.0:
@@ -1051,7 +1131,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.357.0
       '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@aws-sdk/is-array-buffer@3.310.0:
@@ -1066,7 +1146,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.357.0
       '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@aws-sdk/middleware-bucket-endpoint@3.363.0:
@@ -1088,7 +1168,7 @@ packages:
       '@aws-sdk/types': 3.357.0
       '@smithy/protocol-http': 1.1.1
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@aws-sdk/middleware-flexible-checksums@3.363.0:
@@ -1102,7 +1182,7 @@ packages:
       '@smithy/protocol-http': 1.1.1
       '@smithy/types': 1.1.1
       '@smithy/util-utf8': 1.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@aws-sdk/middleware-host-header@3.363.0:
@@ -1115,13 +1195,13 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-host-header@3.418.0:
-    resolution: {integrity: sha512-LrMTdzalkPw/1ujLCKPLwCGvPMCmT4P+vOZQRbSEVZPnlZk+Aj++aL/RaHou0jL4kJH3zl8iQepriBt4a7UvXQ==}
+  /@aws-sdk/middleware-host-header@3.433.0:
+    resolution: {integrity: sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.418.0
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/types': 2.3.3
+      '@aws-sdk/types': 3.433.0
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -1143,12 +1223,12 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-logger@3.418.0:
-    resolution: {integrity: sha512-StKGmyPVfoO/wdNTtKemYwoJsqIl4l7oqarQY7VSf2Mp3mqaa+njLViHsQbirYpyqpgUEusOnuTlH5utxJ1NsQ==}
+  /@aws-sdk/middleware-logger@3.433.0:
+    resolution: {integrity: sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.418.0
-      '@smithy/types': 2.3.3
+      '@aws-sdk/types': 3.433.0
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -1162,13 +1242,13 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-recursion-detection@3.418.0:
-    resolution: {integrity: sha512-kKFrIQglBLUFPbHSDy1+bbe3Na2Kd70JSUC3QLMbUHmqipXN8KeXRfAj7vTv97zXl0WzG0buV++WcNwOm1rFjg==}
+  /@aws-sdk/middleware-recursion-detection@3.433.0:
+    resolution: {integrity: sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.418.0
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/types': 2.3.3
+      '@aws-sdk/types': 3.433.0
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -1193,13 +1273,13 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-sdk-sts@3.418.0:
-    resolution: {integrity: sha512-cW8ijrCTP+mgihvcq4+TbhAcE/we5lFl4ydRqvTdtcSnYQAVQADg47rnTScQiFsPFEB3NKq7BGeyTJF9MKolPA==}
+  /@aws-sdk/middleware-sdk-sts@3.433.0:
+    resolution: {integrity: sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/middleware-signing': 3.418.0
-      '@aws-sdk/types': 3.418.0
-      '@smithy/types': 2.3.3
+      '@aws-sdk/middleware-signing': 3.433.0
+      '@aws-sdk/types': 3.433.0
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -1216,16 +1296,16 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-signing@3.418.0:
-    resolution: {integrity: sha512-onvs5KoYQE8OlOE740RxWBGtsUyVIgAo0CzRKOQO63ZEYqpL1Os+MS1CGzdNhvQnJgJruE1WW+Ix8fjN30zKPA==}
+  /@aws-sdk/middleware-signing@3.433.0:
+    resolution: {integrity: sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.418.0
+      '@aws-sdk/types': 3.433.0
       '@smithy/property-provider': 2.0.10
-      '@smithy/protocol-http': 3.0.5
+      '@smithy/protocol-http': 3.0.8
       '@smithy/signature-v4': 2.0.9
-      '@smithy/types': 2.3.3
-      '@smithy/util-middleware': 2.0.2
+      '@smithy/types': 2.4.0
+      '@smithy/util-middleware': 2.0.5
       tslib: 2.6.2
     dev: false
 
@@ -1249,25 +1329,25 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-user-agent@3.418.0:
-    resolution: {integrity: sha512-Jdcztg9Tal9SEAL0dKRrnpKrm6LFlWmAhvuwv0dQ7bNTJxIxyEFbpqdgy7mpQHsLVZgq1Aad/7gT/72c9igyZw==}
+  /@aws-sdk/middleware-user-agent@3.438.0:
+    resolution: {integrity: sha512-a+xHT1wOxT6EA6YyLmrfaroKWOkwwyiktUfXKM0FsUutGzNi4fKhb5NZ2al58NsXzHgHFrasSDp+Lqbd/X2cEw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.418.0
-      '@aws-sdk/util-endpoints': 3.418.0
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/types': 2.3.3
+      '@aws-sdk/types': 3.433.0
+      '@aws-sdk/util-endpoints': 3.438.0
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/region-config-resolver@3.418.0:
-    resolution: {integrity: sha512-lJRZ/9TjZU6yLz+mAwxJkcJZ6BmyYoIJVo1p5+BN//EFdEmC8/c0c9gXMRzfISV/mqWSttdtccpAyN4/goHTYA==}
+  /@aws-sdk/region-config-resolver@3.433.0:
+    resolution: {integrity: sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/node-config-provider': 2.0.12
-      '@smithy/types': 2.3.3
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/types': 2.4.0
       '@smithy/util-config-provider': 2.0.0
-      '@smithy/util-middleware': 2.0.2
+      '@smithy/util-middleware': 2.0.5
       tslib: 2.6.2
     dev: false
 
@@ -1310,43 +1390,45 @@ packages:
       - aws-crt
     dev: false
 
-  /@aws-sdk/token-providers@3.418.0:
-    resolution: {integrity: sha512-9P7Q0VN0hEzTngy3Sz5eya2qEOEf0Q8qf1vB3um0gE6ID6EVAdz/nc/DztfN32MFxk8FeVBrCP5vWdoOzmd72g==}
+  /@aws-sdk/token-providers@3.438.0:
+    resolution: {integrity: sha512-G2fUfTtU6/1ayYRMu0Pd9Ln4qYSvwJOWCqJMdkDgvXSwdgcOSOLsnAIk1AHGJDAvgLikdCzuyOsdJiexr9Vnww==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/middleware-host-header': 3.418.0
-      '@aws-sdk/middleware-logger': 3.418.0
-      '@aws-sdk/middleware-recursion-detection': 3.418.0
-      '@aws-sdk/middleware-user-agent': 3.418.0
-      '@aws-sdk/types': 3.418.0
-      '@aws-sdk/util-endpoints': 3.418.0
-      '@aws-sdk/util-user-agent-browser': 3.418.0
-      '@aws-sdk/util-user-agent-node': 3.418.0
-      '@smithy/config-resolver': 2.0.10
-      '@smithy/fetch-http-handler': 2.1.5
-      '@smithy/hash-node': 2.0.9
-      '@smithy/invalid-dependency': 2.0.9
-      '@smithy/middleware-content-length': 2.0.11
-      '@smithy/middleware-endpoint': 2.0.9
-      '@smithy/middleware-retry': 2.0.12
-      '@smithy/middleware-serde': 2.0.9
-      '@smithy/middleware-stack': 2.0.3
-      '@smithy/node-config-provider': 2.0.12
-      '@smithy/node-http-handler': 2.1.5
+      '@aws-sdk/middleware-host-header': 3.433.0
+      '@aws-sdk/middleware-logger': 3.433.0
+      '@aws-sdk/middleware-recursion-detection': 3.433.0
+      '@aws-sdk/middleware-user-agent': 3.438.0
+      '@aws-sdk/region-config-resolver': 3.433.0
+      '@aws-sdk/types': 3.433.0
+      '@aws-sdk/util-endpoints': 3.438.0
+      '@aws-sdk/util-user-agent-browser': 3.433.0
+      '@aws-sdk/util-user-agent-node': 3.437.0
+      '@smithy/config-resolver': 2.0.16
+      '@smithy/fetch-http-handler': 2.2.4
+      '@smithy/hash-node': 2.0.12
+      '@smithy/invalid-dependency': 2.0.12
+      '@smithy/middleware-content-length': 2.0.14
+      '@smithy/middleware-endpoint': 2.1.3
+      '@smithy/middleware-retry': 2.0.18
+      '@smithy/middleware-serde': 2.0.12
+      '@smithy/middleware-stack': 2.0.6
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/node-http-handler': 2.1.8
       '@smithy/property-provider': 2.0.10
-      '@smithy/protocol-http': 3.0.5
+      '@smithy/protocol-http': 3.0.8
       '@smithy/shared-ini-file-loader': 2.0.11
-      '@smithy/smithy-client': 2.1.7
-      '@smithy/types': 2.3.3
-      '@smithy/url-parser': 2.0.9
+      '@smithy/smithy-client': 2.1.12
+      '@smithy/types': 2.4.0
+      '@smithy/url-parser': 2.0.12
       '@smithy/util-base64': 2.0.0
       '@smithy/util-body-length-browser': 2.0.0
       '@smithy/util-body-length-node': 2.1.0
-      '@smithy/util-defaults-mode-browser': 2.0.11
-      '@smithy/util-defaults-mode-node': 2.0.13
-      '@smithy/util-retry': 2.0.2
+      '@smithy/util-defaults-mode-browser': 2.0.16
+      '@smithy/util-defaults-mode-node': 2.0.21
+      '@smithy/util-endpoints': 1.0.2
+      '@smithy/util-retry': 2.0.5
       '@smithy/util-utf8': 2.0.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -1367,6 +1449,13 @@ packages:
       '@smithy/types': 2.3.3
       tslib: 2.6.2
     dev: false
+
+  /@aws-sdk/types@3.433.0:
+    resolution: {integrity: sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.4.0
+      tslib: 2.6.2
 
   /@aws-sdk/util-arn-parser@3.310.0:
     resolution: {integrity: sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==}
@@ -1399,11 +1488,12 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-endpoints@3.418.0:
-    resolution: {integrity: sha512-sYSDwRTl7yE7LhHkPzemGzmIXFVHSsi3AQ1KeNEk84eBqxMHHcCc2kqklaBk2roXWe50QDgRMy1ikZUxvtzNHQ==}
+  /@aws-sdk/util-endpoints@3.438.0:
+    resolution: {integrity: sha512-6VyPTq1kN3GWxwFt5DdZfOsr6cJZPLjWh0troY/0uUv3hK74C9o3Y0Xf/z8UAUvQFkVqZse12O0/BgPVMImvfA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.418.0
+      '@aws-sdk/types': 3.433.0
+      '@smithy/util-endpoints': 1.0.2
       tslib: 2.6.2
     dev: false
 
@@ -1423,11 +1513,11 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-user-agent-browser@3.418.0:
-    resolution: {integrity: sha512-c4p4mc0VV/jIeNH0lsXzhJ1MpWRLuboGtNEpqE4s1Vl9ck2amv9VdUUZUmHbg+bVxlMgRQ4nmiovA4qIrqGuyg==}
+  /@aws-sdk/util-user-agent-browser@3.433.0:
+    resolution: {integrity: sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==}
     dependencies:
-      '@aws-sdk/types': 3.418.0
-      '@smithy/types': 2.3.3
+      '@aws-sdk/types': 3.433.0
+      '@smithy/types': 2.4.0
       bowser: 2.11.0
       tslib: 2.6.2
     dev: false
@@ -1447,8 +1537,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-user-agent-node@3.418.0:
-    resolution: {integrity: sha512-BXMskXFtg+dmzSCgmnWOffokxIbPr1lFqa1D9kvM3l3IFRiFGx2IyDg+8MAhq11aPDLvoa/BDuQ0Yqma5izOhg==}
+  /@aws-sdk/util-user-agent-node@3.437.0:
+    resolution: {integrity: sha512-JVEcvWaniamtYVPem4UthtCNoTBCfFTwYj7Y3CrWZ2Qic4TqrwLkAfaBGtI2TGrhIClVr77uzLI6exqMTN7orA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -1456,9 +1546,9 @@ packages:
       aws-crt:
         optional: true
     dependencies:
-      '@aws-sdk/types': 3.418.0
-      '@smithy/node-config-provider': 2.0.12
-      '@smithy/types': 2.3.3
+      '@aws-sdk/types': 3.433.0
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -1978,7 +2068,7 @@ packages:
     resolution: {integrity: sha512-83mdXHMbu1HJDyldJRuJyjtI8MjfCDc10tG3uzRxuvOlgz3hJdqv5E7hYtPcLy26ceTqnRUSzw7rGwLI346bYw==}
     dependencies:
       '@aws-crypto/sha256-js': 4.0.0
-      '@aws-sdk/credential-providers': 3.418.0
+      '@aws-sdk/credential-providers': 3.441.0
       '@aws-sdk/hash-node': 3.374.0
       '@aws-sdk/signature-v4': 3.374.0
     transitivePeerDependencies:
@@ -2132,11 +2222,11 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/abort-controller@2.0.9:
-    resolution: {integrity: sha512-8liHOEbx99xcy4VndeQNQhyA0LS+e7UqsuRnDTSIA26IKBv/7vA9w09KOd4fgNULrvX0r3WpA6cwsQTRJpSWkg==}
+  /@smithy/abort-controller@2.0.12:
+    resolution: {integrity: sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2150,14 +2240,14 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/config-resolver@2.0.10:
-    resolution: {integrity: sha512-MwToDsCltHjumkCuRn883qoNeJUawc2b8sX9caSn5vLz6J5crU1IklklNxWCaMO2z2nDL91Po4b/aI1eHv5PfA==}
+  /@smithy/config-resolver@2.0.16:
+    resolution: {integrity: sha512-1k+FWHQDt2pfpXhJsOmNMmlAZ3NUQ98X5tYsjQhVGq+0X6cOBMhfh6Igd0IX3Ut6lEO6DQAdPMI/blNr3JZfMQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/node-config-provider': 2.0.12
-      '@smithy/types': 2.3.3
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/types': 2.4.0
       '@smithy/util-config-provider': 2.0.0
-      '@smithy/util-middleware': 2.0.2
+      '@smithy/util-middleware': 2.0.5
       tslib: 2.6.2
     dev: false
 
@@ -2178,8 +2268,19 @@ packages:
     dependencies:
       '@smithy/node-config-provider': 2.0.12
       '@smithy/property-provider': 2.0.10
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       '@smithy/url-parser': 2.0.9
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/credential-provider-imds@2.0.18:
+    resolution: {integrity: sha512-QnPBi6D2zj6AHJdUTo5zXmk8vwHJ2bNevhcVned1y+TZz/OI5cizz5DsYNkqFUIDn8tBuEyKNgbmKVNhBbuY3g==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/property-provider': 2.0.13
+      '@smithy/types': 2.4.0
+      '@smithy/url-parser': 2.0.12
       tslib: 2.6.2
     dev: false
 
@@ -2196,7 +2297,7 @@ packages:
     resolution: {integrity: sha512-sy0pcbKnawt1iu+qCoSFbs/h9PAaUgvlJEO3lqkE1HFFj4p5RgL98vH+9CyDoj6YY82cG5XsorFmcLqQJHTOYw==}
     dependencies:
       '@aws-crypto/crc32': 3.0.0
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       '@smithy/util-hex-encoding': 2.0.0
       tslib: 2.6.2
     dev: false
@@ -2207,7 +2308,7 @@ packages:
     dependencies:
       '@smithy/eventstream-serde-universal': 1.0.2
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@smithy/eventstream-serde-config-resolver@1.0.2:
@@ -2215,7 +2316,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@smithy/eventstream-serde-node@1.0.2:
@@ -2224,7 +2325,7 @@ packages:
     dependencies:
       '@smithy/eventstream-serde-universal': 1.0.2
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@smithy/eventstream-serde-universal@1.0.2:
@@ -2243,15 +2344,15 @@ packages:
       '@smithy/querystring-builder': 1.0.2
       '@smithy/types': 1.1.1
       '@smithy/util-base64': 1.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/fetch-http-handler@2.1.5:
-    resolution: {integrity: sha512-BIeCHGfr5JCGN+EMTwZK74ELvjPXOIrI7OLM5OhZJJ6AmZyRv2S9ANJk18AtLwht0TsSm+8WoXIEp8LuxNgUyA==}
+  /@smithy/fetch-http-handler@2.2.4:
+    resolution: {integrity: sha512-gIPRFEGi+c6V52eauGKrjDzPWF2Cu7Z1r5F8A3j2wcwz25sPG/t8kjsbEhli/tS/2zJp/ybCZXe4j4ro3yv/HA==}
     dependencies:
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/querystring-builder': 2.0.9
-      '@smithy/types': 2.3.3
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/querystring-builder': 2.0.12
+      '@smithy/types': 2.4.0
       '@smithy/util-base64': 2.0.0
       tslib: 2.6.2
     dev: false
@@ -2263,14 +2364,14 @@ packages:
       '@smithy/types': 1.1.1
       '@smithy/util-buffer-from': 1.0.2
       '@smithy/util-utf8': 1.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/hash-node@2.0.9:
-    resolution: {integrity: sha512-XP3yWd5wyCtiVmsY5Nuq/FUwyCEQ6YG7DsvRh7ThldNukGpCzyFdP8eivZJVjn4Fx7oYrrOnVoYZ0WEgpW1AvQ==}
+  /@smithy/hash-node@2.0.12:
+    resolution: {integrity: sha512-fDZnTr5j9t5qcbeJ037aMZXxMka13Znqwrgy3PAqYj6Dm3XHXHftTH3q+NWgayUxl1992GFtQt1RuEzRMy3NnQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       '@smithy/util-buffer-from': 2.0.0
       '@smithy/util-utf8': 2.0.0
       tslib: 2.6.2
@@ -2283,10 +2384,10 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/invalid-dependency@2.0.9:
-    resolution: {integrity: sha512-RuJqhYf8nViK96IIO9JbTtjDUuFItVfuuJhWw2yk7fv67yltQ7fZD6IQ2OsHHluoVmstnQJuCg5raXJR696Ubw==}
+  /@smithy/invalid-dependency@2.0.12:
+    resolution: {integrity: sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2313,12 +2414,12 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/middleware-content-length@2.0.11:
-    resolution: {integrity: sha512-Malj4voNTL4+a5ZL3a6+Ij7JTUMTa2R7c3ZIBzMxN5OUUgAspU7uFi1Q97f4B0afVh2joQBAWH5IQJUG25nl8g==}
+  /@smithy/middleware-content-length@2.0.14:
+    resolution: {integrity: sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/types': 2.3.3
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2330,17 +2431,19 @@ packages:
       '@smithy/types': 1.1.1
       '@smithy/url-parser': 1.0.2
       '@smithy/util-middleware': 1.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/middleware-endpoint@2.0.9:
-    resolution: {integrity: sha512-72/o8R6AAO4+nyTI6h4z6PYGTSA4dr1M7tZz29U8DEUHuh1YkhC77js0P6RyF9G0wDLuYqxb+Yh0crI5WG2pJg==}
+  /@smithy/middleware-endpoint@2.1.3:
+    resolution: {integrity: sha512-ZrQ0/YX6hNVTxqMEHtEaDbDv6pNeEji/a5Vk3HuFC5R3ZY8lfoATyxmOGxBVYnF3NUvZLNC7umEv1WzWGWvCGQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/middleware-serde': 2.0.9
-      '@smithy/types': 2.3.3
-      '@smithy/url-parser': 2.0.9
-      '@smithy/util-middleware': 2.0.2
+      '@smithy/middleware-serde': 2.0.12
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/shared-ini-file-loader': 2.2.2
+      '@smithy/types': 2.4.0
+      '@smithy/url-parser': 2.0.12
+      '@smithy/util-middleware': 2.0.5
       tslib: 2.6.2
     dev: false
 
@@ -2357,16 +2460,16 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@smithy/middleware-retry@2.0.12:
-    resolution: {integrity: sha512-YQ/ufXX4/d9/+Jf1QQ4J+CVeupC7BW52qldBTvRV33PDX9vxndlAwkFwzBcmnUFC3Hjf1//HW6I77EItcjNSCA==}
+  /@smithy/middleware-retry@2.0.18:
+    resolution: {integrity: sha512-VyrHQRldGSb3v9oFOB5yPxmLT7U2sQic2ytylOnYlnsmVOLlFIaI6sW22c+w2675yq+XZ6HOuzV7x2OBYCWRNA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/node-config-provider': 2.0.12
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/service-error-classification': 2.0.2
-      '@smithy/types': 2.3.3
-      '@smithy/util-middleware': 2.0.2
-      '@smithy/util-retry': 2.0.2
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/service-error-classification': 2.0.5
+      '@smithy/types': 2.4.0
+      '@smithy/util-middleware': 2.0.5
+      '@smithy/util-retry': 2.0.5
       tslib: 2.6.2
       uuid: 8.3.2
     dev: false
@@ -2376,14 +2479,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/middleware-serde@2.0.9:
-    resolution: {integrity: sha512-GVbauxrr6WmtCaesakktg3t5LR/yDbajpC7KkWc8rtCpddMI4ShAVO5Q6DqwX8MDFi4CLaY8H7eTGcxhl3jbLg==}
+  /@smithy/middleware-serde@2.0.12:
+    resolution: {integrity: sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2391,14 +2494,14 @@ packages:
     resolution: {integrity: sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/middleware-stack@2.0.3:
-    resolution: {integrity: sha512-AlhPmbwpkC4lQBVaVHXczmjFvsAhDHhrakqLt038qFLotnJcvDLhmMzAtu23alBeOSkKxkTQq0LsAt2N0WpAbw==}
+  /@smithy/middleware-stack@2.0.6:
+    resolution: {integrity: sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2409,7 +2512,7 @@ packages:
       '@smithy/property-provider': 1.0.2
       '@smithy/shared-ini-file-loader': 1.0.2
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@smithy/node-config-provider@2.0.12:
@@ -2418,7 +2521,17 @@ packages:
     dependencies:
       '@smithy/property-provider': 2.0.10
       '@smithy/shared-ini-file-loader': 2.0.11
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/node-config-provider@2.1.3:
+    resolution: {integrity: sha512-J6lXvRHGVnSX3n1PYi+e1L5HN73DkkJpUviV3Ebf+8wSaIjAf+eVNbzyvh/S5EQz7nf4KVfwbD5vdoZMAthAEQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/property-provider': 2.0.13
+      '@smithy/shared-ini-file-loader': 2.2.2
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2433,14 +2546,14 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/node-http-handler@2.1.5:
-    resolution: {integrity: sha512-52uF+BrZaFiBh+NT/bADiVDCQO91T+OwDRsuaAeWZC1mlCXFjAPPQdxeQohtuYOe9m7mPP/xIMNiqbe8jvndHA==}
+  /@smithy/node-http-handler@2.1.8:
+    resolution: {integrity: sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/abort-controller': 2.0.9
-      '@smithy/protocol-http': 3.0.5
-      '@smithy/querystring-builder': 2.0.9
-      '@smithy/types': 2.3.3
+      '@smithy/abort-controller': 2.0.12
+      '@smithy/protocol-http': 3.0.8
+      '@smithy/querystring-builder': 2.0.12
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2456,7 +2569,15 @@ packages:
     resolution: {integrity: sha512-YMBVfh0ZMmJtbsUn+WfSwR32iRljZPdRN0Tn2GAcdJ+ejX8WrBXD7Z0jIkQDrQZr8fEuuv5x8WxMIj+qVbsPQw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/property-provider@2.0.13:
+    resolution: {integrity: sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2465,14 +2586,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/protocol-http@3.0.5:
-    resolution: {integrity: sha512-3t3fxj+ip4EPHRC2fQ0JimMxR/qCQ1LSQJjZZVZFgROnFLYWPDgUZqpoi7chr+EzatxJVXF/Rtoi5yLHOWCoZQ==}
+  /@smithy/protocol-http@3.0.8:
+    resolution: {integrity: sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2485,11 +2606,11 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/querystring-builder@2.0.9:
-    resolution: {integrity: sha512-Yt6CPF4j3j1cuwod/DRflbuXxBFjJm7gAjy6W1RE21Rz5/kfGFqiZBXWmmXwGtnnhiLThYwoHK4S6/TQtnx0Fg==}
+  /@smithy/querystring-builder@2.0.12:
+    resolution: {integrity: sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       '@smithy/util-uri-escape': 2.0.0
       tslib: 2.6.2
     dev: false
@@ -2502,11 +2623,19 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@smithy/querystring-parser@2.0.12:
+    resolution: {integrity: sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.4.0
+      tslib: 2.6.2
+    dev: false
+
   /@smithy/querystring-parser@2.0.9:
     resolution: {integrity: sha512-U6z4N743s4vrcxPW8p8+reLV0PjMCYEyb1/wtMVvv3VnbJ74gshdI8SR1sBnEh95cF8TxonmX5IxY25tS9qGfg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2515,11 +2644,11 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@smithy/service-error-classification@2.0.2:
-    resolution: {integrity: sha512-GTUd2j63gKy7A+ggvSdn2hc4sejG7LWfE+ZMF17vzWoNyqERWbRP7HTPS0d0Lwg1p6OQCAzvNigSrEIWVFt6iA==}
+  /@smithy/service-error-classification@2.0.5:
+    resolution: {integrity: sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
     dev: false
 
   /@smithy/shared-ini-file-loader@1.0.2:
@@ -2534,7 +2663,15 @@ packages:
     resolution: {integrity: sha512-Sf0u5C5px6eykXi6jImDTp+edvG3REtPjXnFWU/J+b7S2wkXwUqFXqBL5DdM4zC1F+M8u57ZT7NRqDwMOw7/Tw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/shared-ini-file-loader@2.2.2:
+    resolution: {integrity: sha512-noyQUPn7b1M8uB0GEXc/Zyxq+5K2b7aaqWnLp+hgJ7+xu/FCvtyWy5eWLDjQEsHnAet2IZhS5QF8872OR69uNg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2558,9 +2695,9 @@ packages:
     dependencies:
       '@smithy/eventstream-codec': 2.0.9
       '@smithy/is-array-buffer': 2.0.0
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       '@smithy/util-hex-encoding': 2.0.0
-      '@smithy/util-middleware': 2.0.2
+      '@smithy/util-middleware': 2.0.5
       '@smithy/util-uri-escape': 2.0.0
       '@smithy/util-utf8': 2.0.0
       tslib: 2.6.2
@@ -2573,16 +2710,16 @@ packages:
       '@smithy/middleware-stack': 1.0.2
       '@smithy/types': 1.1.1
       '@smithy/util-stream': 1.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/smithy-client@2.1.7:
-    resolution: {integrity: sha512-r6T/oiBQ8vCbGqObH4/h0YqD0jFB1hAS9KFRmuTfaNJueu/L2hjmjqFjv3PV5lkbNHTgUYraSv4cFQ1naxiELQ==}
+  /@smithy/smithy-client@2.1.12:
+    resolution: {integrity: sha512-XXqhridfkKnpj+lt8vM6HRlZbqUAqBjVC74JIi13F/AYQd/zTj9SOyGfxnbp4mjY9q28LityxIuV8CTinr9r5w==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/middleware-stack': 2.0.3
-      '@smithy/types': 2.3.3
-      '@smithy/util-stream': 2.0.12
+      '@smithy/middleware-stack': 2.0.6
+      '@smithy/types': 2.4.0
+      '@smithy/util-stream': 2.0.17
       tslib: 2.6.2
     dev: false
 
@@ -2590,7 +2727,7 @@ packages:
     resolution: {integrity: sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@smithy/types@2.3.3:
@@ -2600,19 +2737,33 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@smithy/types@2.4.0:
+    resolution: {integrity: sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.2
+
   /@smithy/url-parser@1.0.2:
     resolution: {integrity: sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==}
     dependencies:
       '@smithy/querystring-parser': 1.0.2
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/url-parser@2.0.12:
+    resolution: {integrity: sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==}
+    dependencies:
+      '@smithy/querystring-parser': 2.0.12
+      '@smithy/types': 2.4.0
+      tslib: 2.6.2
     dev: false
 
   /@smithy/url-parser@2.0.9:
     resolution: {integrity: sha512-NBnJ0NiY8z6E82Xd5VYUFQfKwK/wA/+QkKmpYUYP+cpH3aCzE6g2gvixd9vQKYjsIdRfNPCf+SFAozt8ljozOw==}
     dependencies:
       '@smithy/querystring-parser': 2.0.9
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2635,7 +2786,7 @@ packages:
   /@smithy/util-body-length-browser@1.0.2:
     resolution: {integrity: sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@smithy/util-body-length-browser@2.0.0:
@@ -2648,7 +2799,7 @@ packages:
     resolution: {integrity: sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@smithy/util-body-length-node@2.1.0:
@@ -2698,13 +2849,13 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-defaults-mode-browser@2.0.11:
-    resolution: {integrity: sha512-0syV1Mz/mCQ7CG/MHKQfH+w86xq59jpD0EOXv5oe0WBXLmq2lWPpVHl2Y6+jQ+/9fYzyZ5NF+NC/WEIuiv690A==}
+  /@smithy/util-defaults-mode-browser@2.0.16:
+    resolution: {integrity: sha512-Uv5Cu8nVkuvLn0puX+R9zWbSNpLIR3AxUlPoLJ7hC5lvir8B2WVqVEkJLwtixKAncVLasnTVjPDCidtAUTGEQw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@smithy/property-provider': 2.0.10
-      '@smithy/smithy-client': 2.1.7
-      '@smithy/types': 2.3.3
+      '@smithy/property-provider': 2.0.13
+      '@smithy/smithy-client': 2.1.12
+      '@smithy/types': 2.4.0
       bowser: 2.11.0
       tslib: 2.6.2
     dev: false
@@ -2718,19 +2869,28 @@ packages:
       '@smithy/node-config-provider': 1.0.2
       '@smithy/property-provider': 1.0.2
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/util-defaults-mode-node@2.0.13:
-    resolution: {integrity: sha512-6BtCHYdw5Z8r6KpW8tRCc3yURgvcQwfIEeHhR70BeSOfx8T/TXPPjb8A+K45+KASspa3fzrsSxeIwB0sAeMoHA==}
+  /@smithy/util-defaults-mode-node@2.0.21:
+    resolution: {integrity: sha512-cUEsttVZ79B7Al2rWK2FW03HBpD9LyuqFtm+1qFty5u9sHSdesr215gS2Ln53fTopNiPgeXpdoM3IgjvIO0rJw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@smithy/config-resolver': 2.0.10
-      '@smithy/credential-provider-imds': 2.0.12
-      '@smithy/node-config-provider': 2.0.12
-      '@smithy/property-provider': 2.0.10
-      '@smithy/smithy-client': 2.1.7
-      '@smithy/types': 2.3.3
+      '@smithy/config-resolver': 2.0.16
+      '@smithy/credential-provider-imds': 2.0.18
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/property-provider': 2.0.13
+      '@smithy/smithy-client': 2.1.12
+      '@smithy/types': 2.4.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/util-endpoints@1.0.2:
+    resolution: {integrity: sha512-QEdq+sP68IJHAMVB2ugKVVZEWeKQtZLuf+akHzc8eTVElsZ2ZdVLWC6Cp+uKjJ/t4yOj1qu6ZzyxJQEQ8jdEjg==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 2.1.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2755,11 +2915,11 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-middleware@2.0.2:
-    resolution: {integrity: sha512-UGPZM+Ja/vke5pc/S8G0LNiHpVirtjppsXO+GK9m9wbzRGzPJTfnZA/gERUUN/AfxEy/8SL7U1kd7u4t2X8K1w==}
+  /@smithy/util-middleware@2.0.5:
+    resolution: {integrity: sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.3.3
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2768,15 +2928,15 @@ packages:
     engines: {node: '>= 14.0.0'}
     dependencies:
       '@smithy/service-error-classification': 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/util-retry@2.0.2:
-    resolution: {integrity: sha512-ovWiayUB38moZcLhSFFfUgB2IMb7R1JfojU20qSahjxAgfOZvDWme3eOYUMtAVnouZ9kYJiFgHLy27qRH4NeeA==}
+  /@smithy/util-retry@2.0.5:
+    resolution: {integrity: sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==}
     engines: {node: '>= 14.0.0'}
     dependencies:
-      '@smithy/service-error-classification': 2.0.2
-      '@smithy/types': 2.3.3
+      '@smithy/service-error-classification': 2.0.5
+      '@smithy/types': 2.4.0
       tslib: 2.6.2
     dev: false
 
@@ -2791,16 +2951,16 @@ packages:
       '@smithy/util-buffer-from': 1.0.2
       '@smithy/util-hex-encoding': 1.0.2
       '@smithy/util-utf8': 1.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
-  /@smithy/util-stream@2.0.12:
-    resolution: {integrity: sha512-FOCpRLaj6gvSyUC5mJAACT+sPMPmp9sD1o+hVbUH/QxwZfulypA3ZIFdAg/59/IY0d/1Q4CTztsiHEB5LgjN4g==}
+  /@smithy/util-stream@2.0.17:
+    resolution: {integrity: sha512-fP/ZQ27rRvHsqItds8yB7jerwMpZFTL3QqbQbidUiG0+mttMoKdP0ZqnvM8UK5q0/dfc3/pN7g4XKPXOU7oRWw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/fetch-http-handler': 2.1.5
-      '@smithy/node-http-handler': 2.1.5
-      '@smithy/types': 2.3.3
+      '@smithy/fetch-http-handler': 2.2.4
+      '@smithy/node-http-handler': 2.1.8
+      '@smithy/types': 2.4.0
       '@smithy/util-base64': 2.0.0
       '@smithy/util-buffer-from': 2.0.0
       '@smithy/util-hex-encoding': 2.0.0
@@ -2827,7 +2987,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/util-buffer-from': 1.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@smithy/util-utf8@2.0.0:
@@ -2844,7 +3004,7 @@ packages:
     dependencies:
       '@smithy/abort-controller': 1.0.2
       '@smithy/types': 1.1.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@tsconfig/node-lts@18.12.3:
@@ -3626,6 +3786,11 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
+
+  /crypto@1.0.1:
+    resolution: {integrity: sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==}
+    deprecated: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
+    dev: false
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -6112,10 +6277,6 @@ packages:
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
-  /tslib@2.5.3:
-    resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
-    dev: false
-
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
@@ -6244,7 +6405,6 @@ packages:
     resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /ufo@1.1.2:
     resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,13 +337,13 @@ importers:
       pagopa-interop-models:
         specifier: workspace:*
         version: link:../models
-      typescript:
-        specifier: 5.1.3
-        version: 5.1.3
     devDependencies:
       '@aws-sdk/types':
         specifier: ^3.433.0
         version: 3.433.0
+      typescript:
+        specifier: 5.1.3
+        version: 5.1.3
 
   packages/models:
     dependencies:
@@ -6366,6 +6366,7 @@ packages:
     resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /ufo@1.1.2:
     resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}


### PR DESCRIPTION
# Description
Close [IMN-82](https://pagopa.atlassian.net/browse/IMN-82?atlOrigin=eyJpIjoiZjdlMWY0ZDljZTZjNDBhYzhiMDIxMWQ5MmJlMGU1NjciLCJwIjoiaiJ9)
This PR remove definitively the library [@jm18457/kafkajs-msk-iam-authentication-mechanism](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism) from consumers services and introduce a new module `kafka-iam-auth` to create Kafka consumer's connection and authentication to topics.
Authentication mechanism for KafkaJS was implemented with same code of removed library, furthermore some specific custom errors like ours stack, was introduced.
With this new approach Authentication is scheduled to be re-executed approximately every hour.

Running a consumer is now simplified,  using a single function
```
await runConsumer(config, "event-store.{model}.events", processMessageHandler)
```

where `processMessageHandler` if a function that manipulate the message.
Under the hood the authentication is performed using aws-sdk in details using a `Provider<AwsCredentialIdentity>`, credentials was retrieved with a strategy defined in [@aws-sdk/credential-providers](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/functions/_aws_sdk_credential_providers.fromNodeProviderChain.html), currently running service in EKS using token file strategy.

### ℹ️  NOTE 
Implemented authentication mechanism using [AWS pre-signed urls with query params](https://docs.aws.amazon.com/it_it/AmazonS3/latest/API/sigv4-query-string-auth.html) to obtain temporary authentication, in this case the TTL configuration provided are used as param `X-Amz-Expires`.
>A presigned URL can be valid for a maximum of seven days because the signing key you use in signature calculation is valid for up to seven days.

So 7 days (604800s) is the limit, but could be necessary to verify how log is set TTL for role in AWS IAM policy definition.  
 

## Local Testing
To simulate consuming and execute a real SALS authentication with AWS, you need to connect your consumer to specific topic presents in dev environment.
First of all you need to provide the following variables in your consumer `.env` file to simulate the same credential provisioning executed by service in Kubernates pod:

- AWS_WEB_IDENTITY_TOKEN_FILE : token file path
- AWS_ROLE_ARN: should be : "arn:aws:iam::{ID}:role/interop-be-{SERVICE}-consumer-refactor-dev"
- AWS_REGION=eu-central-1
- AWS_STS_REGIONAL_ENDPOINTS=regional
- AWS_DEFAULT_REGION=eu-central-1

Token file should contains a valid token from AWS, by the way all of those variables can be found inspecting pod in cluster.



[IMN-82]: https://pagopa.atlassian.net/browse/IMN-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ