### PR TITLE
Fix date deserialization

### DIFF
--- a/packages/agreement-readmodel-writer/src/model/converter.ts
+++ b/packages/agreement-readmodel-writer/src/model/converter.ts
@@ -70,7 +70,7 @@ export const fromAgreementV1 = (input: AgreementV1): Agreement => ({
   ...input,
   state: fromAgreementState(input.state),
   createdAt: new Date(Number(input.createdAt)),
-  updatedAt: new Date(Number(input.updatedAt)),
+  updatedAt: input.updatedAt ? new Date(Number(input.updatedAt)) : undefined,
   suspendedAt: input.suspendedAt
     ? new Date(Number(input.suspendedAt))
     : undefined,

--- a/packages/catalog-readmodel-writer/src/model/converter.ts
+++ b/packages/catalog-readmodel-writer/src/model/converter.ts
@@ -106,7 +106,9 @@ export const fromDescriptorV1 = (input: EServiceDescriptorV1): Descriptor => ({
   agreementApprovalPolicy: fromAgreementApprovalPolicyV1(
     input.agreementApprovalPolicy
   ),
-  createdAt: new Date(Number(input.createdAt)),
+  // createdAt is required in EService definition but not in protobuf,
+  // this bug is handled with ISSUE https://pagopa.atlassian.net/browse/IMN-171
+  createdAt: safeParserDate(input.createdAt),
   publishedAt: input.publishedAt
     ? new Date(Number(input.publishedAt))
     : undefined,
@@ -131,5 +133,17 @@ export const fromEServiceV1 = (input: EServiceV1): EService => ({
         }
       : undefined,
   descriptors: input.descriptors.map(fromDescriptorV1),
-  createdAt: new Date(Number(input.createdAt)),
+  // createdAt is required in EService definition but not in protobuf,
+  // this bug is handled with ISSUE https://pagopa.atlassian.net/browse/IMN-171
+  createdAt: safeParserDate(input.createdAt),
 });
+
+// Temporary workaround
+const safeParserDate = (date: bigint | undefined): Date => {
+  if (!date) {
+    throw new Error(
+      "createdAt field is required in EService definition but is not provided in serialized byte array events"
+    );
+  }
+  return new Date(Number(date));
+};


### PR DESCRIPTION
### BUG Description 

During events deserialization the Date field could be converted to start epoch date time `January 1st, 1970 at 00:00:00 UTC` if the input is a falsy value.
affected code
```
new Date(Number(input.createdAt))
```

this bug affects Agreement's event converter but also EService too, by the way Eservice protobuf definition contains some inconsistency with model definition, so temporary fix was applied and definitive fix should be solved with ISSUE [IMN-171](https://pagopa.atlassian.net/browse/IMN-171) that must be considerer as a breaking change.

### Fix
Evaluate input and return `undefined` if is a falsy value otherwise return parsed number.
For EService converter a safeParser funciton was created, if the date was `undefined` the error will throws.


[IMN-171]: https://pagopa.atlassian.net/browse/IMN-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ