### PR TITLE
IMN-174 + IMN-179 - Logic fixes for agreement clone and create

### DIFF
--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -437,25 +437,9 @@ export async function createAgreementLogic(
     verifiedAttributes: [],
     certifiedAttributes: [],
     declaredAttributes: [],
-    suspendedByConsumer: undefined,
-    suspendedByProducer: undefined,
-    suspendedByPlatform: undefined,
     consumerDocuments: [],
     createdAt: new Date(),
-    updatedAt: undefined,
-    consumerNotes: undefined,
-    contract: undefined,
-    stamps: {
-      submission: undefined,
-      activation: undefined,
-      rejection: undefined,
-      suspensionByProducer: undefined,
-      suspensionByConsumer: undefined,
-      upgrade: undefined,
-      archiving: undefined,
-    },
-    rejectionReason: undefined,
-    suspendedAt: undefined,
+    stamps: {},
   };
 
   return toCreateEventAgreementAdded(agreementSeed);

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -704,6 +704,7 @@ export async function cloneAgreementLogic({
   validateCertifiedAttributes(descriptor, consumer.data);
 
   const newAgreement: Agreement = {
+    id: uuidv4(),
     eserviceId: agreementToBeCloned.data.eserviceId,
     descriptorId: agreementToBeCloned.data.descriptorId,
     producerId: agreementToBeCloned.data.producerId,
@@ -712,7 +713,6 @@ export async function cloneAgreementLogic({
     verifiedAttributes: [],
     certifiedAttributes: [],
     declaredAttributes: [],
-    id: uuidv4(),
     state: agreementState.draft,
     createdAt: new Date(),
     consumerDocuments: [],

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -719,26 +719,33 @@ export async function cloneAgreementLogic({
 
   validateCertifiedAttributes(descriptor, consumer.data);
 
-  const newAgreement = await createAgreementLogic(
-    {
-      eserviceId: agreementToBeCloned.data.eserviceId,
-      descriptorId: agreementToBeCloned.data.descriptorId,
-    },
-    authData,
-    agreementQuery,
-    eserviceQuery,
-    tenantQuery
-  );
+  const newAgreement: Agreement = {
+    eserviceId: agreementToBeCloned.data.eserviceId,
+    descriptorId: agreementToBeCloned.data.descriptorId,
+    producerId: agreementToBeCloned.data.producerId,
+    consumerId: agreementToBeCloned.data.consumerId,
+    consumerNotes: agreementToBeCloned.data.consumerNotes,
+    verifiedAttributes: [],
+    certifiedAttributes: [],
+    declaredAttributes: [],
+    id: uuidv4(),
+    state: agreementState.draft,
+    createdAt: new Date(),
+    consumerDocuments: [],
+    stamps: {},
+  };
+
+  const createEvent = toCreateEventAgreementAdded(newAgreement);
 
   const docEvents = await createAndCopyDocumentsForClonedAgreement(
-    newAgreement.streamId,
+    createEvent.streamId,
     agreementToBeCloned.data,
     0,
     fileCopy
   );
 
   return {
-    streamId: newAgreement.streamId,
-    events: [newAgreement, ...docEvents],
+    streamId: createEvent.streamId,
+    events: [createEvent, ...docEvents],
   };
 }

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -621,16 +621,24 @@ export async function upgradeAgreementLogic({
       [agreementState.draft],
       agreementQuery
     );
-    const createEvent = await createAgreementLogic(
-      {
-        eserviceId: agreementToBeUpgraded.data.eserviceId,
-        descriptorId: newDescriptor.id,
-      },
-      authData,
-      agreementQuery,
-      eserviceQuery,
-      tenantQuery
-    );
+
+    const newAgreement: Agreement = {
+      eserviceId: agreementToBeUpgraded.data.eserviceId,
+      descriptorId: newDescriptor.id,
+      producerId: agreementToBeUpgraded.data.producerId,
+      consumerId: agreementToBeUpgraded.data.consumerId,
+      verifiedAttributes: agreementToBeUpgraded.data.verifiedAttributes,
+      certifiedAttributes: agreementToBeUpgraded.data.certifiedAttributes,
+      declaredAttributes: agreementToBeUpgraded.data.declaredAttributes,
+      consumerNotes: agreementToBeUpgraded.data.consumerNotes,
+      id: uuidv4(),
+      state: agreementState.draft,
+      createdAt: new Date(),
+      consumerDocuments: [],
+      stamps: {},
+    };
+
+    const createEvent = toCreateEventAgreementAdded(newAgreement);
 
     const docEvents = await createAndCopyDocumentsForClonedAgreement(
       createEvent.streamId,

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -607,6 +607,7 @@ export async function upgradeAgreementLogic({
     );
 
     const newAgreement: Agreement = {
+      id: uuidv4(),
       eserviceId: agreementToBeUpgraded.data.eserviceId,
       descriptorId: newDescriptor.id,
       producerId: agreementToBeUpgraded.data.producerId,
@@ -615,7 +616,6 @@ export async function upgradeAgreementLogic({
       certifiedAttributes: agreementToBeUpgraded.data.certifiedAttributes,
       declaredAttributes: agreementToBeUpgraded.data.declaredAttributes,
       consumerNotes: agreementToBeUpgraded.data.consumerNotes,
-      id: uuidv4(),
       state: agreementState.draft,
       createdAt: new Date(),
       consumerDocuments: [],


### PR DESCRIPTION
Closes [IMN-174](https://pagopa.atlassian.net/browse/IMN-174)
Closes [IMN-179](https://pagopa.atlassian.net/browse/IMN-179)

# Description

While working on #140 and reviewing the logic of other functions involving agreement upgrades, I noticed that both `upgradeAgreement` and `cloneAgreement` reused the `createAgreementLogic` function, which **does not** copy in the new agreement any of the following properties:   `verifiedAttributes`, `certifiedAttributes`, `declaredAttributes`, `consumerNotes`

However, looking at the Scala code, I understand that:
* `upgrade` shall copy in the new agreement all four properties (when it creates a new draft Agreement) - see [here](https://github.com/pagopa/interop-be-agreement-process/blob/ef2615d5eef833c35fd0ef07affc092625b874cc/src/main/scala/it/pagopa/interop/agreementprocess/api/impl/AgreementApiServiceImpl.scala#L232)
* `clone` shall copy the `consumerNotes` - see [here (call to .toSeed)](https://github.com/pagopa/interop-be-agreement-process/blob/ef2615d5eef833c35fd0ef07affc092625b874cc/src/main/scala/it/pagopa/interop/agreementprocess/api/impl/AgreementApiServiceImpl.scala#L286) then [here](https://github.com/pagopa/interop-be-agreement-process/blob/ef2615d5eef833c35fd0ef07affc092625b874cc/src/main/scala/it/pagopa/interop/agreementprocess/common/Adapters.scala#L65)

Also, the case where the upgrade creates a new draft Agreement was failing because by reusing the `createAgreementLogic` it was also performing validations that shall not happen on clone, and was throwing a conflict due to [this call](https://github.com/pagopa/interop-be-monorepo/blob/2d19d69690185601fa7c359b30ab4a1620e4e118/packages/agreement-process/src/services/agreementService.ts#L418) (the conflict, as we see by the code [here](https://github.com/pagopa/interop-be-monorepo/blob/2d19d69690185601fa7c359b30ab4a1620e4e118/packages/agreement-process/src/services/agreementService.ts#L618), should happen only in case a `Draft` agreement already exists). This closes also [IMN-179](https://pagopa.atlassian.net/browse/IMN-179).

This PR fixes these two issues.

# Tests for Agreement upgrade

### Upgrading - before the fix
As described above, It was failing, with the following error:
<img width="1119" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/0259ca1e-6b55-45dd-8e8e-fec3680ef614">


### Upgrading - after the fix
<img width="919" alt="Screenshot 2024-01-15 at 12 36 35" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/97ff67a0-624d-4af6-ac99-939122370fae">

<img width="924" alt="Screenshot 2024-01-15 at 12 38 16" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/07c139b0-0fa5-42d5-a30a-d9fea0f2bf79">

# Tests  for Agreement clone

### Agreement to clone:
<img width="928" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/2a329677-3d5f-4007-9308-162fa0a56fd6">

### Cloning - before the fix
<img width="921" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/ef1b70a5-d21c-4ee8-ae8c-25ee74ea7e66">

### Cloning - after the fix
<img width="919" alt="Screenshot 2024-01-15 at 12 01 37" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/837c2f25-d32c-4548-8d5b-60a24d259619">





[IMN-174]: https://pagopa.atlassian.net/browse/IMN-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[IMN-179]: https://pagopa.atlassian.net/browse/IMN-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IMN-179]: https://pagopa.atlassian.net/browse/IMN-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ