### PR TITLE
Fix DEV CI add properly apiVersion value

### DIFF
--- a/packages/agreement-process/kubernetes/dev/deployment.yaml
+++ b/packages/agreement-process/kubernetes/dev/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: interop-be-agreement-process-refactor

--- a/packages/agreement-readmodel-writer/kubernetes/dev/deployment.yaml
+++ b/packages/agreement-readmodel-writer/kubernetes/dev/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: interop-be-agreement-readmodel-writer

--- a/packages/catalog-process/kubernetes/dev/deployment.yaml
+++ b/packages/catalog-process/kubernetes/dev/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: interop-be-catalog-process-refactor

--- a/packages/catalog-readmodel-writer/kubernetes/dev/deployment.yaml
+++ b/packages/catalog-readmodel-writer/kubernetes/dev/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: interop-be-catalog-readmodel-writer

--- a/packages/tenant-consumer/kubernetes/dev/deployment.yaml
+++ b/packages/tenant-consumer/kubernetes/dev/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: interop-be-tenant-consumer-refactor


### PR DESCRIPTION
## Problem
With last PR [IMN-155-agreement-services-CI ](https://github.com/pagopa/interop-be-monorepo/pull/133) **Build & Deploy** github action task throws the following error [detail here](https://github.com/pagopa/interop-be-monorepo/actions/runs/7407322434/job/20153308935).

```
error: error validating "deployment.yaml": error validating data: failed to check CRD: failed to list CRDs: customresourcedefinitions.apiextensions.k8s.io is forbidden: User "buildo-gh-actions-interop-be-monorepo-105" cannot list resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope; if you choose to ignore these errors, turn validation off with --validate=false
serviceaccount/interop-be-agreement-process-refactor created
```


## FIX 
The deployment.yaml files define fields `apiVersion` as `v1` instead of `apps/v1`, the fix has tested with command 

```
kubectl apply --dry-run=client -f .deployment.yaml 
```

successed oputput 
```
deployment.apps/interop-be-agreement-process-refactor created (dry run)
```
 
