### PR TITLE
IMN 36 - POST Agreement suspend

### DIFF
--- a/packages/agreement-process/open-api/agreement-service-spec.yml
+++ b/packages/agreement-process/open-api/agreement-service-spec.yml
@@ -263,7 +263,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Agreement"
+                $ref: "#/components/schemas/ResourceId"
         "400":
           description: Bad Request
           content:

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -29,6 +29,7 @@ import {
   deleteAgreementErrorMapper,
   getConsumerDocumentErrorMapper,
   submitAgreementErrorMapper,
+  suspendAgreementErrorMapper,
   updateAgreementErrorMapper,
   upgradeAgreementErrorMapper,
 } from "../utilities/errorMappers.js";
@@ -144,8 +145,18 @@ const agreementRouter = (
 
   agreementRouter.post(
     "/agreements/:agreementId/suspend",
-    async (_req, res) => {
-      res.status(501).send();
+    authorizationMiddleware([ADMIN_ROLE]),
+    async (req, res) => {
+      try {
+        const id = await agreementService.suspendAgreement(
+          req.params.agreementId,
+          req.ctx.authData
+        );
+        return res.status(200).json({ id }).send();
+      } catch (error) {
+        const errorRes = makeApiProblem(error, suspendAgreementErrorMapper);
+        return res.status(errorRes.status).json(errorRes).end();
+      }
     }
   );
 

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -170,7 +170,7 @@ export function agreementServiceBuilder(
       agreementId: string,
       payload: ApiAgreementSubmissionPayload
     ): Promise<string> {
-      logger.info("Submitting agreement");
+      logger.info(`Submitting agreement ${agreementId}`);
       const updatesEvents = await submitAgreementLogic(
         agreementId,
         payload,

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -16,7 +16,6 @@ import {
   agreementEventToBinaryData,
   agreementState,
   descriptorState,
-  AgreementStamp,
   agreementUpgradableStates,
   agreementDeletableStates,
   agreementUpdatableStates,
@@ -71,6 +70,7 @@ import { EserviceQuery } from "./readmodel/eserviceQuery.js";
 import { AgreementQueryFilters } from "./readmodel/readModelService.js";
 import { TenantQuery } from "./readmodel/tenantQuery.js";
 import { suspendAgreementLogic } from "./agreementSuspensionProcessor.js";
+import { createStamp } from "./agreementStampUtils.js";
 
 const fileManager = initFileManager(config);
 
@@ -539,10 +539,7 @@ export async function upgradeAgreementLogic({
 
   if (verifiedValid && declaredValid) {
     // upgradeAgreement
-    const stamp: AgreementStamp = {
-      who: authData.organizationId,
-      when: new Date(),
-    };
+    const stamp = createStamp(authData);
     const archived: Agreement = {
       ...agreementToBeUpgraded.data,
       state: agreementState.archived,

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -70,6 +70,7 @@ import { AttributeQuery } from "./readmodel/attributeQuery.js";
 import { EserviceQuery } from "./readmodel/eserviceQuery.js";
 import { AgreementQueryFilters } from "./readmodel/readModelService.js";
 import { TenantQuery } from "./readmodel/tenantQuery.js";
+import { suspendAgreementLogic } from "./agreementSuspensionProcessor.js";
 
 const fileManager = initFileManager(config);
 
@@ -261,6 +262,23 @@ export function agreementServiceBuilder(
       }
 
       return document;
+    },
+    async suspendAgreement(
+      agreementId: Agreement["id"],
+      authData: AuthData
+    ): Promise<Agreement["id"]> {
+      logger.info(`Suspending agreement ${agreementId}`);
+      await repository.createEvent(
+        await suspendAgreementLogic({
+          agreementId,
+          authData,
+          agreementQuery,
+          tenantQuery,
+          eserviceQuery,
+        })
+      );
+
+      return agreementId;
     },
   };
 }

--- a/packages/agreement-process/src/services/agreementStampUtils.ts
+++ b/packages/agreement-process/src/services/agreementStampUtils.ts
@@ -1,4 +1,3 @@
-import { utcToZonedTime } from "date-fns-tz";
 import { AuthData } from "pagopa-interop-commons";
 import {
   Agreement,
@@ -11,7 +10,7 @@ import { P, match } from "ts-pattern";
 
 export const createStamp = (authData: AuthData): AgreementStamp => ({
   who: authData.userId,
-  when: utcToZonedTime(new Date(), "Etc/UTC"),
+  when: new Date(),
 });
 
 export const suspendedByConsumerStamp = (

--- a/packages/agreement-process/src/services/agreementStampUtils.ts
+++ b/packages/agreement-process/src/services/agreementStampUtils.ts
@@ -1,8 +1,37 @@
 import { utcToZonedTime } from "date-fns-tz";
 import { AuthData } from "pagopa-interop-commons";
-import { AgreementStamp } from "pagopa-interop-models";
+import {
+  Agreement,
+  AgreementStamp,
+  AgreementState,
+  Tenant,
+  agreementState,
+} from "pagopa-interop-models";
+import { P, match } from "ts-pattern";
 
 export const createStamp = (authData: AuthData): AgreementStamp => ({
   who: authData.userId,
   when: utcToZonedTime(new Date(), "Etc/UTC"),
 });
+
+export const suspendedByConsumerStamp = (
+  agreement: Agreement,
+  requesterOrgId: Tenant["id"],
+  destinationState: AgreementState,
+  stamp: AgreementStamp
+): AgreementStamp | undefined =>
+  match([requesterOrgId, destinationState])
+    .with([agreement.consumerId, agreementState.suspended], () => stamp)
+    .with([agreement.consumerId, P.any], () => undefined)
+    .otherwise(() => agreement.stamps.suspensionByConsumer);
+
+export const suspendedByProducerStamp = (
+  agreement: Agreement,
+  requesterOrgId: Tenant["id"],
+  destinationState: AgreementState,
+  stamp: AgreementStamp
+): AgreementStamp | undefined =>
+  match([requesterOrgId, destinationState])
+    .with([agreement.producerId, agreementState.suspended], () => stamp)
+    .with([agreement.producerId, P.any], () => undefined)
+    .otherwise(() => agreement.stamps.suspensionByProducer);

--- a/packages/agreement-process/src/services/agreementStampUtils.ts
+++ b/packages/agreement-process/src/services/agreementStampUtils.ts
@@ -1,0 +1,8 @@
+import { utcToZonedTime } from "date-fns-tz";
+import { AuthData } from "pagopa-interop-commons";
+import { AgreementStamp } from "pagopa-interop-models";
+
+export const createStamp = (authData: AuthData): AgreementStamp => ({
+  who: authData.userId,
+  when: utcToZonedTime(new Date(), "Etc/UTC"),
+});

--- a/packages/agreement-process/src/services/agreementStateProcessor.ts
+++ b/packages/agreement-process/src/services/agreementStateProcessor.ts
@@ -139,3 +139,25 @@ export const agreementStateByFlags = (
       () => agreementState.suspended
     )
     .otherwise(() => stateByAttribute);
+
+export const suspendedByPlatformFlag = (fsmState: AgreementState): boolean =>
+  fsmState === agreementState.suspended ||
+  fsmState === agreementState.missingCertifiedAttributes;
+
+export const suspendedByConsumerFlag = (
+  agreement: Agreement,
+  requesterOrgId: Tenant["id"],
+  destinationState: AgreementState
+): boolean | undefined =>
+  requesterOrgId === agreement.consumerId
+    ? destinationState === agreementState.suspended
+    : agreement.suspendedByConsumer;
+
+export const suspendedByProducerFlag = (
+  agreement: Agreement,
+  requesterOrgId: Tenant["id"],
+  destinationState: AgreementState
+): boolean | undefined =>
+  requesterOrgId === agreement.producerId
+    ? destinationState === agreementState.suspended
+    : agreement.suspendedByProducer;

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -36,7 +36,11 @@ import {
   verifySubmissionConflictingAgreements,
 } from "../model/domain/validators.js";
 import { ApiAgreementSubmissionPayload } from "../model/types.js";
-import { agreementStateByFlags, nextState } from "./agreementStateProcessor.js";
+import {
+  agreementStateByFlags,
+  nextState,
+  suspendedByPlatformFlag,
+} from "./agreementStateProcessor.js";
 import {
   ContractBuilder,
   addAgreementContractLogic,
@@ -331,10 +335,6 @@ const getUpdateSeed = (
         consumerNotes: payload.consumerNotes,
         stamps,
       };
-
-const suspendedByPlatformFlag = (fsmState: AgreementState): boolean =>
-  fsmState === agreementState.suspended ||
-  fsmState === agreementState.missingCertifiedAttributes;
 
 const isActiveOrSuspended = (state: AgreementState): boolean =>
   state === agreementState.active || state === agreementState.suspended;

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -48,6 +48,7 @@ import {
 import { AgreementQuery } from "./readmodel/agreementQuery.js";
 import { EserviceQuery } from "./readmodel/eserviceQuery.js";
 import { TenantQuery } from "./readmodel/tenantQuery.js";
+import { createStamp } from "./agreementStampUtils.js";
 
 export type AgremeentSubmissionResults = {
   events: Array<CreateEvent<AgreementEvent>>;
@@ -132,10 +133,7 @@ const submitAgreement = async (
   if (agreement.state === agreementState.draft) {
     await validateConsumerEmail(agreement, tenantQuery);
   }
-  const stamp: AgreementStamp = {
-    who: authData.userId,
-    when: new Date(),
-  };
+  const stamp = createStamp(authData);
   const stamps = calculateStamps(agreement, newState, stamp);
   const updateSeed = getUpdateSeed(
     descriptor,
@@ -196,10 +194,7 @@ const submitAgreement = async (
                 ),
                 stamps: {
                   ...agreement.data.stamps,
-                  archiving: {
-                    who: authData.userId,
-                    when: new Date(),
-                  },
+                  archiving: createStamp(authData),
                 },
               };
 

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -33,6 +33,7 @@ import {
   suspendedByPlatformFlag,
   suspendedByProducerFlag,
 } from "./agreementStateProcessor.js";
+import { createStamp } from "./agreementStampUtils.js";
 
 export async function suspendAgreementLogic({
   agreementId,
@@ -97,10 +98,7 @@ export async function suspendAgreementLogic({
     suspendedByPlatform
   );
 
-  const stamp: AgreementStamp = {
-    who: authData.userId,
-    when: utcToZonedTime(new Date(), "Etc/UTC"),
-  };
+  const stamp = createStamp(authData);
 
   const suspensionByProducerStamp = suspendedByProducerStamp(
     agreement.data,

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -1,0 +1,171 @@
+import { AuthData, CreateEvent } from "pagopa-interop-commons";
+import {
+  Agreement,
+  AgreementEvent,
+  AgreementStamp,
+  AgreementState,
+  Tenant,
+  UpdateAgreementSeed,
+  agreementState,
+  agreementSuspendableStates,
+} from "pagopa-interop-models";
+import { P, match } from "ts-pattern";
+import { utcToZonedTime } from "date-fns-tz";
+import {
+  assertAgreementExist,
+  assertEServiceExist,
+  assertExpectedState,
+  assertRequesterIsConsumerOrProducer,
+  assertTenantExist,
+  matchingCertifiedAttributes,
+  matchingDeclaredAttributes,
+  matchingVerifiedAttributes,
+} from "../model/domain/validators.js";
+import { descriptorNotFound } from "../model/domain/errors.js";
+import { toCreateEventAgreementUpdated } from "../model/domain/toEvent.js";
+import { AgreementQuery } from "./readmodel/agreementQuery.js";
+import { TenantQuery } from "./readmodel/tenantQuery.js";
+import { EserviceQuery } from "./readmodel/eserviceQuery.js";
+import {
+  agreementStateByFlags,
+  nextState,
+  suspendedByConsumerFlag,
+  suspendedByPlatformFlag,
+  suspendedByProducerFlag,
+} from "./agreementStateProcessor.js";
+
+export async function suspendAgreementLogic({
+  agreementId,
+  authData,
+  agreementQuery,
+  tenantQuery,
+  eserviceQuery,
+}: {
+  agreementId: Agreement["id"];
+  authData: AuthData;
+  agreementQuery: AgreementQuery;
+  tenantQuery: TenantQuery;
+  eserviceQuery: EserviceQuery;
+}): Promise<CreateEvent<AgreementEvent>> {
+  const agreement = await agreementQuery.getAgreementById(agreementId);
+  assertAgreementExist(agreementId, agreement);
+
+  assertRequesterIsConsumerOrProducer(agreement.data, authData);
+
+  assertExpectedState(
+    agreementId,
+    agreement.data.state,
+    agreementSuspendableStates
+  );
+
+  const eService = await eserviceQuery.getEServiceById(
+    agreement.data.eserviceId
+  );
+  assertEServiceExist(agreement.data.eserviceId, eService);
+
+  const consumer = await tenantQuery.getTenantById(agreement.data.consumerId);
+  assertTenantExist(agreement.data.consumerId, consumer);
+
+  const descriptor = eService.data.descriptors.find(
+    (d) => d.id === agreement.data.descriptorId
+  );
+  if (descriptor === undefined) {
+    throw descriptorNotFound(eService.data.id, agreement.data.descriptorId);
+  }
+
+  const nextStateByAttributes = nextState(
+    agreement.data,
+    descriptor,
+    consumer.data
+  );
+
+  const suspendedByConsumer = suspendedByConsumerFlag(
+    agreement.data,
+    authData.organizationId,
+    nextStateByAttributes
+  );
+  const suspendedByProducer = suspendedByProducerFlag(
+    agreement.data,
+    authData.organizationId,
+    nextStateByAttributes
+  );
+  const suspendedByPlatform = suspendedByPlatformFlag(nextStateByAttributes);
+  const newState = agreementStateByFlags(
+    nextStateByAttributes,
+    suspendedByProducer,
+    suspendedByConsumer,
+    suspendedByPlatform
+  );
+
+  const stamp: AgreementStamp = {
+    who: authData.userId,
+    when: utcToZonedTime(new Date(), "Etc/UTC"),
+  };
+
+  const suspensionByProducerStamp = suspendedByProducerStamp(
+    agreement.data,
+    authData.organizationId,
+    newState,
+    stamp
+  );
+
+  const suspensionByConsumerStamp = suspendedByConsumerStamp(
+    agreement.data,
+    authData.organizationId,
+    newState,
+    stamp
+  );
+
+  const updateSeed: UpdateAgreementSeed = {
+    state: newState,
+    certifiedAttributes: matchingCertifiedAttributes(descriptor, consumer.data),
+    declaredAttributes: matchingDeclaredAttributes(descriptor, consumer.data),
+    verifiedAttributes: matchingVerifiedAttributes(
+      eService.data,
+      descriptor,
+      consumer.data
+    ),
+    suspendedByConsumer,
+    suspendedByProducer,
+    suspendedByPlatform,
+    stamps: {
+      ...agreement.data.stamps,
+      suspensionByConsumer: suspensionByConsumerStamp,
+      suspensionByProducer: suspensionByProducerStamp,
+    },
+    suspendedAt:
+      agreement.data.suspendedAt ?? utcToZonedTime(new Date(), "Etc/UTC"),
+  };
+
+  const updatedAgreement: Agreement = {
+    ...agreement.data,
+    ...updateSeed,
+  };
+
+  return toCreateEventAgreementUpdated(
+    updatedAgreement,
+    agreement.metadata.version
+  );
+}
+
+const suspendedByConsumerStamp = (
+  agreement: Agreement,
+  requesterOrgId: Tenant["id"],
+  destinationState: AgreementState,
+  stamp: AgreementStamp
+): AgreementStamp | undefined =>
+  match([requesterOrgId, destinationState])
+    .with([agreement.consumerId, agreementState.suspended], () => stamp)
+    .with([agreement.consumerId, P.any], () => undefined)
+    .otherwise(() => agreement.stamps.suspensionByConsumer);
+
+const suspendedByProducerStamp = (
+  agreement: Agreement,
+  requesterOrgId: Tenant["id"],
+  destinationState: AgreementState,
+  stamp: AgreementStamp
+): AgreementStamp | undefined =>
+  match([requesterOrgId, destinationState])
+    .with([agreement.producerId, agreementState.suspended], () => stamp)
+    .with([agreement.producerId, P.any], () => undefined)
+    .otherwise(() => agreement.stamps.suspensionByProducer);

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -12,9 +12,6 @@ import {
   assertExpectedState,
   assertRequesterIsConsumerOrProducer,
   assertTenantExist,
-  matchingCertifiedAttributes,
-  matchingDeclaredAttributes,
-  matchingVerifiedAttributes,
 } from "../model/domain/validators.js";
 import { descriptorNotFound } from "../model/domain/errors.js";
 import { toCreateEventAgreementUpdated } from "../model/domain/toEvent.js";
@@ -115,13 +112,6 @@ export async function suspendAgreementLogic({
 
   const updateSeed: UpdateAgreementSeed = {
     state: newState,
-    certifiedAttributes: matchingCertifiedAttributes(descriptor, consumer.data),
-    declaredAttributes: matchingDeclaredAttributes(descriptor, consumer.data),
-    verifiedAttributes: matchingVerifiedAttributes(
-      eService.data,
-      descriptor,
-      consumer.data
-    ),
     suspendedByConsumer,
     suspendedByProducer,
     suspendedByPlatform,

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -6,7 +6,6 @@ import {
   agreementState,
   agreementSuspendableStates,
 } from "pagopa-interop-models";
-import { utcToZonedTime } from "date-fns-tz";
 import {
   assertAgreementExist,
   assertEServiceExist,
@@ -131,8 +130,7 @@ export async function suspendAgreementLogic({
       suspensionByConsumer: suspensionByConsumerStamp,
       suspensionByProducer: suspensionByProducerStamp,
     },
-    suspendedAt:
-      agreement.data.suspendedAt ?? utcToZonedTime(new Date(), "Etc/UTC"),
+    suspendedAt: agreement.data.suspendedAt ?? new Date(),
   };
 
   const updatedAgreement: Agreement = {

--- a/packages/agreement-process/src/services/pdfGenerator.ts
+++ b/packages/agreement-process/src/services/pdfGenerator.ts
@@ -48,7 +48,7 @@ const getAttributeInvolved = async (
   >(
     type: TenantAttributeType
   ): Promise<Array<[AgreementAttribute, T]>> => {
-    const seedAttributes = seed.certifiedAttributes.map((ca) => ca.id);
+    const seedAttributes = (seed.certifiedAttributes ?? []).map((ca) => ca.id);
     const attributes = consumer.attributes.filter(
       (a) => a.type === type && seedAttributes.includes(a.id)
     );

--- a/packages/agreement-process/src/utilities/errorMappers.ts
+++ b/packages/agreement-process/src/utilities/errorMappers.ts
@@ -115,3 +115,12 @@ export const getConsumerDocumentErrorMapper = (
   match(error.code)
     .with("documentNotFound", () => HTTP_STATUS_NOT_FOUND)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const suspendAgreementErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("agreementNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("operationNotAllowed", () => HTTP_STATUS_FORBIDDEN)
+    .with("agreementNotInExpectedState", () => HTTP_STATUS_BAD_REQUEST)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -173,6 +173,9 @@ export const agreementCloningConflictingStates: AgreementState[] = [
   agreementState.draft,
   agreementState.pending,
   agreementState.missingCertifiedAttributes,
+];
+
+export const agreementSuspendableStates: AgreementState[] = [
   agreementState.active,
   agreementState.suspended,
 ];

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -173,6 +173,8 @@ export const agreementCloningConflictingStates: AgreementState[] = [
   agreementState.draft,
   agreementState.pending,
   agreementState.missingCertifiedAttributes,
+  agreementState.active,
+  agreementState.suspended,
 ];
 
 export const agreementSuspendableStates: AgreementState[] = [

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -107,9 +107,9 @@ export type Agreement = z.infer<typeof Agreement>;
 
 export const UpdateAgreementSeed = z.object({
   state: AgreementState,
-  certifiedAttributes: z.array(CertifiedAgreementAttribute),
-  declaredAttributes: z.array(DeclaredAgreementAttribute),
-  verifiedAttributes: z.array(VerifiedAgreementAttribute),
+  certifiedAttributes: z.optional(z.array(CertifiedAgreementAttribute)),
+  declaredAttributes: z.optional(z.array(DeclaredAgreementAttribute)),
+  verifiedAttributes: z.optional(z.array(VerifiedAgreementAttribute)),
   suspendedByConsumer: z.boolean().optional(),
   suspendedByProducer: z.boolean().optional(),
   suspendedByPlatform: z.boolean().optional(),


### PR DESCRIPTION
Closes [IMN-36](https://pagopa.atlassian.net/browse/IMN-36)

[IMN-36]: https://pagopa.atlassian.net/browse/IMN-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This PR implements API POST `/agreements/:agreementId/suspend`
Here's the link to the [corresponding function in the Scala codebase](https://github.com/pagopa/interop-be-agreement-process/blob/ef2615d5eef833c35fd0ef07affc092625b874cc/src/main/scala/it/pagopa/interop/agreementprocess/api/impl/AgreementApiServiceImpl.scala#L171)

### Bonus
* It creates a utility to create stamps in the right way, avoiding more issues like the one discussed here: https://github.com/pagopa/interop-be-monorepo/pull/136#discussion_r1439575894
* It fixes some logs to make them consistent with what the Scala codebase did

# Tests

Tested locally as follows:

### 1 - Agreement before suspension

<img width="1153" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/14cbba27-a8b8-47d0-8211-909979fef9a9">


### 2 - Call to suspend
<img width="1475" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/d9114d0a-6d96-4979-9aea-f90297661d65">

### 3 - Agreement after suspension
<img width="908" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/1f600fdf-e061-4ddc-93c9-18796c47d861">

