### PR TITLE
IMN-33 post agreement consumer document

### DIFF
--- a/packages/agreement-process/open-api/agreement-service-spec.yml
+++ b/packages/agreement-process/open-api/agreement-service-spec.yml
@@ -164,7 +164,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Document"
+                $ref: "#/components/schemas/ResourceId"
         "400":
           description: Bad Request
           content:

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -2,6 +2,7 @@ import {
   ApiError,
   DescriptorState,
   makeApiProblemBuilder,
+  AgreementState,
 } from "pagopa-interop-models";
 
 const errorCodes = {
@@ -12,7 +13,7 @@ const errorCodes = {
   eServiceNotFound: "0005",
   contractAlreadyExists: "0006",
   operationNotAllowed: "0007",
-  agreementActtivationFailed: "0008",
+  agreementActivationFailed: "0008",
   agreementNotFound: "0009",
   agreementAlreadyExists: "0010",
   noNewerDescriptor: "0011",
@@ -22,13 +23,14 @@ const errorCodes = {
   stampNotFound: "0015",
   missingUserInfo: "0016",
   documentNotFound: "0017",
-  documentChangeNotAllowed: "0018",
+  documentsChangeNotAllowed: "0018",
   selfcareIdNotFound: "0019",
   tenantIdNotFound: "0020",
   notLatestEServiceDescriptor: "0021",
   attributeNotFound: "0022",
   invalidAttributeStructure: "0023",
   consumerWithNotValidEmail: "0024",
+  agreementDocumentAlreadyExists: "0025",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -113,6 +115,26 @@ export function operationNotAllowed(requesterId: string): ApiError<ErrorCodes> {
     detail: `Operation not allowed by ${requesterId}`,
     code: "operationNotAllowed",
     title: "Operation not allowed",
+  });
+}
+
+export function documentsChangeNotAllowed(
+  state: AgreementState
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `The requested operation on consumer documents is not allowed on agreement with state ${state}`,
+    code: "documentsChangeNotAllowed",
+    title: "Operation not allowed on consumer documents",
+  });
+}
+
+export function agreementDocumentAlreadyExists(
+  agreementId: string
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Agreement document for ${agreementId} already exists`,
+    code: "agreementDocumentAlreadyExists",
+    title: "Agreement document already exists",
   });
 }
 

--- a/packages/agreement-process/src/model/domain/toEvent.ts
+++ b/packages/agreement-process/src/model/domain/toEvent.ts
@@ -1,19 +1,19 @@
-import { match } from "ts-pattern";
 import { CreateEvent } from "pagopa-interop-commons";
 import {
   Agreement,
   AgreementDocument,
   AgreementDocumentV1,
   AgreementEvent,
+  AgreementStamp,
+  AgreementStamps,
   AgreementState,
   AgreementStateV1,
   AgreementV1,
-  AgreementStamp,
   StampV1,
-  AgreementStamps,
   StampsV1,
   AgreementUpdateEvent,
 } from "pagopa-interop-models";
+import { match } from "ts-pattern";
 
 export const toAgreementStateV1 = (state: AgreementState): AgreementStateV1 =>
   match(state)

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -29,6 +29,7 @@ import {
   agreementSubmissionFailed,
   descriptorNotInExpectedState,
   eServiceNotFound,
+  documentsChangeNotAllowed,
   missingCertifiedAttributesError,
   notLatestEServiceDescriptor,
   operationNotAllowed,
@@ -96,6 +97,13 @@ export function assertTenantExist(
     throw tenantIdNotFound(tenantId);
   }
 }
+export const assertCanWorkOnConsumerDocuments = (
+  state: AgreementState
+): void => {
+  if (state !== agreementState.draft && state !== agreementState.pending) {
+    throw documentsChangeNotAllowed(state);
+  }
+};
 
 /* =========  VALIDATIONS ========= */
 

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -94,8 +94,19 @@ const agreementRouter = (
 
   agreementRouter.post(
     "/agreements/:agreementId/consumer-documents",
-    async (_req, res) => {
-      res.status(501).send();
+    authorizationMiddleware([ADMIN_ROLE]),
+    async (req, res) => {
+      try {
+        const id = await agreementService.addConsumerDocument(
+          req.params.agreementId,
+          req.body
+        );
+
+        return res.status(200).json({ id }).send();
+      } catch (error) {
+        const errorRes = makeApiProblem(error, createAgreementErrorMapper);
+        return res.status(errorRes.status).json(errorRes).end();
+      }
     }
   );
 

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -100,7 +100,8 @@ const agreementRouter = (
       try {
         const id = await agreementService.addConsumerDocument(
           req.params.agreementId,
-          req.body
+          req.body,
+          req.ctx.authData
         );
 
         return res.status(200).json({ id }).send();

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -23,6 +23,7 @@ import { readModelServiceBuilder } from "../services/readmodel/readModelService.
 import { agreementNotFound, makeApiProblem } from "../model/domain/errors.js";
 import {
   cloneAgreementErrorMapper,
+  addConsumerDocumentErrorMapper,
   createAgreementErrorMapper,
   deleteAgreementErrorMapper,
   submitAgreementErrorMapper,
@@ -104,7 +105,7 @@ const agreementRouter = (
 
         return res.status(200).json({ id }).send();
       } catch (error) {
-        const errorRes = makeApiProblem(error, createAgreementErrorMapper);
+        const errorRes = makeApiProblem(error, addConsumerDocumentErrorMapper);
         return res.status(errorRes.status).json(errorRes).end();
       }
     }

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -31,7 +31,6 @@ import {
   unexpectedVersionFormat,
   publishedDescriptorNotFound,
   agreementDocumentAlreadyExists,
-  agreementNotFound,
 } from "../model/domain/errors.js";
 
 import {
@@ -661,10 +660,8 @@ export async function addConsumerDocumentLogic(
 ): Promise<CreateEvent<AgreementEvent>> {
   const authData = getContext().authData;
   const agreement = await agreementQuery.getAgreementById(agreementId);
-  if (!agreement) {
-    throw agreementNotFound(agreementId);
-  }
 
+  assertAgreementExist(agreementId, agreement);
   assertRequesterIsConsumer(agreement.data, authData);
   assertCanWorkOnConsumerDocuments(agreement.data.state);
 

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -4,7 +4,6 @@ import {
   CreateEvent,
   DB,
   eventRepository,
-  getContext,
   initFileManager,
   logger,
 } from "pagopa-interop-commons";
@@ -226,14 +225,16 @@ export function agreementServiceBuilder(
     },
     async addConsumerDocument(
       agreementId: string,
-      documentSeed: ApiAgreementDocumentSeed
+      documentSeed: ApiAgreementDocumentSeed,
+      authData: AuthData
     ): Promise<string> {
       logger.info(`Adding a consumer document to agreement ${agreementId}`);
 
       const addDocumentEvent = await addConsumerDocumentLogic(
         agreementId,
         documentSeed,
-        agreementQuery
+        agreementQuery,
+        authData
       );
       return await repository.createEvent(addDocumentEvent);
     },
@@ -656,9 +657,9 @@ export async function cloneAgreementLogic({
 export async function addConsumerDocumentLogic(
   agreementId: string,
   payload: ApiAgreementDocumentSeed,
-  agreementQuery: AgreementQuery
+  agreementQuery: AgreementQuery,
+  authData: AuthData
 ): Promise<CreateEvent<AgreementEvent>> {
-  const authData = getContext().authData;
   const agreement = await agreementQuery.getAgreementById(agreementId);
 
   assertAgreementExist(agreementId, agreement);

--- a/packages/agreement-process/src/utilities/errorMappers.ts
+++ b/packages/agreement-process/src/utilities/errorMappers.ts
@@ -61,7 +61,7 @@ export const addConsumerDocumentErrorMapper = (
   match(error.code)
     .with("agreementNotFound", () => 404)
     .with("operationNotAllowed", "documentsChangeNotAllowed", () => 403)
-    .with("agreementDocumentAlreadyExists", () => 500)
+    .with("agreementDocumentAlreadyExists", () => 409)
     .otherwise(() => 500);
 
 export const upgradeAgreementErrorMapper = (

--- a/packages/agreement-process/src/utilities/errorMappers.ts
+++ b/packages/agreement-process/src/utilities/errorMappers.ts
@@ -55,6 +55,15 @@ export const submitAgreementErrorMapper = (
     .with("agreementAlreadyExists", "contractAlreadyExists", () => 409)
     .otherwise(() => 500);
 
+export const addConsumerDocumentErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("agreementNotFound", () => 404)
+    .with("operationNotAllowed", "documentsChangeNotAllowed", () => 403)
+    .with("agreementDocumentAlreadyExists", () => 500)
+    .otherwise(() => 500);
+
 export const upgradeAgreementErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>

--- a/packages/agreement-readmodel-writer/src/model/models.ts
+++ b/packages/agreement-readmodel-writer/src/model/models.ts
@@ -34,10 +34,6 @@ const Event = z.discriminatedUnion("type", [
     data: protobufDecoder(AgreementConsumerDocumentAddedV1),
   }),
   z.object({
-    type: z.literal("AgreementConsumerDocumentAdded"),
-    data: protobufDecoder(AgreementConsumerDocumentAddedV1),
-  }),
-  z.object({
     type: z.literal("AgreementContractAdded"),
     data: protobufDecoder(AgreementContractAddedV1),
   }),

--- a/packages/agreement-readmodel-writer/src/model/models.ts
+++ b/packages/agreement-readmodel-writer/src/model/models.ts
@@ -6,6 +6,7 @@ import {
   AgreementConsumerDocumentAddedV1,
   AgreementContractAddedV1,
   AgreementDeletedV1,
+  AgreementUpdatedV1,
 } from "pagopa-interop-models";
 import { KafkaMessage } from "kafkajs";
 
@@ -26,7 +27,11 @@ const Event = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("AgreementUpdated"),
-    data: protobufDecoder(AgreementAddedV1),
+    data: protobufDecoder(AgreementUpdatedV1),
+  }),
+  z.object({
+    type: z.literal("AgreementConsumerDocumentAdded"),
+    data: protobufDecoder(AgreementConsumerDocumentAddedV1),
   }),
   z.object({
     type: z.literal("AgreementConsumerDocumentAdded"),

--- a/packages/models/src/agreement/agreementEvents.ts
+++ b/packages/models/src/agreement/agreementEvents.ts
@@ -48,4 +48,7 @@ export type AgreementEvent =
       type: "AgreementContractAdded";
       data: AgreementContractAddedV1;
     }
-  | AgreementConsumerDocumentAdded;
+  | {
+      type: "AgreementConsumerDocumentAdded";
+      data: AgreementConsumerDocumentAddedV1;
+    };

--- a/packages/models/src/agreement/agreementEvents.ts
+++ b/packages/models/src/agreement/agreementEvents.ts
@@ -40,6 +40,7 @@ export type AgreementConsumerDocumentAdded = {
 export type AgreementEvent =
   | { type: "AgreementAdded"; data: AgreementAddedV1 }
   | AgreementUpdateEvent
+  | AgreementConsumerDocumentAdded
   | {
       type: "AgreementDeleted";
       data: AgreementDeletedV1;
@@ -47,8 +48,4 @@ export type AgreementEvent =
   | {
       type: "AgreementContractAdded";
       data: AgreementContractAddedV1;
-    }
-  | {
-      type: "AgreementConsumerDocumentAdded";
-      data: AgreementConsumerDocumentAddedV1;
     };


### PR DESCRIPTION
Close [IMN-33](https://pagopa.atlassian.net/browse/IMN-33)

This PR add API `/agreements/:agreementId/consumer-documents/:documentId` also add the message handler method in consumer service to update readmodel entity.

[IMN-33]: https://pagopa.atlassian.net/browse/IMN-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ