### PR TITLE
Fixing GET /agreements query

### DIFF
--- a/packages/agreement-process/src/services/readmodel/readModelService.ts
+++ b/packages/agreement-process/src/services/readmodel/readModelService.ts
@@ -47,7 +47,9 @@ const makeFilter = (
     .with(P.string, () => ({
       [`data.${fieldName}`]: value,
     }))
-    .with(P.array(P.string), () => ({ [`data.${fieldName}`]: { $in: value } }))
+    .with(P.array(P.string), (a) =>
+      a.length === 0 ? undefined : { [`data.${fieldName}`]: { $in: value } }
+    )
     .otherwise(() => {
       logger.error(
         `Unable to build filter for field ${fieldName} and value ${value}`
@@ -323,7 +325,7 @@ export function readModelServiceBuilder(
       return {
         results: result.data,
         totalCount: await ReadModelRepository.getTotalCount(
-          eservices,
+          agreements,
           aggregationPipeline
         ),
       };


### PR DESCRIPTION
# Bug description

GET `/agreements` was not returning any agreement, even though I have two agreements in the mongo collection.

<img width="1522" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/79629139-87fe-4c82-a8be-0c75d6a96c97">

The only way to get some agreements is to specify ALL the following optional filters: eservicesIds, descriptorsIds, producersIds, consumersIds. In that case, you also see another bug: the totalCount is wrong, always `0`.

<img width="1530" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/d5d3ce6a-46df-46b4-98d0-68b197e8bfc4">


# After this PR

The total count now is correct:

<img width="1536" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/880c9d65-ae94-4aae-8981-9a8212ec1635">

And also, if I don't specify the filters above, it returns all agreements (paginated):

<img width="1527" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/5b1c051b-16cb-4536-8769-286ca315c713">
