### PR TITLE
Add missing env variables config in deployment.yaml

### DIFF
--- a/packages/agreement-process/kubernetes/dev/configmap.yaml
+++ b/packages/agreement-process/kubernetes/dev/configmap.yaml
@@ -7,3 +7,4 @@ data:
   MOCK_FILE_MANAGER: "true"
   EVENTSTORE_DB_USE_SSL: "true"
   EVENTSTORE_DB_SCHEMA: "agreement"
+  CONSUMER_DOCUMENTS_PATH: ""

--- a/packages/agreement-process/kubernetes/dev/deployment.yaml
+++ b/packages/agreement-process/kubernetes/dev/deployment.yaml
@@ -125,3 +125,8 @@ spec:
                 secretKeyRef:
                   name: read-model
                   key: REFACTOR_USER_PASSWORD
+            - name: CONSUMER_DOCUMENTS_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: interop-be-agreement-process-refactor
+                  key: CONSUMER_DOCUMENTS_PATH

--- a/packages/agreement-readmodel-writer/kubernetes/dev/deployment.yaml
+++ b/packages/agreement-readmodel-writer/kubernetes/dev/deployment.yaml
@@ -97,3 +97,8 @@ spec:
                 configMapKeyRef:
                   name: interop-be-agreement-readmodel-writer
                   key: KAFKA_BROKERS
+            - name: KAFKA_TOPICS
+              valueFrom:
+                configMapKeyRef:
+                  name: interop-be-agreement-readmodel-writer
+                  key: KAFKA_TOPICS

--- a/packages/catalog-readmodel-writer/kubernetes/dev/deployment.yaml
+++ b/packages/catalog-readmodel-writer/kubernetes/dev/deployment.yaml
@@ -101,7 +101,7 @@ spec:
                 configMapKeyRef:
                   name: interop-be-catalog-readmodel-writer
                   key: KAFKA_BROKERS
-            - name:
+            - name: KAFKA_TOPICS
               valueFrom:
                 configMapKeyRef:
                   name: interop-be-catalog-readmodel-writer


### PR DESCRIPTION
## Problem

With last PR [Fix DEV CI add properly apiVersion value ](https://github.com/pagopa/interop-be-monorepo/pull/143) **Build & Deploy** github action task throws the following error [detail here](https://github.com/pagopa/interop-be-monorepo/actions/runs/7409291657/job/20159259962).

```
error: The Deployment "interop-be-catalog-readmodel-writer" is invalid: spec.template.spec.containers[0].env[13].name: Required value
```


## FIX 
For the two services `catalog-readmode-writer` and `agreement-readmodel-writer` was added missed variables `KAFKA_TOPICS` into deployment.yaml files.
 
