### PR TITLE
IMN 140 - Refactor error code

### DIFF
--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -1,6 +1,10 @@
-import { ApiError, DescriptorState } from "pagopa-interop-models";
+import {
+  ApiError,
+  DescriptorState,
+  makeApiProblemBuilder,
+} from "pagopa-interop-models";
 
-export const errorCodes = {
+const errorCodes = {
   missingCertifiedAttributesError: "0001",
   agreementSubmissionFailed: "0002",
   agreementNotInExpectedState: "0003",
@@ -18,26 +22,32 @@ export const errorCodes = {
   consumerWithNotValidEmail: "0024",
 };
 
-export function eServiceNotFound(eServiceId: string): ApiError {
+export type ErrorCodes = keyof typeof errorCodes;
+
+export const makeApiProblem = makeApiProblemBuilder(errorCodes);
+
+export function eServiceNotFound(eServiceId: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `EService ${eServiceId} not found`,
-    code: errorCodes.eServiceNotFound,
+    code: "eServiceNotFound",
     title: "EService not found",
   });
 }
 
-export function agreementNotFound(agreementId: string): ApiError {
+export function agreementNotFound(agreementId: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Agreement ${agreementId} not found`,
-    code: errorCodes.agreementNotFound,
+    code: "agreementNotFound",
     title: "Agreement not found",
   });
 }
 
-export function notLatestEServiceDescriptor(descriptorId: string): ApiError {
+export function notLatestEServiceDescriptor(
+  descriptorId: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor with descriptorId: ${descriptorId} is not the latest descriptor`,
-    code: errorCodes.notLatestEServiceDescriptor,
+    code: "notLatestEServiceDescriptor",
     title: "Descriptor provided is not the latest descriptor",
   });
 }
@@ -46,12 +56,12 @@ export function descriptorNotInExpectedState(
   eServiceId: string,
   descriptorId: string,
   allowedStates: DescriptorState[]
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor ${descriptorId} of EService ${eServiceId} has not status in ${allowedStates.join(
       ","
     )}`,
-    code: errorCodes.descriptorNotInExpectedState,
+    code: "descriptorNotInExpectedState",
     title: "Descriptor not in expected state",
   });
 }
@@ -59,10 +69,10 @@ export function descriptorNotInExpectedState(
 export function missingCertifiedAttributesError(
   descriptorId: string,
   consumerId: string
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Required certified attribute is missing. Descriptor ${descriptorId}, Consumer: ${consumerId}`,
-    code: errorCodes.missingCertifiedAttributesError,
+    code: "missingCertifiedAttributesError",
     title: `Required certified attribute is missing`,
   });
 }
@@ -70,18 +80,18 @@ export function missingCertifiedAttributesError(
 export function agreementAlreadyExists(
   consumerId: string,
   eServiceId: string
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Agreement already exists for Consumer = ${consumerId}, EService = ${eServiceId}`,
-    code: errorCodes.agreementAlreadyExists,
+    code: "agreementAlreadyExists",
     title: "Agreement already exists",
   });
 }
 
-export function operationNotAllowed(requesterId: string): ApiError {
+export function operationNotAllowed(requesterId: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Operation not allowed by ${requesterId}`,
-    code: errorCodes.operationNotAllowed,
+    code: "operationNotAllowed",
     title: "Operation not allowed",
   });
 }
@@ -89,18 +99,18 @@ export function operationNotAllowed(requesterId: string): ApiError {
 export function agreementNotInExpectedState(
   agreementId: string,
   state: string
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Agreement ${agreementId} not in expected state (current state: ${state})`,
-    code: errorCodes.agreementNotInExpectedState,
+    code: "agreementNotInExpectedState",
     title: "Agreement not in expected state",
   });
 }
 
-export function tenantIdNotFound(tenantId: string): ApiError {
+export function tenantIdNotFound(tenantId: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Tenant ${tenantId} not found`,
-    code: errorCodes.tenantIdNotFound,
+    code: "tenantIdNotFound",
     title: "Tenant not found",
   });
 }

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -115,10 +115,12 @@ export function tenantIdNotFound(tenantId: string): ApiError<ErrorCodes> {
   });
 }
 
-export function agreementSubmissionFailed(agreementId: string): ApiError {
+export function agreementSubmissionFailed(
+  agreementId: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Unable to activate agreement ${agreementId}. Please check if attributes requirements and suspension flags are satisfied`,
-    code: errorCodes.agreementSubmissionFailed,
+    code: "agreementSubmissionFailed",
     title: "Unable to activate agreement",
   });
 }
@@ -126,34 +128,36 @@ export function agreementSubmissionFailed(agreementId: string): ApiError {
 export function consumerWithNotValidEmail(
   agreementId: string,
   tenantId: string
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Agreement ${agreementId} has a consumer tenant ${tenantId} with no valid email`,
-    code: errorCodes.consumerWithNotValidEmail,
+    code: "consumerWithNotValidEmail",
     title: "Agreement with invalid consumer email",
   });
 }
 
-export function agreementStampNotFound(stamp: string): ApiError {
+export function agreementStampNotFound(stamp: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Agreement stamp ${stamp} not found`,
-    code: errorCodes.agreementStampNotFound,
+    code: "agreementStampNotFound",
     title: "Stamp not found",
   });
 }
 
-export function agreementMissingUserInfo(userId: string): ApiError {
+export function agreementMissingUserInfo(userId: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Some mandatory info are missing for user ${userId}`,
-    code: errorCodes.agreementMissingUserInfo,
+    code: "agreementMissingUserInfo",
     title: "Some mandatory info are missing for user",
   });
 }
 
-export function agreementSelfcareIdNotFound(tenantId: string): ApiError {
+export function agreementSelfcareIdNotFound(
+  tenantId: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Selfcare id not found for tenant ${tenantId}`,
-    code: errorCodes.agreementSelfcareIdNotFound,
+    code: "agreementSelfcareIdNotFound",
     title: "Selfcare id not found for tenant",
   });
 }
@@ -161,20 +165,10 @@ export function agreementSelfcareIdNotFound(tenantId: string): ApiError {
 export function agreementDescriptorNotFound(
   eserviceId: string,
   descriptorId: string
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor ${descriptorId} not found in EService ${eserviceId}`,
-    code: errorCodes.agreementDescriptorNotFound,
+    code: "agreementDescriptorNotFound",
     title: "Descriptor not found",
-  });
-}
-
-export function agreementSubmitOperationNotAllowed(
-  requesterId: string
-): ApiError {
-  return new ApiError({
-    detail: `Operation not allowed by ${requesterId}`,
-    code: errorCodes.agreementSubmitOperationNotAllowed,
-    title: "Operation not allowed",
   });
 }

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -1,13 +1,12 @@
 import { ApiError, DescriptorState } from "pagopa-interop-models";
 
-const errorCodes = {
+export const errorCodes = {
   missingCertifiedAttributesError: "0001",
   agreementSubmissionFailed: "0002",
   agreementNotInExpectedState: "0003",
   descriptorNotInExpectedState: "0004",
   operationNotAllowed: "0005",
   eServiceNotFound: "0007",
-  agreementSubmitOperationNotAllowed: "0008",
   agreementNotFound: "0009",
   agreementAlreadyExists: "0011",
   agreementDescriptorNotFound: "0014",
@@ -19,14 +18,10 @@ const errorCodes = {
   consumerWithNotValidEmail: "0024",
 };
 
-export function eServiceNotFound(
-  httpStatus: number,
-  eServiceId: string
-): ApiError {
+export function eServiceNotFound(eServiceId: string): ApiError {
   return new ApiError({
     detail: `EService ${eServiceId} not found`,
     code: errorCodes.eServiceNotFound,
-    httpStatus,
     title: "EService not found",
   });
 }
@@ -35,7 +30,6 @@ export function agreementNotFound(agreementId: string): ApiError {
   return new ApiError({
     detail: `Agreement ${agreementId} not found`,
     code: errorCodes.agreementNotFound,
-    httpStatus: 404,
     title: "Agreement not found",
   });
 }
@@ -44,7 +38,6 @@ export function notLatestEServiceDescriptor(descriptorId: string): ApiError {
   return new ApiError({
     detail: `Descriptor with descriptorId: ${descriptorId} is not the latest descriptor`,
     code: errorCodes.notLatestEServiceDescriptor,
-    httpStatus: 400,
     title: "Descriptor provided is not the latest descriptor",
   });
 }
@@ -59,7 +52,6 @@ export function descriptorNotInExpectedState(
       ","
     )}`,
     code: errorCodes.descriptorNotInExpectedState,
-    httpStatus: 400,
     title: "Descriptor not in expected state",
   });
 }
@@ -71,7 +63,6 @@ export function missingCertifiedAttributesError(
   return new ApiError({
     detail: `Required certified attribute is missing. Descriptor ${descriptorId}, Consumer: ${consumerId}`,
     code: errorCodes.missingCertifiedAttributesError,
-    httpStatus: 400,
     title: `Required certified attribute is missing`,
   });
 }
@@ -83,7 +74,6 @@ export function agreementAlreadyExists(
   return new ApiError({
     detail: `Agreement already exists for Consumer = ${consumerId}, EService = ${eServiceId}`,
     code: errorCodes.agreementAlreadyExists,
-    httpStatus: 404,
     title: "Agreement already exists",
   });
 }
@@ -92,7 +82,6 @@ export function operationNotAllowed(requesterId: string): ApiError {
   return new ApiError({
     detail: `Operation not allowed by ${requesterId}`,
     code: errorCodes.operationNotAllowed,
-    httpStatus: 400,
     title: "Operation not allowed",
   });
 }
@@ -104,19 +93,14 @@ export function agreementNotInExpectedState(
   return new ApiError({
     detail: `Agreement ${agreementId} not in expected state (current state: ${state})`,
     code: errorCodes.agreementNotInExpectedState,
-    httpStatus: 400,
     title: "Agreement not in expected state",
   });
 }
 
-export function tenantIdNotFound(
-  httpStatus: number,
-  tenantId: string
-): ApiError {
+export function tenantIdNotFound(tenantId: string): ApiError {
   return new ApiError({
     detail: `Tenant ${tenantId} not found`,
     code: errorCodes.tenantIdNotFound,
-    httpStatus,
     title: "Tenant not found",
   });
 }
@@ -125,7 +109,6 @@ export function agreementSubmissionFailed(agreementId: string): ApiError {
   return new ApiError({
     detail: `Unable to activate agreement ${agreementId}. Please check if attributes requirements and suspension flags are satisfied`,
     code: errorCodes.agreementSubmissionFailed,
-    httpStatus: 400,
     title: "Unable to activate agreement",
   });
 }
@@ -137,7 +120,6 @@ export function consumerWithNotValidEmail(
   return new ApiError({
     detail: `Agreement ${agreementId} has a consumer tenant ${tenantId} with no valid email`,
     code: errorCodes.consumerWithNotValidEmail,
-    httpStatus: 400,
     title: "Agreement with invalid consumer email",
   });
 }
@@ -146,7 +128,6 @@ export function agreementStampNotFound(stamp: string): ApiError {
   return new ApiError({
     detail: `Agreement stamp ${stamp} not found`,
     code: errorCodes.agreementStampNotFound,
-    httpStatus: 500,
     title: "Stamp not found",
   });
 }
@@ -155,7 +136,6 @@ export function agreementMissingUserInfo(userId: string): ApiError {
   return new ApiError({
     detail: `Some mandatory info are missing for user ${userId}`,
     code: errorCodes.agreementMissingUserInfo,
-    httpStatus: 500,
     title: "Some mandatory info are missing for user",
   });
 }
@@ -164,7 +144,6 @@ export function agreementSelfcareIdNotFound(tenantId: string): ApiError {
   return new ApiError({
     detail: `Selfcare id not found for tenant ${tenantId}`,
     code: errorCodes.agreementSelfcareIdNotFound,
-    httpStatus: 500,
     title: "Selfcare id not found for tenant",
   });
 }
@@ -176,7 +155,6 @@ export function agreementDescriptorNotFound(
   return new ApiError({
     detail: `Descriptor ${descriptorId} not found in EService ${eserviceId}`,
     code: errorCodes.agreementDescriptorNotFound,
-    httpStatus: 500,
     title: "Descriptor not found",
   });
 }
@@ -187,7 +165,6 @@ export function agreementSubmitOperationNotAllowed(
   return new ApiError({
     detail: `Operation not allowed by ${requesterId}`,
     code: errorCodes.agreementSubmitOperationNotAllowed,
-    httpStatus: 403,
     title: "Operation not allowed",
   });
 }

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -8,14 +8,12 @@ import {
   initDB,
   ReadModelRepository,
 } from "pagopa-interop-commons";
-import { makeApiProblem } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import {
   agreementToApiAgreement,
   apiAgreementStateToAgreementState,
 } from "../model/domain/apiConverter.js";
 import { config } from "../utilities/config.js";
-import { agreementNotFound } from "../model/domain/errors.js";
 import { agreementServiceBuilder } from "../services/agreementService.js";
 import { agreementQueryBuilder } from "../services/readmodel/agreementQuery.js";
 import { tenantQueryBuilder } from "../services/readmodel/tenantQuery.js";
@@ -25,8 +23,10 @@ import { readModelServiceBuilder } from "../services/readmodel/readModelService.
 import {
   createAgreementErrorMapper,
   deleteAgreementErrorMapper,
+  submitAgreementErrorMapper,
   updateAgreementErrorMapper,
 } from "../utilities/errorMappers.js";
+import { agreementNotFound, makeApiProblem } from "../model/domain/errors.js";
 
 const readModelService = readModelServiceBuilder(
   ReadModelRepository.init(config)
@@ -77,7 +77,7 @@ const agreementRouter = (
         );
         return res.status(200).json({ id }).end();
       } catch (error) {
-        const errorRes = makeApiProblem(error);
+        const errorRes = makeApiProblem(error, submitAgreementErrorMapper);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -20,6 +20,7 @@ import { tenantQueryBuilder } from "../services/readmodel/tenantQuery.js";
 import { eserviceQueryBuilder } from "../services/readmodel/eserviceQuery.js";
 import { attributeQueryBuilder } from "../services/readmodel/attributeQuery.js";
 import { readModelServiceBuilder } from "../services/readmodel/readModelService.js";
+import { agreementNotFound, makeApiProblem } from "../model/domain/errors.js";
 import {
   createAgreementErrorMapper,
   deleteAgreementErrorMapper,

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -22,6 +22,11 @@ import { tenantQueryBuilder } from "../services/readmodel/tenantQuery.js";
 import { eserviceQueryBuilder } from "../services/readmodel/eserviceQuery.js";
 import { attributeQueryBuilder } from "../services/readmodel/attributeQuery.js";
 import { readModelServiceBuilder } from "../services/readmodel/readModelService.js";
+import {
+  createAgreementErrorMapper,
+  deleteAgreementErrorMapper,
+  updateAgreementErrorMapper,
+} from "../utilities/errorMappers.js";
 
 const readModelService = readModelServiceBuilder(
   ReadModelRepository.init(config)
@@ -135,7 +140,7 @@ const agreementRouter = (
         );
         return res.status(200).json({ id }).send();
       } catch (error) {
-        const errorRes = makeApiProblem(error);
+        const errorRes = makeApiProblem(error, createAgreementErrorMapper);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }
@@ -175,7 +180,7 @@ const agreementRouter = (
           })
           .end();
       } catch (error) {
-        const errorRes = makeApiProblem(error);
+        const errorRes = makeApiProblem(error, () => 500);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }
@@ -212,11 +217,16 @@ const agreementRouter = (
         } else {
           return res
             .status(404)
-            .json(makeApiProblem(agreementNotFound(req.params.agreementId)))
+            .json(
+              makeApiProblem(
+                agreementNotFound(req.params.agreementId),
+                () => 404
+              )
+            )
             .send();
         }
       } catch (error) {
-        const errorRes = makeApiProblem(error);
+        const errorRes = makeApiProblem(error, () => 500);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }
@@ -233,7 +243,7 @@ const agreementRouter = (
         );
         return res.status(204).send();
       } catch (error) {
-        const errorRes = makeApiProblem(error);
+        const errorRes = makeApiProblem(error, deleteAgreementErrorMapper);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }
@@ -252,7 +262,7 @@ const agreementRouter = (
 
         return res.status(200).send();
       } catch (error) {
-        const errorRes = makeApiProblem(error);
+        const errorRes = makeApiProblem(error, updateAgreementErrorMapper);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -27,7 +27,6 @@ import {
   submitAgreementErrorMapper,
   updateAgreementErrorMapper,
 } from "../utilities/errorMappers.js";
-import { agreementNotFound, makeApiProblem } from "../model/domain/errors.js";
 
 const readModelService = readModelServiceBuilder(
   ReadModelRepository.init(config)

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -185,7 +185,7 @@ export async function createAgreementLogic(
   const eservice = await eserviceQuery.getEServiceById(agreement.eserviceId);
 
   if (!eservice) {
-    throw eServiceNotFound(400, agreement.eserviceId);
+    throw eServiceNotFound(agreement.eserviceId);
   }
 
   const descriptor = validateCreationOnDescriptor(
@@ -201,7 +201,7 @@ export async function createAgreementLogic(
   const consumer = await tenantQuery.getTenantById(authData.organizationId);
 
   if (!consumer) {
-    throw tenantIdNotFound(404, authData.organizationId);
+    throw tenantIdNotFound(authData.organizationId);
   }
 
   if (eservice.data.producerId !== consumer.data.id) {

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -78,7 +78,7 @@ export async function submitAgreementLogic(
     await eserviceQuery.getEServiceById(agreement.data.eserviceId)
   )?.data;
   if (!eservice) {
-    throw eServiceNotFound(500, agreement.data.eserviceId);
+    throw eServiceNotFound(agreement.data.eserviceId);
   }
 
   const descriptor = await validateSubmitOnDescriptor(
@@ -90,7 +90,7 @@ export async function submitAgreementLogic(
     ?.data;
 
   if (!consumer) {
-    throw tenantIdNotFound(500, agreement.data.consumerId);
+    throw tenantIdNotFound(agreement.data.consumerId);
   }
 
   return await submitAgreement(
@@ -256,7 +256,7 @@ const createContract = async (
   const producer = await tenantQuery.getTenantById(agreement.producerId);
 
   if (!producer?.data) {
-    throw tenantIdNotFound(500, agreement.producerId);
+    throw tenantIdNotFound(agreement.producerId);
   }
 
   const agreementdocumentSeed = {

--- a/packages/agreement-process/src/utilities/errorMappers.ts
+++ b/packages/agreement-process/src/utilities/errorMappers.ts
@@ -1,0 +1,46 @@
+/* eslint-disable sonarjs/no-identical-functions */
+import { ApiError } from "pagopa-interop-models";
+import { match } from "ts-pattern";
+import { errorCodes } from "../model/domain/errors.js";
+
+export const createAgreementErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.notLatestEServiceDescriptor,
+      errorCodes.descriptorNotInExpectedState,
+      errorCodes.missingCertifiedAttributesError,
+      errorCodes.eServiceNotFound,
+      () => 400
+    )
+    .with(errorCodes.agreementAlreadyExists, () => 409)
+    .otherwise(() => 500);
+
+export const deleteAgreementErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(errorCodes.agreementNotFound, () => 404)
+    .with(errorCodes.agreementNotInExpectedState, () => 400)
+    .with(errorCodes.operationNotAllowed, () => 403)
+    .otherwise(() => 500);
+
+export const updateAgreementErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(errorCodes.agreementNotFound, () => 404)
+    .with(errorCodes.agreementNotInExpectedState, () => 400)
+    .with(errorCodes.operationNotAllowed, () => 403)
+    .otherwise(() => 500);
+
+export const submitAgreementErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.notLatestEServiceDescriptor,
+      errorCodes.agreementNotInExpectedState,
+      errorCodes.consumerWithNotValidEmail,
+      errorCodes.agreementSubmissionFailed,
+      errorCodes.missingCertifiedAttributesError,
+      errorCodes.descriptorNotInExpectedState,
+      () => 400
+    )
+    .with(errorCodes.agreementNotFound, () => 404)
+    .with(errorCodes.operationNotAllowed, () => 403)
+    .with(errorCodes.agreementAlreadyExists, () => 409)
+    .otherwise(() => 500);

--- a/packages/agreement-process/src/utilities/errorMappers.ts
+++ b/packages/agreement-process/src/utilities/errorMappers.ts
@@ -1,46 +1,56 @@
 /* eslint-disable sonarjs/no-identical-functions */
-import { ApiError } from "pagopa-interop-models";
+import { ApiError, CommonErrorCodes } from "pagopa-interop-models";
 import { match } from "ts-pattern";
-import { errorCodes } from "../model/domain/errors.js";
+import { ErrorCodes as LocalErrorCodes } from "../model/domain/errors.js";
 
-export const createAgreementErrorMapper = (error: ApiError): number =>
+type ErrorCodes = LocalErrorCodes | CommonErrorCodes;
+
+export const createAgreementErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
     .with(
-      errorCodes.notLatestEServiceDescriptor,
-      errorCodes.descriptorNotInExpectedState,
-      errorCodes.missingCertifiedAttributesError,
-      errorCodes.eServiceNotFound,
+      "notLatestEServiceDescriptor",
+      "descriptorNotInExpectedState",
+      "missingCertifiedAttributesError",
+      "eServiceNotFound",
       () => 400
     )
-    .with(errorCodes.agreementAlreadyExists, () => 409)
+    .with("agreementAlreadyExists", () => 409)
     .otherwise(() => 500);
 
-export const deleteAgreementErrorMapper = (error: ApiError): number =>
+export const deleteAgreementErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(errorCodes.agreementNotFound, () => 404)
-    .with(errorCodes.agreementNotInExpectedState, () => 400)
-    .with(errorCodes.operationNotAllowed, () => 403)
+    .with("agreementNotFound", () => 404)
+    .with("agreementNotInExpectedState", () => 400)
+    .with("operationNotAllowed", () => 403)
     .otherwise(() => 500);
 
-export const updateAgreementErrorMapper = (error: ApiError): number =>
+export const updateAgreementErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(errorCodes.agreementNotFound, () => 404)
-    .with(errorCodes.agreementNotInExpectedState, () => 400)
-    .with(errorCodes.operationNotAllowed, () => 403)
+    .with("agreementNotFound", () => 404)
+    .with("agreementNotInExpectedState", () => 400)
+    .with("operationNotAllowed", () => 403)
     .otherwise(() => 500);
 
-export const submitAgreementErrorMapper = (error: ApiError): number =>
+export const submitAgreementErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
     .with(
-      errorCodes.notLatestEServiceDescriptor,
-      errorCodes.agreementNotInExpectedState,
-      errorCodes.consumerWithNotValidEmail,
-      errorCodes.agreementSubmissionFailed,
-      errorCodes.missingCertifiedAttributesError,
-      errorCodes.descriptorNotInExpectedState,
+      "notLatestEServiceDescriptor",
+      "agreementNotInExpectedState",
+      "consumerWithNotValidEmail",
+      "agreementSubmissionFailed",
+      "missingCertifiedAttributesError",
+      "descriptorNotInExpectedState",
       () => 400
     )
-    .with(errorCodes.agreementNotFound, () => 404)
-    .with(errorCodes.operationNotAllowed, () => 403)
-    .with(errorCodes.agreementAlreadyExists, () => 409)
+    .with("agreementNotFound", () => 404)
+    .with("operationNotAllowed", () => 403)
+    .with("agreementAlreadyExists", () => 409)
     .otherwise(() => 500);

--- a/packages/attribute-registry-process/src/model/domain/errors.ts
+++ b/packages/attribute-registry-process/src/model/domain/errors.ts
@@ -1,34 +1,37 @@
-import { ApiError } from "pagopa-interop-models";
+import { ApiError, makeApiProblemBuilder } from "pagopa-interop-models";
 
-const errorCodes = {
+export const errorCodes = {
   attributeNotFound: "0001",
   attributeDuplicate: "0002",
   originNotCompliant: "0003",
 };
 
-export function attributeNotFound(identifier: string): ApiError {
+export type ErrorCodes = keyof typeof errorCodes;
+
+export const makeApiProblem = makeApiProblemBuilder(errorCodes);
+
+export function attributeNotFound(identifier: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Attribute ${identifier} not found`,
-    code: errorCodes.attributeNotFound,
-    httpStatus: 404,
+    code: "attributeNotFound",
     title: "Attribute not found",
   });
 }
 
-export function attributeDuplicate(attributeName: string): ApiError {
+export function attributeDuplicate(
+  attributeName: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `ApiError during Attribute creation with name ${attributeName}`,
-    code: errorCodes.attributeDuplicate,
-    httpStatus: 409,
+    code: "attributeDuplicate",
     title: "Duplicated attribute name",
   });
 }
 
-export function originNotCompliant(origin: string): ApiError {
+export function originNotCompliant(origin: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Requester has not origin ${origin}`,
-    code: errorCodes.originNotCompliant,
-    httpStatus: 400,
+    code: "originNotCompliant",
     title: "Origin is not compliant",
   });
 }

--- a/packages/attribute-registry-process/src/routers/AttributeRouter.ts
+++ b/packages/attribute-registry-process/src/routers/AttributeRouter.ts
@@ -6,7 +6,6 @@ import {
   ZodiosContext,
   authorizationMiddleware,
 } from "pagopa-interop-commons";
-import { makeApiProblem } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import { readModelServiceBuilder } from "../services/readModelService.js";
 import {
@@ -14,8 +13,13 @@ import {
   toApiAttribute,
 } from "../model/domain/apiConverter.js";
 import { config } from "../utilities/config.js";
-import { attributeNotFound } from "../model/domain/errors.js";
+import { attributeNotFound, makeApiProblem } from "../model/domain/errors.js";
 import { attributeRegistryServiceBuilder } from "../services/attributeRegistryService.js";
+import {
+  getAttributeByIdErrorMapper,
+  getAttributeByOriginAndCodeErrorMapper,
+  getAttributesByNameErrorMapper,
+} from "../utilities/errorMappers.js";
 
 const readModelService = readModelServiceBuilder(config);
 const attributeRegistryService = attributeRegistryServiceBuilder(
@@ -87,13 +91,17 @@ const attributeRouter = (
           if (attribute) {
             return res.status(200).json(toApiAttribute(attribute.data)).end();
           } else {
-            return res
-              .status(404)
-              .json(makeApiProblem(attributeNotFound(req.params.name)))
-              .end();
+            const errorRes = makeApiProblem(
+              attributeNotFound,
+              getAttributesByNameErrorMapper
+            );
+            return res.status(errorRes.status).json(errorRes).end();
           }
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(
+            error,
+            getAttributesByNameErrorMapper
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -118,13 +126,17 @@ const attributeRouter = (
           if (attribute) {
             return res.status(200).json(toApiAttribute(attribute.data)).end();
           } else {
-            return res
-              .status(404)
-              .json(makeApiProblem(attributeNotFound(`${origin}/${code}`)))
-              .end();
+            const errorRes = makeApiProblem(
+              attributeNotFound(`${origin}/${code}`),
+              getAttributeByOriginAndCodeErrorMapper
+            );
+            return res.status(errorRes.status).json(errorRes).end();
           }
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(
+            error,
+            getAttributeByOriginAndCodeErrorMapper
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -148,13 +160,17 @@ const attributeRouter = (
           if (attribute) {
             return res.status(200).json(toApiAttribute(attribute.data)).end();
           } else {
-            return res
-              .status(404)
-              .json(makeApiProblem(attributeNotFound(req.params.attributeId)))
-              .end();
+            const errorRes = makeApiProblem(
+              attributeNotFound(req.params.attributeId),
+              getAttributeByIdErrorMapper
+            );
+            return res.status(errorRes.status).json(errorRes).end();
           }
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(
+            attributeNotFound(req.params.attributeId),
+            getAttributeByIdErrorMapper
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -205,7 +221,7 @@ const attributeRouter = (
           );
           return res.status(200).json({ id }).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, getAttributeByIdErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -221,7 +237,7 @@ const attributeRouter = (
           );
           return res.status(200).json({ id }).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, getAttributeByIdErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }

--- a/packages/attribute-registry-process/src/utilities/errorMappers.ts
+++ b/packages/attribute-registry-process/src/utilities/errorMappers.ts
@@ -42,4 +42,3 @@ export const createVerifiedAttributesErrorMapper = (
   match(error.code)
     .with("originNotCompliant", () => 403)
     .otherwise(() => 500);
-

--- a/packages/attribute-registry-process/src/utilities/errorMappers.ts
+++ b/packages/attribute-registry-process/src/utilities/errorMappers.ts
@@ -1,0 +1,45 @@
+/* eslint-disable sonarjs/no-identical-functions */
+import { ApiError, CommonErrorCodes } from "pagopa-interop-models";
+import { match } from "ts-pattern";
+import { ErrorCodes as LocalErrorCodes } from "../model/domain/errors.js";
+
+type ErrorCodes = LocalErrorCodes | CommonErrorCodes;
+
+export const getAttributesByNameErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("attributeNotFound", () => 404)
+    .with("operationForbidden", () => 403)
+    .otherwise(() => 500);
+
+export const getAttributeByOriginAndCodeErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("attributeNotFound", () => 404)
+    .with("operationForbidden", () => 403)
+    .otherwise(() => 500);
+
+export const getAttributeByIdErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("attributeNotFound", () => 404)
+    .with("operationForbidden", () => 403)
+    .otherwise(() => 500);
+
+export const createDeclaredAttributesErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("originNotCompliant", () => 403)
+    .otherwise(() => 500);
+
+export const createVerifiedAttributesErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("originNotCompliant", () => 403)
+    .otherwise(() => 500);
+

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -1,6 +1,6 @@
 import { ApiError } from "pagopa-interop-models";
 
-const errorCodes = {
+export cconst errorCodes = {
   eServiceDescriptorNotFound: "0002",
   eServiceDocumentNotFound: "0003",
   notValidDescriptor: "0004",

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -1,9 +1,10 @@
 import { ApiError } from "pagopa-interop-models";
 
-export cconst errorCodes = {
+export const errorCodes = {
   eServiceDescriptorNotFound: "0002",
-  eServiceDocumentNotFound: "0003",
+  eServiceDescriptorWithoutInterface: "0003",
   notValidDescriptor: "0004",
+  eServiceDocumentNotFound: "0006",
   eServiceNotFound: "0007",
   draftDescriptorAlreadyExists: "0008",
   eserviceCannotBeUpdatedOrDeleted: "0009",
@@ -12,7 +13,6 @@ export cconst errorCodes = {
 
 const eserviceCannotBeUpdatedOrDeleted = {
   code: errorCodes.eserviceCannotBeUpdatedOrDeleted,
-  httpStatus: 400,
   title: "EService cannot be updated or deleted",
 };
 
@@ -20,7 +20,6 @@ export function eServiceNotFound(eServiceId: string): ApiError {
   return new ApiError({
     detail: `EService ${eServiceId} not found`,
     code: errorCodes.eServiceNotFound,
-    httpStatus: 404,
     title: "EService not found",
   });
 }
@@ -29,7 +28,6 @@ export function eServiceDuplicate(eServiceNameSeed: string): ApiError {
   return new ApiError({
     detail: `ApiError during EService creation with name ${eServiceNameSeed}`,
     code: errorCodes.eServiceDuplicate,
-    httpStatus: 409,
     title: "Duplicated service name",
   });
 }
@@ -55,7 +53,6 @@ export function eServiceDescriptorNotFound(
   return new ApiError({
     detail: `Descriptor ${descriptorId} for EService ${eServiceId} not found`,
     code: errorCodes.eServiceDescriptorNotFound,
-    httpStatus: 404,
     title: "EService descriptor not found",
   });
 }
@@ -68,7 +65,6 @@ export function eServiceDocumentNotFound(
   return new ApiError({
     detail: `Document with id ${documentId} not found in EService ${eServiceId} / Descriptor ${descriptorId}`,
     code: errorCodes.eServiceDocumentNotFound,
-    httpStatus: 404,
     title: "EService document not found",
   });
 }
@@ -80,7 +76,16 @@ export function notValidDescriptor(
   return new ApiError({
     detail: `Descriptor ${descriptorId} has a not valid status for this operation ${descriptorStatus}`,
     code: errorCodes.notValidDescriptor,
-    httpStatus: 400,
+    title: "Not valid descriptor",
+  });
+}
+
+export function eServiceDescriptorWithoutInterface(
+  descriptorId: string
+): ApiError {
+  return new ApiError({
+    detail: `Descriptor ${descriptorId} does not have an interface`,
+    code: errorCodes.eServiceDescriptorWithoutInterface,
     title: "Not valid descriptor",
   });
 }
@@ -89,7 +94,6 @@ export function draftDescriptorAlreadyExists(eServiceId: string): ApiError {
   return new ApiError({
     detail: `EService ${eServiceId} already contains a draft descriptor`,
     code: errorCodes.draftDescriptorAlreadyExists,
-    httpStatus: 400,
     title: "EService already contains a draft descriptor",
   });
 }
@@ -98,7 +102,6 @@ export function invalidDescriptorVersion(details: string): ApiError {
   return new ApiError({
     detail: details,
     code: errorCodes.notValidDescriptor,
-    httpStatus: 400,
     title: "Version is not a valid descriptor version",
   });
 }

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "pagopa-interop-models";
+import { ApiError, makeApiProblemBuilder } from "pagopa-interop-models";
 
 export const errorCodes = {
   eServiceDescriptorNotFound: "0002",
@@ -11,35 +11,48 @@ export const errorCodes = {
   eServiceDuplicate: "0010",
 };
 
-const eserviceCannotBeUpdatedOrDeleted = {
-  code: errorCodes.eserviceCannotBeUpdatedOrDeleted,
+export type ErrorCodes = keyof typeof errorCodes;
+
+export const makeApiProblem = makeApiProblemBuilder(errorCodes);
+
+const eserviceCannotBeUpdatedOrDeleted: {
+  code: ErrorCodes;
+  title: string;
+} = {
+  code: "eserviceCannotBeUpdatedOrDeleted",
   title: "EService cannot be updated or deleted",
 };
 
-export function eServiceNotFound(eServiceId: string): ApiError {
+export function eServiceNotFound(eServiceId: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `EService ${eServiceId} not found`,
-    code: errorCodes.eServiceNotFound,
+    code: "eServiceNotFound",
     title: "EService not found",
   });
 }
 
-export function eServiceDuplicate(eServiceNameSeed: string): ApiError {
+export function eServiceDuplicate(
+  eServiceNameSeed: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `ApiError during EService creation with name ${eServiceNameSeed}`,
-    code: errorCodes.eServiceDuplicate,
+    code: "eServiceDuplicate",
     title: "Duplicated service name",
   });
 }
 
-export function eServiceCannotBeUpdated(eServiceId: string): ApiError {
+export function eServiceCannotBeUpdated(
+  eServiceId: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `EService ${eServiceId} contains valid descriptors and cannot be updated`,
     ...eserviceCannotBeUpdatedOrDeleted,
   });
 }
 
-export function eServiceCannotBeDeleted(eServiceId: string): ApiError {
+export function eServiceCannotBeDeleted(
+  eServiceId: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `EService ${eServiceId} contains descriptors and cannot be deleted`,
     ...eserviceCannotBeUpdatedOrDeleted,
@@ -49,10 +62,10 @@ export function eServiceCannotBeDeleted(eServiceId: string): ApiError {
 export function eServiceDescriptorNotFound(
   eServiceId: string,
   descriptorId: string
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor ${descriptorId} for EService ${eServiceId} not found`,
-    code: errorCodes.eServiceDescriptorNotFound,
+    code: "eServiceDescriptorNotFound",
     title: "EService descriptor not found",
   });
 }
@@ -61,10 +74,10 @@ export function eServiceDocumentNotFound(
   eServiceId: string,
   descriptorId: string,
   documentId: string
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Document with id ${documentId} not found in EService ${eServiceId} / Descriptor ${descriptorId}`,
-    code: errorCodes.eServiceDocumentNotFound,
+    code: "eServiceDocumentNotFound",
     title: "EService document not found",
   });
 }
@@ -72,36 +85,40 @@ export function eServiceDocumentNotFound(
 export function notValidDescriptor(
   descriptorId: string,
   descriptorStatus: string
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor ${descriptorId} has a not valid status for this operation ${descriptorStatus}`,
-    code: errorCodes.notValidDescriptor,
+    code: "notValidDescriptor",
     title: "Not valid descriptor",
   });
 }
 
 export function eServiceDescriptorWithoutInterface(
   descriptorId: string
-): ApiError {
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor ${descriptorId} does not have an interface`,
-    code: errorCodes.eServiceDescriptorWithoutInterface,
+    code: "eServiceDescriptorWithoutInterface",
     title: "Not valid descriptor",
   });
 }
 
-export function draftDescriptorAlreadyExists(eServiceId: string): ApiError {
+export function draftDescriptorAlreadyExists(
+  eServiceId: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `EService ${eServiceId} already contains a draft descriptor`,
-    code: errorCodes.draftDescriptorAlreadyExists,
+    code: "draftDescriptorAlreadyExists",
     title: "EService already contains a draft descriptor",
   });
 }
 
-export function invalidDescriptorVersion(details: string): ApiError {
+export function invalidDescriptorVersion(
+  details: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: details,
-    code: errorCodes.notValidDescriptor,
+    code: "notValidDescriptor",
     title: "Version is not a valid descriptor version",
   });
 }

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -1,5 +1,6 @@
 import { ZodiosEndpointDefinitions } from "@zodios/core";
 import { ZodiosRouter } from "@zodios/express";
+import { match } from "ts-pattern";
 import { makeApiProblem } from "pagopa-interop-models";
 import {
   ExpressContext,
@@ -19,6 +20,7 @@ import {
 import { api } from "../model/generated/api.js";
 import { config } from "../utilities/config.js";
 import {
+  errorCodes,
   eServiceNotFound,
   eServiceDocumentNotFound,
 } from "../model/domain/errors.js";
@@ -114,7 +116,11 @@ const eservicesRouter = (
           );
           return res.status(201).json({ id }).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, (error) =>
+            match(error.code)
+              .with(errorCodes.eServiceDuplicate, () => 409)
+              .otherwise(() => 500)
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -1,6 +1,5 @@
 import { ZodiosEndpointDefinitions } from "@zodios/core";
 import { ZodiosRouter } from "@zodios/express";
-import { makeApiProblem } from "pagopa-interop-models";
 import {
   ExpressContext,
   userRoles,
@@ -20,6 +19,13 @@ import { api } from "../model/generated/api.js";
 import { config } from "../utilities/config.js";
 import { readModelServiceBuilder } from "../services/readModelService.js";
 import { catalogServiceBuilder } from "../services/catalogService.js";
+import { catalogService } from "../services/catalogService.js";
+import { readModelService } from "../services/readModelService.js";
+import {
+  makeApiProblem,
+  eServiceNotFound,
+  eServiceDocumentNotFound,
+} from "../model/domain/errors.js";
 import {
   activateDescriptorErrorMapper,
   archiveDescriptorErrorMapper,

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -27,6 +27,7 @@ import { readModelServiceBuilder } from "../services/readModelService.js";
 import { catalogServiceBuilder } from "../services/catalogService.js";
 import {
   activateDescriptorErrorMapper,
+  archiveDescriptorErrorMapper,
   cloneEServiceByDescriptorErrorMapper,
   createDescriptorErrorMapper,
   createEServiceErrorMapper,
@@ -493,7 +494,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error, () => 500);
+          const errorRes = makeApiProblem(error, archiveDescriptorErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -20,12 +20,25 @@ import {
 import { api } from "../model/generated/api.js";
 import { config } from "../utilities/config.js";
 import {
-  errorCodes,
   eServiceNotFound,
   eServiceDocumentNotFound,
 } from "../model/domain/errors.js";
 import { readModelServiceBuilder } from "../services/readModelService.js";
 import { catalogServiceBuilder } from "../services/catalogService.js";
+import {
+  activateDescriptorErrorMapper,
+  cloneEServiceByDescriptorErrorMapper,
+  createDescriptorErrorMapper,
+  createEServiceErrorMapper,
+  deleteDraftDescriptorErrorMapper,
+  deleteEServiceErrorMapper,
+  documentCreateErrorMapper,
+  documentUpdateDeleteErrorMapper,
+  publishDescriptorErrorMapper,
+  suspendDescriptorErrorMapper,
+  updateDescriptorErrorMapper,
+  updateEServiceErrorMapper,
+} from "../utilities/errorMappers.js";
 
 const readModelService = readModelServiceBuilder(
   ReadModelRepository.init(config)
@@ -116,11 +129,7 @@ const eservicesRouter = (
           );
           return res.status(201).json({ id }).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error, (error) =>
-            match(error.code)
-              .with(errorCodes.eServiceDuplicate, () => 409)
-              .otherwise(() => 500)
-          );
+          const errorRes = makeApiProblem(error, createEServiceErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -148,11 +157,16 @@ const eservicesRouter = (
           } else {
             return res
               .status(404)
-              .json(makeApiProblem(eServiceNotFound(req.params.eServiceId)))
+              .json(
+                makeApiProblem(
+                  eServiceNotFound(req.params.eServiceId),
+                  () => 404
+                )
+              )
               .end();
           }
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, () => 500);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -169,7 +183,7 @@ const eservicesRouter = (
           );
           return res.status(200).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, updateEServiceErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -185,7 +199,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, deleteEServiceErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -229,7 +243,7 @@ const eservicesRouter = (
             })
             .end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, () => 500);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -263,13 +277,18 @@ const eservicesRouter = (
               .status(404)
               .json(
                 makeApiProblem(
-                  eServiceDocumentNotFound(eServiceId, descriptorId, documentId)
+                  eServiceDocumentNotFound(
+                    eServiceId,
+                    descriptorId,
+                    documentId
+                  ),
+                  () => 404
                 )
               )
               .end();
           }
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, () => 500);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -287,7 +306,7 @@ const eservicesRouter = (
           );
           return res.status(200).json({ id }).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, documentCreateErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -305,7 +324,10 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(
+            error,
+            documentUpdateDeleteErrorMapper
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -324,7 +346,10 @@ const eservicesRouter = (
           );
           return res.status(200).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(
+            error,
+            documentUpdateDeleteErrorMapper
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -341,7 +366,7 @@ const eservicesRouter = (
           );
           return res.status(200).json({ id }).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, createDescriptorErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -358,7 +383,10 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(
+            error,
+            deleteDraftDescriptorErrorMapper
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -376,7 +404,7 @@ const eservicesRouter = (
           );
           return res.status(200).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, updateDescriptorErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -393,7 +421,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, publishDescriptorErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -410,7 +438,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, suspendDescriptorErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -427,7 +455,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, activateDescriptorErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -445,7 +473,10 @@ const eservicesRouter = (
             );
           return res.status(200).json(clonedEserviceByDescriptor).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(
+            error,
+            cloneEServiceByDescriptorErrorMapper
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -462,7 +493,7 @@ const eservicesRouter = (
           );
           return res.status(204).end();
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, () => 500);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -1,6 +1,5 @@
 import { ZodiosEndpointDefinitions } from "@zodios/core";
 import { ZodiosRouter } from "@zodios/express";
-import { match } from "ts-pattern";
 import { makeApiProblem } from "pagopa-interop-models";
 import {
   ExpressContext,
@@ -19,10 +18,6 @@ import {
 } from "../model/domain/apiConverter.js";
 import { api } from "../model/generated/api.js";
 import { config } from "../utilities/config.js";
-import {
-  eServiceNotFound,
-  eServiceDocumentNotFound,
-} from "../model/domain/errors.js";
 import { readModelServiceBuilder } from "../services/readModelService.js";
 import { catalogServiceBuilder } from "../services/catalogService.js";
 import {
@@ -40,6 +35,10 @@ import {
   updateDescriptorErrorMapper,
   updateEServiceErrorMapper,
 } from "../utilities/errorMappers.js";
+import {
+  eServiceDocumentNotFound,
+  eServiceNotFound,
+} from "../model/domain/errors.js";
 
 const readModelService = readModelServiceBuilder(
   ReadModelRepository.init(config)

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -19,8 +19,6 @@ import { api } from "../model/generated/api.js";
 import { config } from "../utilities/config.js";
 import { readModelServiceBuilder } from "../services/readModelService.js";
 import { catalogServiceBuilder } from "../services/catalogService.js";
-import { catalogService } from "../services/catalogService.js";
-import { readModelService } from "../services/readModelService.js";
 import {
   makeApiProblem,
   eServiceNotFound,
@@ -41,10 +39,6 @@ import {
   updateDescriptorErrorMapper,
   updateEServiceErrorMapper,
 } from "../utilities/errorMappers.js";
-import {
-  eServiceDocumentNotFound,
-  eServiceNotFound,
-} from "../model/domain/errors.js";
 
 const readModelService = readModelServiceBuilder(
   ReadModelRepository.init(config)

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -57,6 +57,7 @@ import {
   eServiceDuplicate,
   notValidDescriptor,
   eServiceNotFound,
+  eServiceDescriptorWithoutInterface,
 } from "../model/domain/errors.js";
 import { ReadModelService } from "./readModelService.js";
 
@@ -864,6 +865,10 @@ export function publishDescriptorLogic({
   const descriptor = retrieveDescriptor(descriptorId, eService);
   if (descriptor.state !== descriptorState.draft) {
     throw notValidDescriptor(descriptor.id, descriptor.state.toString());
+  }
+
+  if (descriptor.interface === undefined) {
+    throw eServiceDescriptorWithoutInterface(descriptor.id);
   }
 
   const currentActiveDescriptor = eService.data.descriptors.find(

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-identical-functions */
 import { ApiError, CommonErrorCodes } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { ErrorCodes as LocalErrorCodes } from "../model/domain/errors.js";
@@ -55,7 +56,6 @@ export const createDescriptorErrorMapper = (
 
 export const deleteDraftDescriptorErrorMapper = (
   error: ApiError<ErrorCodes>
-  // eslint-disable-next-line sonarjs/no-identical-functions
 ): number =>
   match(error.code)
     .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
@@ -91,7 +91,6 @@ export const suspendDescriptorErrorMapper = (
 
 export const activateDescriptorErrorMapper = (
   error: ApiError<ErrorCodes>
-  // eslint-disable-next-line sonarjs/no-identical-functions
 ): number =>
   match(error.code)
     .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
@@ -101,7 +100,6 @@ export const activateDescriptorErrorMapper = (
 
 export const cloneEServiceByDescriptorErrorMapper = (
   error: ApiError<ErrorCodes>
-  // eslint-disable-next-line sonarjs/no-identical-functions
 ): number =>
   match(error.code)
     .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
@@ -110,7 +108,6 @@ export const cloneEServiceByDescriptorErrorMapper = (
 
 export const archiveDescriptorErrorMapper = (
   error: ApiError<ErrorCodes>
-  // eslint-disable-next-line sonarjs/no-identical-functions
 ): number =>
   match(error.code)
     .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -116,3 +116,15 @@ export const cloneEServiceByDescriptorErrorMapper = (error: ApiError): number =>
     )
     .with(commonErrorCodes.operationForbidden, () => 403)
     .otherwise(() => 500);
+
+// eslint-disable-next-line sonarjs/no-identical-functions
+export const archiveDescriptorErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.eServiceNotFound,
+      errorCodes.eServiceDescriptorNotFound,
+      () => 404
+    )
+    .with(errorCodes.notValidDescriptor, () => 400)
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -1,0 +1,118 @@
+import {
+  ApiError,
+  errorCodes as commonErrorCodes,
+} from "pagopa-interop-models";
+import { match } from "ts-pattern";
+import { errorCodes } from "../model/domain/errors.js";
+
+export const createEServiceErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(errorCodes.eServiceDuplicate, () => 409)
+    .otherwise(() => 500);
+
+export const updateEServiceErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(errorCodes.eServiceDuplicate, () => 404)
+    .with(errorCodes.eserviceCannotBeUpdatedOrDeleted, () => 400)
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);
+
+export const deleteEServiceErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(errorCodes.eServiceNotFound, () => 404)
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);
+
+export const documentCreateErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.eServiceNotFound,
+      errorCodes.eServiceDescriptorNotFound,
+      () => 404
+    )
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);
+
+export const documentUpdateDeleteErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.eServiceNotFound,
+      errorCodes.eServiceDocumentNotFound,
+      () => 404
+    )
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);
+
+export const createDescriptorErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(errorCodes.eServiceNotFound, () => 404)
+    .with(errorCodes.draftDescriptorAlreadyExists, () => 400)
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);
+
+// eslint-disable-next-line sonarjs/no-identical-functions
+export const deleteDraftDescriptorErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.eServiceNotFound,
+      errorCodes.eServiceDescriptorNotFound,
+      () => 404
+    )
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);
+
+export const updateDescriptorErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.eServiceNotFound,
+      errorCodes.eServiceDescriptorNotFound,
+      () => 404
+    )
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with(errorCodes.notValidDescriptor, () => 400)
+    .otherwise(() => 500);
+
+export const publishDescriptorErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.eServiceNotFound,
+      errorCodes.eServiceDescriptorNotFound,
+      () => 404
+    )
+    .with(errorCodes.eServiceDescriptorWithoutInterface, () => 400)
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);
+
+export const suspendDescriptorErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.eServiceNotFound,
+      errorCodes.eServiceDescriptorNotFound,
+      () => 404
+    )
+    .with(errorCodes.notValidDescriptor, () => 400)
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);
+
+// eslint-disable-next-line sonarjs/no-identical-functions
+export const activateDescriptorErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.eServiceNotFound,
+      errorCodes.eServiceDescriptorNotFound,
+      () => 404
+    )
+    .with(errorCodes.notValidDescriptor, () => 400)
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);
+
+// eslint-disable-next-line sonarjs/no-identical-functions
+export const cloneEServiceByDescriptorErrorMapper = (error: ApiError): number =>
+  match(error.code)
+    .with(
+      errorCodes.eServiceNotFound,
+      errorCodes.eServiceDescriptorNotFound,
+      () => 404
+    )
+    .with(commonErrorCodes.operationForbidden, () => 403)
+    .otherwise(() => 500);

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -1,130 +1,119 @@
-import {
-  ApiError,
-  errorCodes as commonErrorCodes,
-} from "pagopa-interop-models";
+import { ApiError, CommonErrorCodes } from "pagopa-interop-models";
 import { match } from "ts-pattern";
-import { errorCodes } from "../model/domain/errors.js";
+import { ErrorCodes as LocalErrorCodes } from "../model/domain/errors.js";
 
-export const createEServiceErrorMapper = (error: ApiError): number =>
+type ErrorCodes = LocalErrorCodes | CommonErrorCodes;
+
+export const createEServiceErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(errorCodes.eServiceDuplicate, () => 409)
+    .with("eServiceDuplicate", () => 409)
     .otherwise(() => 500);
 
-export const updateEServiceErrorMapper = (error: ApiError): number =>
+export const updateEServiceErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(errorCodes.eServiceDuplicate, () => 404)
-    .with(errorCodes.eserviceCannotBeUpdatedOrDeleted, () => 400)
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceDuplicate", () => 404)
+    .with("eserviceCannotBeUpdatedOrDeleted", () => 400)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-export const deleteEServiceErrorMapper = (error: ApiError): number =>
+export const deleteEServiceErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(errorCodes.eServiceNotFound, () => 404)
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", () => 404)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-export const documentCreateErrorMapper = (error: ApiError): number =>
+export const documentCreateErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(
-      errorCodes.eServiceNotFound,
-      errorCodes.eServiceDescriptorNotFound,
-      () => 404
-    )
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-export const documentUpdateDeleteErrorMapper = (error: ApiError): number =>
+export const documentUpdateDeleteErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(
-      errorCodes.eServiceNotFound,
-      errorCodes.eServiceDocumentNotFound,
-      () => 404
-    )
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", "eServiceDocumentNotFound", () => 404)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-export const createDescriptorErrorMapper = (error: ApiError): number =>
+export const createDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(errorCodes.eServiceNotFound, () => 404)
-    .with(errorCodes.draftDescriptorAlreadyExists, () => 400)
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", () => 404)
+    .with("draftDescriptorAlreadyExists", () => 400)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-// eslint-disable-next-line sonarjs/no-identical-functions
-export const deleteDraftDescriptorErrorMapper = (error: ApiError): number =>
+export const deleteDraftDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+  // eslint-disable-next-line sonarjs/no-identical-functions
+): number =>
   match(error.code)
-    .with(
-      errorCodes.eServiceNotFound,
-      errorCodes.eServiceDescriptorNotFound,
-      () => 404
-    )
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-export const updateDescriptorErrorMapper = (error: ApiError): number =>
+export const updateDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(
-      errorCodes.eServiceNotFound,
-      errorCodes.eServiceDescriptorNotFound,
-      () => 404
-    )
-    .with(commonErrorCodes.operationForbidden, () => 403)
-    .with(errorCodes.notValidDescriptor, () => 400)
+    .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
+    .with("operationForbidden", () => 403)
+    .with("notValidDescriptor", () => 400)
     .otherwise(() => 500);
 
-export const publishDescriptorErrorMapper = (error: ApiError): number =>
+export const publishDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(
-      errorCodes.eServiceNotFound,
-      errorCodes.eServiceDescriptorNotFound,
-      () => 404
-    )
-    .with(errorCodes.eServiceDescriptorWithoutInterface, () => 400)
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
+    .with("eServiceDescriptorWithoutInterface", () => 400)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-export const suspendDescriptorErrorMapper = (error: ApiError): number =>
+export const suspendDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
   match(error.code)
-    .with(
-      errorCodes.eServiceNotFound,
-      errorCodes.eServiceDescriptorNotFound,
-      () => 404
-    )
-    .with(errorCodes.notValidDescriptor, () => 400)
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
+    .with("notValidDescriptor", () => 400)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-// eslint-disable-next-line sonarjs/no-identical-functions
-export const activateDescriptorErrorMapper = (error: ApiError): number =>
+export const activateDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+  // eslint-disable-next-line sonarjs/no-identical-functions
+): number =>
   match(error.code)
-    .with(
-      errorCodes.eServiceNotFound,
-      errorCodes.eServiceDescriptorNotFound,
-      () => 404
-    )
-    .with(errorCodes.notValidDescriptor, () => 400)
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
+    .with("notValidDescriptor", () => 400)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-// eslint-disable-next-line sonarjs/no-identical-functions
-export const cloneEServiceByDescriptorErrorMapper = (error: ApiError): number =>
+export const cloneEServiceByDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+  // eslint-disable-next-line sonarjs/no-identical-functions
+): number =>
   match(error.code)
-    .with(
-      errorCodes.eServiceNotFound,
-      errorCodes.eServiceDescriptorNotFound,
-      () => 404
-    )
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);
 
-// eslint-disable-next-line sonarjs/no-identical-functions
-export const archiveDescriptorErrorMapper = (error: ApiError): number =>
+export const archiveDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+  // eslint-disable-next-line sonarjs/no-identical-functions
+): number =>
   match(error.code)
-    .with(
-      errorCodes.eServiceNotFound,
-      errorCodes.eServiceDescriptorNotFound,
-      () => 404
-    )
-    .with(errorCodes.notValidDescriptor, () => 400)
-    .with(commonErrorCodes.operationForbidden, () => 403)
+    .with("eServiceNotFound", "eServiceDescriptorNotFound", () => 404)
+    .with("notValidDescriptor", () => 400)
+    .with("operationForbidden", () => 403)
     .otherwise(() => 500);

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { ZodiosRouterContextRequestHandler } from "@zodios/express";
 import {
-  errorCodes,
-  makeApiProblem,
+  makeApiProblemBuilder,
   missingBearer,
   missingClaim,
   missingHeader,
@@ -14,6 +13,8 @@ import { logger } from "../logging/index.js";
 import { AuthData } from "./authData.js";
 import { Headers } from "./headers.js";
 import { readAuthDataFromJwtToken, verifyJwtToken } from "./jwt.js";
+
+const makeApiProblem = makeApiProblemBuilder({});
 
 export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<ExpressContext> =
   () => {
@@ -103,9 +104,9 @@ export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<E
       } catch (error) {
         const problem = makeApiProblem(error, (err) =>
           match(err.code)
-            .with(errorCodes.unauthorizedError, () => 401)
-            .with(errorCodes.operationForbidden, () => 403)
-            .with(errorCodes.missingHeader, () => 400)
+            .with("unauthorizedError", () => 401)
+            .with("operationForbidden", () => 403)
+            .with("missingHeader", () => 400)
             .otherwise(() => 500)
         );
         return res.status(problem.status).json(problem).end();

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -1,8 +1,7 @@
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/naming-convention */
 import { ZodiosRouterContextRequestHandler } from "@zodios/express";
-import { Response } from "express";
 import {
+  errorCodes,
   makeApiProblem,
   missingBearer,
   missingClaim,
@@ -15,11 +14,6 @@ import { logger } from "../logging/index.js";
 import { AuthData } from "./authData.js";
 import { Headers } from "./headers.js";
 import { readAuthDataFromJwtToken, verifyJwtToken } from "./jwt.js";
-
-export const apiErrorHandler = (error: unknown, res: Response): void => {
-  const apiError = makeApiProblem(error);
-  res.status(apiError.status).json(apiError).end();
-};
 
 export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<ExpressContext> =
   () => {
@@ -99,11 +93,22 @@ export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<E
               authorization: P.string,
               "x-correlation-id": P.nullish,
             },
-            () => missingHeader("x-correlation-id")
+            () => {
+              throw missingHeader("x-correlation-id");
+            }
           )
-          .otherwise(() => apiErrorHandler(missingHeader(), res));
+          .otherwise(() => {
+            throw missingHeader();
+          });
       } catch (error) {
-        return apiErrorHandler(error, res);
+        const problem = makeApiProblem(error, (err) =>
+          match(err.code)
+            .with(errorCodes.unauthorizedError, () => 401)
+            .with(errorCodes.operationForbidden, () => 403)
+            .with(errorCodes.missingHeader, () => 400)
+            .otherwise(() => 500)
+        );
+        return res.status(problem.status).json(problem).end();
       }
     };
 

--- a/packages/commons/src/auth/authorizationMiddleware.ts
+++ b/packages/commons/src/auth/authorizationMiddleware.ts
@@ -10,6 +10,7 @@ import {
   genericError,
   ApiError,
   unauthorizedError,
+  errorCodes,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { z } from "zod";
@@ -95,14 +96,16 @@ export const authorizationMiddleware =
             new ApiError({
               ...error,
               correlationId: headers?.correlationId,
-            })
+            }),
+            (error) => (error.code === errorCodes.unauthorizedError ? 401 : 500)
           )
         )
         .otherwise(() =>
           makeApiProblem(
             genericError(
               "An unexpected error occurred during authorization checks"
-            )
+            ),
+            () => 500
           )
         );
 

--- a/packages/commons/src/auth/authorizationMiddleware.ts
+++ b/packages/commons/src/auth/authorizationMiddleware.ts
@@ -6,11 +6,11 @@ import {
 import { Request } from "express";
 import {
   Problem,
-  makeApiProblem,
+  makeApiProblemBuilder,
   genericError,
   ApiError,
   unauthorizedError,
-  errorCodes,
+  CommonErrorCodes,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { z } from "zod";
@@ -22,9 +22,11 @@ import { readAuthDataFromJwtToken } from "./jwt.js";
 type RoleValidation =
   | {
       isValid: false;
-      error: ApiError;
+      error: ApiError<CommonErrorCodes>;
     }
   | { isValid: true };
+
+const makeApiProblem = makeApiProblemBuilder({});
 
 const hasValidRoles = (
   req: Request,
@@ -97,7 +99,7 @@ export const authorizationMiddleware =
               ...error,
               correlationId: headers?.correlationId,
             }),
-            (error) => (error.code === errorCodes.unauthorizedError ? 401 : 500)
+            (error) => (error.code === "unauthorizedError" ? 401 : 500)
           )
         )
         .otherwise(() =>

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-classes-per-file */
 import { P, match } from "ts-pattern";
 
-export class ApiError extends Error {
-  public code: string;
+export class ApiError<T> extends Error {
+  public code: T;
   public title: string;
   public detail: string;
   public correlationId?: string;
@@ -13,7 +13,7 @@ export class ApiError extends Error {
     detail,
     correlationId,
   }: {
-    code: string;
+    code: T;
     title: string;
     detail: string;
     correlationId?: string;
@@ -40,94 +40,103 @@ export type Problem = {
   errors: ProblemError[];
 };
 
-export function makeApiProblem(
+export function makeApiProblemBuilder<T extends string>(errors: {
+  [K in T]: string;
+}): (
   error: unknown,
-  httpMapper: (apiError: ApiError) => number
-): Problem {
-  const makeProblem = (
-    httpStatus: number,
-    { code, title, detail, correlationId }: ApiError
-  ): Problem => ({
-    type: "about:blank",
-    title,
-    status: httpStatus,
-    detail,
-    correlationId,
-    errors: [
-      {
-        code,
-        detail,
-      },
-    ],
-  });
+  httpMapper: (apiError: ApiError<T | CommonErrorCodes>) => number
+) => Problem {
+  const allErrors = { ...errorCodes, ...errors };
+  return (error, httpMapper) => {
+    const makeProblem = (
+      httpStatus: number,
+      { code, title, detail, correlationId }: ApiError<T | CommonErrorCodes>
+    ): Problem => ({
+      type: "about:blank",
+      title,
+      status: httpStatus,
+      detail,
+      correlationId,
+      errors: [
+        {
+          code: allErrors[code],
+          detail,
+        },
+      ],
+    });
 
-  return match<unknown, Problem>(error)
-    .with(P.instanceOf(ApiError), (error) =>
-      makeProblem(httpMapper(error), error)
-    )
-    .otherwise(() => makeProblem(500, genericError("Unexpected error")));
+    return match<unknown, Problem>(error)
+      .with(P.instanceOf(ApiError<T | CommonErrorCodes>), (error) =>
+        makeProblem(httpMapper(error), error)
+      )
+      .otherwise(() => makeProblem(500, genericError("Unexpected error")));
+  };
 }
 
-export const errorCodes = {
+const errorCodes = {
   authenticationSaslFailed: "9000",
   operationForbidden: "9989",
   missingClaim: "9990",
   genericError: "9991",
   unauthorizedError: "9991",
   missingHeader: "9994",
-};
+} as const;
 
-export function authenticationSaslFailed(message: string): ApiError {
+export type CommonErrorCodes = keyof typeof errorCodes;
+
+export function authenticationSaslFailed(
+  message: string
+): ApiError<CommonErrorCodes> {
   return new ApiError({
-    code: errorCodes.authenticationSaslFailed,
+    code: "authenticationSaslFailed",
     title: "SASL authentication fails",
     detail: `SALS Authentication fails with this error : ${message}`,
   });
 }
 
-export function genericError(details: string): ApiError {
+export function genericError(details: string): ApiError<CommonErrorCodes> {
   return new ApiError({
     detail: details,
-    code: errorCodes.genericError,
+    code: "genericError",
     title: "Unexpected error",
   });
 }
 
-export function unauthorizedError(details: string): ApiError {
+export function unauthorizedError(details: string): ApiError<CommonErrorCodes> {
   return new ApiError({
     detail: details,
-    code: errorCodes.unauthorizedError,
+    code: "unauthorizedError",
     title: "Unauthorized",
   });
 }
 
-export function missingClaim(claimName: string): ApiError {
+export function missingClaim(claimName: string): ApiError<CommonErrorCodes> {
   return new ApiError({
     detail: `Claim ${claimName} has not been passed`,
-    code: errorCodes.missingClaim,
+    code: "missingClaim",
     title: "Claim has not been passed",
   });
 }
 
-export function missingHeader(headerName?: string): ApiError {
+export function missingHeader(headerName?: string): ApiError<CommonErrorCodes> {
   const title = "Header has not been passed";
   return new ApiError({
     detail: headerName
       ? `Header ${headerName} not existing in this request`
       : title,
-    code: errorCodes.missingHeader,
+    code: "missingHeader",
     title,
   });
 }
 
-export const missingBearer: ApiError = new ApiError({
+export const missingBearer: ApiError<CommonErrorCodes> = new ApiError({
   detail: `Authorization Illegal header key.`,
-  code: errorCodes.missingHeader,
+  code: "missingHeader",
   title: "Bearer token has not been passed",
 });
 
-export const operationForbidden = new ApiError({
+export const operationForbidden: ApiError<CommonErrorCodes> = new ApiError({
   detail: `Insufficient privileges`,
-  code: errorCodes.operationForbidden,
+  code: "operationForbidden",
   title: "Insufficient privileges",
 });

--- a/packages/tenant-process/src/model/domain/errors.ts
+++ b/packages/tenant-process/src/model/domain/errors.ts
@@ -1,24 +1,28 @@
-import { ApiError } from "pagopa-interop-models";
+import { ApiError, makeApiProblemBuilder } from "pagopa-interop-models";
 
 const errorCodes = {
   tenantNotFound: "0001",
   tenantBySelfcateIdNotFound: "0002",
 };
 
-export function tenantNotFound(tenantId: string): ApiError {
+export type ErrorCodes = keyof typeof errorCodes;
+
+export const makeApiProblem = makeApiProblemBuilder(errorCodes);
+
+export function tenantNotFound(tenantId: string): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Tenant ${tenantId} not found`,
-    code: errorCodes.tenantNotFound,
-    httpStatus: 404,
+    code: "tenantNotFound",
     title: "Tenant not found",
   });
 }
 
-export function tenantBySelfcateIdNotFound(selfcareId: string): ApiError {
+export function tenantBySelfcateIdNotFound(
+  selfcareId: string
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Tenant with selfcareId ${selfcareId} not found in the catalog`,
-    code: errorCodes.tenantBySelfcateIdNotFound,
-    httpStatus: 404,
+    code: "tenantBySelfcateIdNotFound",
     title: "Tenant with selfcareId not found",
   });
 }

--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -6,14 +6,19 @@ import {
   ZodiosContext,
   authorizationMiddleware,
 } from "pagopa-interop-commons";
-import { makeApiProblem } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import { toApiTenant } from "../model/domain/apiConverter.js";
 import { readModelService } from "../services/readModelService.js";
 import {
+  makeApiProblem,
   tenantBySelfcateIdNotFound,
   tenantNotFound,
 } from "../model/domain/errors.js";
+import {
+  getTenantByExternalIdErrorMapper,
+  getTenantByIdErrorMapper,
+  getTenantBySelfcareIdErrorMapper,
+} from "../utilities/errorMappers.js";
 
 const tenantsRouter = (
   ctx: ZodiosContext
@@ -76,11 +81,16 @@ const tenantsRouter = (
           } else {
             return res
               .status(404)
-              .json(makeApiProblem(tenantNotFound(req.params.id)))
+              .json(
+                makeApiProblem(
+                  tenantNotFound(req.params.id),
+                  getTenantByIdErrorMapper
+                )
+              )
               .end();
           }
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(error, getTenantByIdErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -107,7 +117,12 @@ const tenantsRouter = (
           } else {
             return res
               .status(404)
-              .json(makeApiProblem(tenantNotFound(`${origin}/${code}`)))
+              .json(
+                makeApiProblem(
+                  tenantNotFound(`${origin}/${code}`),
+                  getTenantByExternalIdErrorMapper
+                )
+              )
               .end();
           }
         } catch (error) {
@@ -139,13 +154,17 @@ const tenantsRouter = (
               .status(404)
               .json(
                 makeApiProblem(
-                  tenantBySelfcateIdNotFound(req.params.selfcareId)
+                  tenantBySelfcateIdNotFound(req.params.selfcareId),
+                  getTenantBySelfcareIdErrorMapper
                 )
               )
               .end();
           }
         } catch (error) {
-          const errorRes = makeApiProblem(error);
+          const errorRes = makeApiProblem(
+            error,
+            getTenantBySelfcareIdErrorMapper
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }

--- a/packages/tenant-process/src/utilities/errorMappers.ts
+++ b/packages/tenant-process/src/utilities/errorMappers.ts
@@ -1,0 +1,25 @@
+/* eslint-disable sonarjs/no-identical-functions */
+import { ApiError, CommonErrorCodes } from "pagopa-interop-models";
+import { match } from "ts-pattern";
+import { ErrorCodes as LocalErrorCodes } from "../model/domain/errors.js";
+
+type ErrorCodes = LocalErrorCodes | CommonErrorCodes;
+
+export const getTenantByIdErrorMapper = (error: ApiError<ErrorCodes>): number =>
+  match(error.code)
+    .with("tenantNotFound", () => 404)
+    .otherwise(() => 500);
+
+export const getTenantByExternalIdErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("tenantNotFound", () => 404)
+    .otherwise(() => 500);
+
+export const getTenantBySelfcareIdErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("tenantBySelfcateIdNotFound", () => 404)
+    .otherwise(() => 500);


### PR DESCRIPTION
## Description
This PR removes the `httpCode` from `ApiError`. The `makeApiProblem` function that every router (and middleware) should use to create a `Problem`  now requires a function to map every `ApiError` with an `httpCode`.

Every process service should declare an `errorMappers.ts` file that contains the required functions (one for each route) that map the `ApiError` with the corresponding `httpCode`.

The `makeApiProblem` function is changed into a `makeApiProblemBuilder`. Each service that would use this function should create an instance `const makeApiProblem = makeApiProblemBuilder({ ... })` using as argument an object with the desired custom error code.

example:
```typescript
export const errorCodes = {
  eServiceDescriptorNotFound: "0002",
  eServiceDescriptorWithoutInterface: "0003",
  notValidDescriptor: "0004",
  eServiceDocumentNotFound: "0006",
  eServiceNotFound: "0007",
  draftDescriptorAlreadyExists: "0008",
  eserviceCannotBeUpdatedOrDeleted: "0009",
  eServiceDuplicate: "0010",
};

export type ErrorCodes = keyof typeof errorCodes;

export const makeApiProblem = makeApiProblemBuilder(errorCodes);
```

The reason behind this change is to make the `errorCode` unique. The error code value could still have some overlapping but when we map from an `ApiError` to an `httpStatusCode` we can use something that is unique for each type of error.