### PR TITLE
Utc date creation remove

### DIFF
--- a/packages/agreement-process/package.json
+++ b/packages/agreement-process/package.json
@@ -37,8 +37,6 @@
   "dependencies": {
     "@zodios/core": "^10.9.2",
     "@zodios/express": "^10.6.1",
-    "date-fns": "^2.30.0",
-    "date-fns-tz": "^2.0.0",
     "dotenv-flow": "^3.2.0",
     "express": "^4.18.2",
     "mongodb": "5.6.0",

--- a/packages/agreement-process/src/model/domain/apiConverter.ts
+++ b/packages/agreement-process/src/model/domain/apiConverter.ts
@@ -5,7 +5,6 @@ import {
   agreementState,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
-import { utcToZonedTime } from "date-fns-tz";
 
 import {
   ApiAgreement,
@@ -95,5 +94,5 @@ export const apiAgreementDocumentToAgreementDocument = (
   prettyName: input.prettyName,
   contentType: input.contentType,
   path: input.path,
-  createdAt: utcToZonedTime(new Date(), "Etc/UTC"),
+  createdAt: new Date(),
 });

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -23,7 +23,6 @@ import {
   agreementCloningConflictingStates,
 } from "pagopa-interop-models";
 import { v4 as uuidv4 } from "uuid";
-import { utcToZonedTime } from "date-fns-tz";
 import {
   agreementAlreadyExists,
   descriptorNotFound,
@@ -304,7 +303,7 @@ async function createAndCopyDocumentsForClonedAgreement(
         prettyName: clonedAgreement.consumerDocuments[i].prettyName,
         contentType: clonedAgreement.consumerDocuments[i].contentType,
         path: d.newPath,
-        createdAt: utcToZonedTime(new Date(), "ETC/UTC"),
+        createdAt: new Date(),
       },
       startingVersion + i
     )

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-params */
-import { utcToZonedTime } from "date-fns-tz";
 import { CreateEvent, getContext, logger } from "pagopa-interop-commons";
 import {
   Agreement,
@@ -131,7 +130,7 @@ const submitAgreement = async (
   }
   const stamp: AgreementStamp = {
     who: authData.userId,
-    when: utcToZonedTime(new Date(), "Etc/UTC"),
+    when: new Date(),
   };
   const stamps = calculateStamps(agreement, newState, stamp);
   const updateSeed = getUpdateSeed(
@@ -195,7 +194,7 @@ const submitAgreement = async (
                   ...agreement.data.stamps,
                   archiving: {
                     who: authData.userId,
-                    when: utcToZonedTime(new Date(), "Etc/UTC"),
+                    when: new Date(),
                   },
                 },
               };
@@ -270,7 +269,7 @@ const createContract = async (
       producer.data,
       seed
     )),
-    createdAt: utcToZonedTime(new Date(), "Etc/UTC"),
+    createdAt: new Date(),
   };
 
   return addAgreementContractLogic(

--- a/packages/agreement-process/src/services/pdfGenerator.ts
+++ b/packages/agreement-process/src/services/pdfGenerator.ts
@@ -8,7 +8,6 @@
 import fs from "fs";
 import path from "path";
 
-import { utcToZonedTime } from "date-fns-tz";
 import { selfcareServiceMock, initFileManager } from "pagopa-interop-commons";
 import {
   Agreement,
@@ -175,11 +174,7 @@ const agreementTemplateMock = fs
 const createAgreementDocumentName = (
   consumerId: string,
   producerId: string
-): string =>
-  `${consumerId}_${producerId}_${utcToZonedTime(
-    new Date(),
-    "Etc/UTC"
-  )}_agreement_contract.pdf`;
+): string => `${consumerId}_${producerId}_${new Date()}_agreement_contract.pdf`;
 
 export const pdfGenerator = {
   createDocumentSeed: async (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,6 @@ importers:
       '@zodios/express':
         specifier: ^10.6.1
         version: 10.6.1(@zodios/core@10.9.2)(express@4.18.2)(zod@3.21.4)
-      date-fns:
-        specifier: ^2.30.0
-        version: 2.30.0
-      date-fns-tz:
-        specifier: ^2.0.0
-        version: 2.0.0(date-fns@2.30.0)
       dotenv-flow:
         specifier: ^3.2.0
         version: 3.2.0
@@ -2004,13 +1998,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.22.5
-    dev: false
-
-  /@babel/runtime@7.23.2:
-    resolution: {integrity: sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.14.0
     dev: false
 
   /@babel/template@7.22.5:
@@ -4441,21 +4428,6 @@ packages:
   /crypto@1.0.1:
     resolution: {integrity: sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==}
     deprecated: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
-    dev: false
-
-  /date-fns-tz@2.0.0(date-fns@2.30.0):
-    resolution: {integrity: sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==}
-    peerDependencies:
-      date-fns: '>=2.0.0'
-    dependencies:
-      date-fns: 2.30.0
-    dev: false
-
-  /date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
-    dependencies:
-      '@babel/runtime': 7.23.2
     dev: false
 
   /debug@2.6.9:
@@ -7174,10 +7146,6 @@ packages:
   /regenerator-runtime@0.11.1:
     resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
     dev: true
-
-  /regenerator-runtime@0.14.0:
-    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
-    dev: false
 
   /regex-cache@0.4.4:
     resolution: {integrity: sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==}


### PR DESCRIPTION
### Description

This PR removes the usage of the `utcToZonedTime` utility method in [date-fns-tz](https://github.com/marnusw/date-fns-tz) . Unlike what was explored previously, this method does not produce a correct UTC date 😅 , as creating new dates with the 'new Date()' command defaults to the UTC time zone. This means that only the stringified date value is affected by applying the local time zone of the machine from which it is executed.
Therefore, the value is simply replaced with the 'new Date()', which similarly generates a UTC date and don't needs manipulation.

----
However, there are two aspects that will need to be addressed in this [IMN-172](https://pagopa.atlassian.net/browse/IMN-172) JIRA ISSUE: 

First concerning the centralization into a single shared utility that can operates with dates (optionally create them according to a specific time zone) and is capable of transforming big integers received from protobuf events into UTC dates.

Finally, an additional check will be performed to ensure that the MongoDB library persisting objects of type Date creates them as UTC dates, and similarly, the protobuf serializer creates UTC date bigints and deserialize them accordingly.

[IMN-172]: https://pagopa.atlassian.net/browse/IMN-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ