### PR TITLE
Improving Agreement attribute specific types

### DIFF
--- a/packages/agreement-process/src/model/domain/models.ts
+++ b/packages/agreement-process/src/model/domain/models.ts
@@ -1,4 +1,41 @@
+import {
+  AgreementStamps,
+  AgreementState,
+  AgreementAttribute,
+} from "pagopa-interop-models";
 import { z } from "zod";
+
+export const CertifiedAgreementAttribute =
+  AgreementAttribute.brand<"CertifiedAgreementAttribute">();
+export type CertifiedAgreementAttribute = z.infer<
+  typeof CertifiedAgreementAttribute
+>;
+
+export const DeclaredAgreementAttribute =
+  AgreementAttribute.brand<"DeclaredAgreementAttribute">();
+export type DeclaredAgreementAttribute = z.infer<
+  typeof DeclaredAgreementAttribute
+>;
+
+export const VerifiedAgreementAttribute =
+  AgreementAttribute.brand<"VerifiedAgreementAttribute">();
+export type VerifiedAgreementAttribute = z.infer<
+  typeof VerifiedAgreementAttribute
+>;
+
+export type UpdateAgreementSeed = {
+  state: AgreementState;
+  certifiedAttributes?: CertifiedAgreementAttribute[];
+  declaredAttributes?: DeclaredAgreementAttribute[];
+  verifiedAttributes?: VerifiedAgreementAttribute[];
+  suspendedByConsumer?: boolean;
+  suspendedByProducer?: boolean;
+  suspendedByPlatform?: boolean;
+  stamps: AgreementStamps;
+  consumerNotes?: string;
+  rejectionReason?: string;
+  suspendedAt?: Date;
+};
 
 export const CompactOrganization = z.object({
   id: z.string().uuid(),

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -1,19 +1,15 @@
 import {
   Agreement,
   AgreementState,
-  CertifiedAgreementAttribute,
   CertifiedTenantAttribute,
-  DeclaredAgreementAttribute,
   DeclaredTenantAttribute,
   Descriptor,
   DescriptorState,
   EService,
   EServiceAttribute,
   Tenant,
-  VerifiedAgreementAttribute,
   VerifiedTenantAttribute,
   WithMetadata,
-  agreementAttributeType,
   agreementState,
   descriptorState,
   tenantAttributeType,
@@ -39,6 +35,11 @@ import {
   operationNotAllowed,
   tenantIdNotFound,
 } from "./errors.js";
+import {
+  CertifiedAgreementAttribute,
+  DeclaredAgreementAttribute,
+  VerifiedAgreementAttribute,
+} from "./models.js";
 
 type NotRevocableTenantAttribute = Pick<VerifiedTenantAttribute, "id">;
 type RevocableTenantAttribute =
@@ -397,10 +398,7 @@ export const matchingCertifiedAttributes = (
     .map((a) => a.id);
 
   return matchingAttributes(descriptor.attributes.certified, attributes).map(
-    (id) => ({
-      type: agreementAttributeType.CERTIFIED,
-      id,
-    })
+    (id) => ({ id } as CertifiedAgreementAttribute)
   );
 };
 
@@ -415,10 +413,7 @@ export const matchingDeclaredAttributes = (
     .map((a) => a.id);
 
   return matchingAttributes(descriptor.attributes.declared, attributes).map(
-    (id) => ({
-      type: agreementAttributeType.DECLARED,
-      id,
-    })
+    (id) => ({ id } as DeclaredAgreementAttribute)
   );
 };
 
@@ -435,10 +430,7 @@ export const matchingVerifiedAttributes = (
   return matchingAttributes(
     descriptor.attributes.verified,
     verifiedAttributes
-  ).map((id) => ({
-    type: agreementAttributeType.VERIFIED,
-    id,
-  }));
+  ).map((id) => ({ id } as VerifiedAgreementAttribute));
 };
 
 /* ========= FILTERS ========= */

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -5,7 +5,6 @@ import {
   Descriptor,
   EService,
   Tenant,
-  UpdateAgreementSeed,
   agreementState,
   agreementArchivableStates,
   WithMetadata,
@@ -26,6 +25,7 @@ import {
   assertEServiceExist,
 } from "../model/domain/validators.js";
 import { toCreateEventAgreementUpdated } from "../model/domain/toEvent.js";
+import { UpdateAgreementSeed } from "../model/domain/models.js";
 import {
   agreementStateByFlags,
   nextState,

--- a/packages/agreement-process/src/services/agreementContractBuilder.ts
+++ b/packages/agreement-process/src/services/agreementContractBuilder.ts
@@ -5,10 +5,10 @@ import {
   AgreementEvent,
   EService,
   Tenant,
-  UpdateAgreementSeed,
 } from "pagopa-interop-models";
 import { toCreateEventAgreementContractAdded } from "../model/domain/toEvent.js";
 import { ApiAgreementDocumentSeed } from "../model/types.js";
+import { UpdateAgreementSeed } from "../model/domain/models.js";
 import { pdfGenerator } from "./pdfGenerator.js";
 import { AttributeQuery } from "./readmodel/attributeQuery.js";
 

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -9,9 +9,7 @@ import {
   Descriptor,
   EService,
   Tenant,
-  UpdateAgreementSeed,
   WithMetadata,
-  agreementAttributeType,
   agreementState,
   tenantMailKind,
 } from "pagopa-interop-models";
@@ -36,6 +34,7 @@ import {
   verifySubmissionConflictingAgreements,
 } from "../model/domain/validators.js";
 import { ApiAgreementSubmissionPayload } from "../model/types.js";
+import { UpdateAgreementSeed } from "../model/domain/models.js";
 import {
   agreementStateByFlags,
   nextState,
@@ -174,24 +173,6 @@ const submitAgreement = async (
             ): Promise<CreateEvent<AgreementEvent>> => {
               const updateSeed: UpdateAgreementSeed = {
                 state: agreementState.archived,
-                certifiedAttributes: agreement.data.certifiedAttributes.map(
-                  (ca) => ({
-                    type: agreementAttributeType.CERTIFIED,
-                    id: ca.id,
-                  })
-                ),
-                declaredAttributes: agreement.data.declaredAttributes.map(
-                  (da) => ({
-                    type: agreementAttributeType.DECLARED,
-                    id: da.id,
-                  })
-                ),
-                verifiedAttributes: agreement.data.verifiedAttributes.map(
-                  (va) => ({
-                    type: agreementAttributeType.VERIFIED,
-                    id: va.id,
-                  })
-                ),
                 stamps: {
                   ...agreement.data.stamps,
                   archiving: createStamp(authData),

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -2,7 +2,6 @@ import { AuthData, CreateEvent } from "pagopa-interop-commons";
 import {
   Agreement,
   AgreementEvent,
-  UpdateAgreementSeed,
   agreementState,
   agreementSuspendableStates,
 } from "pagopa-interop-models";
@@ -15,6 +14,7 @@ import {
   assertDescriptorExist,
 } from "../model/domain/validators.js";
 import { toCreateEventAgreementUpdated } from "../model/domain/toEvent.js";
+import { UpdateAgreementSeed } from "../model/domain/models.js";
 import { AgreementQuery } from "./readmodel/agreementQuery.js";
 import { TenantQuery } from "./readmodel/tenantQuery.js";
 import { EserviceQuery } from "./readmodel/eserviceQuery.js";

--- a/packages/agreement-process/src/services/pdfGenerator.ts
+++ b/packages/agreement-process/src/services/pdfGenerator.ts
@@ -13,14 +13,10 @@ import {
   Agreement,
   AgreementAttribute,
   AgreementInvolvedAttributes,
-  CertifiedAgreementAttribute,
-  DeclaredAgreementAttribute,
   EService,
   PDFPayload,
   Tenant,
   TenantAttributeType,
-  UpdateAgreementSeed,
-  VerifiedAgreementAttribute,
   genericError,
   tenantAttributeType,
 } from "pagopa-interop-models";
@@ -31,6 +27,12 @@ import {
 } from "../model/domain/errors.js";
 import { ApiAgreementDocumentSeed } from "../model/types.js";
 import { config } from "../utilities/config.js";
+import {
+  CertifiedAgreementAttribute,
+  DeclaredAgreementAttribute,
+  UpdateAgreementSeed,
+  VerifiedAgreementAttribute,
+} from "../model/domain/models.js";
 import { AttributeQuery } from "./readmodel/attributeQuery.js";
 
 const fileManager = initFileManager(config);

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -62,44 +62,8 @@ export const agreementCloningConflictingStates: AgreementState[] = [
   agreementState.suspended,
 ];
 
-export const agreementAttributeType = {
-  CERTIFIED: "Certified",
-  VERIFIED: "Verified",
-  DECLARED: "Declared",
-} as const;
-
-export const AgreementAttributeType = z.enum([
-  Object.values(agreementAttributeType)[0],
-  ...Object.values(agreementAttributeType).slice(1),
-]);
-
-export type AgreementAttributeType = z.infer<typeof AgreementAttributeType>;
-
-const AgreementAttribute = z.object({ id: z.string().uuid() });
+export const AgreementAttribute = z.object({ id: z.string().uuid() });
 export type AgreementAttribute = z.infer<typeof AgreementAttribute>;
-
-export const CertifiedAgreementAttribute = z.object({
-  type: z.literal(agreementAttributeType.CERTIFIED),
-  id: z.string().uuid(),
-});
-export type CertifiedAgreementAttribute = z.infer<
-  typeof CertifiedAgreementAttribute
->;
-export const DeclaredAgreementAttribute = z.object({
-  type: z.literal(agreementAttributeType.DECLARED),
-  id: z.string().uuid(),
-});
-export type DeclaredAgreementAttribute = z.infer<
-  typeof DeclaredAgreementAttribute
->;
-
-export const VerifiedAgreementAttribute = z.object({
-  type: z.literal(agreementAttributeType.VERIFIED),
-  id: z.string().uuid(),
-});
-export type VerifiedAgreementAttribute = z.infer<
-  typeof VerifiedAgreementAttribute
->;
 
 export const AgreementDocument = z.object({
   id: z.string().uuid(),
@@ -152,21 +116,6 @@ export const Agreement = z.object({
 });
 export type Agreement = z.infer<typeof Agreement>;
 
-export const UpdateAgreementSeed = z.object({
-  state: AgreementState,
-  certifiedAttributes: z.optional(z.array(CertifiedAgreementAttribute)),
-  declaredAttributes: z.optional(z.array(DeclaredAgreementAttribute)),
-  verifiedAttributes: z.optional(z.array(VerifiedAgreementAttribute)),
-  suspendedByConsumer: z.boolean().optional(),
-  suspendedByProducer: z.boolean().optional(),
-  suspendedByPlatform: z.boolean().optional(),
-  stamps: AgreementStamps,
-  consumerNotes: z.string().optional(),
-  rejectionReason: z.string().optional(),
-  suspendedAt: z.date().optional(),
-});
-export type UpdateAgreementSeed = z.infer<typeof UpdateAgreementSeed>;
-
 export const PDFPayload = z.object({
   today: z.date(),
   agreementId: z.string().uuid(),
@@ -177,11 +126,9 @@ export const PDFPayload = z.object({
   consumerName: z.string(),
   consumerOrigin: z.string(),
   consumerIPACode: z.string(),
-  certified: z.array(
-    z.tuple([AgreementAttribute, CertifiedAgreementAttribute])
-  ),
-  declared: z.array(z.tuple([AgreementAttribute, DeclaredAgreementAttribute])),
-  verified: z.array(z.tuple([AgreementAttribute, VerifiedAgreementAttribute])),
+  certified: z.array(z.tuple([AgreementAttribute, AgreementAttribute])),
+  declared: z.array(z.tuple([AgreementAttribute, AgreementAttribute])),
+  verified: z.array(z.tuple([AgreementAttribute, AgreementAttribute])),
   submitter: z.string(),
   submissionTimestamp: z.date(),
   activator: z.string(),
@@ -191,11 +138,9 @@ export const PDFPayload = z.object({
 export type PDFPayload = z.infer<typeof PDFPayload>;
 
 export const AgreementInvolvedAttributes = z.object({
-  certified: z.array(
-    z.tuple([AgreementAttribute, CertifiedAgreementAttribute])
-  ),
-  declared: z.array(z.tuple([AgreementAttribute, DeclaredAgreementAttribute])),
-  verified: z.array(z.tuple([AgreementAttribute, VerifiedAgreementAttribute])),
+  certified: z.array(z.tuple([AgreementAttribute, AgreementAttribute])),
+  declared: z.array(z.tuple([AgreementAttribute, AgreementAttribute])),
+  verified: z.array(z.tuple([AgreementAttribute, AgreementAttribute])),
 });
 
 export type AgreementInvolvedAttributes = z.infer<


### PR DESCRIPTION
# Tests

### Agreement with different kinds of attributes

<img width="913" alt="Screenshot 2024-01-16 at 17 30 09" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/eb9bd94e-a90f-41a5-8ccf-d1448843d9b8">

<img width="919" alt="Screenshot 2024-01-16 at 17 30 15" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/31e079af-a9ef-47de-b08e-6b4a17463a3c">

### Submitting this agreement works correctly

All the attributes match the ones in the descriptor & consumer, so they are all copied

<img width="917" alt="Screenshot 2024-01-16 at 17 43 24" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/cffe2ff6-7b7a-4288-a1ff-26f91d8e04c5">

<img width="935" alt="Screenshot 2024-01-16 at 17 43 19" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/65bb94fb-3e31-40d4-b7f7-ed71c775c07d">
