### PR TITLE
IMN 113 - Errors refactor

### DIFF
--- a/packages/agreement-process/src/app.ts
+++ b/packages/agreement-process/src/app.ts
@@ -1,4 +1,3 @@
-import { makeApiProblem } from "pagopa-interop-models";
 import {
   authenticationMiddleware,
   contextDataMiddleware,
@@ -6,7 +5,6 @@ import {
   loggerMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
-import { Response } from "express";
 import healthRouter from "./routers/HealthRouter.js";
 import agreementRouter from "./routers/AgreementRouter.js";
 
@@ -25,10 +23,7 @@ app.use(loggerMiddleware);
 app.use(healthRouter);
 app.use(
   // The following callback handles generic authorization errors with current service behaviour
-  authenticationMiddleware((error: unknown, res: Response) => {
-    const apiError = makeApiProblem(error);
-    res.status(apiError.status).json(apiError).end();
-  })
+  authenticationMiddleware()
 );
 app.use(agreementRouter(zodiosCtx));
 

--- a/packages/agreement-process/src/app.ts
+++ b/packages/agreement-process/src/app.ts
@@ -21,10 +21,7 @@ app.use(loggerMiddleware);
 // NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes
 // we want to be unauthenticated.
 app.use(healthRouter);
-app.use(
-  // The following callback handles generic authorization errors with current service behaviour
-  authenticationMiddleware()
-);
+app.use(authenticationMiddleware());
 app.use(agreementRouter(zodiosCtx));
 
 export default app;

--- a/packages/agreement-process/src/app.ts
+++ b/packages/agreement-process/src/app.ts
@@ -1,3 +1,4 @@
+import { makeApiProblem } from "pagopa-interop-models";
 import {
   authenticationMiddleware,
   contextDataMiddleware,
@@ -8,7 +9,6 @@ import {
 import { Response } from "express";
 import healthRouter from "./routers/HealthRouter.js";
 import agreementRouter from "./routers/AgreementRouter.js";
-import { ApiError, makeApiError } from "./model/types.js";
 
 const app = zodiosCtx.app();
 
@@ -26,7 +26,7 @@ app.use(healthRouter);
 app.use(
   // The following callback handles generic authorization errors with current service behaviour
   authenticationMiddleware((error: unknown, res: Response) => {
-    const apiError: ApiError = makeApiError(error);
+    const apiError = makeApiProblem(error);
     res.status(apiError.status).json(apiError).end();
   })
 );

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -1,6 +1,6 @@
 import { ApiError, DescriptorState } from "pagopa-interop-models";
 
-export function agreementEServiceNotFound(eServiceId: string): ApiError {
+export function eServiceNotFound(eServiceId: string): ApiError {
   return new ApiError({
     detail: `EService ${eServiceId} not found`,
     code: "0007",

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -1,12 +1,24 @@
 import { ApiError, DescriptorState } from "pagopa-interop-models";
 
+const errorCodes = {
+  missingCertifiedAttributesError: "0001",
+  agreementNotInExpectedState: "0003",
+  descriptorNotInExpectedState: "0004",
+  eServiceNotFound: "0007",
+  operationNotAllowed: "0007",
+  agreementNotFound: "0009",
+  agreementAlreadyExists: "0011",
+  tenantIdNotFound: "0020",
+  notLatestEServiceDescriptor: "0021",
+};
+
 export function eServiceNotFound(
   httpStatus: number,
   eServiceId: string
 ): ApiError {
   return new ApiError({
     detail: `EService ${eServiceId} not found`,
-    code: "0007",
+    code: errorCodes.eServiceNotFound,
     httpStatus,
     title: "EService not found",
   });
@@ -15,7 +27,7 @@ export function eServiceNotFound(
 export function agreementNotFound(agreementId: string): ApiError {
   return new ApiError({
     detail: `Agreement ${agreementId} not found`,
-    code: "0009",
+    code: errorCodes.agreementNotFound,
     httpStatus: 404,
     title: "Agreement not found",
   });
@@ -24,7 +36,7 @@ export function agreementNotFound(agreementId: string): ApiError {
 export function notLatestEServiceDescriptor(descriptorId: string): ApiError {
   return new ApiError({
     detail: `Descriptor with descriptorId: ${descriptorId} is not the latest descriptor`,
-    code: "0021",
+    code: errorCodes.notLatestEServiceDescriptor,
     httpStatus: 400,
     title: "Descriptor provided is not the latest descriptor",
   });
@@ -39,7 +51,7 @@ export function descriptorNotInExpectedState(
     detail: `Descriptor ${descriptorId} of EService ${eServiceId} has not status in ${allowedStates.join(
       ","
     )}`,
-    code: "0004",
+    code: errorCodes.descriptorNotInExpectedState,
     httpStatus: 400,
     title: "Descriptor not in expected state",
   });
@@ -51,7 +63,7 @@ export function missingCertifiedAttributesError(
 ): ApiError {
   return new ApiError({
     detail: `Required certified attribute is missing. Descriptor ${descriptorId}, Consumer: ${consumerId}`,
-    code: "0001",
+    code: errorCodes.missingCertifiedAttributesError,
     httpStatus: 400,
     title: `Required certified attribute is missing`,
   });
@@ -63,7 +75,7 @@ export function agreementAlreadyExists(
 ): ApiError {
   return new ApiError({
     detail: `Agreement already exists for Consumer = ${consumerId}, EService = ${eServiceId}`,
-    code: "0011",
+    code: errorCodes.agreementAlreadyExists,
     httpStatus: 404,
     title: "Agreement already exists",
   });
@@ -72,7 +84,7 @@ export function agreementAlreadyExists(
 export function operationNotAllowed(requesterId: string): ApiError {
   return new ApiError({
     detail: `Operation not allowed by ${requesterId}`,
-    code: "0007",
+    code: errorCodes.operationNotAllowed,
     httpStatus: 400,
     title: "Operation not allowed",
   });
@@ -84,7 +96,7 @@ export function agreementNotInExpectedState(
 ): ApiError {
   return new ApiError({
     detail: `Agreement ${agreementId} not in expected state (current state: ${state})`,
-    code: "0003",
+    code: errorCodes.agreementNotInExpectedState,
     httpStatus: 400,
     title: "Agreement not in expected state",
   });
@@ -93,7 +105,7 @@ export function agreementNotInExpectedState(
 export function tenantIdNotFound(tenantId: string): ApiError {
   return new ApiError({
     detail: `Tenant ${tenantId} not found`,
-    code: "0020",
+    code: errorCodes.tenantIdNotFound,
     httpStatus: 404,
     title: "Tenant not found",
   });

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -1,0 +1,97 @@
+import { ApiError, DescriptorState } from "pagopa-interop-models";
+
+export function agreementEServiceNotFound(eServiceId: string): ApiError {
+  return {
+    detail: `EService ${eServiceId} not found`,
+    code: "0007",
+    httpStatus: 400,
+    title: "EService not found",
+  };
+}
+
+export function agreementNotFound(agreementId: string): ApiError {
+  return {
+    detail: `Agreement ${agreementId} not found`,
+    code: "0009",
+    httpStatus: 404,
+    title: "Agreement not found",
+  };
+}
+
+export function notLatestEServiceDescriptor(descriptorId: string): ApiError {
+  return {
+    detail: `Descriptor with descriptorId: ${descriptorId} is not the latest descriptor`,
+    code: "0021",
+    httpStatus: 400,
+    title: "Descriptor provided is not the latest descriptor",
+  };
+}
+
+export function descriptorNotInExpectedState(
+  eServiceId: string,
+  descriptorId: string,
+  allowedStates: DescriptorState[]
+): ApiError {
+  return {
+    detail: `Descriptor ${descriptorId} of EService ${eServiceId} has not status in ${allowedStates.join(
+      ","
+    )}`,
+    code: "0004",
+    httpStatus: 400,
+    title: "Descriptor not in expected state",
+  };
+}
+
+export function missingCertifiedAttributesError(
+  descriptorId: string,
+  consumerId: string
+): ApiError {
+  return {
+    detail: `Required certified attribute is missing. Descriptor ${descriptorId}, Consumer: ${consumerId}`,
+    code: "0001",
+    httpStatus: 400,
+    title: `Required certified attribute is missing`,
+  };
+}
+
+export function agreementAlreadyExists(
+  consumerId: string,
+  eServiceId: string
+): ApiError {
+  return {
+    detail: `Agreement already exists for Consumer = ${consumerId}, EService = ${eServiceId}`,
+    code: "0011",
+    httpStatus: 404,
+    title: "Agreement already exists",
+  };
+}
+
+export function operationNotAllowed(requesterId: string): ApiError {
+  return {
+    detail: `Operation not allowed by ${requesterId}`,
+    code: "0007",
+    httpStatus: 400,
+    title: "Operation not allowed",
+  };
+}
+
+export function agreementNotInExpectedState(
+  agreementId: string,
+  state: string
+): ApiError {
+  return {
+    detail: `Agreement ${agreementId} not in expected state (current state: ${state})`,
+    code: "0003",
+    httpStatus: 400,
+    title: "Agreement not in expected state",
+  };
+}
+
+export function tenantIdNotFound(tenantId: string): ApiError {
+  return {
+    detail: `Tenant ${tenantId} not found`,
+    code: "0020",
+    httpStatus: 404,
+    title: "Tenant not found",
+  };
+}

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -1,30 +1,30 @@
 import { ApiError, DescriptorState } from "pagopa-interop-models";
 
 export function agreementEServiceNotFound(eServiceId: string): ApiError {
-  return {
+  return new ApiError({
     detail: `EService ${eServiceId} not found`,
     code: "0007",
     httpStatus: 400,
     title: "EService not found",
-  };
+  });
 }
 
 export function agreementNotFound(agreementId: string): ApiError {
-  return {
+  return new ApiError({
     detail: `Agreement ${agreementId} not found`,
     code: "0009",
     httpStatus: 404,
     title: "Agreement not found",
-  };
+  });
 }
 
 export function notLatestEServiceDescriptor(descriptorId: string): ApiError {
-  return {
+  return new ApiError({
     detail: `Descriptor with descriptorId: ${descriptorId} is not the latest descriptor`,
     code: "0021",
     httpStatus: 400,
     title: "Descriptor provided is not the latest descriptor",
-  };
+  });
 }
 
 export function descriptorNotInExpectedState(
@@ -32,66 +32,66 @@ export function descriptorNotInExpectedState(
   descriptorId: string,
   allowedStates: DescriptorState[]
 ): ApiError {
-  return {
+  return new ApiError({
     detail: `Descriptor ${descriptorId} of EService ${eServiceId} has not status in ${allowedStates.join(
       ","
     )}`,
     code: "0004",
     httpStatus: 400,
     title: "Descriptor not in expected state",
-  };
+  });
 }
 
 export function missingCertifiedAttributesError(
   descriptorId: string,
   consumerId: string
 ): ApiError {
-  return {
+  return new ApiError({
     detail: `Required certified attribute is missing. Descriptor ${descriptorId}, Consumer: ${consumerId}`,
     code: "0001",
     httpStatus: 400,
     title: `Required certified attribute is missing`,
-  };
+  });
 }
 
 export function agreementAlreadyExists(
   consumerId: string,
   eServiceId: string
 ): ApiError {
-  return {
+  return new ApiError({
     detail: `Agreement already exists for Consumer = ${consumerId}, EService = ${eServiceId}`,
     code: "0011",
     httpStatus: 404,
     title: "Agreement already exists",
-  };
+  });
 }
 
 export function operationNotAllowed(requesterId: string): ApiError {
-  return {
+  return new ApiError({
     detail: `Operation not allowed by ${requesterId}`,
     code: "0007",
     httpStatus: 400,
     title: "Operation not allowed",
-  };
+  });
 }
 
 export function agreementNotInExpectedState(
   agreementId: string,
   state: string
 ): ApiError {
-  return {
+  return new ApiError({
     detail: `Agreement ${agreementId} not in expected state (current state: ${state})`,
     code: "0003",
     httpStatus: 400,
     title: "Agreement not in expected state",
-  };
+  });
 }
 
 export function tenantIdNotFound(tenantId: string): ApiError {
-  return {
+  return new ApiError({
     detail: `Tenant ${tenantId} not found`,
     code: "0020",
     httpStatus: 404,
     title: "Tenant not found",
-  };
+  });
 }

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -1,10 +1,13 @@
 import { ApiError, DescriptorState } from "pagopa-interop-models";
 
-export function eServiceNotFound(eServiceId: string): ApiError {
+export function eServiceNotFound(
+  httpStatus: number,
+  eServiceId: string
+): ApiError {
   return new ApiError({
     detail: `EService ${eServiceId} not found`,
     code: "0007",
-    httpStatus: 400,
+    httpStatus,
     title: "EService not found",
   });
 }

--- a/packages/agreement-process/src/model/types.ts
+++ b/packages/agreement-process/src/model/types.ts
@@ -1,16 +1,6 @@
-import {
-  AgreementProcessError,
-  ErrorTypes,
-  Problem,
-  ProcessError,
-  makeApiProblem,
-} from "pagopa-interop-models";
-import { P, match } from "ts-pattern";
 import { ZodiosBodyByPath } from "@zodios/core";
 import { z } from "zod";
 import { api, schemas } from "./generated/api.js";
-
-const servicePrefix = "agreement";
 
 type Api = typeof api.api;
 export type ApiAgreement = z.infer<typeof schemas.Agreement>;
@@ -20,29 +10,3 @@ export type ApiAgreementState = z.infer<typeof schemas.AgreementState>;
 export type ApiAgreementDocument = z.infer<typeof schemas.Document>;
 
 export type ApiAgreementPayload = ZodiosBodyByPath<Api, "post", "/agreements">;
-
-export type ApiError = Problem;
-
-export function makeApiError(error: unknown): ApiError {
-  return match<unknown, ApiError>(error)
-    .with(
-      P.instanceOf(ProcessError),
-      P.instanceOf(AgreementProcessError),
-      (error) =>
-        makeApiProblem(
-          error.type.code,
-          error.type.httpStatus,
-          error.type.title,
-          error.message
-        )
-    )
-    .otherwise(() =>
-      makeApiProblem(
-        `${servicePrefix}-${ErrorTypes.GenericError.code}`,
-        ErrorTypes.GenericError.httpStatus,
-        // eslint-disable-next-line sonarjs/no-duplicate-string
-        ErrorTypes.GenericError.title,
-        "Generic error while processing agreement process error"
-      )
-    );
-}

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -6,14 +6,14 @@ import {
   userRoles,
   authorizationMiddleware,
 } from "pagopa-interop-commons";
-import { agreementNotFound } from "pagopa-interop-models";
+import { makeApiProblem } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import {
   agreementToApiAgreement,
   apiAgreementStateToAgreementState,
 } from "../model/domain/apiConverter.js";
 import { agreementService } from "../services/agreementService.js";
-import { ApiError, makeApiError } from "../model/types.js";
+import { agreementNotFound } from "../model/domain/errors.js";
 
 const {
   ADMIN_ROLE,
@@ -90,7 +90,7 @@ const agreementRouter = (
         );
         return res.status(200).json({ id }).send();
       } catch (error) {
-        const errorRes: ApiError = makeApiError(error);
+        const errorRes = makeApiProblem(error);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }
@@ -128,7 +128,7 @@ const agreementRouter = (
           })
           .end();
       } catch (error) {
-        const errorRes: ApiError = makeApiError(error);
+        const errorRes = makeApiProblem(error);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }
@@ -165,11 +165,11 @@ const agreementRouter = (
         } else {
           return res
             .status(404)
-            .json(makeApiError(agreementNotFound(req.params.agreementId)))
+            .json(makeApiProblem(agreementNotFound(req.params.agreementId)))
             .send();
         }
       } catch (error) {
-        const errorRes: ApiError = makeApiError(error);
+        const errorRes = makeApiProblem(error);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }
@@ -186,7 +186,7 @@ const agreementRouter = (
         );
         return res.status(204).send();
       } catch (error) {
-        const errorRes: ApiError = makeApiError(error);
+        const errorRes = makeApiProblem(error);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -142,7 +142,7 @@ export async function createAgreementLogic(
   const eservice = await readModelService.getEServiceById(agreement.eserviceId);
 
   if (!eservice) {
-    throw eServiceNotFound(agreement.eserviceId);
+    throw eServiceNotFound(400, agreement.eserviceId);
   }
 
   const descriptor = validateCreationOnDescriptor(

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -22,8 +22,8 @@ import {
   toCreateEventAgreementDeleted,
 } from "../model/domain/toEvent.js";
 import {
-  agreementEServiceNotFound,
   agreementNotInExpectedState,
+  eServiceNotFound,
   tenantIdNotFound,
 } from "../model/domain/errors.js";
 import { ApiAgreementPayload } from "../model/types.js";
@@ -142,7 +142,7 @@ export async function createAgreementLogic(
   const eservice = await readModelService.getEServiceById(agreement.eserviceId);
 
   if (!eservice) {
-    throw agreementEServiceNotFound(agreement.eserviceId);
+    throw eServiceNotFound(agreement.eserviceId);
   }
 
   const descriptor = validateCreationOnDescriptor(

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -11,11 +11,8 @@ import {
   AgreementEvent,
   AgreementState,
   WithMetadata,
-  agreementEServiceNotFound,
   agreementEventToBinaryData,
-  agreementNotInExpectedState,
   agreementState,
-  tenantIdNotFound,
   ListResult,
 } from "pagopa-interop-models";
 import { v4 as uuidv4 } from "uuid";
@@ -24,6 +21,11 @@ import {
   toCreateEventAgreementAdded,
   toCreateEventAgreementDeleted,
 } from "../model/domain/toEvent.js";
+import {
+  agreementEServiceNotFound,
+  agreementNotInExpectedState,
+  tenantIdNotFound,
+} from "../model/domain/errors.js";
 import { ApiAgreementPayload } from "../model/types.js";
 import { readModelService } from "./readModelService.js";
 import {

--- a/packages/agreement-process/src/services/readModelService.ts
+++ b/packages/agreement-process/src/services/readModelService.ts
@@ -167,7 +167,7 @@ const getAgreements = async (
         result
       )} - data ${JSON.stringify(data)} `
     );
-    throw genericError("Unable to parse eservices items");
+    throw genericError("Unable to parse agreements items");
   }
 
   return result.data;
@@ -369,7 +369,7 @@ export const readModelService = {
           )} - data ${JSON.stringify(data)} `
         );
 
-        throw genericError("Unable to parse eservices item");
+        throw genericError(`Unable to parse eservice ${id}`);
       }
 
       return {
@@ -403,7 +403,7 @@ export const readModelService = {
           )} - data ${JSON.stringify(data)} `
         );
 
-        throw genericError("Unable to parse tenant item");
+        throw genericError(`Unable to parse tenant ${tenantId}`);
       }
 
       return {

--- a/packages/agreement-process/src/services/readModelService.ts
+++ b/packages/agreement-process/src/services/readModelService.ts
@@ -5,13 +5,13 @@ import { logger, ReadModelRepository } from "pagopa-interop-commons";
 import {
   Agreement,
   AgreementState,
-  ErrorTypes,
   ListResult,
   WithMetadata,
   agreementState,
   descriptorState,
   EService,
   Tenant,
+  genericError,
 } from "pagopa-interop-models";
 import { z } from "zod";
 import { match, P } from "ts-pattern";
@@ -167,7 +167,7 @@ const getAgreements = async (
         result
       )} - data ${JSON.stringify(data)} `
     );
-    throw ErrorTypes.GenericError;
+    throw genericError("Unable to parse eservices items");
   }
 
   return result.data;
@@ -291,7 +291,7 @@ export const readModelService = {
         )} - data ${JSON.stringify(data)} `
       );
 
-      throw ErrorTypes.GenericError;
+      throw genericError("Unable to parse agreements items");
     }
 
     return {
@@ -319,7 +319,7 @@ export const readModelService = {
         .safeParse(data);
       if (!result.success) {
         logger.error(`Agreement ${agreementId} not found`);
-        throw ErrorTypes.GenericError;
+        throw genericError(`Agreement ${agreementId} not found`);
       }
       return {
         data: result.data.data,
@@ -369,7 +369,7 @@ export const readModelService = {
           )} - data ${JSON.stringify(data)} `
         );
 
-        throw ErrorTypes.GenericError;
+        throw genericError("Unable to parse eservices item");
       }
 
       return {
@@ -403,7 +403,7 @@ export const readModelService = {
           )} - data ${JSON.stringify(data)} `
         );
 
-        throw ErrorTypes.GenericError;
+        throw genericError("Unable to parse tenant item");
       }
 
       return {

--- a/packages/agreement-process/src/services/validators.ts
+++ b/packages/agreement-process/src/services/validators.ts
@@ -6,19 +6,21 @@ import {
   EServiceAttribute,
   Tenant,
   WithMetadata,
-  agreementAlreadyExists,
-  agreementNotFound,
   Agreement,
   AgreementState,
   agreementState,
-  descriptorNotInExpectedState,
+  tenantAttributeType,
   descriptorState,
+} from "pagopa-interop-models";
+import { ApiAgreementPayload } from "../model/types.js";
+import {
+  agreementAlreadyExists,
+  agreementNotFound,
+  descriptorNotInExpectedState,
   missingCertifiedAttributesError,
   notLatestEServiceDescriptor,
   operationNotAllowed,
-  tenantAttributeType,
-} from "pagopa-interop-models";
-import { ApiAgreementPayload } from "../model/types.js";
+} from "../model/domain/errors.js";
 import { readModelService } from "./readModelService.js";
 
 const validateDescriptorState = (

--- a/packages/catalog-process/src/app.ts
+++ b/packages/catalog-process/src/app.ts
@@ -1,4 +1,5 @@
 import { Response } from "express";
+import { makeApiProblem } from "pagopa-interop-models";
 import {
   contextDataMiddleware,
   globalContextMiddleware,
@@ -8,7 +9,6 @@ import {
 } from "pagopa-interop-commons";
 import eservicesRouter from "./routers/EServiceRouter.js";
 import healthRouter from "./routers/HealthRouter.js";
-import { ApiError, makeApiError } from "./model/types.js";
 
 const app = zodiosCtx.app();
 
@@ -25,7 +25,7 @@ app.use(healthRouter);
 app.use(
   // The following callback handles generic authorization errors with current service behaviour
   authenticationMiddleware((error: unknown, res: Response) => {
-    const apiError: ApiError = makeApiError(error);
+    const apiError = makeApiProblem(error);
     res.status(apiError.status).json(apiError).end();
   })
 );

--- a/packages/catalog-process/src/app.ts
+++ b/packages/catalog-process/src/app.ts
@@ -1,5 +1,3 @@
-import { Response } from "express";
-import { makeApiProblem } from "pagopa-interop-models";
 import {
   contextDataMiddleware,
   globalContextMiddleware,
@@ -24,10 +22,7 @@ app.use(loggerMiddleware);
 app.use(healthRouter);
 app.use(
   // The following callback handles generic authorization errors with current service behaviour
-  authenticationMiddleware((error: unknown, res: Response) => {
-    const apiError = makeApiProblem(error);
-    res.status(apiError.status).json(apiError).end();
-  })
+  authenticationMiddleware()
 );
 app.use(eservicesRouter(zodiosCtx));
 

--- a/packages/catalog-process/src/app.ts
+++ b/packages/catalog-process/src/app.ts
@@ -20,10 +20,7 @@ app.use(loggerMiddleware);
 // NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes
 // we want to be unauthenticated.
 app.use(healthRouter);
-app.use(
-  // The following callback handles generic authorization errors with current service behaviour
-  authenticationMiddleware()
-);
+app.use(authenticationMiddleware());
 app.use(eservicesRouter(zodiosCtx));
 
 export default app;

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -1,0 +1,104 @@
+import { ApiError } from "pagopa-interop-models";
+
+const duplicateEserviceName = {
+  code: "0010",
+  httpStatus: 409,
+  title: "Duplicated service name",
+};
+
+const eserviceCannotBeUpdatedOrDeleted = {
+  code: "0009",
+  httpStatus: 400,
+  title: "EService cannot be updated or deleted",
+};
+
+const eserviceDescriptorNotFound = {
+  code: "0002",
+  httpStatus: 404,
+  title: "EService descriptor not found",
+};
+
+const eserviceDocumentNotFound = {
+  code: "0003",
+  httpStatus: 404,
+  title: "EService document not found",
+}; // TODO: reorganize error codes
+
+export function eServiceDuplicate(eServiceNameSeed: string): ApiError {
+  return {
+    detail: `ApiError during EService creation with name ${eServiceNameSeed}`,
+    ...duplicateEserviceName,
+  };
+}
+
+export const operationForbidden = {
+  detail: `Insufficient privileges`,
+  code: "9989",
+  httpStatus: 400,
+  title: "Insufficient privileges",
+};
+
+export function eServiceCannotBeUpdated(eServiceId: string): ApiError {
+  return {
+    detail: `EService ${eServiceId} contains valid descriptors and cannot be updated`,
+    ...eserviceCannotBeUpdatedOrDeleted,
+  };
+}
+
+export function eServiceCannotBeDeleted(eServiceId: string): ApiError {
+  return {
+    detail: `EService ${eServiceId} contains descriptors and cannot be deleted`,
+    ...eserviceCannotBeUpdatedOrDeleted,
+  };
+}
+
+export function eServiceDescriptorNotFound(
+  eServiceId: string,
+  descriptorId: string
+): ApiError {
+  return {
+    detail: `Descriptor ${descriptorId} for EService ${eServiceId} not found`,
+    ...eserviceDescriptorNotFound,
+  };
+}
+
+export function eServiceDocumentNotFound(
+  eServiceId: string,
+  descriptorId: string,
+  documentId: string
+): ApiError {
+  return {
+    detail: `Document with id ${documentId} not found in EService ${eServiceId} / Descriptor ${descriptorId}`,
+    ...eserviceDocumentNotFound,
+  };
+}
+
+export function notValidDescriptor(
+  descriptorId: string,
+  descriptorStatus: string
+): ApiError {
+  return {
+    detail: `Descriptor ${descriptorId} has a not valid status for this operation ${descriptorStatus}`,
+    code: "0004",
+    httpStatus: 400,
+    title: "Not valid descriptor",
+  };
+}
+
+export function draftDescriptorAlreadyExists(eServiceId: string): ApiError {
+  return {
+    detail: `EService ${eServiceId} already contains a draft descriptor`,
+    code: "0008",
+    httpStatus: 400,
+    title: "EService already contains a draft descriptor",
+  };
+}
+
+export function invalidDescriptorVersion(details: string): ApiError {
+  return {
+    detail: details,
+    code: "0004",
+    httpStatus: 400,
+    title: "Version is not a valid descriptor version",
+  };
+}

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -8,7 +8,6 @@ const errorCodes = {
   draftDescriptorAlreadyExists: "0008",
   eserviceCannotBeUpdatedOrDeleted: "0009",
   eServiceDuplicate: "0010",
-  operationForbidden: "9989",
 };
 
 const eserviceCannotBeUpdatedOrDeleted = {
@@ -34,13 +33,6 @@ export function eServiceDuplicate(eServiceNameSeed: string): ApiError {
     title: "Duplicated service name",
   });
 }
-
-export const operationForbidden = new ApiError({
-  detail: `Insufficient privileges`,
-  code: errorCodes.operationForbidden,
-  httpStatus: 400,
-  title: "Insufficient privileges",
-});
 
 export function eServiceCannotBeUpdated(eServiceId: string): ApiError {
   return new ApiError({

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -1,7 +1,18 @@
 import { ApiError } from "pagopa-interop-models";
 
+const errorCodes = {
+  eServiceDescriptorNotFound: "0002",
+  eServiceDocumentNotFound: "0003",
+  notValidDescriptor: "0004",
+  eServiceNotFound: "0007",
+  draftDescriptorAlreadyExists: "0008",
+  eserviceCannotBeUpdatedOrDeleted: "0009",
+  eServiceDuplicate: "0010",
+  operationForbidden: "9989",
+};
+
 const eserviceCannotBeUpdatedOrDeleted = {
-  code: "0009",
+  code: errorCodes.eserviceCannotBeUpdatedOrDeleted,
   httpStatus: 400,
   title: "EService cannot be updated or deleted",
 };
@@ -9,7 +20,7 @@ const eserviceCannotBeUpdatedOrDeleted = {
 export function eServiceNotFound(eServiceId: string): ApiError {
   return new ApiError({
     detail: `EService ${eServiceId} not found`,
-    code: "0007",
+    code: errorCodes.eServiceNotFound,
     httpStatus: 404,
     title: "EService not found",
   });
@@ -18,7 +29,7 @@ export function eServiceNotFound(eServiceId: string): ApiError {
 export function eServiceDuplicate(eServiceNameSeed: string): ApiError {
   return new ApiError({
     detail: `ApiError during EService creation with name ${eServiceNameSeed}`,
-    code: "0010",
+    code: errorCodes.eServiceDuplicate,
     httpStatus: 409,
     title: "Duplicated service name",
   });
@@ -26,7 +37,7 @@ export function eServiceDuplicate(eServiceNameSeed: string): ApiError {
 
 export const operationForbidden = new ApiError({
   detail: `Insufficient privileges`,
-  code: "9989",
+  code: errorCodes.operationForbidden,
   httpStatus: 400,
   title: "Insufficient privileges",
 });
@@ -51,7 +62,7 @@ export function eServiceDescriptorNotFound(
 ): ApiError {
   return new ApiError({
     detail: `Descriptor ${descriptorId} for EService ${eServiceId} not found`,
-    code: "0002",
+    code: errorCodes.eServiceDescriptorNotFound,
     httpStatus: 404,
     title: "EService descriptor not found",
   });
@@ -64,7 +75,7 @@ export function eServiceDocumentNotFound(
 ): ApiError {
   return new ApiError({
     detail: `Document with id ${documentId} not found in EService ${eServiceId} / Descriptor ${descriptorId}`,
-    code: "0003",
+    code: errorCodes.eServiceDocumentNotFound,
     httpStatus: 404,
     title: "EService document not found",
   });
@@ -76,7 +87,7 @@ export function notValidDescriptor(
 ): ApiError {
   return new ApiError({
     detail: `Descriptor ${descriptorId} has a not valid status for this operation ${descriptorStatus}`,
-    code: "0004",
+    code: errorCodes.notValidDescriptor,
     httpStatus: 400,
     title: "Not valid descriptor",
   });
@@ -85,7 +96,7 @@ export function notValidDescriptor(
 export function draftDescriptorAlreadyExists(eServiceId: string): ApiError {
   return new ApiError({
     detail: `EService ${eServiceId} already contains a draft descriptor`,
-    code: "0008",
+    code: errorCodes.draftDescriptorAlreadyExists,
     httpStatus: 400,
     title: "EService already contains a draft descriptor",
   });
@@ -94,7 +105,7 @@ export function draftDescriptorAlreadyExists(eServiceId: string): ApiError {
 export function invalidDescriptorVersion(details: string): ApiError {
   return new ApiError({
     detail: details,
-    code: "0004",
+    code: errorCodes.notValidDescriptor,
     httpStatus: 400,
     title: "Version is not a valid descriptor version",
   });

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -25,41 +25,41 @@ const eserviceDocumentNotFound = {
 }; // TODO: reorganize error codes
 
 export function eServiceDuplicate(eServiceNameSeed: string): ApiError {
-  return {
+  return new ApiError({
     detail: `ApiError during EService creation with name ${eServiceNameSeed}`,
     ...duplicateEserviceName,
-  };
+  });
 }
 
-export const operationForbidden = {
+export const operationForbidden = new ApiError({
   detail: `Insufficient privileges`,
   code: "9989",
   httpStatus: 400,
   title: "Insufficient privileges",
-};
+});
 
 export function eServiceCannotBeUpdated(eServiceId: string): ApiError {
-  return {
+  return new ApiError({
     detail: `EService ${eServiceId} contains valid descriptors and cannot be updated`,
     ...eserviceCannotBeUpdatedOrDeleted,
-  };
+  });
 }
 
 export function eServiceCannotBeDeleted(eServiceId: string): ApiError {
-  return {
+  return new ApiError({
     detail: `EService ${eServiceId} contains descriptors and cannot be deleted`,
     ...eserviceCannotBeUpdatedOrDeleted,
-  };
+  });
 }
 
 export function eServiceDescriptorNotFound(
   eServiceId: string,
   descriptorId: string
 ): ApiError {
-  return {
+  return new ApiError({
     detail: `Descriptor ${descriptorId} for EService ${eServiceId} not found`,
     ...eserviceDescriptorNotFound,
-  };
+  });
 }
 
 export function eServiceDocumentNotFound(
@@ -67,38 +67,38 @@ export function eServiceDocumentNotFound(
   descriptorId: string,
   documentId: string
 ): ApiError {
-  return {
+  return new ApiError({
     detail: `Document with id ${documentId} not found in EService ${eServiceId} / Descriptor ${descriptorId}`,
     ...eserviceDocumentNotFound,
-  };
+  });
 }
 
 export function notValidDescriptor(
   descriptorId: string,
   descriptorStatus: string
 ): ApiError {
-  return {
+  return new ApiError({
     detail: `Descriptor ${descriptorId} has a not valid status for this operation ${descriptorStatus}`,
     code: "0004",
     httpStatus: 400,
     title: "Not valid descriptor",
-  };
+  });
 }
 
 export function draftDescriptorAlreadyExists(eServiceId: string): ApiError {
-  return {
+  return new ApiError({
     detail: `EService ${eServiceId} already contains a draft descriptor`,
     code: "0008",
     httpStatus: 400,
     title: "EService already contains a draft descriptor",
-  };
+  });
 }
 
 export function invalidDescriptorVersion(details: string): ApiError {
-  return {
+  return new ApiError({
     detail: details,
     code: "0004",
     httpStatus: 400,
     title: "Version is not a valid descriptor version",
-  };
+  });
 }

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -24,6 +24,15 @@ const eserviceDocumentNotFound = {
   title: "EService document not found",
 }; // TODO: reorganize error codes
 
+export function eServiceNotFound(eServiceId: string): ApiError {
+  return new ApiError({
+    detail: `EService ${eServiceId} not found`,
+    code: "0007",
+    httpStatus: 404,
+    title: "EService not found",
+  });
+}
+
 export function eServiceDuplicate(eServiceNameSeed: string): ApiError {
   return new ApiError({
     detail: `ApiError during EService creation with name ${eServiceNameSeed}`,

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -1,28 +1,10 @@
 import { ApiError } from "pagopa-interop-models";
 
-const duplicateEserviceName = {
-  code: "0010",
-  httpStatus: 409,
-  title: "Duplicated service name",
-};
-
 const eserviceCannotBeUpdatedOrDeleted = {
   code: "0009",
   httpStatus: 400,
   title: "EService cannot be updated or deleted",
 };
-
-const eserviceDescriptorNotFound = {
-  code: "0002",
-  httpStatus: 404,
-  title: "EService descriptor not found",
-};
-
-const eserviceDocumentNotFound = {
-  code: "0003",
-  httpStatus: 404,
-  title: "EService document not found",
-}; // TODO: reorganize error codes
 
 export function eServiceNotFound(eServiceId: string): ApiError {
   return new ApiError({
@@ -36,7 +18,9 @@ export function eServiceNotFound(eServiceId: string): ApiError {
 export function eServiceDuplicate(eServiceNameSeed: string): ApiError {
   return new ApiError({
     detail: `ApiError during EService creation with name ${eServiceNameSeed}`,
-    ...duplicateEserviceName,
+    code: "0010",
+    httpStatus: 409,
+    title: "Duplicated service name",
   });
 }
 
@@ -67,7 +51,9 @@ export function eServiceDescriptorNotFound(
 ): ApiError {
   return new ApiError({
     detail: `Descriptor ${descriptorId} for EService ${eServiceId} not found`,
-    ...eserviceDescriptorNotFound,
+    code: "0002",
+    httpStatus: 404,
+    title: "EService descriptor not found",
   });
 }
 
@@ -78,7 +64,9 @@ export function eServiceDocumentNotFound(
 ): ApiError {
   return new ApiError({
     detail: `Document with id ${documentId} not found in EService ${eServiceId} / Descriptor ${descriptorId}`,
-    ...eserviceDocumentNotFound,
+    code: "0003",
+    httpStatus: 404,
+    title: "EService document not found",
   });
 }
 

--- a/packages/catalog-process/src/model/types.ts
+++ b/packages/catalog-process/src/model/types.ts
@@ -1,15 +1,6 @@
-import { ZodiosBodyByPath, ZodiosErrorByPath } from "@zodios/core";
-import { P, match } from "ts-pattern";
-import {
-  CatalogProcessError,
-  ErrorTypes,
-  Problem,
-  ProcessError,
-  makeApiProblem,
-} from "pagopa-interop-models";
+import { ZodiosBodyByPath } from "@zodios/core";
 import { api } from "./generated/api.js";
 
-const servicePrefix = "catalog";
 type Api = typeof api.api;
 export type ApiEServiceSeed = ZodiosBodyByPath<Api, "post", "/eservices">;
 
@@ -24,50 +15,3 @@ export type ApiEServiceDescriptorDocumentUpdateSeed = ZodiosBodyByPath<
   "post",
   "/eservices/:eServiceId/descriptors/:descriptorId/documents/:documentId/update"
 >;
-
-export type ApiErrorInvalidInput = ZodiosErrorByPath<
-  Api,
-  "post",
-  "/eservices",
-  400
->;
-
-export type ApiErrorNameConflict = ZodiosErrorByPath<
-  Api,
-  "post",
-  "/eservices",
-  409
->;
-export type ApiInternalServerError = Problem & {
-  status: 500;
-};
-
-export type ApiError =
-  | ApiErrorInvalidInput
-  | ApiErrorNameConflict
-  | ApiInternalServerError
-  | Problem;
-
-export function makeApiError(error: unknown): ApiError {
-  return match<unknown, ApiError>(error)
-    .with(
-      P.instanceOf(ProcessError),
-      P.instanceOf(CatalogProcessError),
-      (error) =>
-        makeApiProblem(
-          error.type.code,
-          error.type.httpStatus,
-          error.type.title,
-          error.message
-        )
-    )
-    .otherwise(() =>
-      makeApiProblem(
-        `${servicePrefix}-${ErrorTypes.GenericError.code}`,
-        ErrorTypes.GenericError.httpStatus,
-        // eslint-disable-next-line sonarjs/no-duplicate-string
-        ErrorTypes.GenericError.title,
-        "Generic error while processing catalog process error"
-      )
-    );
-}

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -1,6 +1,6 @@
 import { ZodiosEndpointDefinitions } from "@zodios/core";
 import { ZodiosRouter } from "@zodios/express";
-import { eServiceNotFound, makeApiProblem } from "pagopa-interop-models";
+import { makeApiProblem } from "pagopa-interop-models";
 import {
   ExpressContext,
   userRoles,
@@ -17,7 +17,10 @@ import {
 import { api } from "../model/generated/api.js";
 import { catalogService } from "../services/catalogService.js";
 import { readModelService } from "../services/readModelService.js";
-import { eServiceDocumentNotFound } from "../model/domain/errors.js";
+import {
+  eServiceNotFound,
+  eServiceDocumentNotFound,
+} from "../model/domain/errors.js";
 
 const eservicesRouter = (
   ctx: ZodiosContext

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -1,9 +1,6 @@
 import { ZodiosEndpointDefinitions } from "@zodios/core";
 import { ZodiosRouter } from "@zodios/express";
-import {
-  eServiceDocumentNotFound,
-  eServiceNotFound,
-} from "pagopa-interop-models";
+import { eServiceNotFound, makeApiProblem } from "pagopa-interop-models";
 import {
   ExpressContext,
   userRoles,
@@ -18,9 +15,9 @@ import {
   eServiceToApiEService,
 } from "../model/domain/apiConverter.js";
 import { api } from "../model/generated/api.js";
-import { ApiError, makeApiError } from "../model/types.js";
 import { catalogService } from "../services/catalogService.js";
 import { readModelService } from "../services/readModelService.js";
+import { eServiceDocumentNotFound } from "../model/domain/errors.js";
 
 const eservicesRouter = (
   ctx: ZodiosContext
@@ -94,7 +91,7 @@ const eservicesRouter = (
           );
           return res.status(201).json({ id }).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -122,11 +119,11 @@ const eservicesRouter = (
           } else {
             return res
               .status(404)
-              .json(makeApiError(eServiceNotFound(req.params.eServiceId)))
+              .json(makeApiProblem(eServiceNotFound(req.params.eServiceId)))
               .end();
           }
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -143,7 +140,7 @@ const eservicesRouter = (
           );
           return res.status(200).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -159,7 +156,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -203,7 +200,7 @@ const eservicesRouter = (
             })
             .end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -236,14 +233,14 @@ const eservicesRouter = (
             return res
               .status(404)
               .json(
-                makeApiError(
+                makeApiProblem(
                   eServiceDocumentNotFound(eServiceId, descriptorId, documentId)
                 )
               )
               .end();
           }
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -261,7 +258,7 @@ const eservicesRouter = (
           );
           return res.status(200).json({ id }).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -279,7 +276,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -298,7 +295,7 @@ const eservicesRouter = (
           );
           return res.status(200).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -315,7 +312,7 @@ const eservicesRouter = (
           );
           return res.status(200).json({ id }).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -332,7 +329,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -350,7 +347,7 @@ const eservicesRouter = (
           );
           return res.status(200).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -367,7 +364,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -384,7 +381,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -401,7 +398,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -419,7 +416,7 @@ const eservicesRouter = (
             );
           return res.status(200).json(clonedEserviceByDescriptor).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -436,7 +433,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes: ApiError = makeApiError(error);
+          const errorRes = makeApiProblem(error);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -17,6 +17,7 @@ import {
   WithMetadata,
   catalogEventToBinaryData,
   descriptorState,
+  operationForbidden,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { v4 as uuidv4 } from "uuid";
@@ -55,7 +56,6 @@ import {
   eServiceDocumentNotFound,
   eServiceDuplicate,
   notValidDescriptor,
-  operationForbidden,
   eServiceNotFound,
 } from "../model/domain/errors.js";
 import { readModelService } from "./readModelService.js";

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -17,7 +17,6 @@ import {
   WithMetadata,
   catalogEventToBinaryData,
   descriptorState,
-  eServiceNotFound,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { v4 as uuidv4 } from "uuid";
@@ -57,6 +56,7 @@ import {
   eServiceDuplicate,
   notValidDescriptor,
   operationForbidden,
+  eServiceNotFound,
 } from "../model/domain/errors.js";
 import { readModelService } from "./readModelService.js";
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -17,15 +17,7 @@ import {
   WithMetadata,
   catalogEventToBinaryData,
   descriptorState,
-  draftDescriptorAlreadyExists,
-  eServiceCannotBeDeleted,
-  eServiceCannotBeUpdated,
-  eServiceDescriptorNotFound,
-  eServiceDocumentNotFound,
-  eServiceDuplicate,
   eServiceNotFound,
-  notValidDescriptor,
-  operationForbidden,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { v4 as uuidv4 } from "uuid";
@@ -56,6 +48,16 @@ import {
 } from "../model/types.js";
 import { config } from "../utilities/config.js";
 import { nextDescriptorVersion } from "../utilities/versionGenerator.js";
+import {
+  draftDescriptorAlreadyExists,
+  eServiceCannotBeDeleted,
+  eServiceCannotBeUpdated,
+  eServiceDescriptorNotFound,
+  eServiceDocumentNotFound,
+  eServiceDuplicate,
+  notValidDescriptor,
+  operationForbidden,
+} from "../model/domain/errors.js";
 import { readModelService } from "./readModelService.js";
 
 const fileManager = initFileManager(config);

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -8,7 +8,6 @@ import {
   DescriptorState,
   Document,
   EService,
-  ErrorTypes,
   Agreement,
   AgreementState,
   descriptorState,
@@ -16,6 +15,7 @@ import {
   ListResult,
   WithMetadata,
   emptyListResult,
+  genericError,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { z } from "zod";
@@ -111,7 +111,7 @@ export const readModelService = {
         )} - data ${JSON.stringify(data)} `
       );
 
-      throw ErrorTypes.GenericError;
+      throw genericError("Unable to parse eservices items");
     }
 
     return {
@@ -145,7 +145,7 @@ export const readModelService = {
           )} - data ${JSON.stringify(data)} `
         );
 
-        throw ErrorTypes.GenericError;
+        throw genericError("Unable to parse eservices item");
       }
 
       return {
@@ -253,7 +253,7 @@ export const readModelService = {
         )} - data ${JSON.stringify(data)} `
       );
 
-      throw ErrorTypes.GenericError;
+      throw genericError("Unable to parse consumers");
     }
 
     return {
@@ -316,7 +316,7 @@ export const readModelService = {
         )} - data ${JSON.stringify(data)} `
       );
 
-      throw ErrorTypes.GenericError;
+      throw genericError("Unable to parse agreements");
     }
 
     return result.data;

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -145,7 +145,7 @@ export const readModelService = {
           )} - data ${JSON.stringify(data)} `
         );
 
-        throw genericError("Unable to parse eservices item");
+        throw genericError(`Unable to parse eservice ${id}`);
       }
 
       return {

--- a/packages/catalog-process/src/utilities/versionGenerator.ts
+++ b/packages/catalog-process/src/utilities/versionGenerator.ts
@@ -1,9 +1,6 @@
-import {
-  CatalogProcessError,
-  ErrorTypes,
-  EService,
-} from "pagopa-interop-models";
+import { EService } from "pagopa-interop-models";
 import { z } from "zod";
+import { invalidDescriptorVersion } from "../model/domain/errors.js";
 
 export const nextDescriptorVersion = (eservice: EService): string => {
   const currentVersion = eservice.descriptors.reduce((max, descriptor) => {
@@ -11,9 +8,8 @@ export const nextDescriptorVersion = (eservice: EService): string => {
       .number()
       .safeParse(descriptor.version);
     if (!currentVersionNumber.success) {
-      throw new CatalogProcessError(
-        `${descriptor.version} is not a valid descriptor version`,
-        ErrorTypes.InvalidDescriptorVersion
+      throw invalidDescriptorVersion(
+        `${descriptor.version} is not a valid descriptor version`
       );
     }
 

--- a/packages/catalog-process/test/catalogService.test.ts
+++ b/packages/catalog-process/test/catalogService.test.ts
@@ -4,22 +4,13 @@ import {
   Descriptor,
   EService,
   descriptorState,
-  draftDescriptorAlreadyExists,
-  eServiceCannotBeDeleted,
-  eServiceCannotBeUpdated,
-  eServiceDescriptorNotFound,
-  eServiceDocumentNotFound,
-  eServiceDuplicate,
   eServiceNotFound,
-  notValidDescriptor,
-  operationForbidden,
   WithMetadata,
 } from "pagopa-interop-models";
 import {
   apiAgreementApprovalPolicyToAgreementApprovalPolicy,
   apiTechnologyToTechnology,
 } from "../src/model/domain/apiConverter.js";
-
 import {
   activateDescriptorLogic,
   archiveDescriptorLogic,
@@ -45,6 +36,16 @@ import {
   toEServiceTechnologyV1,
   toEServiceV1,
 } from "../src/model/domain/toEvent.js";
+import {
+  draftDescriptorAlreadyExists,
+  eServiceCannotBeDeleted,
+  eServiceCannotBeUpdated,
+  eServiceDescriptorNotFound,
+  eServiceDocumentNotFound,
+  eServiceDuplicate,
+  notValidDescriptor,
+  operationForbidden,
+} from "../src/model/domain/errors.js";
 
 const shuffle = <T>(array: T[]): T[] => array.sort(() => Math.random() - 0.5);
 

--- a/packages/catalog-process/test/catalogService.test.ts
+++ b/packages/catalog-process/test/catalogService.test.ts
@@ -4,7 +4,6 @@ import {
   Descriptor,
   EService,
   descriptorState,
-  eServiceNotFound,
   WithMetadata,
 } from "pagopa-interop-models";
 import {
@@ -43,6 +42,7 @@ import {
   eServiceDescriptorNotFound,
   eServiceDocumentNotFound,
   eServiceDuplicate,
+  eServiceNotFound,
   notValidDescriptor,
   operationForbidden,
 } from "../src/model/domain/errors.js";

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -33,7 +33,7 @@ export const authenticationMiddleware: (
         logger.warn(
           `No authentication has been provided for this call ${req.method} ${req.url}`
         );
-        throw missingBearer();
+        throw missingBearer;
       }
 
       const jwtToken = authorizationHeader[1];
@@ -86,7 +86,7 @@ export const authenticationMiddleware: (
               `No authentication has been provided for this call ${req.method} ${req.url}`
             );
 
-            throw missingBearer();
+            throw missingBearer;
           }
         )
         .with(

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -3,6 +3,7 @@
 import { ZodiosRouterContextRequestHandler } from "@zodios/express";
 import { Response } from "express";
 import {
+  makeApiProblem,
   missingBearer,
   missingClaim,
   missingHeader,
@@ -15,92 +16,96 @@ import { AuthData } from "./authData.js";
 import { Headers } from "./headers.js";
 import { readAuthDataFromJwtToken, verifyJwtToken } from "./jwt.js";
 
-export const authenticationMiddleware: (
-  apiErrorHandler: (err: unknown, res: Response) => void
-) => ZodiosRouterContextRequestHandler<ExpressContext> = (apiErrorHandler) => {
-  const authMiddleware: ZodiosRouterContextRequestHandler<
-    ExpressContext
-  > = async (req, res, next): Promise<unknown> => {
-    const addCtxAuthData = async (
-      authHeader: string,
-      correlationId: string
-    ): Promise<void> => {
-      const authorizationHeader = authHeader.split(" ");
-      if (
-        authorizationHeader.length !== 2 ||
-        authorizationHeader[0] !== "Bearer"
-      ) {
-        logger.warn(
-          `No authentication has been provided for this call ${req.method} ${req.url}`
-        );
-        throw missingBearer;
-      }
+export const apiErrorHandler = (error: unknown, res: Response): void => {
+  const apiError = makeApiProblem(error);
+  res.status(apiError.status).json(apiError).end();
+};
 
-      const jwtToken = authorizationHeader[1];
-      const valid = await verifyJwtToken(jwtToken);
-      if (!valid) {
-        logger.warn(`The jwt token is not valid`);
-        throw unauthorizedError("The jwt token is not valid");
+export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<ExpressContext> =
+  () => {
+    const authMiddleware: ZodiosRouterContextRequestHandler<
+      ExpressContext
+    > = async (req, res, next): Promise<unknown> => {
+      const addCtxAuthData = async (
+        authHeader: string,
+        correlationId: string
+      ): Promise<void> => {
+        const authorizationHeader = authHeader.split(" ");
+        if (
+          authorizationHeader.length !== 2 ||
+          authorizationHeader[0] !== "Bearer"
+        ) {
+          logger.warn(
+            `No authentication has been provided for this call ${req.method} ${req.url}`
+          );
+          throw missingBearer;
+        }
+
+        const jwtToken = authorizationHeader[1];
+        const valid = await verifyJwtToken(jwtToken);
+        if (!valid) {
+          logger.warn(`The jwt token is not valid`);
+          throw unauthorizedError("The jwt token is not valid");
+        }
+        const authData = readAuthDataFromJwtToken(jwtToken);
+        match(authData)
+          .with(P.instanceOf(Error), (err) => {
+            logger.warn(`Invalid authentication provided: ${err.message}`);
+            throw missingClaim(`Invalid claims: ${err.message}`);
+          })
+          .otherwise((claimsRes: AuthData) => {
+            // eslint-disable-next-line functional/immutable-data
+            req.ctx = {
+              authData: { ...claimsRes },
+              correlationId,
+            };
+            next();
+          });
+      };
+
+      try {
+        const headers = Headers.safeParse(req.headers);
+        if (!headers.success) {
+          throw missingHeader();
+        }
+
+        return await match(headers.data)
+          .with(
+            {
+              authorization: P.string,
+              "x-correlation-id": P.string,
+            },
+            async (headers) =>
+              await addCtxAuthData(
+                headers.authorization,
+                headers["x-correlation-id"]
+              )
+          )
+          .with(
+            {
+              authorization: P.nullish,
+              "x-correlation-id": P._,
+            },
+            () => {
+              logger.warn(
+                `No authentication has been provided for this call ${req.method} ${req.url}`
+              );
+
+              throw missingBearer;
+            }
+          )
+          .with(
+            {
+              authorization: P.string,
+              "x-correlation-id": P.nullish,
+            },
+            () => missingHeader("x-correlation-id")
+          )
+          .otherwise(() => apiErrorHandler(missingHeader(), res));
+      } catch (error) {
+        return apiErrorHandler(error, res);
       }
-      const authData = readAuthDataFromJwtToken(jwtToken);
-      match(authData)
-        .with(P.instanceOf(Error), (err) => {
-          logger.warn(`Invalid authentication provided: ${err.message}`);
-          throw missingClaim(`Invalid claims: ${err.message}`);
-        })
-        .otherwise((claimsRes: AuthData) => {
-          // eslint-disable-next-line functional/immutable-data
-          req.ctx = {
-            authData: { ...claimsRes },
-            correlationId,
-          };
-          next();
-        });
     };
 
-    try {
-      const headers = Headers.safeParse(req.headers);
-      if (!headers.success) {
-        throw missingHeader();
-      }
-
-      return await match(headers.data)
-        .with(
-          {
-            authorization: P.string,
-            "x-correlation-id": P.string,
-          },
-          async (headers) =>
-            await addCtxAuthData(
-              headers.authorization,
-              headers["x-correlation-id"]
-            )
-        )
-        .with(
-          {
-            authorization: P.nullish,
-            "x-correlation-id": P._,
-          },
-          () => {
-            logger.warn(
-              `No authentication has been provided for this call ${req.method} ${req.url}`
-            );
-
-            throw missingBearer;
-          }
-        )
-        .with(
-          {
-            authorization: P.string,
-            "x-correlation-id": P.nullish,
-          },
-          () => missingHeader("x-correlation-id")
-        )
-        .otherwise(() => apiErrorHandler(missingHeader(), res));
-    } catch (error) {
-      return apiErrorHandler(error, res);
-    }
+    return authMiddleware;
   };
-
-  return authMiddleware;
-};

--- a/packages/commons/src/auth/authorizationMiddleware.ts
+++ b/packages/commons/src/auth/authorizationMiddleware.ts
@@ -90,18 +90,13 @@ export const authorizationMiddleware =
     } catch (err) {
       const headers = readHeaders(req as Request);
       const problem = match<unknown, Problem>(err)
-        .with(
-          {
-            code: P.string,
-            httpStatus: P.number,
-            title: P.string,
-            detail: P.string,
-          },
-          (error) =>
-            makeApiProblem({
+        .with(P.instanceOf(ApiError), (error) =>
+          makeApiProblem(
+            new ApiError({
               ...error,
               correlationId: headers?.correlationId,
             })
+          )
         )
         .otherwise(() => makeApiProblem(genericError("Generic error")));
 

--- a/packages/commons/src/auth/authorizationMiddleware.ts
+++ b/packages/commons/src/auth/authorizationMiddleware.ts
@@ -98,7 +98,13 @@ export const authorizationMiddleware =
             })
           )
         )
-        .otherwise(() => makeApiProblem(genericError("Generic error")));
+        .otherwise(() =>
+          makeApiProblem(
+            genericError(
+              "An unexpected error occurred during authorization checks"
+            )
+          )
+        );
 
       return (
         res

--- a/packages/commons/src/auth/authorizationMiddleware.ts
+++ b/packages/commons/src/auth/authorizationMiddleware.ts
@@ -5,10 +5,11 @@ import {
 } from "@zodios/core";
 import { Request } from "express";
 import {
-  ProcessError,
-  ErrorTypes,
   Problem,
   makeApiProblem,
+  genericError,
+  ApiError,
+  unauthorizedError,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { z } from "zod";
@@ -20,7 +21,7 @@ import { readAuthDataFromJwtToken } from "./jwt.js";
 type RoleValidation =
   | {
       isValid: false;
-      error: ProcessError;
+      error: ApiError;
     }
   | { isValid: true };
 
@@ -30,24 +31,21 @@ const hasValidRoles = (
 ): RoleValidation => {
   const jwtToken = req.headers.authorization?.split(" ")[1];
   if (!jwtToken) {
-    throw new ProcessError("The jwt token not found", ErrorTypes.Unauthorized);
+    throw unauthorizedError("The jwt token not found");
   }
   const authData = readAuthDataFromJwtToken(jwtToken);
 
   if (authData instanceof Error) {
     return {
       isValid: false,
-      error: new ProcessError(authData.message, ErrorTypes.Unauthorized),
+      error: unauthorizedError(authData.message),
     };
   }
 
   if (!authData.userRoles || authData.userRoles.length === 0) {
     return {
       isValid: false,
-      error: new ProcessError(
-        "No user roles found to execute this request",
-        ErrorTypes.Unauthorized
-      ),
+      error: unauthorizedError("No user roles found to execute this request"),
     };
   }
 
@@ -63,11 +61,10 @@ const hasValidRoles = (
     ? { isValid: true }
     : {
         isValid: false,
-        error: new ProcessError(
+        error: unauthorizedError(
           `Invalid user roles (${authData.userRoles.join(
             ","
-          )}) to execute this request`,
-          ErrorTypes.Unauthorized
+          )}) to execute this request`
         ),
       };
 };
@@ -92,25 +89,21 @@ export const authorizationMiddleware =
       return next();
     } catch (err) {
       const headers = readHeaders(req as Request);
-
       const problem = match<unknown, Problem>(err)
-        .with(P.instanceOf(ProcessError), (error) =>
-          makeApiProblem(
-            error.type.code,
-            error.type.httpStatus,
-            error.type.title,
-            error.message,
-            headers?.correlationId
-          )
+        .with(
+          {
+            code: P.string,
+            httpStatus: P.number,
+            title: P.string,
+            detail: P.string,
+          },
+          (error) =>
+            makeApiProblem({
+              ...error,
+              correlationId: headers?.correlationId,
+            })
         )
-        .otherwise(() =>
-          makeApiProblem(
-            `${ErrorTypes.GenericError.code}`,
-            ErrorTypes.GenericError.httpStatus,
-            ErrorTypes.GenericError.title,
-            "Generic error"
-          )
-        );
+        .otherwise(() => makeApiProblem(genericError("Generic error")));
 
       return (
         res

--- a/packages/commons/src/repositories/ReadModelRepository.ts
+++ b/packages/commons/src/repositories/ReadModelRepository.ts
@@ -1,6 +1,7 @@
 import {
   Agreement,
   EService,
+  EService,
   Tenant,
   genericError,
 } from "pagopa-interop-models";

--- a/packages/commons/src/repositories/ReadModelRepository.ts
+++ b/packages/commons/src/repositories/ReadModelRepository.ts
@@ -1,4 +1,9 @@
-import { Agreement, EService, ErrorTypes, Tenant } from "pagopa-interop-models";
+import {
+  Agreement,
+  EService,
+  Tenant,
+  genericError,
+} from "pagopa-interop-models";
 import { Collection, Db, MongoClient } from "mongodb";
 import { z } from "zod";
 import { ReadModelDbConfig, logger } from "../index.js";
@@ -75,6 +80,6 @@ export class ReadModelRepository {
         result
       )} - data ${JSON.stringify(data)} `
     );
-    throw ErrorTypes.GenericError;
+    throw genericError("Unable to get total count from aggregation pipeline");
   }
 }

--- a/packages/commons/src/repositories/ReadModelRepository.ts
+++ b/packages/commons/src/repositories/ReadModelRepository.ts
@@ -1,7 +1,6 @@
 import {
   Agreement,
   EService,
-  EService,
   Tenant,
   genericError,
 } from "pagopa-interop-models";

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -1,343 +1,13 @@
 /* eslint-disable max-classes-per-file */
-import { DescriptorState } from "./eservice/eservice.js";
+import { P, match } from "ts-pattern";
 
-export const ErrorTypes = {
-  DuplicateEserviceName: {
-    code: "0010",
-    httpStatus: 409,
-    title: "Duplicated service name",
-  },
-  ContentTypeParsingError: {
-    code: "0001",
-    httpStatus: 400,
-    title: "Malformed request",
-  },
-  EServiceNotFound: {
-    code: "0007",
-    httpStatus: 404,
-    title: "EService not found",
-  },
-  EServiceCannotBeUpdatedOrDeleted: {
-    code: "0009",
-    httpStatus: 400,
-    title: "EService cannot be updated or deleted",
-  },
-  EServiceDescriptorNotFound: {
-    code: "0002",
-    httpStatus: 404,
-    title: "EService descriptor not found",
-  },
-  EServiceDocumentNotFound: {
-    code: "0003",
-    httpStatus: 404,
-    title: "EService document not found",
-  }, // TODO: reorganize error codes
-  OperationForbidden: {
-    code: "9989",
-    httpStatus: 400,
-    title: "Insufficient privileges",
-  },
-  GenericError: { code: "9991", httpStatus: 500, title: "Unexpected error" },
-  MissingBearer: {
-    code: "9999",
-    httpStatus: 400,
-    title: "Bearer token has not been passed",
-  },
-  MissingClaim: {
-    code: "9990",
-    httpStatus: 400,
-    title: "Claim has not been passed",
-  },
-  MissingHeader: {
-    code: "9994",
-    httpStatus: 400,
-    title: "Header has not been passed",
-  },
-  MissingSub: {
-    code: "9995",
-    httpStatus: 400,
-    title: "Subject has not been passed",
-  },
-  MissingUserId: {
-    code: "9996",
-    httpStatus: 400,
-    title: "Uid has not been passed",
-  },
-  Unauthorized: {
-    code: "9991",
-    httpStatus: 401,
-    title: "Unauthorized",
-  },
-  InvalidDescriptorVersion: {
-    code: "0004",
-    httpStatus: 400,
-    title: "Version is not a valid descriptor version",
-  },
-  NotValidDescriptor: {
-    code: "0004",
-    httpStatus: 400,
-    title: "Not valid descriptor",
-  },
-  DraftDescriptorAlreadyExists: {
-    code: "0008",
-    httpStatus: 400,
-    title: "EService already contains a draft descriptor",
-  },
-  NotLatestEServiceDescriptor: {
-    code: "0021",
-    httpStatus: 400,
-    title: "Descriptor provided is not the latest descriptor",
-  },
-  DescriptorNotInExpectedState: {
-    code: "0004",
-    httpStatus: 400,
-    title: "Descriptor not in expected state",
-  },
-  AgreementNotFound: {
-    code: "0009",
-    httpStatus: 404,
-    title: "Agreement not found",
-  },
-  AgreementAlreadyExists: {
-    code: "0011",
-    httpStatus: 409,
-    title: "Agreement already exists",
-  },
-  AgreementESerivceNotFound: {
-    code: "0007",
-    httpStatus: 400,
-    title: "EService not found",
-  },
-  OperationNotAllowed: {
-    code: "0007",
-    httpStatus: 400,
-    title: "Operation not allowed",
-  },
-  AgreementNotInExpectedState: {
-    code: "0003",
-    httpStatus: 400,
-    title: "Agreement not in expected state",
-  },
-  MissingCertifiedAttributes: {
-    code: "0001",
-    httpStatus: 400,
-    title: `Required certified attribute is missing`,
-  },
-  TenantIdNotFound: {
-    code: "0020",
-    httpStatus: 404,
-    title: "Tenant not found",
-  },
-  // TODO: refactor this error code when diffent building strategy are implemented
-  TenantIdNotFoundException: {
-    code: "0020",
-    httpStatus: 500,
-    title: "Tenant not found",
-  },
-  AuthenticationSaslFailed: {
-    code: "9000",
-    httpStatus: 500,
-    title: "SASL authentication fails",
-  },
-} as const;
-
-export type ErrorType = (typeof ErrorTypes)[keyof typeof ErrorTypes];
-
-export class ProcessError extends Error {
-  public readonly type: ErrorType;
-
-  constructor(message: string, type: ErrorType) {
-    super(message);
-    this.type = type;
-  }
-}
-
-export class CatalogProcessError extends ProcessError {}
-export class AgreementProcessError extends ProcessError {}
-
-export function eServiceDuplicate(
-  eServiceNameSeed: string
-): CatalogProcessError {
-  return new CatalogProcessError(
-    `Error during EService creation with name ${eServiceNameSeed}`,
-    ErrorTypes.DuplicateEserviceName
-  );
-}
-
-export function eServiceNotFound(eServiceId: string): CatalogProcessError {
-  return new CatalogProcessError(
-    `EService ${eServiceId} not found`,
-    ErrorTypes.EServiceNotFound
-  );
-}
-
-export function agreementEServiceNotFound(
-  eServiceId: string
-): AgreementProcessError {
-  return new AgreementProcessError(
-    `EService ${eServiceId} not found`,
-    ErrorTypes.AgreementESerivceNotFound
-  );
-}
-
-export const operationForbidden = new CatalogProcessError(
-  `Insufficient privileges`,
-  ErrorTypes.OperationForbidden
-);
-
-export function eServiceCannotBeUpdated(
-  eServiceId: string
-): CatalogProcessError {
-  return new CatalogProcessError(
-    `EService ${eServiceId} contains valid descriptors and cannot be updated`,
-    ErrorTypes.EServiceCannotBeUpdatedOrDeleted
-  );
-}
-
-export function eServiceCannotBeDeleted(
-  eServiceId: string
-): CatalogProcessError {
-  return new CatalogProcessError(
-    `EService ${eServiceId} contains descriptors and cannot be deleted`,
-    ErrorTypes.EServiceCannotBeUpdatedOrDeleted
-  );
-}
-
-export function eServiceDescriptorNotFound(
-  eServiceId: string,
-  descriptorId: string
-): CatalogProcessError {
-  return new CatalogProcessError(
-    `Descriptor ${descriptorId} for EService ${eServiceId} not found`,
-    ErrorTypes.EServiceDescriptorNotFound
-  );
-}
-
-export function missingClaim(claimName: string): CatalogProcessError {
-  return new CatalogProcessError(
-    `Claim ${claimName} has not been passed`,
-    ErrorTypes.MissingClaim
-  );
-}
-
-export function missingHeader(headerName: string): CatalogProcessError {
-  return new CatalogProcessError(
-    `Header ${headerName} not existing in this request`,
-    ErrorTypes.MissingHeader
-  );
-}
-
-export function notValidDescriptor(
-  descriptorId: string,
-  descriptorStatus: string
-): CatalogProcessError {
-  return new CatalogProcessError(
-    `Descriptor ${descriptorId} has a not valid status for this operation ${descriptorStatus}`,
-    ErrorTypes.NotValidDescriptor
-  );
-}
-
-export function draftDescriptorAlreadyExists(
-  eServiceId: string
-): CatalogProcessError {
-  return new CatalogProcessError(
-    `EService ${eServiceId} already contains a draft descriptor`,
-    ErrorTypes.DraftDescriptorAlreadyExists
-  );
-}
-
-export function notLatestEServiceDescriptor(
-  descriptorId: string
-): AgreementProcessError {
-  return new AgreementProcessError(
-    `Descriptor with descriptorId: ${descriptorId} is not the latest descriptor`,
-    ErrorTypes.NotLatestEServiceDescriptor
-  );
-}
-
-export function descriptorNotInExpectedState(
-  eServiceId: string,
-  descriptorId: string,
-  allowedStates: DescriptorState[]
-): AgreementProcessError {
-  return new AgreementProcessError(
-    `Descriptor ${descriptorId} of EService ${eServiceId} has not status in ${allowedStates.join(
-      ","
-    )}`,
-    ErrorTypes.DescriptorNotInExpectedState
-  );
-}
-
-export function missingCertifiedAttributesError(
-  descriptorId: string,
-  consumerId: string
-): AgreementProcessError {
-  return new AgreementProcessError(
-    `Required certified attribute is missing. Descriptor ${descriptorId}, Consumer: ${consumerId}`,
-    ErrorTypes.MissingCertifiedAttributes
-  );
-}
-
-export function eServiceDocumentNotFound(
-  eServiceId: string,
-  descriptorId: string,
-  documentId: string
-): CatalogProcessError {
-  return new CatalogProcessError(
-    `Document with id ${documentId} not found in EService ${eServiceId} / Descriptor ${descriptorId}`,
-    ErrorTypes.EServiceDocumentNotFound
-  );
-}
-
-export function agreementNotFound(agreementId: string): AgreementProcessError {
-  return new AgreementProcessError(
-    `Agreement ${agreementId} not found`,
-    ErrorTypes.AgreementNotFound
-  );
-}
-
-export function agreementAlreadyExists(
-  consumerId: string,
-  eServiceId: string
-): AgreementProcessError {
-  return new AgreementProcessError(
-    `Agreement already exists for Consumer = ${consumerId}, EService = ${eServiceId}`,
-    ErrorTypes.AgreementAlreadyExists
-  );
-}
-
-export function operationNotAllowed(
-  requesterId: string
-): AgreementProcessError {
-  return new AgreementProcessError(
-    `Operation not allowed by ${requesterId}`,
-    ErrorTypes.OperationNotAllowed
-  );
-}
-
-export function agreementNotInExpectedState(
-  agreementId: string,
-  state: string
-): AgreementProcessError {
-  return new AgreementProcessError(
-    `Agreement ${agreementId} not in expected state (current state: ${state})`,
-    ErrorTypes.AgreementNotInExpectedState
-  );
-}
-
-export function tenantIdNotFound(tenantId: string): AgreementProcessError {
-  return new AgreementProcessError(
-    `Tenant ${tenantId} not found`,
-    ErrorTypes.TenantIdNotFound
-  );
-}
-
-export function authenticationSaslFailed(message: string): ProcessError {
-  return new ProcessError(
-    `SALS Authentication fails with this error : ${message}`,
-    ErrorTypes.AuthenticationSaslFailed
-  );
-}
+export type ApiError = {
+  code: string;
+  httpStatus: number;
+  title: string;
+  detail: string;
+  correlationId?: string;
+};
 
 export type ProblemError = {
   code: string;
@@ -353,14 +23,14 @@ export type Problem = {
   errors: ProblemError[];
 };
 
-export function makeApiProblem(
-  errorCode: string,
-  httpStatus: number,
-  title: string,
-  detail: string,
-  correlationId?: string
-): Problem {
-  return {
+export function makeApiProblem(error: unknown): Problem {
+  const makeProblem = ({
+    code,
+    httpStatus,
+    title,
+    detail,
+    correlationId,
+  }: ApiError): Problem => ({
     type: "https://docs.pagopa.it/interoperabilita-1/", // TODO change this with properly schema definition URI
     title,
     status: httpStatus,
@@ -368,9 +38,102 @@ export function makeApiProblem(
     correlationId,
     errors: [
       {
-        code: errorCode,
+        code,
         detail,
       },
     ],
+  });
+
+  return match<unknown, Problem>(error)
+    .with(
+      {
+        code: P.string,
+        httpStatus: P.number,
+        title: P.string,
+        detail: P.string,
+        correlationId: P.string.optional(),
+      },
+      (error) =>
+        makeProblem({
+          code: error.code,
+          httpStatus: error.httpStatus,
+          title: error.title,
+          detail: error.detail,
+          correlationId: error.correlationId,
+        })
+    )
+    .otherwise(() =>
+      makeProblem({
+        code: "9991",
+        httpStatus: 500,
+        title: "Unexpected error",
+        detail: "Generic error",
+      })
+    );
+}
+
+export function authenticationSaslFailed(message: string): ApiError {
+  return {
+    code: "9000",
+    httpStatus: 500,
+    title: "SASL authentication fails",
+    detail: `SALS Authentication fails with this error : ${message}`,
+  };
+}
+
+export function genericError(details: string): ApiError {
+  return {
+    detail: details,
+    code: `9991`,
+    httpStatus: 500,
+    title: "Unexpected error",
+  };
+}
+
+export function unauthorizedError(details: string): ApiError {
+  return {
+    detail: details,
+    code: `9991`,
+    httpStatus: 401,
+    title: "Unauthorized",
+  };
+}
+
+export function missingClaim(claimName: string): ApiError {
+  return {
+    detail: `Claim ${claimName} has not been passed`,
+    code: "9990",
+    httpStatus: 400,
+    title: "Claim has not been passed",
+  };
+}
+
+export function missingHeader(headerName?: string): ApiError {
+  const title = "Header has not been passed";
+  return {
+    detail: headerName
+      ? `Header ${headerName} not existing in this request`
+      : title,
+    code: "9994",
+    httpStatus: 400,
+    title,
+  };
+}
+
+export function missingBearer(): ApiError {
+  return {
+    detail: `Authorization Illegal header key.`,
+    code: "9999",
+    httpStatus: 400,
+    title: "Bearer token has not been passed",
+  };
+}
+
+export function eServiceNotFound(eServiceId: string): ApiError {
+  return {
+    detail: `EService ${eServiceId} not found`,
+    code: "0007",
+    httpStatus: 404,
+    title: "EService not found",
   };
 }

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -153,12 +153,3 @@ export function missingBearer(): ApiError {
     title: "Bearer token has not been passed",
   });
 }
-
-export function eServiceNotFound(eServiceId: string): ApiError {
-  return new ApiError({
-    detail: `EService ${eServiceId} not found`,
-    code: "0007",
-    httpStatus: 404,
-    title: "EService not found",
-  });
-}

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -71,12 +71,12 @@ export function makeApiProblem(error: unknown): Problem {
 }
 
 export function authenticationSaslFailed(message: string): ApiError {
-  return {
+  return new ApiError({
     code: "9000",
     httpStatus: 500,
     title: "SASL authentication fails",
     detail: `SALS Authentication fails with this error : ${message}`,
-  };
+  });
 }
 
 export function genericError(details: string): ApiError {

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -70,9 +70,17 @@ export function makeApiProblem(error: unknown): Problem {
     .otherwise(() => makeProblem(genericError("Unexpected error")));
 }
 
+const errorCodes = {
+  authenticationSaslFailed: "9000",
+  missingClaim: "9990",
+  genericError: "9991",
+  unauthorizedError: "9991",
+  missingHeader: "9994",
+};
+
 export function authenticationSaslFailed(message: string): ApiError {
   return new ApiError({
-    code: "9000",
+    code: errorCodes.authenticationSaslFailed,
     httpStatus: 500,
     title: "SASL authentication fails",
     detail: `SALS Authentication fails with this error : ${message}`,
@@ -82,7 +90,7 @@ export function authenticationSaslFailed(message: string): ApiError {
 export function genericError(details: string): ApiError {
   return new ApiError({
     detail: details,
-    code: `9991`,
+    code: errorCodes.genericError,
     httpStatus: 500,
     title: "Unexpected error",
   });
@@ -91,7 +99,7 @@ export function genericError(details: string): ApiError {
 export function unauthorizedError(details: string): ApiError {
   return new ApiError({
     detail: details,
-    code: `9991`,
+    code: errorCodes.unauthorizedError,
     httpStatus: 401,
     title: "Unauthorized",
   });
@@ -100,7 +108,7 @@ export function unauthorizedError(details: string): ApiError {
 export function missingClaim(claimName: string): ApiError {
   return new ApiError({
     detail: `Claim ${claimName} has not been passed`,
-    code: "9990",
+    code: errorCodes.missingClaim,
     httpStatus: 400,
     title: "Claim has not been passed",
   });
@@ -112,7 +120,7 @@ export function missingHeader(headerName?: string): ApiError {
     detail: headerName
       ? `Header ${headerName} not existing in this request`
       : title,
-    code: "9994",
+    code: errorCodes.missingHeader,
     httpStatus: 400,
     title,
   });
@@ -120,7 +128,7 @@ export function missingHeader(headerName?: string): ApiError {
 
 export const missingBearer: ApiError = new ApiError({
   detail: `Authorization Illegal header key.`,
-  code: "9999",
+  code: errorCodes.missingHeader,
   httpStatus: 400,
   title: "Bearer token has not been passed",
 });

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -66,35 +66,8 @@ export function makeApiProblem(error: unknown): Problem {
   });
 
   return match<unknown, Problem>(error)
-    .with(
-      {
-        code: P.string,
-        httpStatus: P.number,
-        title: P.string,
-        detail: P.string,
-        correlationId: P.string.optional(),
-      },
-      (error) =>
-        makeProblem(
-          new ApiError({
-            code: error.code,
-            httpStatus: error.httpStatus,
-            title: error.title,
-            detail: error.detail,
-            correlationId: error.correlationId,
-          })
-        )
-    )
-    .otherwise(() =>
-      makeProblem(
-        new ApiError({
-          code: "9991",
-          httpStatus: 500,
-          title: "Unexpected error",
-          detail: "Generic error",
-        })
-      )
-    );
+    .with(P.instanceOf(ApiError), (error) => makeProblem(error))
+    .otherwise(() => makeProblem(genericError("Unexpected error")));
 }
 
 export function authenticationSaslFailed(message: string): ApiError {
@@ -145,11 +118,9 @@ export function missingHeader(headerName?: string): ApiError {
   });
 }
 
-export function missingBearer(): ApiError {
-  return new ApiError({
-    detail: `Authorization Illegal header key.`,
-    code: "9999",
-    httpStatus: 400,
-    title: "Bearer token has not been passed",
-  });
-}
+export const missingBearer: ApiError = new ApiError({
+  detail: `Authorization Illegal header key.`,
+  code: "9999",
+  httpStatus: 400,
+  title: "Bearer token has not been passed",
+});

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -1,13 +1,34 @@
 /* eslint-disable max-classes-per-file */
 import { P, match } from "ts-pattern";
 
-export type ApiError = {
-  code: string;
-  httpStatus: number;
-  title: string;
-  detail: string;
-  correlationId?: string;
-};
+export class ApiError extends Error {
+  public code: string;
+  public httpStatus: number;
+  public title: string;
+  public detail: string;
+  public correlationId?: string;
+
+  constructor({
+    code,
+    httpStatus,
+    title,
+    detail,
+    correlationId,
+  }: {
+    code: string;
+    httpStatus: number;
+    title: string;
+    detail: string;
+    correlationId?: string;
+  }) {
+    super();
+    this.code = code;
+    this.httpStatus = httpStatus;
+    this.title = title;
+    this.detail = detail;
+    this.correlationId = correlationId;
+  }
+}
 
 export type ProblemError = {
   code: string;
@@ -54,21 +75,25 @@ export function makeApiProblem(error: unknown): Problem {
         correlationId: P.string.optional(),
       },
       (error) =>
-        makeProblem({
-          code: error.code,
-          httpStatus: error.httpStatus,
-          title: error.title,
-          detail: error.detail,
-          correlationId: error.correlationId,
-        })
+        makeProblem(
+          new ApiError({
+            code: error.code,
+            httpStatus: error.httpStatus,
+            title: error.title,
+            detail: error.detail,
+            correlationId: error.correlationId,
+          })
+        )
     )
     .otherwise(() =>
-      makeProblem({
-        code: "9991",
-        httpStatus: 500,
-        title: "Unexpected error",
-        detail: "Generic error",
-      })
+      makeProblem(
+        new ApiError({
+          code: "9991",
+          httpStatus: 500,
+          title: "Unexpected error",
+          detail: "Generic error",
+        })
+      )
     );
 }
 
@@ -82,58 +107,58 @@ export function authenticationSaslFailed(message: string): ApiError {
 }
 
 export function genericError(details: string): ApiError {
-  return {
+  return new ApiError({
     detail: details,
     code: `9991`,
     httpStatus: 500,
     title: "Unexpected error",
-  };
+  });
 }
 
 export function unauthorizedError(details: string): ApiError {
-  return {
+  return new ApiError({
     detail: details,
     code: `9991`,
     httpStatus: 401,
     title: "Unauthorized",
-  };
+  });
 }
 
 export function missingClaim(claimName: string): ApiError {
-  return {
+  return new ApiError({
     detail: `Claim ${claimName} has not been passed`,
     code: "9990",
     httpStatus: 400,
     title: "Claim has not been passed",
-  };
+  });
 }
 
 export function missingHeader(headerName?: string): ApiError {
   const title = "Header has not been passed";
-  return {
+  return new ApiError({
     detail: headerName
       ? `Header ${headerName} not existing in this request`
       : title,
     code: "9994",
     httpStatus: 400,
     title,
-  };
+  });
 }
 
 export function missingBearer(): ApiError {
-  return {
+  return new ApiError({
     detail: `Authorization Illegal header key.`,
     code: "9999",
     httpStatus: 400,
     title: "Bearer token has not been passed",
-  };
+  });
 }
 
 export function eServiceNotFound(eServiceId: string): ApiError {
-  return {
+  return new ApiError({
     detail: `EService ${eServiceId} not found`,
     code: "0007",
     httpStatus: 404,
     title: "EService not found",
-  };
+  });
 }

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -52,7 +52,7 @@ export function makeApiProblem(error: unknown): Problem {
     detail,
     correlationId,
   }: ApiError): Problem => ({
-    type: "https://docs.pagopa.it/interoperabilita-1/", // TODO change this with properly schema definition URI
+    type: "about:blank",
     title,
     status: httpStatus,
     detail,
@@ -72,6 +72,7 @@ export function makeApiProblem(error: unknown): Problem {
 
 const errorCodes = {
   authenticationSaslFailed: "9000",
+  operationForbidden: "9989",
   missingClaim: "9990",
   genericError: "9991",
   unauthorizedError: "9991",
@@ -109,7 +110,7 @@ export function missingClaim(claimName: string): ApiError {
   return new ApiError({
     detail: `Claim ${claimName} has not been passed`,
     code: errorCodes.missingClaim,
-    httpStatus: 400,
+    httpStatus: 500,
     title: "Claim has not been passed",
   });
 }
@@ -129,6 +130,13 @@ export function missingHeader(headerName?: string): ApiError {
 export const missingBearer: ApiError = new ApiError({
   detail: `Authorization Illegal header key.`,
   code: errorCodes.missingHeader,
-  httpStatus: 400,
+  httpStatus: 401,
   title: "Bearer token has not been passed",
+});
+
+export const operationForbidden = new ApiError({
+  detail: `Insufficient privileges`,
+  code: errorCodes.operationForbidden,
+  httpStatus: 403,
+  title: "Insufficient privileges",
 });


### PR DESCRIPTION
## Description
- removed `makeApiError` functions and merged all the functionality into `makeApiProblem`
- removed `ProcessError`, `CatalogProcessError`, and `AgreementProcessError` in favor of a common `ApiError`
- removed `ErrorTypes`
- every `process` service declares its error types (via const or function that creates an `ApiError`). Some common error types remain inside the `models` package.
- Some `genericError` has an additional `detail` (see `readModelService` files)