### PR TITLE
IMN-32 post agreement activate

### DIFF
--- a/packages/agreement-process/open-api/agreement-service-spec.yml
+++ b/packages/agreement-process/open-api/agreement-service-spec.yml
@@ -111,7 +111,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Agreement"
+                $ref: "#/components/schemas/ResourceId"
         "400":
           description: Bad Request
           content:

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -3,7 +3,6 @@ import {
   ApiError,
   DescriptorState,
   makeApiProblemBuilder,
-  AgreementState,
 } from "pagopa-interop-models";
 
 const errorCodes = {
@@ -273,7 +272,7 @@ export function documentChangeNotAllowed(
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `The requested operation on consumer documents is not allowed on agreement with state ${state}`,
-    code: "documentChangeNotAllowed",
+    code: "documentsChangeNotAllowed",
     title: "Document change not allowed",
   });
 }

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -1,4 +1,5 @@
 import {
+  AgreementState,
   ApiError,
   DescriptorState,
   makeApiProblemBuilder,
@@ -188,6 +189,16 @@ export function contractAlreadyExists(
   });
 }
 
+export function agreementActivationFailed(
+  agreementId: string
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    code: "agreementActivationFailed",
+    title: "Unable to activate agreement",
+    detail: `Unable to activate agreement ${agreementId}. Please check if attributes requirements and suspension flags are satisfied`,
+  });
+}
+
 export function consumerWithNotValidEmail(
   agreementId: string,
   tenantId: string
@@ -254,5 +265,15 @@ export function noNewerDescriptor(
     detail: `No newer descriptor in EService ${eserviceId} exists for upgrade. Current descriptor ${descriptorId}`,
     code: "noNewerDescriptor",
     title: "Agreement cannot be upgraded",
+  });
+}
+
+export function documentChangeNotAllowed(
+  state: AgreementState
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `The requested operation on consumer documents is not allowed on agreement with state ${state}`,
+    code: "documentChangeNotAllowed",
+    title: "Document change not allowed",
   });
 }

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -17,17 +17,22 @@ import {
   agreementState,
   descriptorState,
   tenantAttributeType,
+  agreementActivableStates,
+  agreementActivationFailureStates,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { AuthData } from "pagopa-interop-commons";
 import { AgreementQuery } from "../../services/readmodel/agreementQuery.js";
 import { ApiAgreementPayload } from "../types.js";
 import {
+  agreementActivationFailed,
   agreementAlreadyExists,
   agreementNotFound,
   agreementNotInExpectedState,
   agreementSubmissionFailed,
+  descriptorNotFound,
   descriptorNotInExpectedState,
+  documentChangeNotAllowed,
   eServiceNotFound,
   documentsChangeNotAllowed,
   missingCertifiedAttributesError,
@@ -123,7 +128,13 @@ export const assertCanWorkOnConsumerDocuments = (
   state: AgreementState
 ): void => {
   if (state !== agreementState.draft && state !== agreementState.pending) {
-    throw documentsChangeNotAllowed(state);
+    throw documentChangeNotAllowed(state);
+  }
+};
+
+export const assertActivableState = (agreement: Agreement): void => {
+  if (!agreementActivableStates.includes(agreement.state)) {
+    throw agreementNotInExpectedState(agreement.id, agreement.state);
   }
 };
 
@@ -140,8 +151,8 @@ export function assertDescriptorExist(
 /* =========  VALIDATIONS ========= */
 
 const validateDescriptorState = (
-  eserviceId: string,
-  descriptorId: string,
+  eserviceId: EService["id"],
+  descriptorId: Descriptor["id"],
   descriptorState: DescriptorState,
   allowedStates: DescriptorState[]
 ): void => {
@@ -311,6 +322,44 @@ export const verifyConflictingAgreements = async (
   }
 };
 
+export const verifyConsumerDoesNotActivatePending = (
+  agreement: Agreement,
+  authData: AuthData
+): void => {
+  const activationPendingAllowed =
+    agreement.state === agreementState.pending &&
+    agreement.consumerId === authData.organizationId &&
+    agreement.producerId !== agreement.consumerId;
+  if (!activationPendingAllowed) {
+    throw operationNotAllowed(authData.organizationId);
+  }
+};
+
+export const validateActivationOnDescriptor = (
+  eservice: EService,
+  descriptorId: Descriptor["id"]
+): Descriptor => {
+  const allowedStatus: DescriptorState[] = [
+    descriptorState.published,
+    descriptorState.deprecated,
+    descriptorState.suspended,
+  ];
+
+  const descriptor = eservice.descriptors.find((d) => d.id === descriptorId);
+  if (!descriptor) {
+    throw descriptorNotFound(eservice.id, descriptorId);
+  }
+
+  validateDescriptorState(
+    eservice.id,
+    descriptor.id,
+    descriptor.state,
+    allowedStatus
+  );
+
+  return descriptor;
+};
+
 const attributesSatisfied = <
   T extends RevocableTenantAttribute | NotRevocableTenantAttribute
 >(
@@ -423,3 +472,12 @@ const notRevocatedTenantAttributesFilter = <
           !a.revocationTimestamp
     )
     .otherwise(() => () => true);
+
+export const failOnActivationFailure = (
+  newState: AgreementState,
+  agreement: Agreement
+): void => {
+  if (agreementActivationFailureStates.includes(newState)) {
+    throw agreementActivationFailed(agreement.id);
+  }
+};

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -34,7 +34,6 @@ import {
   descriptorNotInExpectedState,
   documentChangeNotAllowed,
   eServiceNotFound,
-  documentsChangeNotAllowed,
   missingCertifiedAttributesError,
   notLatestEServiceDescriptor,
   operationNotAllowed,

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -338,7 +338,7 @@ export const validateActivationOnDescriptor = (
   eservice: EService,
   descriptorId: Descriptor["id"]
 ): Descriptor => {
-  const allowedStatus: DescriptorState[] = [
+  const allowedState: DescriptorState[] = [
     descriptorState.published,
     descriptorState.deprecated,
     descriptorState.suspended,
@@ -353,7 +353,7 @@ export const validateActivationOnDescriptor = (
     eservice.id,
     descriptor.id,
     descriptor.state,
-    allowedStatus
+    allowedState
   );
 
   return descriptor;

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -38,7 +38,6 @@ import {
   notLatestEServiceDescriptor,
   operationNotAllowed,
   tenantIdNotFound,
-  descriptorNotFound,
 } from "./errors.js";
 
 type NotRevocableTenantAttribute = Pick<VerifiedTenantAttribute, "id">;
@@ -325,11 +324,11 @@ export const verifyConsumerDoesNotActivatePending = (
   agreement: Agreement,
   authData: AuthData
 ): void => {
-  const activationPendingAllowed =
+  const activationPendingNotAllowed =
     agreement.state === agreementState.pending &&
     agreement.consumerId === authData.organizationId &&
     agreement.producerId !== agreement.consumerId;
-  if (!activationPendingAllowed) {
+  if (activationPendingNotAllowed) {
     throw operationNotAllowed(authData.organizationId);
   }
 };

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -8,6 +8,7 @@ import {
   initDB,
   ReadModelRepository,
 } from "pagopa-interop-commons";
+import { Agreement } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import {
   agreementDocumentToApiAgreementDocument,
@@ -25,6 +26,7 @@ import { agreementNotFound, makeApiProblem } from "../model/domain/errors.js";
 import {
   cloneAgreementErrorMapper,
   addConsumerDocumentErrorMapper,
+  activateAgreementErrorMapper,
   createAgreementErrorMapper,
   deleteAgreementErrorMapper,
   getConsumerDocumentErrorMapper,
@@ -93,8 +95,20 @@ const agreementRouter = (
 
   agreementRouter.post(
     "/agreements/:agreementId/activate",
-    async (_req, res) => {
-      res.status(501).send();
+    authorizationMiddleware([ADMIN_ROLE]),
+    async (req, res) => {
+      try {
+        const agreementId: Agreement["id"] =
+          await agreementService.activateAgreement(
+            req.params.agreementId,
+            req.ctx.authData
+          );
+
+        return res.status(200).json({ id: agreementId }).end();
+      } catch (error) {
+        const errorRes = makeApiProblem(error, activateAgreementErrorMapper);
+        return res.status(errorRes.status).json(errorRes).end();
+      }
     }
   );
 

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -1,0 +1,265 @@
+/* eslint-disable max-params */
+import { AuthData, CreateEvent, logger } from "pagopa-interop-commons";
+import {
+  Agreement,
+  Descriptor,
+  EService,
+  Tenant,
+  UpdateAgreementSeed,
+  agreementState,
+  agreementArchivableStates,
+  WithMetadata,
+  AgreementEvent,
+  agreementAttributeType,
+  AgreementUpdateEvent,
+} from "pagopa-interop-models";
+import {
+  assertAgreementExist,
+  assertRequesterIsConsumerOrProducer,
+  assertTenantExist,
+  failOnActivationFailure,
+  matchingCertifiedAttributes,
+  matchingDeclaredAttributes,
+  matchingVerifiedAttributes,
+  validateActivationOnDescriptor,
+  assertActivableState,
+  verifyConsumerDoesNotActivatePending,
+  assertEServiceExist,
+} from "../model/domain/validators.js";
+import { toCreateEventAgreementUpdated } from "../model/domain/toEvent.js";
+import {
+  agreementStateByFlags,
+  nextState,
+  suspendedByConsumerFlag,
+  suspendedByConsumerStamp,
+  suspendedByPlatformFlag,
+  suspendedByProducerFlag,
+  suspendedByProducerStamp,
+} from "./agreementStateProcessor.js";
+import { contractBuilder } from "./agreementContractBuilder.js";
+import { AgreementQuery } from "./readmodel/agreementQuery.js";
+import { EserviceQuery } from "./readmodel/eserviceQuery.js";
+import { TenantQuery } from "./readmodel/tenantQuery.js";
+import { createStamp } from "./agreementStampUtils.js";
+import { AttributeQuery } from "./readmodel/attributeQuery.js";
+
+export async function activateAgreementLogic(
+  agreementId: string,
+  agreementQuery: AgreementQuery,
+  eserviceQuery: EserviceQuery,
+  tenantQuery: TenantQuery,
+  attributeQuery: AttributeQuery,
+  authData: AuthData
+): Promise<Array<CreateEvent<AgreementEvent>>> {
+  logger.info(`Activating agreement ${agreementId}`);
+
+  const agreement = await agreementQuery.getAgreementById(agreementId);
+  assertAgreementExist(agreementId, agreement);
+
+  assertRequesterIsConsumerOrProducer(agreement.data, authData);
+  verifyConsumerDoesNotActivatePending(agreement.data, authData);
+  assertActivableState(agreement.data);
+
+  const eservice = await eserviceQuery.getEServiceById(
+    agreement.data.eserviceId
+  );
+  assertEServiceExist(agreement.data.eserviceId, eservice);
+
+  const descriptor = validateActivationOnDescriptor(
+    eservice.data,
+    agreement.data.descriptorId
+  );
+
+  const tenant = await tenantQuery.getTenantById(agreement.data.consumerId);
+  assertTenantExist(agreement.data.consumerId, tenant);
+
+  return activateAgreement(
+    agreement,
+    eservice.data,
+    descriptor,
+    tenant.data,
+    authData,
+    tenantQuery,
+    agreementQuery,
+    attributeQuery
+  );
+}
+
+async function activateAgreement(
+  agreementData: WithMetadata<Agreement>,
+  eService: EService,
+  descriptor: Descriptor,
+  consumer: Tenant,
+  authData: AuthData,
+  tenantQuery: TenantQuery,
+  agreementQuery: AgreementQuery,
+  attributeQuery: AttributeQuery
+): Promise<Array<CreateEvent<AgreementEvent>>> {
+  const agreement = agreementData.data;
+  const nextAttributesState = nextState(agreement, descriptor, consumer);
+
+  const suspendedByConsumer = suspendedByConsumerFlag(
+    agreement,
+    authData.organizationId,
+    agreementState.active
+  );
+  const suspendedByProducer = suspendedByProducerFlag(
+    agreement,
+    authData.organizationId,
+    agreementState.active
+  );
+  const suspendedByPlatform = suspendedByPlatformFlag(nextAttributesState);
+
+  const newState = agreementStateByFlags(
+    nextAttributesState,
+    suspendedByProducer,
+    suspendedByConsumer,
+    suspendedByPlatform
+  );
+
+  failOnActivationFailure(newState, agreement);
+
+  const firstActivation =
+    agreement.state === agreementState.pending &&
+    newState === agreementState.active;
+
+  const updatedAgreementSeed: UpdateAgreementSeed = firstActivation
+    ? {
+        state: newState,
+        certifiedAttributes: matchingCertifiedAttributes(descriptor, consumer),
+        declaredAttributes: matchingDeclaredAttributes(descriptor, consumer),
+        verifiedAttributes: matchingVerifiedAttributes(
+          eService,
+          descriptor,
+          consumer
+        ),
+        suspendedByConsumer,
+        suspendedByProducer,
+        suspendedByPlatform,
+        stamps: {
+          ...agreement.stamps,
+          activation: createStamp(authData),
+        },
+      }
+    : {
+        state: newState,
+        certifiedAttributes: agreement.certifiedAttributes.map((a) => ({
+          id: a.id,
+          type: agreementAttributeType.CERTIFIED,
+        })),
+        declaredAttributes: agreement.declaredAttributes.map((a) => ({
+          id: a.id,
+          type: agreementAttributeType.DECLARED,
+        })),
+        verifiedAttributes: agreement.verifiedAttributes.map((a) => ({
+          id: a.id,
+          type: agreementAttributeType.VERIFIED,
+        })),
+        suspendedByConsumer,
+        suspendedByProducer,
+        suspendedByPlatform,
+        stamps: {
+          ...agreement.stamps,
+          suspensionByConsumer: suspendedByConsumerStamp(
+            agreement,
+            agreementState.active,
+            authData
+          ),
+          suspensionByProducer: suspendedByProducerStamp(
+            agreement,
+            agreementState.active,
+            authData
+          ),
+        },
+        suspendedAt:
+          newState === agreementState.active
+            ? undefined
+            : agreement.suspendedAt,
+      };
+
+  const updatedAgreement = {
+    ...agreement,
+    ...updatedAgreementSeed,
+  };
+
+  const updateAgreementEvent = toCreateEventAgreementUpdated(
+    updatedAgreement,
+    agreementData.metadata.version
+  );
+
+  if (firstActivation) {
+    await createContract(
+      updatedAgreement,
+      updatedAgreementSeed,
+      eService,
+      consumer,
+      attributeQuery,
+      tenantQuery
+    );
+  }
+
+  const archieveEvents = await archieveRelatedToAgreements(
+    agreement,
+    authData,
+    agreementQuery
+  );
+
+  return [updateAgreementEvent, ...archieveEvents];
+}
+
+const archieveRelatedToAgreements = async (
+  agreement: Agreement,
+  authData: AuthData,
+  agreementQuery: AgreementQuery
+): Promise<Array<CreateEvent<AgreementUpdateEvent>>> => {
+  const existingAgreements = await agreementQuery.getAllAgreements({
+    consumerId: agreement.consumerId,
+    eserviceId: agreement.eserviceId,
+  });
+
+  const archivables = existingAgreements.filter(
+    (a) =>
+      agreementArchivableStates.includes(a.data.state) &&
+      a.data.id !== agreement.id
+  );
+
+  return archivables.map((agreementData) =>
+    toCreateEventAgreementUpdated(
+      {
+        ...agreementData.data,
+        state: agreementState.archived,
+        certifiedAttributes: agreementData.data.certifiedAttributes,
+        declaredAttributes: agreementData.data.declaredAttributes,
+        verifiedAttributes: agreementData.data.verifiedAttributes,
+        suspendedByConsumer: agreementData.data.suspendedByConsumer,
+        suspendedByProducer: agreementData.data.suspendedByProducer,
+        suspendedByPlatform: agreementData.data.suspendedByPlatform,
+        stamps: {
+          ...agreementData.data.stamps,
+          archiving: createStamp(authData),
+        },
+      },
+      agreementData.metadata.version
+    )
+  );
+};
+
+const createContract = async (
+  agreement: Agreement,
+  updateSeed: UpdateAgreementSeed,
+  eService: EService,
+  consumer: Tenant,
+  attributeQuery: AttributeQuery,
+  tenantQuery: TenantQuery
+): Promise<void> => {
+  const producer = await tenantQuery.getTenantById(agreement.producerId);
+  assertTenantExist(agreement.producerId, producer);
+
+  await contractBuilder(attributeQuery).createContract(
+    agreement,
+    eService,
+    consumer,
+    producer.data,
+    updateSeed
+  );
+};

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -10,7 +10,6 @@ import {
   agreementArchivableStates,
   WithMetadata,
   AgreementEvent,
-  agreementAttributeType,
   AgreementUpdateEvent,
 } from "pagopa-interop-models";
 import {
@@ -143,18 +142,6 @@ async function activateAgreement(
       }
     : {
         state: newState,
-        certifiedAttributes: agreement.certifiedAttributes.map((a) => ({
-          id: a.id,
-          type: agreementAttributeType.CERTIFIED,
-        })),
-        declaredAttributes: agreement.declaredAttributes.map((a) => ({
-          id: a.id,
-          type: agreementAttributeType.DECLARED,
-        })),
-        verifiedAttributes: agreement.verifiedAttributes.map((a) => ({
-          id: a.id,
-          type: agreementAttributeType.VERIFIED,
-        })),
         suspendedByConsumer,
         suspendedByProducer,
         suspendedByPlatform,

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -185,16 +185,16 @@ async function activateAgreement(
     );
   }
 
-  const archieveEvents = await archieveRelatedToAgreements(
+  const archiveEvents = await archiveRelatedToAgreements(
     agreement,
     authData,
     agreementQuery
   );
 
-  return [updateAgreementEvent, ...archieveEvents];
+  return [updateAgreementEvent, ...archiveEvents];
 }
 
-const archieveRelatedToAgreements = async (
+const archiveRelatedToAgreements = async (
   agreement: Agreement,
   authData: AuthData,
   agreementQuery: AgreementQuery

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -30,16 +30,18 @@ import {
   agreementStateByFlags,
   nextState,
   suspendedByConsumerFlag,
-  suspendedByConsumerStamp,
   suspendedByPlatformFlag,
   suspendedByProducerFlag,
-  suspendedByProducerStamp,
 } from "./agreementStateProcessor.js";
 import { contractBuilder } from "./agreementContractBuilder.js";
 import { AgreementQuery } from "./readmodel/agreementQuery.js";
 import { EserviceQuery } from "./readmodel/eserviceQuery.js";
 import { TenantQuery } from "./readmodel/tenantQuery.js";
-import { createStamp } from "./agreementStampUtils.js";
+import {
+  createStamp,
+  suspendedByConsumerStamp,
+  suspendedByProducerStamp,
+} from "./agreementStampUtils.js";
 import { AttributeQuery } from "./readmodel/attributeQuery.js";
 
 export async function activateAgreementLogic(
@@ -149,13 +151,15 @@ async function activateAgreement(
           ...agreement.stamps,
           suspensionByConsumer: suspendedByConsumerStamp(
             agreement,
+            authData.organizationId,
             agreementState.active,
-            authData
+            createStamp(authData)
           ),
           suspensionByProducer: suspendedByProducerStamp(
             agreement,
+            authData.organizationId,
             agreementState.active,
-            authData
+            createStamp(authData)
           ),
         },
         suspendedAt:

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -68,12 +68,12 @@ import {
   ApiAgreementDocumentSeed,
 } from "../model/types.js";
 import { config } from "../utilities/config.js";
+import { AttributeQuery } from "./readmodel/attributeQuery.js";
+import { AgreementQueryFilters } from "./readmodel/readModelService.js";
 import { contractBuilder } from "./agreementContractBuilder.js";
 import { submitAgreementLogic } from "./agreementSubmissionProcessor.js";
 import { AgreementQuery } from "./readmodel/agreementQuery.js";
-import { AttributeQuery } from "./readmodel/attributeQuery.js";
 import { EserviceQuery } from "./readmodel/eserviceQuery.js";
-import { AgreementQueryFilters } from "./readmodel/readModelService.js";
 import { TenantQuery } from "./readmodel/tenantQuery.js";
 import { suspendAgreementLogic } from "./agreementSuspensionProcessor.js";
 import { createStamp } from "./agreementStampUtils.js";
@@ -81,6 +81,7 @@ import {
   removeAgreementConsumerDocumentLogic,
   addConsumerDocumentLogic,
 } from "./agreementConsumerDocumentProcessor.js";
+import { activateAgreementLogic } from "./agreementActivationProcessor.js";
 
 const fileManager = initFileManager(config);
 
@@ -344,7 +345,23 @@ export function agreementServiceBuilder(
           eserviceQuery,
         })
       );
+    },
+    async activateAgreement(
+      agreementId: Agreement["id"],
+      authData: AuthData
+    ): Promise<Agreement["id"]> {
+      const updatesEvents = await activateAgreementLogic(
+        agreementId,
+        agreementQuery,
+        eserviceQuery,
+        tenantQuery,
+        attributeQuery,
+        authData
+      );
 
+      for (const event of updatesEvents) {
+        await repository.createEvent(event);
+      }
       return agreementId;
     },
   };

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -345,6 +345,7 @@ export function agreementServiceBuilder(
           eserviceQuery,
         })
       );
+      return agreementId;
     },
     async activateAgreement(
       agreementId: Agreement["id"],

--- a/packages/agreement-process/src/services/agreementStateProcessor.ts
+++ b/packages/agreement-process/src/services/agreementStateProcessor.ts
@@ -1,19 +1,16 @@
 import {
   Agreement,
-  AgreementStamp,
   AgreementState,
   Descriptor,
   Tenant,
   agreementState,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
-import { AuthData } from "pagopa-interop-commons";
 import {
   certifiedAttributesSatisfied,
   declaredAttributesSatisfied,
   verifiedAttributesSatisfied,
 } from "../model/domain/validators.js";
-import { createStamp } from "./agreementStampUtils.js";
 
 const {
   draft,
@@ -164,27 +161,3 @@ export const suspendedByProducerFlag = (
   requesterOrgId === agreement.producerId
     ? destinationState === agreementState.suspended
     : agreement.suspendedByProducer;
-
-export const suspendedByConsumerStamp = (
-  agreement: Agreement,
-  destinationState: AgreementState,
-  authData: AuthData
-): AgreementStamp | undefined =>
-  match([authData.organizationId, destinationState])
-    .with([agreement.consumerId, agreementState.suspended], () =>
-      createStamp(authData)
-    )
-    .with([agreement.consumerId, P.any], () => undefined)
-    .otherwise(() => agreement.stamps.suspensionByConsumer);
-
-export const suspendedByProducerStamp = (
-  agreement: Agreement,
-  destinationState: AgreementState,
-  authData: AuthData
-): AgreementStamp | undefined =>
-  match([authData.organizationId, destinationState])
-    .with([agreement.producerId, agreementState.suspended], () =>
-      createStamp(authData)
-    )
-    .with([agreement.producerId, P.any], () => undefined)
-    .otherwise(() => agreement.stamps.suspensionByProducer);

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -41,11 +41,11 @@ import {
   nextState,
   suspendedByPlatformFlag,
 } from "./agreementStateProcessor.js";
+import { AgreementQuery } from "./readmodel/agreementQuery.js";
 import {
   ContractBuilder,
   addAgreementContractLogic,
 } from "./agreementContractBuilder.js";
-import { AgreementQuery } from "./readmodel/agreementQuery.js";
 import { EserviceQuery } from "./readmodel/eserviceQuery.js";
 import { TenantQuery } from "./readmodel/tenantQuery.js";
 import { createStamp } from "./agreementStampUtils.js";

--- a/packages/agreement-process/src/utilities/errorMappers.ts
+++ b/packages/agreement-process/src/utilities/errorMappers.ts
@@ -120,7 +120,7 @@ export const suspendAgreementErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)
-    .with("agreementNotFound", "documentNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("agreementNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with("operationNotAllowed", () => HTTP_STATUS_FORBIDDEN)
     .with("agreementNotInExpectedState", () => HTTP_STATUS_BAD_REQUEST)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/agreement-process/src/utilities/errorMappers.ts
+++ b/packages/agreement-process/src/utilities/errorMappers.ts
@@ -120,7 +120,7 @@ export const suspendAgreementErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)
-    .with("agreementNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("agreementNotFound", "documentNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with("operationNotAllowed", () => HTTP_STATUS_FORBIDDEN)
     .with("agreementNotInExpectedState", () => HTTP_STATUS_BAD_REQUEST)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -144,4 +144,20 @@ export const rejectAgreementErrorMapper = (
     .with("agreementNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with("agreementNotInExpectedState", () => HTTP_STATUS_BAD_REQUEST)
     .with("operationNotAllowed", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const activateAgreementErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "notLatestEServiceDescriptor",
+      "agreementNotInExpectedState",
+      "agreementActivationFailed",
+      "descriptorNotInExpectedState",
+      () => HTTP_STATUS_BAD_REQUEST
+    )
+    .with("agreementNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("operationNotAllowed", () => HTTP_STATUS_FORBIDDEN)
+    .with("agreementAlreadyExists", () => HTTP_STATUS_CONFLICT)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -15,6 +15,53 @@ export const AgreementState = z.enum([
 ]);
 export type AgreementState = z.infer<typeof AgreementState>;
 
+export const agreementActivableStates: AgreementState[] = [
+  agreementState.pending,
+  agreementState.suspended,
+];
+export const agreementSuspendableStates: AgreementState[] = [
+  agreementState.active,
+  agreementState.suspended,
+];
+export const agreementArchivableStates: AgreementState[] = [
+  agreementState.active,
+  agreementState.suspended,
+];
+export const agreementSubmittableStates: AgreementState[] = [
+  agreementState.draft,
+];
+
+export const agreementUpdatableStates: AgreementState[] = [
+  agreementState.draft,
+];
+
+export const agreementUpgradableStates: AgreementState[] = [
+  agreementState.active,
+  agreementState.suspended,
+];
+export const agreementRejectableStates: AgreementState[] = [
+  agreementState.pending,
+];
+
+export const agreementDeletableStates: AgreementState[] = [
+  agreementState.draft,
+  agreementState.missingCertifiedAttributes,
+];
+
+export const agreementActivationFailureStates: AgreementState[] = [
+  agreementState.draft,
+  agreementState.pending,
+  agreementState.missingCertifiedAttributes,
+];
+
+export const agreementCloningConflictingStates: AgreementState[] = [
+  agreementState.draft,
+  agreementState.pending,
+  agreementState.missingCertifiedAttributes,
+  agreementState.active,
+  agreementState.suspended,
+];
+
 export const agreementAttributeType = {
   CERTIFIED: "Certified",
   VERIFIED: "Verified",
@@ -154,34 +201,3 @@ export const AgreementInvolvedAttributes = z.object({
 export type AgreementInvolvedAttributes = z.infer<
   typeof AgreementInvolvedAttributes
 >;
-
-export const agreementUpdatableStates: AgreementState[] = [
-  agreementState.draft,
-];
-
-export const agreementUpgradableStates: AgreementState[] = [
-  agreementState.active,
-  agreementState.suspended,
-];
-
-export const agreementDeletableStates: AgreementState[] = [
-  agreementState.draft,
-  agreementState.missingCertifiedAttributes,
-];
-
-export const agreementCloningConflictingStates: AgreementState[] = [
-  agreementState.draft,
-  agreementState.pending,
-  agreementState.missingCertifiedAttributes,
-  agreementState.active,
-  agreementState.suspended,
-];
-
-export const agreementSuspendableStates: AgreementState[] = [
-  agreementState.active,
-  agreementState.suspended,
-];
-
-export const agreementRejectableStates: AgreementState[] = [
-  agreementState.pending,
-];


### PR DESCRIPTION
## Description
Close [IMN-32](https://pagopa.atlassian.net/browse/IMN-32?atlOrigin=eyJpIjoiZDI2NjVkYzdkZGI0NGM2NGE1OGUxMTM0NGI5MzhiMjciLCJwIjoiaiJ9)

This PR implements agreement `activation` API in agreement-service.

## Test
Tested E2E locally.

**Test steps** 
- create a valid descriptor in relative agreement's Eservice
- create agreement and set to state PENDING
- create two different tenant producer and consumer

<img width="1295" alt="Screenshot 2024-01-11 at 17 47 30" src="https://github.com/pagopa/interop-be-monorepo/assets/5895397/097b3472-e176-4b0f-a4de-82ec9d49bcf7">


[IMN-32]: https://pagopa.atlassian.net/browse/IMN-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ