### PR TITLE
IMN 166 - Add branded type on resource Id

### DIFF
--- a/packages/agreement-process/open-api/agreement-service-spec.yml
+++ b/packages/agreement-process/open-api/agreement-service-spec.yml
@@ -63,7 +63,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#components/schemas/AgreementSubmissionPayload"
+              $ref: "#/components/schemas/AgreementSubmissionPayload"
         description: payload for agreement submission
         required: true
       responses:

--- a/packages/agreement-process/package.json
+++ b/packages/agreement-process/package.json
@@ -14,7 +14,7 @@
     "start": "node --watch --no-warnings --loader ts-node/esm -r 'dotenv-flow/config' ./src/index.ts",
     "build": "tsc && pnpm cpx './src/resources/**/*' './dist/resources'",
     "generate-model": "mkdir -p ./src/model/generated && pnpm openapi-zod-client './open-api/agreement-service-spec.yml' -o './src/model/generated/api.ts'",
-    "clean-generated": "pnpm exec rm ./src/models/generated/api.ts"
+    "clean-generated": "pnpm exec rm ./src/model/generated/api.ts"
   },
   "keywords": [],
   "author": "",
@@ -27,6 +27,7 @@
     "@types/node": "^20.3.1",
     "@types/uuid": "^9.0.2",
     "cpx": "^1.5.0",
+    "openapi-zod-client": "^1.7.1",
     "pg-promise": "^11.5.0",
     "prettier": "^2.8.8",
     "testcontainers": "^10.2.2",
@@ -40,7 +41,6 @@
     "dotenv-flow": "^3.2.0",
     "express": "^4.18.2",
     "mongodb": "5.6.0",
-    "openapi-zod-client": "^1.7.1",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
     "ts-pattern": "^5.0.1",

--- a/packages/agreement-process/src/model/domain/apiConverter.ts
+++ b/packages/agreement-process/src/model/domain/apiConverter.ts
@@ -3,7 +3,7 @@ import {
   AgreementState,
   AgreementDocument,
   agreementState,
-  AgreementDocumentId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
@@ -90,7 +90,7 @@ export const agreementToApiAgreement = (
 export const apiAgreementDocumentToAgreementDocument = (
   input: ApiAgreementDocumentSeed
 ): AgreementDocument => ({
-  id: input.id as AgreementDocumentId,
+  id: unsafeBrandId(input.id),
   name: input.name,
   prettyName: input.prettyName,
   contentType: input.contentType,

--- a/packages/agreement-process/src/model/domain/apiConverter.ts
+++ b/packages/agreement-process/src/model/domain/apiConverter.ts
@@ -3,6 +3,7 @@ import {
   AgreementState,
   AgreementDocument,
   agreementState,
+  AgreementDocumentId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
@@ -89,7 +90,7 @@ export const agreementToApiAgreement = (
 export const apiAgreementDocumentToAgreementDocument = (
   input: ApiAgreementDocumentSeed
 ): AgreementDocument => ({
-  id: input.id,
+  id: input.id as AgreementDocumentId,
   name: input.name,
   prettyName: input.prettyName,
   contentType: input.contentType,

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -1,6 +1,9 @@
 import {
+  AgreementDocumentId,
+  AgreementId,
   AgreementState,
   ApiError,
+  DescriptorId,
   DescriptorState,
   makeApiProblemBuilder,
 } from "pagopa-interop-models";
@@ -45,7 +48,9 @@ export function eServiceNotFound(eServiceId: string): ApiError<ErrorCodes> {
   });
 }
 
-export function agreementNotFound(agreementId: string): ApiError<ErrorCodes> {
+export function agreementNotFound(
+  agreementId: AgreementId
+): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Agreement ${agreementId} not found`,
     code: "agreementNotFound",
@@ -54,7 +59,7 @@ export function agreementNotFound(agreementId: string): ApiError<ErrorCodes> {
 }
 
 export function notLatestEServiceDescriptor(
-  descriptorId: string
+  descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor with descriptorId: ${descriptorId} is not the latest descriptor`,
@@ -65,7 +70,7 @@ export function notLatestEServiceDescriptor(
 
 export function descriptorNotFound(
   eServiceId: string,
-  descriptorId: string
+  descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor ${descriptorId} not found in EService ${eServiceId}`,
@@ -76,7 +81,7 @@ export function descriptorNotFound(
 
 export function descriptorNotInExpectedState(
   eServiceId: string,
-  descriptorId: string,
+  descriptorId: DescriptorId,
   allowedStates: DescriptorState[]
 ): ApiError<ErrorCodes> {
   return new ApiError({
@@ -89,7 +94,7 @@ export function descriptorNotInExpectedState(
 }
 
 export function missingCertifiedAttributesError(
-  descriptorId: string,
+  descriptorId: DescriptorId,
   consumerId: string
 ): ApiError<ErrorCodes> {
   return new ApiError({
@@ -129,7 +134,7 @@ export function documentsChangeNotAllowed(
 }
 
 export function agreementDocumentAlreadyExists(
-  agreementId: string
+  agreementId: AgreementId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Agreement document for ${agreementId} already exists`,
@@ -139,8 +144,8 @@ export function agreementDocumentAlreadyExists(
 }
 
 export function agreementDocumentNotFound(
-  documentId: string,
-  agreementId: string
+  documentId: AgreementDocumentId,
+  agreementId: AgreementId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Document ${documentId} in agreement ${agreementId} not found`,
@@ -150,7 +155,7 @@ export function agreementDocumentNotFound(
 }
 
 export function agreementNotInExpectedState(
-  agreementId: string,
+  agreementId: AgreementId,
   state: string
 ): ApiError<ErrorCodes> {
   return new ApiError({
@@ -169,7 +174,7 @@ export function tenantIdNotFound(tenantId: string): ApiError<ErrorCodes> {
 }
 
 export function agreementSubmissionFailed(
-  agreementId: string
+  agreementId: AgreementId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Unable to activate agreement ${agreementId}. Please check if attributes requirements and suspension flags are satisfied`,
@@ -179,7 +184,7 @@ export function agreementSubmissionFailed(
 }
 
 export function contractAlreadyExists(
-  agreementId: string
+  agreementId: AgreementId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Agreement document for ${agreementId} already exists`,
@@ -189,7 +194,7 @@ export function contractAlreadyExists(
 }
 
 export function agreementActivationFailed(
-  agreementId: string
+  agreementId: AgreementId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     code: "agreementActivationFailed",
@@ -199,7 +204,7 @@ export function agreementActivationFailed(
 }
 
 export function consumerWithNotValidEmail(
-  agreementId: string,
+  agreementId: AgreementId,
   tenantId: string
 ): ApiError<ErrorCodes> {
   return new ApiError({
@@ -247,7 +252,7 @@ export function publishedDescriptorNotFound(
 
 export function unexpectedVersionFormat(
   eserviceId: string,
-  descriptorId: string
+  descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Version in not an Int for descriptor ${descriptorId} of EService ${eserviceId}`,
@@ -258,7 +263,7 @@ export function unexpectedVersionFormat(
 
 export function noNewerDescriptor(
   eserviceId: string,
-  descriptorId: string
+  descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `No newer descriptor in EService ${eserviceId} exists for upgrade. Current descriptor ${descriptorId}`,

--- a/packages/agreement-process/src/model/domain/models.ts
+++ b/packages/agreement-process/src/model/domain/models.ts
@@ -1,7 +1,7 @@
 import {
+  AgreementAttribute,
   AgreementStamps,
   AgreementState,
-  AgreementAttribute,
 } from "pagopa-interop-models";
 import { z } from "zod";
 

--- a/packages/agreement-process/src/model/domain/toEvent.ts
+++ b/packages/agreement-process/src/model/domain/toEvent.ts
@@ -7,7 +7,6 @@ import {
   AgreementDeleteEvent,
   AgreementDocument,
   AgreementDocumentV1,
-  AgreementRemoveConsumerDocumentEvent,
   AgreementStamp,
   AgreementStamps,
   AgreementState,
@@ -16,6 +15,9 @@ import {
   AgreementV1,
   StampV1,
   StampsV1,
+  AgreementId,
+  AgreementDocumentId,
+  AgreementRemoveConsumerDocumentEvent,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
@@ -120,7 +122,7 @@ export function toCreateEventAgreementUpdated(
 }
 
 export function toCreateEventAgreementContractAdded(
-  agreementId: string,
+  agreementId: AgreementId,
   agreementDocument: AgreementDocument,
   version: number
 ): CreateEvent<AgreementAddContractEvent> {
@@ -138,7 +140,7 @@ export function toCreateEventAgreementContractAdded(
 }
 
 export function toCreateEventAgreementConsumerDocumentAdded(
-  agreementId: string,
+  agreementId: AgreementId,
   agreementDocument: AgreementDocument,
   version: number
 ): CreateEvent<AgreementAddConsumerDocumentEvent> {
@@ -156,8 +158,8 @@ export function toCreateEventAgreementConsumerDocumentAdded(
 }
 
 export function toCreateEventAgreementConsumerDocumentRemoved(
-  agreementId: string,
-  documentId: string,
+  agreementId: AgreementId,
+  documentId: AgreementDocumentId,
   version: number
 ): CreateEvent<AgreementRemoveConsumerDocumentEvent> {
   return {

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -1,6 +1,7 @@
 import {
   Agreement,
   AgreementState,
+  AttributeId,
   CertifiedTenantAttribute,
   DeclaredTenantAttribute,
   Descriptor,
@@ -381,8 +382,8 @@ const attributesSatisfied = <
 
 const matchingAttributes = (
   eServiceAttributes: EServiceAttribute[][],
-  consumerAttributes: string[]
-): string[] =>
+  consumerAttributes: AttributeId[]
+): AttributeId[] =>
   eServiceAttributes
     .flatMap((atts) => atts.map((att) => att.id))
     .filter((att) => consumerAttributes.includes(att));

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -16,6 +16,8 @@ import {
   tenantAttributeType,
   agreementActivableStates,
   agreementActivationFailureStates,
+  AgreementId,
+  DescriptorId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { AuthData } from "pagopa-interop-commons";
@@ -50,7 +52,7 @@ type RevocableTenantAttribute =
 /* ========= ASSERTIONS ========= */
 
 export function assertAgreementExist(
-  agreementId: string,
+  agreementId: AgreementId,
   agreement: WithMetadata<Agreement> | undefined
 ): asserts agreement is NonNullable<WithMetadata<Agreement>> {
   if (agreement === undefined) {
@@ -98,7 +100,7 @@ export const assertRequesterIsConsumerOrProducer = (
 
 export const assertSubmittableState = (
   state: AgreementState,
-  agreementId: string
+  agreementId: AgreementId
 ): void => {
   if (state !== agreementState.draft) {
     throw agreementNotInExpectedState(agreementId, state);
@@ -106,7 +108,7 @@ export const assertSubmittableState = (
 };
 
 export const assertExpectedState = (
-  agreementId: string,
+  agreementId: AgreementId,
   agreementState: AgreementState,
   expectedStates: AgreementState[]
 ): void => {
@@ -140,7 +142,7 @@ export const assertActivableState = (agreement: Agreement): void => {
 
 export function assertDescriptorExist(
   eserviceId: string,
-  descriptorId: string,
+  descriptorId: DescriptorId,
   descriptor: Descriptor | undefined
 ): asserts descriptor is NonNullable<Descriptor> {
   if (descriptor === undefined) {
@@ -163,7 +165,7 @@ const validateDescriptorState = (
 
 const validateLatestDescriptor = (
   eService: EService,
-  descriptorId: string,
+  descriptorId: DescriptorId,
   allowedStates: DescriptorState[]
 ): Descriptor => {
   const recentActiveDescriptors = eService.descriptors
@@ -190,7 +192,7 @@ const validateLatestDescriptor = (
 
 export const validateCreationOnDescriptor = (
   eservice: EService,
-  descriptorId: string
+  descriptorId: DescriptorId
 ): Descriptor => {
   const allowedStatus = [descriptorState.published];
   return validateLatestDescriptor(eservice, descriptorId, allowedStatus);
@@ -243,7 +245,7 @@ export const validateCertifiedAttributes = (
 
 export const validateSubmitOnDescriptor = async (
   eservice: EService,
-  descriptorId: string
+  descriptorId: DescriptorId
 ): Promise<Descriptor> => {
   const allowedStatus: DescriptorState[] = [
     descriptorState.published,
@@ -253,7 +255,7 @@ export const validateSubmitOnDescriptor = async (
 };
 
 export const validateActiveOrPendingAgreement = (
-  agreementId: string,
+  agreementId: AgreementId,
   state: AgreementState
 ): void => {
   if (agreementState.active !== state && agreementState.pending !== state) {

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -8,7 +8,11 @@ import {
   initDB,
   ReadModelRepository,
 } from "pagopa-interop-commons";
-import { Agreement } from "pagopa-interop-models";
+import {
+  Agreement,
+  AgreementDocumentId,
+  AgreementId,
+} from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import {
   agreementDocumentToApiAgreementDocument,
@@ -83,7 +87,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.submitAgreement(
-          req.params.agreementId,
+          req.params.agreementId as AgreementId,
           req.body
         );
         return res.status(200).json({ id }).end();
@@ -119,7 +123,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.addConsumerDocument(
-          req.params.agreementId,
+          req.params.agreementId as AgreementId,
           req.body,
           req.ctx.authData
         );
@@ -138,8 +142,8 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const document = await agreementService.getAgreementConsumerDocument(
-          req.params.agreementId,
-          req.params.documentId,
+          req.params.agreementId as AgreementId,
+          req.params.documentId as AgreementDocumentId,
           req.ctx.authData
         );
         return res
@@ -159,8 +163,8 @@ const agreementRouter = (
     async (req, res) => {
       try {
         await agreementService.removeAgreementConsumerDocument(
-          req.params.agreementId,
-          req.params.documentId,
+          req.params.agreementId as AgreementId,
+          req.params.documentId as AgreementDocumentId,
           req.ctx.authData
         );
         return res.status(204).send();
@@ -180,7 +184,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.suspendAgreement(
-          req.params.agreementId,
+          req.params.agreementId as AgreementId,
           req.ctx.authData
         );
         return res.status(200).json({ id }).send();
@@ -197,7 +201,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.rejectAgreement(
-          req.params.agreementId,
+          req.params.agreementId as AgreementId,
           req.body.reason,
           req.ctx.authData
         );
@@ -356,7 +360,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const agreement = await agreementService.getAgreementById(
-          req.params.agreementId
+          req.params.agreementId as AgreementId
         );
         if (agreement) {
           return res
@@ -387,7 +391,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         await agreementService.deleteAgreementById(
-          req.params.agreementId,
+          req.params.agreementId as AgreementId,
           req.ctx.authData
         );
         return res.status(204).send();
@@ -404,7 +408,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         await agreementService.updateAgreement(
-          req.params.agreementId,
+          req.params.agreementId as AgreementId,
           req.body,
           req.ctx.authData
         );
@@ -423,7 +427,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.upgradeAgreement(
-          req.params.agreementId,
+          req.params.agreementId as AgreementId,
           req.ctx.authData
         );
 
@@ -441,7 +445,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.cloneAgreement(
-          req.params.agreementId,
+          req.params.agreementId as AgreementId,
           req.ctx.authData
         );
 

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -8,11 +8,7 @@ import {
   initDB,
   ReadModelRepository,
 } from "pagopa-interop-commons";
-import {
-  Agreement,
-  AgreementDocumentId,
-  AgreementId,
-} from "pagopa-interop-models";
+import { Agreement, unsafeBrandId } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import {
   agreementDocumentToApiAgreementDocument,
@@ -87,7 +83,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.submitAgreement(
-          req.params.agreementId as AgreementId,
+          unsafeBrandId(req.params.agreementId),
           req.body
         );
         return res.status(200).json({ id }).end();
@@ -105,7 +101,7 @@ const agreementRouter = (
       try {
         const agreementId: Agreement["id"] =
           await agreementService.activateAgreement(
-            req.params.agreementId,
+            unsafeBrandId(req.params.agreementId),
             req.ctx.authData
           );
 
@@ -123,7 +119,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.addConsumerDocument(
-          req.params.agreementId as AgreementId,
+          unsafeBrandId(req.params.agreementId),
           req.body,
           req.ctx.authData
         );
@@ -142,8 +138,8 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const document = await agreementService.getAgreementConsumerDocument(
-          req.params.agreementId as AgreementId,
-          req.params.documentId as AgreementDocumentId,
+          unsafeBrandId(req.params.agreementId),
+          unsafeBrandId(req.params.documentId),
           req.ctx.authData
         );
         return res
@@ -163,8 +159,8 @@ const agreementRouter = (
     async (req, res) => {
       try {
         await agreementService.removeAgreementConsumerDocument(
-          req.params.agreementId as AgreementId,
-          req.params.documentId as AgreementDocumentId,
+          unsafeBrandId(req.params.agreementId),
+          unsafeBrandId(req.params.documentId),
           req.ctx.authData
         );
         return res.status(204).send();
@@ -184,7 +180,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.suspendAgreement(
-          req.params.agreementId as AgreementId,
+          unsafeBrandId(req.params.agreementId),
           req.ctx.authData
         );
         return res.status(200).json({ id }).send();
@@ -201,7 +197,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.rejectAgreement(
-          req.params.agreementId as AgreementId,
+          unsafeBrandId(req.params.agreementId),
           req.body.reason,
           req.ctx.authData
         );
@@ -219,7 +215,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const agreementId = await agreementService.archiveAgreement(
-          req.params.agreementId,
+          unsafeBrandId(req.params.agreementId),
           req.ctx.authData
         );
         return res.status(200).send({ id: agreementId });
@@ -360,7 +356,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const agreement = await agreementService.getAgreementById(
-          req.params.agreementId as AgreementId
+          unsafeBrandId(req.params.agreementId)
         );
         if (agreement) {
           return res
@@ -391,7 +387,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         await agreementService.deleteAgreementById(
-          req.params.agreementId as AgreementId,
+          unsafeBrandId(req.params.agreementId),
           req.ctx.authData
         );
         return res.status(204).send();
@@ -408,7 +404,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         await agreementService.updateAgreement(
-          req.params.agreementId as AgreementId,
+          unsafeBrandId(req.params.agreementId),
           req.body,
           req.ctx.authData
         );
@@ -427,7 +423,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.upgradeAgreement(
-          req.params.agreementId as AgreementId,
+          unsafeBrandId(req.params.agreementId),
           req.ctx.authData
         );
 
@@ -445,7 +441,7 @@ const agreementRouter = (
     async (req, res) => {
       try {
         const id = await agreementService.cloneAgreement(
-          req.params.agreementId as AgreementId,
+          unsafeBrandId(req.params.agreementId),
           req.ctx.authData
         );
 

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -8,7 +8,7 @@ import {
   initDB,
   ReadModelRepository,
 } from "pagopa-interop-commons";
-import { Agreement, unsafeBrandId } from "pagopa-interop-models";
+import { Agreement, DescriptorId, unsafeBrandId } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import {
   agreementDocumentToApiAgreementDocument,
@@ -259,7 +259,9 @@ const agreementRouter = (
             eserviceId: req.query.eservicesIds,
             consumerId: req.query.consumersIds,
             producerId: req.query.producersIds,
-            descriptorId: req.query.descriptorsIds,
+            descriptorId: req.query.descriptorsIds.map(
+              unsafeBrandId<DescriptorId>
+            ),
             agreementStates: req.query.states.map(
               apiAgreementStateToAgreementState
             ),

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -370,7 +370,7 @@ const agreementRouter = (
             .status(404)
             .json(
               makeApiProblem(
-                agreementNotFound(req.params.agreementId),
+                agreementNotFound(unsafeBrandId(req.params.agreementId)),
                 () => 404
               )
             )

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -10,6 +10,7 @@ import {
   WithMetadata,
   AgreementEvent,
   AgreementUpdateEvent,
+  AgreementId,
 } from "pagopa-interop-models";
 import {
   assertAgreementExist,
@@ -45,7 +46,7 @@ import {
 import { AttributeQuery } from "./readmodel/attributeQuery.js";
 
 export async function activateAgreementLogic(
-  agreementId: string,
+  agreementId: AgreementId,
   agreementQuery: AgreementQuery,
   eserviceQuery: EserviceQuery,
   tenantQuery: TenantQuery,

--- a/packages/agreement-process/src/services/agreementConsumerDocumentProcessor.ts
+++ b/packages/agreement-process/src/services/agreementConsumerDocumentProcessor.ts
@@ -1,5 +1,9 @@
 import { AuthData, CreateEvent } from "pagopa-interop-commons";
-import { AgreementEvent } from "pagopa-interop-models";
+import {
+  AgreementDocumentId,
+  AgreementEvent,
+  AgreementId,
+} from "pagopa-interop-models";
 import { ApiAgreementDocumentSeed } from "../model/types.js";
 import {
   agreementDocumentAlreadyExists,
@@ -19,7 +23,7 @@ import { config } from "../utilities/config.js";
 import { AgreementQuery } from "./readmodel/agreementQuery.js";
 
 export async function addConsumerDocumentLogic(
-  agreementId: string,
+  agreementId: AgreementId,
   payload: ApiAgreementDocumentSeed,
   agreementQuery: AgreementQuery,
   authData: AuthData
@@ -46,8 +50,8 @@ export async function addConsumerDocumentLogic(
 }
 
 export async function removeAgreementConsumerDocumentLogic(
-  agreementId: string,
-  documentId: string,
+  agreementId: AgreementId,
+  documentId: AgreementDocumentId,
   agreementQuery: AgreementQuery,
   authData: AuthData,
   fileRemove: (container: string, path: string) => Promise<void>

--- a/packages/agreement-process/src/services/agreementContractBuilder.ts
+++ b/packages/agreement-process/src/services/agreementContractBuilder.ts
@@ -3,6 +3,7 @@ import {
   Agreement,
   AgreementDocument,
   AgreementEvent,
+  AgreementId,
   EService,
   Tenant,
 } from "pagopa-interop-models";
@@ -34,7 +35,7 @@ export const contractBuilder = (attributeQuery: AttributeQuery) => ({
 export type ContractBuilder = ReturnType<typeof contractBuilder>;
 
 export async function addAgreementContractLogic(
-  agreementId: string,
+  agreementId: AgreementId,
   agreementDocument: AgreementDocument,
   version: number
 ): Promise<CreateEvent<AgreementEvent>> {

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -24,8 +24,8 @@ import {
   agreementRejectableStates,
   AgreementUpdateEvent,
   AgreementDocumentId,
-  DescriptorId,
   AgreementId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import {
   agreementAlreadyExists,
@@ -489,7 +489,7 @@ export async function createAgreementLogic(
   const agreementSeed: Agreement = {
     id: generateId(),
     eserviceId: agreement.eserviceId,
-    descriptorId: agreement.descriptorId as DescriptorId,
+    descriptorId: unsafeBrandId(agreement.descriptorId),
     producerId: eservice.data.producerId,
     consumerId: authData.organizationId,
     state: agreementState.draft,
@@ -636,7 +636,7 @@ export async function upgradeAgreementLogic({
     const upgraded: Agreement = {
       ...agreementToBeUpgraded.data,
       id: generateId(),
-      descriptorId: newDescriptor.id as DescriptorId,
+      descriptorId: unsafeBrandId(newDescriptor.id),
       createdAt: new Date(),
       updatedAt: undefined,
       rejectionReason: undefined,
@@ -668,7 +668,7 @@ export async function upgradeAgreementLogic({
     const newAgreement: Agreement = {
       id: generateId(),
       eserviceId: agreementToBeUpgraded.data.eserviceId,
-      descriptorId: unsafeBrandedId(newDescriptor.id),
+      descriptorId: unsafeBrandId(newDescriptor.id),
       producerId: agreementToBeUpgraded.data.producerId,
       consumerId: agreementToBeUpgraded.data.consumerId,
       verifiedAttributes: agreementToBeUpgraded.data.verifiedAttributes,

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -387,7 +387,7 @@ export function agreementServiceBuilder(
 export type AgreementService = ReturnType<typeof agreementServiceBuilder>;
 
 async function createAndCopyDocumentsForClonedAgreement(
-  newAgreementId: string,
+  newAgreementId: AgreementId,
   clonedAgreement: Agreement,
   startingVersion: number,
   fileCopy: (
@@ -435,7 +435,7 @@ export async function deleteAgreementLogic({
   deleteFile,
   agreement,
 }: {
-  agreementId: string;
+  agreementId: AgreementId;
   authData: AuthData;
   deleteFile: (container: string, path: string) => Promise<void>;
   agreement: WithMetadata<Agreement> | undefined;
@@ -471,7 +471,7 @@ export async function createAgreementLogic(
 
   const descriptor = validateCreationOnDescriptor(
     eservice.data,
-    agreement.descriptorId
+    unsafeBrandId(agreement.descriptorId)
   );
 
   await verifyCreationConflictingAgreements(
@@ -510,7 +510,7 @@ export async function updateAgreementLogic({
   authData,
   agreementToBeUpdated,
 }: {
-  agreementId: string;
+  agreementId: AgreementId;
   agreement: ApiAgreementUpdatePayload;
   authData: AuthData;
   agreementToBeUpdated: WithMetadata<Agreement> | undefined;
@@ -684,7 +684,7 @@ export async function upgradeAgreementLogic({
     const createEvent = toCreateEventAgreementAdded(newAgreement);
 
     const docEvents = await createAndCopyDocumentsForClonedAgreement(
-      createEvent.streamId,
+      newAgreement.id,
       agreementToBeUpgraded.data,
       1,
       fileCopy
@@ -780,7 +780,7 @@ export async function cloneAgreementLogic({
   const createEvent = toCreateEventAgreementAdded(newAgreement);
 
   const docEvents = await createAndCopyDocumentsForClonedAgreement(
-    createEvent.streamId,
+    newAgreement.id,
     agreementToBeCloned.data,
     0,
     fileCopy

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -636,7 +636,7 @@ export async function upgradeAgreementLogic({
     const upgraded: Agreement = {
       ...agreementToBeUpgraded.data,
       id: generateId(),
-      descriptorId: unsafeBrandId(newDescriptor.id),
+      descriptorId: newDescriptor.id,
       createdAt: new Date(),
       updatedAt: undefined,
       rejectionReason: undefined,
@@ -668,7 +668,7 @@ export async function upgradeAgreementLogic({
     const newAgreement: Agreement = {
       id: generateId(),
       eserviceId: agreementToBeUpgraded.data.eserviceId,
-      descriptorId: unsafeBrandId(newDescriptor.id),
+      descriptorId: newDescriptor.id,
       producerId: agreementToBeUpgraded.data.producerId,
       consumerId: agreementToBeUpgraded.data.consumerId,
       verifiedAttributes: agreementToBeUpgraded.data.verifiedAttributes,

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -2,7 +2,9 @@
 import { CreateEvent, getContext, logger } from "pagopa-interop-commons";
 import {
   Agreement,
+  AgreementDocumentId,
   AgreementEvent,
+  AgreementId,
   AgreementStamp,
   AgreementStamps,
   AgreementState,
@@ -56,7 +58,7 @@ export type AgremeentSubmissionResults = {
 };
 
 export async function submitAgreementLogic(
-  agreementId: string,
+  agreementId: AgreementId,
   payload: ApiAgreementSubmissionPayload,
   constractBuilder: ContractBuilder,
   eserviceQuery: EserviceQuery,
@@ -241,14 +243,16 @@ const createContract = async (
     throw contractAlreadyExists(agreement.id);
   }
 
+  const newContract = await constractBuilder.createContract(
+    agreement,
+    eservice,
+    consumer,
+    producer.data,
+    seed
+  );
   const agreementdocumentSeed = {
-    ...(await constractBuilder.createContract(
-      agreement,
-      eservice,
-      consumer,
-      producer.data,
-      seed
-    )),
+    ...newContract,
+    id: newContract.id as AgreementDocumentId,
     createdAt: new Date(),
   };
 

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -2,7 +2,7 @@
 import { CreateEvent, getContext, logger } from "pagopa-interop-commons";
 import {
   Agreement,
-  AgreementDocumentId,
+  AgreementDocument,
   AgreementEvent,
   AgreementId,
   AgreementStamp,
@@ -14,6 +14,7 @@ import {
   WithMetadata,
   agreementState,
   tenantMailKind,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import {
@@ -250,9 +251,9 @@ const createContract = async (
     producer.data,
     seed
   );
-  const agreementdocumentSeed = {
+  const agreementdocumentSeed: AgreementDocument = {
     ...newContract,
-    id: newContract.id as AgreementDocumentId,
+    id: unsafeBrandId(newContract.id),
     createdAt: new Date(),
   };
 

--- a/packages/agreement-process/src/services/readmodel/agreementQuery.ts
+++ b/packages/agreement-process/src/services/readmodel/agreementQuery.ts
@@ -1,4 +1,9 @@
-import { Agreement, ListResult, WithMetadata } from "pagopa-interop-models";
+import {
+  Agreement,
+  AgreementId,
+  ListResult,
+  WithMetadata,
+} from "pagopa-interop-models";
 import { CompactOrganization } from "../../model/domain/models.js";
 import { AgreementQueryFilters, ReadModelService } from "./readModelService.js";
 
@@ -6,7 +11,7 @@ import { AgreementQueryFilters, ReadModelService } from "./readModelService.js";
 export function agreementQueryBuilder(readModelService: ReadModelService) {
   return {
     getAgreementById: async (
-      id: string
+      id: AgreementId
     ): Promise<WithMetadata<Agreement> | undefined> =>
       await readModelService.readAgreementById(id),
     getAllAgreements: (

--- a/packages/agreement-process/src/services/readmodel/attributeQuery.ts
+++ b/packages/agreement-process/src/services/readmodel/attributeQuery.ts
@@ -1,10 +1,10 @@
-import { Attribute, WithMetadata } from "pagopa-interop-models";
+import { Attribute, AttributeId, WithMetadata } from "pagopa-interop-models";
 import { ReadModelService } from "./readModelService.js";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const attributeQueryBuilder = (readModelService: ReadModelService) => ({
   getAttributeById: async (
-    attributeId: string
+    attributeId: AttributeId
   ): Promise<WithMetadata<Attribute> | undefined> =>
     await readModelService.getAttributeById(attributeId),
 });

--- a/packages/agreement-process/src/services/readmodel/readModelService.ts
+++ b/packages/agreement-process/src/services/readmodel/readModelService.ts
@@ -37,9 +37,9 @@ export type AgreementQueryFilters = {
   producerId?: string | string[];
   consumerId?: string | string[];
   eserviceId?: string | string[];
-  descriptorId?: DescriptorId | string[];
+  descriptorId?: DescriptorId | DescriptorId[];
   agreementStates?: AgreementState[];
-  attributeId?: AttributeId | string[];
+  attributeId?: AttributeId | AttributeId[];
   showOnlyUpgradeable?: boolean;
 };
 

--- a/packages/agreement-process/src/services/readmodel/readModelService.ts
+++ b/packages/agreement-process/src/services/readmodel/readModelService.ts
@@ -12,8 +12,11 @@ import {
 } from "pagopa-interop-commons";
 import {
   Agreement,
+  AttributeId,
+  AgreementId,
   AgreementState,
   Attribute,
+  DescriptorId,
   EService,
   ListResult,
   Tenant,
@@ -34,9 +37,9 @@ export type AgreementQueryFilters = {
   producerId?: string | string[];
   consumerId?: string | string[];
   eserviceId?: string | string[];
-  descriptorId?: string | string[];
+  descriptorId?: DescriptorId | string[];
   agreementStates?: AgreementState[];
-  attributeId?: string | string[];
+  attributeId?: AttributeId | string[];
   showOnlyUpgradeable?: boolean;
 };
 
@@ -380,7 +383,7 @@ export function readModelServiceBuilder(
       };
     },
     async readAgreementById(
-      agreementId: string
+      agreementId: AgreementId
     ): Promise<WithMetadata<Agreement> | undefined> {
       const data = await agreements.findOne(
         { "data.id": agreementId },

--- a/packages/agreement-readmodel-writer/src/model/converter.ts
+++ b/packages/agreement-readmodel-writer/src/model/converter.ts
@@ -10,12 +10,17 @@ import {
   StampsV1,
   AgreementStamps,
   agreementState,
+  AgreementDocumentId,
+  AgreementId,
+  DescriptorId,
+  AttributeId,
 } from "pagopa-interop-models";
 
 export const fromDocumentV1 = (
   input: AgreementDocumentV1
 ): AgreementDocument => ({
   ...input,
+  id: input.id as AgreementDocumentId,
   createdAt: new Date(Number(input.createdAt)),
 });
 
@@ -68,6 +73,20 @@ export const fromAgreementState = (input: AgreementStateV1): AgreementState => {
 
 export const fromAgreementV1 = (input: AgreementV1): Agreement => ({
   ...input,
+  id: input.id as AgreementId,
+  descriptorId: input.descriptorId as DescriptorId,
+  certifiedAttributes: input.certifiedAttributes.map((a) => ({
+    ...a,
+    id: AttributeId.parse(a.id),
+  })),
+  declaredAttributes: input.declaredAttributes.map((a) => ({
+    ...a,
+    id: AttributeId.parse(a.id),
+  })),
+  verifiedAttributes: input.verifiedAttributes.map((a) => ({
+    ...a,
+    id: AttributeId.parse(a.id),
+  })),
   state: fromAgreementState(input.state),
   createdAt: new Date(Number(input.createdAt)),
   updatedAt: input.updatedAt ? new Date(Number(input.updatedAt)) : undefined,

--- a/packages/agreement-readmodel-writer/src/model/converter.ts
+++ b/packages/agreement-readmodel-writer/src/model/converter.ts
@@ -10,17 +10,15 @@ import {
   StampsV1,
   AgreementStamps,
   agreementState,
-  AgreementDocumentId,
-  AgreementId,
-  DescriptorId,
   AttributeId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 
 export const fromDocumentV1 = (
   input: AgreementDocumentV1
 ): AgreementDocument => ({
   ...input,
-  id: input.id as AgreementDocumentId,
+  id: unsafeBrandId(input.id),
   createdAt: new Date(Number(input.createdAt)),
 });
 
@@ -73,8 +71,8 @@ export const fromAgreementState = (input: AgreementStateV1): AgreementState => {
 
 export const fromAgreementV1 = (input: AgreementV1): Agreement => ({
   ...input,
-  id: input.id as AgreementId,
-  descriptorId: input.descriptorId as DescriptorId,
+  id: unsafeBrandId(input.id),
+  descriptorId: unsafeBrandId(input.descriptorId),
   certifiedAttributes: input.certifiedAttributes.map((a) => ({
     ...a,
     id: AttributeId.parse(a.id),

--- a/packages/agreement-readmodel-writer/src/model/converter.ts
+++ b/packages/agreement-readmodel-writer/src/model/converter.ts
@@ -10,7 +10,6 @@ import {
   StampsV1,
   AgreementStamps,
   agreementState,
-  AttributeId,
   unsafeBrandId,
 } from "pagopa-interop-models";
 
@@ -75,15 +74,15 @@ export const fromAgreementV1 = (input: AgreementV1): Agreement => ({
   descriptorId: unsafeBrandId(input.descriptorId),
   certifiedAttributes: input.certifiedAttributes.map((a) => ({
     ...a,
-    id: AttributeId.parse(a.id),
+    id: unsafeBrandId(a.id),
   })),
   declaredAttributes: input.declaredAttributes.map((a) => ({
     ...a,
-    id: AttributeId.parse(a.id),
+    id: unsafeBrandId(a.id),
   })),
   verifiedAttributes: input.verifiedAttributes.map((a) => ({
     ...a,
-    id: AttributeId.parse(a.id),
+    id: unsafeBrandId(a.id),
   })),
   state: fromAgreementState(input.state),
   createdAt: new Date(Number(input.createdAt)),

--- a/packages/attribute-registry-consumer/src/model/converter.ts
+++ b/packages/attribute-registry-consumer/src/model/converter.ts
@@ -4,6 +4,7 @@ import {
   AttributeKind,
   attributeKind,
   Attribute,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 
 export const fromAttributeKindV1 = (input: AttributeKindV1): AttributeKind => {
@@ -20,6 +21,7 @@ export const fromAttributeKindV1 = (input: AttributeKindV1): AttributeKind => {
 };
 export const fromAttributeV1 = (input: AttributeV1): Attribute => ({
   ...input,
+  id: unsafeBrandId(input.id),
   kind: fromAttributeKindV1(input.kind),
   creationTime: new Date(input.creationTime),
 });

--- a/packages/attribute-registry-process/src/services/attributeRegistryService.ts
+++ b/packages/attribute-registry-process/src/services/attributeRegistryService.ts
@@ -10,8 +10,8 @@ import {
   WithMetadata,
   attributeEventToBinaryData,
   attributeKind,
+  generateId,
 } from "pagopa-interop-models";
-import { v4 as uuidv4 } from "uuid";
 import { AttributeRegistryConfig } from "../utilities/config.js";
 import {
   ApiCertifiedAttributeSeed,
@@ -151,7 +151,7 @@ export function createDeclaredAttributeLogic({
   }
 
   const newDeclaredAttribute: Attribute = {
-    id: uuidv4(),
+    id: generateId(),
     kind: attributeKind.declared,
     name: apiDeclaredAttributeSeed.name,
     description: apiDeclaredAttributeSeed.description,
@@ -175,7 +175,7 @@ export function createVerifiedAttributeLogic({
   }
 
   const newVerifiedAttribute: Attribute = {
-    id: uuidv4(),
+    id: generateId(),
     kind: attributeKind.verified,
     name: apiVerifiedAttributeSeed.name,
     description: apiVerifiedAttributeSeed.description,
@@ -201,7 +201,7 @@ export function createCertifiedAttributeLogic({
   }
 
   const newCertifiedAttribute: Attribute = {
-    id: uuidv4(),
+    id: generateId(),
     kind: attributeKind.certified,
     name: apiCertifiedAttributeSeed.name,
     description: apiCertifiedAttributeSeed.description,
@@ -225,7 +225,7 @@ export function createInternalCertifiedAttributeLogic({
   }
 
   const newInternalCertifiedAttribute: Attribute = {
-    id: uuidv4(),
+    id: generateId(),
     kind: attributeKind.certified,
     name: apiInternalCertifiedAttributeSeed.name,
     description: apiInternalCertifiedAttributeSeed.description,

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -1,4 +1,8 @@
-import { ApiError, makeApiProblemBuilder } from "pagopa-interop-models";
+import {
+  ApiError,
+  DescriptorId,
+  makeApiProblemBuilder,
+} from "pagopa-interop-models";
 
 export const errorCodes = {
   eServiceDescriptorNotFound: "0002",
@@ -61,7 +65,7 @@ export function eServiceCannotBeDeleted(
 
 export function eServiceDescriptorNotFound(
   eServiceId: string,
-  descriptorId: string
+  descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor ${descriptorId} for EService ${eServiceId} not found`,
@@ -72,7 +76,7 @@ export function eServiceDescriptorNotFound(
 
 export function eServiceDocumentNotFound(
   eServiceId: string,
-  descriptorId: string,
+  descriptorId: DescriptorId,
   documentId: string
 ): ApiError<ErrorCodes> {
   return new ApiError({
@@ -83,7 +87,7 @@ export function eServiceDocumentNotFound(
 }
 
 export function notValidDescriptor(
-  descriptorId: string,
+  descriptorId: DescriptorId,
   descriptorStatus: string
 ): ApiError<ErrorCodes> {
   return new ApiError({
@@ -94,7 +98,7 @@ export function notValidDescriptor(
 }
 
 export function eServiceDescriptorWithoutInterface(
-  descriptorId: string
+  descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor ${descriptorId} does not have an interface`,

--- a/packages/catalog-process/src/model/domain/models.ts
+++ b/packages/catalog-process/src/model/domain/models.ts
@@ -3,7 +3,11 @@
   This file will be removed once all models are converted from scala.
  */
 import { z } from "zod";
-import { DescriptorState, AgreementState } from "pagopa-interop-models";
+import {
+  DescriptorState,
+  AgreementState,
+  DescriptorId,
+} from "pagopa-interop-models";
 import * as api from "../generated/api.js";
 import { ApiEServiceDescriptorDocumentSeed } from "../types.js";
 
@@ -13,7 +17,7 @@ export type EServiceSeed = z.infer<typeof api.schemas.EServiceSeed> & {
 
 export type EServiceDocument = {
   readonly eServiceId: string;
-  readonly descriptorId: string;
+  readonly descriptorId: DescriptorId;
   readonly document: {
     readonly name: string;
     readonly contentType: string;
@@ -63,7 +67,7 @@ export type Consumer = z.infer<typeof consumer>;
 
 export const convertToDocumentEServiceEventData = (
   eServiceId: string,
-  descriptorId: string,
+  descriptorId: DescriptorId,
   apiEServiceDescriptorDocumentSeed: ApiEServiceDescriptorDocumentSeed
 ): EServiceDocument => ({
   eServiceId,
@@ -82,7 +86,7 @@ export const convertToDocumentEServiceEventData = (
 
 export const convertToDescriptorEServiceEventData = (
   eserviceDescriptorSeed: EServiceDescriptorSeed,
-  descriptorId: string,
+  descriptorId: DescriptorId,
   version: string
 ): EServiceDescriptor => ({
   id: descriptorId,

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -16,6 +16,7 @@ import {
   Technology,
   WithMetadata,
   EServiceEvent,
+  DescriptorId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 
@@ -130,7 +131,7 @@ export const toCreateEventClonedEServiceAdded = (
 export const toCreateEventEServiceDocumentAdded = (
   streamId: string,
   version: number,
-  descriptorId: string,
+  descriptorId: DescriptorId,
   {
     newDocument,
     isInterface,
@@ -192,7 +193,7 @@ export const toCreateEventEServiceDocumentUpdated = ({
 }: {
   streamId: string;
   version: number;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   documentId: string;
   updatedDocument: Document;
   serverUrls: string[];
@@ -244,7 +245,7 @@ export const toCreateEventEServiceDeleted = (
 export const toCreateEventEServiceDocumentDeleted = (
   streamId: string,
   version: number,
-  descriptorId: string,
+  descriptorId: DescriptorId,
   documentId: string
 ): CreateEvent<EServiceEvent> => ({
   streamId,
@@ -261,7 +262,7 @@ export const toCreateEventEServiceDocumentDeleted = (
 
 export const toCreateEventEServiceWithDescriptorsDeleted = (
   eService: WithMetadata<EService>,
-  descriptorId: string
+  descriptorId: DescriptorId
 ): CreateEvent<EServiceEvent> => ({
   streamId: eService.data.id,
   version: eService.metadata.version,

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -8,6 +8,7 @@ import {
   ReadModelRepository,
   initDB,
 } from "pagopa-interop-commons";
+import { unsafeBrandId } from "pagopa-interop-models";
 import {
   agreementStateToApiAgreementState,
   apiAgreementStateToAgreementState,
@@ -257,7 +258,7 @@ const eservicesRouter = (
 
           const document = await readModelService.getDocumentById(
             eServiceId,
-            descriptorId,
+            unsafeBrandId(descriptorId),
             documentId
           );
 
@@ -279,7 +280,7 @@ const eservicesRouter = (
                 makeApiProblem(
                   eServiceDocumentNotFound(
                     eServiceId,
-                    descriptorId,
+                    unsafeBrandId(descriptorId),
                     documentId
                   ),
                   () => 404
@@ -300,7 +301,7 @@ const eservicesRouter = (
         try {
           const id = await catalogService.uploadDocument(
             req.params.eServiceId,
-            req.params.descriptorId,
+            unsafeBrandId(req.params.descriptorId),
             req.body,
             req.ctx.authData
           );
@@ -318,7 +319,7 @@ const eservicesRouter = (
         try {
           await catalogService.deleteDocument(
             req.params.eServiceId,
-            req.params.descriptorId,
+            unsafeBrandId(req.params.descriptorId),
             req.params.documentId,
             req.ctx.authData
           );
@@ -339,7 +340,7 @@ const eservicesRouter = (
         try {
           await catalogService.updateDocument(
             req.params.eServiceId,
-            req.params.descriptorId,
+            unsafeBrandId(req.params.descriptorId),
             req.params.documentId,
             req.body,
             req.ctx.authData
@@ -378,7 +379,7 @@ const eservicesRouter = (
         try {
           await catalogService.deleteDraftDescriptor(
             req.params.eServiceId,
-            req.params.descriptorId,
+            unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );
           return res.status(204).end();
@@ -398,7 +399,7 @@ const eservicesRouter = (
         try {
           await catalogService.updateDescriptor(
             req.params.eServiceId,
-            req.params.descriptorId,
+            unsafeBrandId(req.params.descriptorId),
             req.body,
             req.ctx.authData
           );
@@ -416,7 +417,7 @@ const eservicesRouter = (
         try {
           await catalogService.publishDescriptor(
             req.params.eServiceId,
-            req.params.descriptorId,
+            unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );
           return res.status(204).end();
@@ -433,7 +434,7 @@ const eservicesRouter = (
         try {
           await catalogService.suspendDescriptor(
             req.params.eServiceId,
-            req.params.descriptorId,
+            unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );
           return res.status(204).end();
@@ -450,7 +451,7 @@ const eservicesRouter = (
         try {
           await catalogService.activateDescriptor(
             req.params.eServiceId,
-            req.params.descriptorId,
+            unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );
           return res.status(204).end();
@@ -468,7 +469,7 @@ const eservicesRouter = (
           const clonedEserviceByDescriptor =
             await catalogService.cloneDescriptor(
               req.params.eServiceId,
-              req.params.descriptorId,
+              unsafeBrandId(req.params.descriptorId),
               req.ctx.authData
             );
           return res.status(200).json(clonedEserviceByDescriptor).end();
@@ -488,7 +489,7 @@ const eservicesRouter = (
         try {
           await catalogService.archiveDescriptor(
             req.params.eServiceId,
-            req.params.descriptorId,
+            unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );
           return res.status(204).end();

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -8,6 +8,7 @@ import {
 } from "pagopa-interop-commons";
 import {
   Descriptor,
+  DescriptorId,
   DescriptorState,
   Document,
   EService,
@@ -15,6 +16,7 @@ import {
   WithMetadata,
   catalogEventToBinaryData,
   descriptorState,
+  generateId,
   operationForbidden,
   unsafeBrandId,
 } from "pagopa-interop-models";
@@ -92,7 +94,7 @@ export const retrieveEService = async (
 };
 
 const retrieveDescriptor = (
-  descriptorId: string,
+  descriptorId: DescriptorId,
   eService: WithMetadata<EService>
 ): Descriptor => {
   const descriptor = eService.data.descriptors.find(
@@ -233,7 +235,7 @@ export function catalogServiceBuilder(
 
     async uploadDocument(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       document: ApiEServiceDescriptorDocumentSeed,
       authData: AuthData
     ): Promise<string> {
@@ -252,7 +254,7 @@ export function catalogServiceBuilder(
 
     async deleteDocument(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       documentId: string,
       authData: AuthData
     ): Promise<void> {
@@ -272,7 +274,7 @@ export function catalogServiceBuilder(
 
     async updateDocument(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       documentId: string,
       apiEServiceDescriptorDocumentUpdateSeed: ApiEServiceDescriptorDocumentUpdateSeed,
       authData: AuthData
@@ -312,7 +314,7 @@ export function catalogServiceBuilder(
 
     async deleteDraftDescriptor(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       authData: AuthData
     ): Promise<void> {
       logger.info(
@@ -333,7 +335,7 @@ export function catalogServiceBuilder(
 
     async updateDescriptor(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       seed: UpdateEServiceDescriptorSeed,
       authData: AuthData
     ): Promise<void> {
@@ -352,7 +354,7 @@ export function catalogServiceBuilder(
 
     async publishDescriptor(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       authData: AuthData
     ): Promise<void> {
       logger.info(
@@ -373,7 +375,7 @@ export function catalogServiceBuilder(
 
     async suspendDescriptor(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       authData: AuthData
     ): Promise<void> {
       logger.info(
@@ -394,7 +396,7 @@ export function catalogServiceBuilder(
 
     async activateDescriptor(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       authData: AuthData
     ): Promise<void> {
       logger.info(
@@ -415,7 +417,7 @@ export function catalogServiceBuilder(
 
     async cloneDescriptor(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       authData: AuthData
     ): Promise<EService> {
       logger.info(
@@ -439,7 +441,7 @@ export function catalogServiceBuilder(
 
     async archiveDescriptor(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       authData: AuthData
     ): Promise<void> {
       logger.info(
@@ -553,7 +555,7 @@ export function uploadDocumentLogic({
   eService,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   document: ApiEServiceDescriptorDocumentSeed;
   authData: AuthData;
   eService: WithMetadata<EService> | undefined;
@@ -597,7 +599,7 @@ export async function deleteDocumentLogic({
   deleteRemoteFile,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   documentId: string;
   authData: AuthData;
   eService: WithMetadata<EService> | undefined;
@@ -636,7 +638,7 @@ export async function updateDocumentLogic({
   eService,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   documentId: string;
   apiEServiceDescriptorDocumentUpdateSeed: ApiEServiceDescriptorDocumentUpdateSeed;
   authData: AuthData;
@@ -695,7 +697,7 @@ export function createDescriptorLogic({
   const certifiedAttributes = eserviceDescriptorSeed.attributes.certified;
 
   const newDescriptor: Descriptor = {
-    id: uuidv4(),
+    id: generateId(),
     description: eserviceDescriptorSeed.description,
     version: newVersion,
     interface: undefined,
@@ -742,7 +744,7 @@ export async function deleteDraftDescriptorLogic({
   eService,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   authData: AuthData;
   deleteFile: (container: string, path: string) => Promise<void>;
   eService: WithMetadata<EService> | undefined;
@@ -787,7 +789,7 @@ export function updateDescriptorLogic({
   eService,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   seed: UpdateEServiceDescriptorSeed;
   authData: AuthData;
   eService: WithMetadata<EService> | undefined;
@@ -843,7 +845,7 @@ export function publishDescriptorLogic({
   eService,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   authData: AuthData;
   eService: WithMetadata<EService> | undefined;
 }): Array<CreateEvent<EServiceEvent>> {
@@ -899,7 +901,7 @@ export function suspendDescriptorLogic({
   eService,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   authData: AuthData;
   eService: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
@@ -933,7 +935,7 @@ export function activateDescriptorLogic({
   eService,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   authData: AuthData;
   eService: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
@@ -989,7 +991,7 @@ export async function cloneDescriptorLogic({
   eService,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   authData: AuthData;
   copyFile: (
     container: string,
@@ -1066,7 +1068,7 @@ export async function cloneDescriptorLogic({
     descriptors: [
       {
         ...descriptor,
-        id: uuidv4(),
+        id: generateId(),
         version: "1",
         interface: clonedInterfaceDocument,
         docs: clonedDocuments,
@@ -1093,7 +1095,7 @@ export function archiveDescriptorLogic({
   eService,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   authData: AuthData;
   eService: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -7,6 +7,7 @@ import {
   logger,
 } from "pagopa-interop-commons";
 import {
+  AttributeId,
   Descriptor,
   DescriptorState,
   Document,
@@ -715,7 +716,12 @@ export function createDescriptorLogic({
     archivedAt: undefined,
     createdAt: new Date(),
     attributes: {
-      certified: certifiedAttributes,
+      certified: certifiedAttributes.map((a) =>
+        a.map((a) => ({
+          ...a,
+          id: a.id as AttributeId,
+        }))
+      ),
       declared: [],
       verified: [],
     },

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -7,7 +7,6 @@ import {
   logger,
 } from "pagopa-interop-commons";
 import {
-  AttributeId,
   Descriptor,
   DescriptorState,
   Document,
@@ -17,6 +16,7 @@ import {
   catalogEventToBinaryData,
   descriptorState,
   operationForbidden,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { v4 as uuidv4 } from "uuid";
@@ -719,7 +719,7 @@ export function createDescriptorLogic({
       certified: certifiedAttributes.map((a) =>
         a.map((a) => ({
           ...a,
-          id: a.id as AttributeId,
+          id: unsafeBrandId(a.id),
         }))
       ),
       declared: [],

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -17,6 +17,7 @@ import {
   WithMetadata,
   emptyListResult,
   genericError,
+  DescriptorId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { z } from "zod";
@@ -292,7 +293,7 @@ export function readModelServiceBuilder(
     },
     async getDocumentById(
       eServiceId: string,
-      descriptorId: string,
+      descriptorId: DescriptorId,
       documentId: string
     ): Promise<Document | undefined> {
       const eService = await this.getEServiceById(eServiceId);

--- a/packages/catalog-process/test/utils.ts
+++ b/packages/catalog-process/test/utils.ts
@@ -9,12 +9,14 @@ import { v4 as uuidv4 } from "uuid";
 import {
   Agreement,
   Descriptor,
+  DescriptorId,
   EService,
   EServiceEvent,
   Tenant,
   agreementState,
   catalogEventToBinaryData,
   descriptorState,
+  generateId,
   technology,
 } from "pagopa-interop-models";
 import { MessageType } from "@protobuf-ts/runtime";
@@ -121,7 +123,7 @@ export const getMockEService = (): EService => ({
 });
 
 export const getMockDescriptor = (): Descriptor => ({
-  id: uuidv4(),
+  id: generateId(),
   version: "0",
   docs: [],
   state: descriptorState.draft,
@@ -159,11 +161,11 @@ export const getMockAgreement = ({
   consumerId,
 }: {
   eServiceId: string;
-  descriptorId: string;
+  descriptorId: DescriptorId;
   producerId: string;
   consumerId: string;
 }): Agreement => ({
-  id: uuidv4(),
+  id: generateId(),
   createdAt: new Date(),
   eserviceId: eServiceId,
   descriptorId,

--- a/packages/catalog-readmodel-writer/src/model/converter.ts
+++ b/packages/catalog-readmodel-writer/src/model/converter.ts
@@ -90,6 +90,7 @@ export const fromDocumentV1 = (input: EServiceDocumentV1): Document => ({
 
 export const fromDescriptorV1 = (input: EServiceDescriptorV1): Descriptor => ({
   ...input,
+  id: unsafeBrandId(input.id),
   attributes:
     input.attributes != null
       ? {

--- a/packages/catalog-readmodel-writer/src/model/converter.ts
+++ b/packages/catalog-readmodel-writer/src/model/converter.ts
@@ -16,7 +16,7 @@ import {
   agreementApprovalPolicy,
   descriptorState,
   technology,
-  AttributeId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 
@@ -77,10 +77,10 @@ export const fromEServiceAttributeV1 = (
       {
         single: P.not(P.nullish),
       },
-      ({ single }) => [{ ...single, id: single.id as AttributeId }]
+      ({ single }) => [{ ...single, id: unsafeBrandId(single.id) }]
     )
     .otherwise(() =>
-      input.group.map((a) => ({ ...a, id: a.id as AttributeId }))
+      input.group.map((a) => ({ ...a, id: unsafeBrandId(a.id) }))
     );
 
 export const fromDocumentV1 = (input: EServiceDocumentV1): Document => ({

--- a/packages/catalog-readmodel-writer/src/model/converter.ts
+++ b/packages/catalog-readmodel-writer/src/model/converter.ts
@@ -16,6 +16,7 @@ import {
   agreementApprovalPolicy,
   descriptorState,
   technology,
+  AttributeId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 
@@ -76,9 +77,11 @@ export const fromEServiceAttributeV1 = (
       {
         single: P.not(P.nullish),
       },
-      ({ single }) => [single]
+      ({ single }) => [{ ...single, id: single.id as AttributeId }]
     )
-    .otherwise(() => input.group);
+    .otherwise(() =>
+      input.group.map((a) => ({ ...a, id: a.id as AttributeId }))
+    );
 
 export const fromDocumentV1 = (input: EServiceDocumentV1): Document => ({
   ...input,

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -25,7 +25,9 @@
     "@protobuf-ts/protoc": "^2.9.1",
     "@protobuf-ts/runtime": "^2.9.1",
     "@types/node": "^20.3.1",
+    "@types/uuid": "^9.0.2",
     "ts-pattern": "^5.0.1",
+    "uuid": "^9.0.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -68,7 +68,7 @@ export const agreementCloningConflictingStates: AgreementState[] = [
   agreementState.suspended,
 ];
 
-const AgreementAttribute = z.object({ id: AttributeId });
+export const AgreementAttribute = z.object({ id: AttributeId });
 export type AgreementAttribute = z.infer<typeof AgreementAttribute>;
 
 export const AgreementDocument = z.object({

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -1,4 +1,10 @@
 import z from "zod";
+import {
+  AttributeId,
+  AgreementDocumentId,
+  AgreementId,
+  DescriptorId,
+} from "./../brandedIds.js";
 
 export const agreementState = {
   draft: "Draft",
@@ -62,11 +68,11 @@ export const agreementCloningConflictingStates: AgreementState[] = [
   agreementState.suspended,
 ];
 
-export const AgreementAttribute = z.object({ id: z.string().uuid() });
+const AgreementAttribute = z.object({ id: AttributeId });
 export type AgreementAttribute = z.infer<typeof AgreementAttribute>;
 
 export const AgreementDocument = z.object({
-  id: z.string().uuid(),
+  id: AgreementDocumentId,
   name: z.string(),
   prettyName: z.string(),
   contentType: z.string(),
@@ -93,9 +99,9 @@ export const AgreementStamps = z.object({
 export type AgreementStamps = z.infer<typeof AgreementStamps>;
 
 export const Agreement = z.object({
-  id: z.string().uuid(),
+  id: AgreementId,
   eserviceId: z.string().uuid(),
-  descriptorId: z.string().uuid(),
+  descriptorId: DescriptorId,
   producerId: z.string().uuid(),
   consumerId: z.string().uuid(),
   state: AgreementState,
@@ -118,7 +124,7 @@ export type Agreement = z.infer<typeof Agreement>;
 
 export const PDFPayload = z.object({
   today: z.date(),
-  agreementId: z.string().uuid(),
+  agreementId: AgreementId,
   eService: z.string(),
   producerName: z.string(),
   producerOrigin: z.string(),

--- a/packages/models/src/attribute/attribute.ts
+++ b/packages/models/src/attribute/attribute.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { AttributeId } from "../brandedIds.js";
 
 export const attributeKind = {
   certified: "Certified",
@@ -12,7 +13,7 @@ export const AttributeKind = z.enum([
 export type AttributeKind = z.infer<typeof AttributeKind>;
 
 export const Attribute = z.object({
-  id: z.string().uuid(),
+  id: AttributeId,
   code: z.string().optional(),
   kind: AttributeKind,
   description: z.string(),

--- a/packages/models/src/brandedIds.ts
+++ b/packages/models/src/brandedIds.ts
@@ -18,10 +18,19 @@ export type DescriptorId = z.infer<typeof DescriptorId>;
 
 type IDS = AgreementId | AgreementDocumentId | DescriptorId | AttributeId;
 
+// This function is used to generate a new ID for a new object
+// it infers the type of the ID based on how is used the result
+// the 'as' is used to cast the uuid string to the inferred type
 export function generateId<T extends IDS>(): T {
   return uuidv4() as T;
 }
 
+// This function is used to get a branded ID from a string
+// it's an unsafe function because it doesn't check if the string
+// is a valid uuid and it doen't check if the string rappresent
+// a valid ID for the type.
+// The user of this function must be sure that the string is a valid
+// uuid and that the string rappresent a valid ID for the type
 export function unsafeBrandId<T extends IDS>(id: string): T {
   return id as T;
 }

--- a/packages/models/src/brandedIds.ts
+++ b/packages/models/src/brandedIds.ts
@@ -17,7 +17,13 @@ export const DescriptorId = z.string().uuid().brand("DescriptorId");
 export type DescriptorId = z.infer<typeof DescriptorId>;
 
 export function generateId<
-  T extends AgreementId | AgreementDocumentId | DescriptorId
+  T extends AgreementId | AgreementDocumentId | DescriptorId | AttributeId
 >(): T {
   return uuidv4() as T;
+}
+
+export function unsafeBrandId<
+  T extends AgreementId | AgreementDocumentId | DescriptorId | AttributeId
+>(id: string): T {
+  return id as T;
 }

--- a/packages/models/src/brandedIds.ts
+++ b/packages/models/src/brandedIds.ts
@@ -16,14 +16,12 @@ export type AttributeId = z.infer<typeof AttributeId>;
 export const DescriptorId = z.string().uuid().brand("DescriptorId");
 export type DescriptorId = z.infer<typeof DescriptorId>;
 
-export function generateId<
-  T extends AgreementId | AgreementDocumentId | DescriptorId | AttributeId
->(): T {
+type IDS = AgreementId | AgreementDocumentId | DescriptorId | AttributeId;
+
+export function generateId<T extends IDS>(): T {
   return uuidv4() as T;
 }
 
-export function unsafeBrandId<
-  T extends AgreementId | AgreementDocumentId | DescriptorId | AttributeId
->(id: string): T {
+export function unsafeBrandId<T extends IDS>(id: string): T {
   return id as T;
 }

--- a/packages/models/src/brandedIds.ts
+++ b/packages/models/src/brandedIds.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { v4 as uuidv4 } from "uuid";
+
+export const AgreementId = z.string().uuid().brand("AgreementId");
+export type AgreementId = z.infer<typeof AgreementId>;
+
+export const AgreementDocumentId = z
+  .string()
+  .uuid()
+  .brand("AgreementDocumentId");
+export type AgreementDocumentId = z.infer<typeof AgreementDocumentId>;
+
+export const AttributeId = z.string().uuid().brand("AttributeId");
+export type AttributeId = z.infer<typeof AttributeId>;
+
+export const DescriptorId = z.string().uuid().brand("DescriptorId");
+export type DescriptorId = z.infer<typeof DescriptorId>;
+
+export function generateId<
+  T extends AgreementId | AgreementDocumentId | DescriptorId
+>(): T {
+  return uuidv4() as T;
+}

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { AttributeId } from "../brandedIds.js";
 
 export const technology = { rest: "Rest", soap: "Soap" } as const;
 export const Technology = z.enum([
@@ -31,7 +32,7 @@ export const AgreementApprovalPolicy = z.enum([
 export type AgreementApprovalPolicy = z.infer<typeof AgreementApprovalPolicy>;
 
 const EServiceAttribute = z.object({
-  id: z.string().uuid(),
+  id: AttributeId,
   explicitAttributeVerification: z.boolean(),
 });
 export type EServiceAttribute = z.infer<typeof EServiceAttribute>;

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { AttributeId } from "../brandedIds.js";
+import { AttributeId, DescriptorId } from "../brandedIds.js";
 
 export const technology = { rest: "Rest", soap: "Soap" } as const;
 export const Technology = z.enum([
@@ -56,7 +56,7 @@ export const Document = z.object({
 export type Document = z.infer<typeof Document>;
 
 export const Descriptor = z.object({
-  id: z.string().uuid(),
+  id: DescriptorId,
   version: z.string(),
   description: z.string().optional(),
   interface: Document.optional(),

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./protobuf/protobuf.js";
 export * from "./readModels/events.js";
 export * from "./readModels/readModels.js";
+export * from "./brandedIds.js";
 export * from "./agreement/agreement.js";
 export * from "./agreement/agreementEvents.js";
 export * from "./attribute/attribute.js";

--- a/packages/models/src/tenant/tenant.ts
+++ b/packages/models/src/tenant/tenant.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { AttributeId } from "../brandedIds.js";
 
 export const tenantKind = {
   PA: "PA",
@@ -63,7 +64,7 @@ export type TenantRevoker = z.infer<typeof TenantRevoker>;
 
 export const CertifiedTenantAttribute = z.object({
   assignmentTimestamp: z.coerce.date(),
-  id: z.string().uuid(),
+  id: AttributeId,
   type: z.literal(tenantAttributeType.CERTIFIED),
   revocationTimestamp: z.coerce.date().optional(),
 });
@@ -72,7 +73,7 @@ export type CertifiedTenantAttribute = z.infer<typeof CertifiedTenantAttribute>;
 export const VerifiedTenantAttribute = z.object({
   assignmentTimestamp: z.coerce.date(),
   type: z.literal(tenantAttributeType.VERIFIED),
-  id: z.string().uuid(),
+  id: AttributeId,
   verifiedBy: z.array(TenantVerifier),
   revokedBy: z.array(TenantRevoker),
 });
@@ -80,7 +81,7 @@ export type VerifiedTenantAttribute = z.infer<typeof VerifiedTenantAttribute>;
 
 export const DeclaredTenantAttribute = z.object({
   type: z.literal(tenantAttributeType.DECLARED),
-  id: z.string().uuid(),
+  id: AttributeId,
   assignmentTimestamp: z.date(),
   revocationTimestamp: z.date().optional(),
 });

--- a/packages/tenant-consumer/src/model/converter.ts
+++ b/packages/tenant-consumer/src/model/converter.ts
@@ -19,6 +19,7 @@ import {
   tenantMailKind,
   ExternalId,
   genericError,
+  AttributeId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
@@ -101,7 +102,7 @@ export const fromTenantAttributesV1 = (
     case "certifiedAttribute":
       const { certifiedAttribute } = sealedValue;
       return {
-        id: certifiedAttribute.id,
+        id: certifiedAttribute.id as AttributeId,
         assignmentTimestamp: new Date(
           Number(certifiedAttribute.assignmentTimestamp)
         ),
@@ -110,7 +111,7 @@ export const fromTenantAttributesV1 = (
     case "verifiedAttribute":
       const { verifiedAttribute } = sealedValue;
       return {
-        id: verifiedAttribute.id,
+        id: verifiedAttribute.id as AttributeId,
         assignmentTimestamp: new Date(
           Number(verifiedAttribute.assignmentTimestamp)
         ),
@@ -121,7 +122,7 @@ export const fromTenantAttributesV1 = (
     case "declaredAttribute":
       const { declaredAttribute } = sealedValue;
       return {
-        id: declaredAttribute.id,
+        id: declaredAttribute.id as AttributeId,
         assignmentTimestamp: new Date(
           Number(declaredAttribute.assignmentTimestamp)
         ),

--- a/packages/tenant-consumer/src/model/converter.ts
+++ b/packages/tenant-consumer/src/model/converter.ts
@@ -19,7 +19,7 @@ import {
   tenantMailKind,
   ExternalId,
   genericError,
-  AttributeId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
@@ -102,7 +102,7 @@ export const fromTenantAttributesV1 = (
     case "certifiedAttribute":
       const { certifiedAttribute } = sealedValue;
       return {
-        id: certifiedAttribute.id as AttributeId,
+        id: unsafeBrandId(certifiedAttribute.id),
         assignmentTimestamp: new Date(
           Number(certifiedAttribute.assignmentTimestamp)
         ),
@@ -111,7 +111,7 @@ export const fromTenantAttributesV1 = (
     case "verifiedAttribute":
       const { verifiedAttribute } = sealedValue;
       return {
-        id: verifiedAttribute.id as AttributeId,
+        id: unsafeBrandId(verifiedAttribute.id),
         assignmentTimestamp: new Date(
           Number(verifiedAttribute.assignmentTimestamp)
         ),
@@ -122,7 +122,7 @@ export const fromTenantAttributesV1 = (
     case "declaredAttribute":
       const { declaredAttribute } = sealedValue;
       return {
-        id: declaredAttribute.id as AttributeId,
+        id: unsafeBrandId(declaredAttribute.id),
         assignmentTimestamp: new Date(
           Number(declaredAttribute.assignmentTimestamp)
         ),

--- a/packages/tenant-process/src/model/domain/errors.ts
+++ b/packages/tenant-process/src/model/domain/errors.ts
@@ -1,4 +1,8 @@
-import { ApiError, makeApiProblemBuilder } from "pagopa-interop-models";
+import {
+  ApiError,
+  AttributeId,
+  makeApiProblemBuilder,
+} from "pagopa-interop-models";
 
 const errorCodes = {
   attributeNotFound: "0001",
@@ -61,7 +65,7 @@ export function eServiceNotFound(eServiceId: string): ApiError<ErrorCodes> {
 
 export function verifiedAttributeNotFoundInTenant(
   tenantId: string,
-  attributeId: string
+  attributeId: AttributeId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Verified attribute ${attributeId} not found in tenant ${tenantId}`,
@@ -83,7 +87,7 @@ export function expirationDateCannotBeInThePast(
 export function organizationNotFoundInVerifiers(
   requesterId: string,
   tenantId: string,
-  attributeId: string
+  attributeId: AttributeId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Organization ${requesterId} not found in verifier for Tenant ${tenantId} and attribute ${attributeId}`,

--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -6,6 +6,7 @@ import {
   ZodiosContext,
   authorizationMiddleware,
 } from "pagopa-interop-commons";
+import { unsafeBrandId } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import { toApiTenant } from "../model/domain/apiConverter.js";
 import {
@@ -285,7 +286,7 @@ const tenantsRouter = (
           await tenantService.updateTenantVerifiedAttribute({
             verifierId: req.ctx.authData.organizationId,
             tenantId,
-            attributeId,
+            attributeId: unsafeBrandId(attributeId),
             updateVerifiedTenantAttributeSeed: req.body,
           });
           return res.status(200).end();
@@ -306,7 +307,7 @@ const tenantsRouter = (
           const { tenantId, attributeId, verifierId } = req.params;
           await tenantService.updateVerifiedAttributeExtensionDate(
             tenantId,
-            attributeId,
+            unsafeBrandId(attributeId),
             verifierId
           );
           return res.status(200).end();

--- a/packages/tenant-process/src/services/readModelService.ts
+++ b/packages/tenant-process/src/services/readModelService.ts
@@ -13,6 +13,7 @@ import {
   genericError,
   ListResult,
   agreementState,
+  AttributeId,
 } from "pagopa-interop-models";
 import { z } from "zod";
 import { Filter, WithId } from "mongodb";
@@ -311,7 +312,7 @@ export function readModelServiceBuilder(config: TenantProcessConfig) {
     },
 
     async getAttributesById(
-      attributeIds: string[]
+      attributeIds: AttributeId[]
     ): Promise<Array<WithMetadata<Attribute>>> {
       const fetchAttributeById = async (
         id: string

--- a/packages/tenant-process/src/services/tenantService.ts
+++ b/packages/tenant-process/src/services/tenantService.ts
@@ -6,6 +6,7 @@ import {
 } from "pagopa-interop-commons";
 import {
   Attribute,
+  AttributeId,
   ExternalId,
   Tenant,
   TenantAttribute,
@@ -64,7 +65,7 @@ export function tenantServiceBuilder(
   return {
     async updateVerifiedAttributeExtensionDate(
       tenantId: string,
-      attributeId: string,
+      attributeId: AttributeId,
       verifierId: string
     ): Promise<string> {
       const tenant = await readModelService.getTenantById(tenantId);
@@ -109,7 +110,7 @@ export function tenantServiceBuilder(
     }: {
       verifierId: string;
       tenantId: string;
-      attributeId: string;
+      attributeId: AttributeId;
       updateVerifiedTenantAttributeSeed: UpdateVerifiedTenantAttributeSeed;
     }): Promise<void> {
       const tenant = await readModelService.getTenantById(tenantId);
@@ -193,7 +194,7 @@ async function updateTenantVerifiedAttributeLogic({
   verifierId: string;
   tenant: WithMetadata<Tenant> | undefined;
   tenantId: string;
-  attributeId: string;
+  attributeId: AttributeId;
   updateVerifiedTenantAttributeSeed: UpdateVerifiedTenantAttributeSeed;
 }): Promise<CreateEvent<TenantEvent>> {
   assertTenantExists(tenantId, tenant);
@@ -314,7 +315,7 @@ export async function updateVerifiedAttributeExtensionDateLogic({
   tenant,
 }: {
   tenantId: string;
-  attributeId: string;
+  attributeId: AttributeId;
   verifierId: string;
   tenant: WithMetadata<Tenant> | undefined;
 }): Promise<CreateEvent<TenantEvent>> {
@@ -324,7 +325,7 @@ export async function updateVerifiedAttributeExtensionDateLogic({
     (att) => att.id === attributeId
   );
 
-  assertVerifiedAttributeExistsInTenant(tenantId, attribute, tenant);
+  assertVerifiedAttributeExistsInTenant(attributeId, attribute, tenant);
 
   const oldVerifier = attribute.verifiedBy.find(
     (verifier) => verifier.id === verifierId

--- a/packages/tenant-process/src/services/validators.ts
+++ b/packages/tenant-process/src/services/validators.ts
@@ -1,6 +1,7 @@
 import { AuthData, userRoles } from "pagopa-interop-commons";
 import {
   Attribute,
+  AttributeId,
   ExternalId,
   Tenant,
   TenantAttribute,
@@ -33,7 +34,7 @@ export function assertTenantExists(
 }
 
 export function assertVerifiedAttributeExistsInTenant(
-  attributeId: string,
+  attributeId: AttributeId,
   attribute: TenantAttribute | undefined,
   tenant: WithMetadata<Tenant>
 ): asserts attribute is NonNullable<
@@ -47,7 +48,7 @@ export function assertVerifiedAttributeExistsInTenant(
 export function assertOrganizationVerifierExist(
   verifierId: string,
   tenantId: string,
-  attributeId: string,
+  attributeId: AttributeId,
   tenantVerifier: TenantVerifier | undefined
 ): asserts tenantVerifier is NonNullable<TenantVerifier> {
   if (tenantVerifier === undefined) {
@@ -117,7 +118,9 @@ export async function getTenantKindLoadingCertifiedAttributes(
   attributes: TenantAttribute[],
   externalId: ExternalId
 ): Promise<TenantKind> {
-  function getCertifiedAttributesIds(attributes: TenantAttribute[]): string[] {
+  function getCertifiedAttributesIds(
+    attributes: TenantAttribute[]
+  ): AttributeId[] {
     return attributes.flatMap((attr) =>
       attr.type === "certified" ? attr.id : []
     );
@@ -144,7 +147,7 @@ export async function getTenantKindLoadingCertifiedAttributes(
 }
 
 export function assertAttributeExists(
-  attributeId: string,
+  attributeId: AttributeId,
   attributes: TenantAttribute[]
 ): asserts attributes is NonNullable<TenantAttribute[]> {
   if (!attributes.some((attr) => attr.id === attributeId)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,9 +535,15 @@ importers:
       '@types/node':
         specifier: ^20.3.1
         version: 20.3.1
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.2
       ts-pattern:
         specifier: ^5.0.1
         version: 5.0.1
+      uuid:
+        specifier: ^9.0.0
+        version: 9.0.0
       zod:
         specifier: ^3.21.4
         version: 3.21.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       mongodb:
         specifier: 5.6.0
         version: 5.6.0
-      openapi-zod-client:
-        specifier: ^1.7.1
-        version: 1.7.1
       pagopa-interop-commons:
         specifier: workspace:*
         version: link:../commons
@@ -72,6 +69,9 @@ importers:
       cpx:
         specifier: ^1.5.0
         version: 1.5.0
+      openapi-zod-client:
+        specifier: ^1.7.1
+        version: 1.7.1
       pg-promise:
         specifier: ^11.5.0
         version: 11.5.0
@@ -687,7 +687,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
-    dev: false
 
   /@anatine/zod-mock@3.13.1(@faker-js/faker@8.0.2):
     resolution: {integrity: sha512-wm0Bf+hWqoG9m4289CHv7bq+IV87voAb5FUy90DE99CPDGRFmICImaJcau8KHTwn5o7/YBnZYV6c36Vbx/2u0w==}
@@ -704,16 +703,13 @@ packages:
       '@jsdevtools/ono': 7.1.3
       call-me-maybe: 1.0.2
       js-yaml: 3.14.1
-    dev: false
 
   /@apidevtools/openapi-schemas@2.1.0:
     resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
     engines: {node: '>=10'}
-    dev: false
 
   /@apidevtools/swagger-methods@3.0.2:
     resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
-    dev: false
 
   /@apidevtools/swagger-parser@10.1.0(openapi-types@12.1.3):
     resolution: {integrity: sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==}
@@ -728,7 +724,6 @@ packages:
       ajv-draft-04: 1.0.0(ajv@8.12.0)
       call-me-maybe: 1.0.2
       openapi-types: 12.1.3
-    dev: false
 
   /@aws-crypto/crc32@3.0.0:
     resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
@@ -1870,12 +1865,10 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.22.5
-    dev: false
 
   /@babel/compat-data@7.22.5:
     resolution: {integrity: sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/core@7.22.5:
     resolution: {integrity: sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==}
@@ -1898,7 +1891,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/generator@7.22.5:
     resolution: {integrity: sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==}
@@ -1908,7 +1900,6 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
-    dev: false
 
   /@babel/helper-compilation-targets@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==}
@@ -1922,12 +1913,10 @@ packages:
       browserslist: 4.21.9
       lru-cache: 5.1.1
       semver: 6.3.0
-    dev: false
 
   /@babel/helper-environment-visitor@7.22.5:
     resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helper-function-name@7.22.5:
     resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
@@ -1935,21 +1924,18 @@ packages:
     dependencies:
       '@babel/template': 7.22.5
       '@babel/types': 7.22.5
-    dev: false
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-    dev: false
 
   /@babel/helper-module-imports@7.22.5:
     resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-    dev: false
 
   /@babel/helper-module-transforms@7.22.5:
     resolution: {integrity: sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==}
@@ -1965,36 +1951,30 @@ packages:
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-    dev: false
 
   /@babel/helper-split-export-declaration@7.22.5:
     resolution: {integrity: sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-    dev: false
 
   /@babel/helper-string-parser@7.22.5:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helper-validator-identifier@7.22.5:
     resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helper-validator-option@7.22.5:
     resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helpers@7.22.5:
     resolution: {integrity: sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==}
@@ -2005,7 +1985,6 @@ packages:
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/highlight@7.22.5:
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
@@ -2014,7 +1993,6 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
-    dev: false
 
   /@babel/parser@7.22.5:
     resolution: {integrity: sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==}
@@ -2022,7 +2000,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.22.5
-    dev: false
 
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
@@ -2031,7 +2008,6 @@ packages:
       '@babel/code-frame': 7.22.5
       '@babel/parser': 7.22.5
       '@babel/types': 7.22.5
-    dev: false
 
   /@babel/traverse@7.22.5:
     resolution: {integrity: sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==}
@@ -2049,7 +2025,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/types@7.22.5:
     resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
@@ -2058,7 +2033,6 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
-    dev: false
 
   /@balena/dockerignore@1.0.2:
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
@@ -2378,12 +2352,10 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.18
-    dev: false
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
-    dev: false
 
   /@jridgewell/resolve-uri@3.1.1:
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
@@ -2393,11 +2365,9 @@ packages:
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
-    dev: false
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: false
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
@@ -2407,7 +2377,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
-    dev: false
 
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -2418,14 +2387,12 @@ packages:
 
   /@jsdevtools/ono@7.1.3:
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
-    dev: false
 
   /@liuli-util/fs-extra@0.1.0:
     resolution: {integrity: sha512-eaAyDyMGT23QuRGbITVY3SOJff3G9ekAAyGqB9joAnTBmqvFN+9a1FazOdO70G6IUqgpKV451eBHYSRcOJ/FNQ==}
     dependencies:
       '@types/fs-extra': 9.0.13
       fs-extra: 10.1.0
-    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3385,7 +3352,6 @@ packages:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
       '@types/node': 20.3.1
-    dev: false
 
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
@@ -3638,7 +3604,6 @@ packages:
     dependencies:
       axios: 0.27.2
       zod: 3.21.4
-    dev: false
 
   /@zodios/core@10.9.2(axios@1.4.0)(zod@3.21.4):
     resolution: {integrity: sha512-aY8FgE6Y+91oBaMfTnqibGoHO62OiKKHoiQAq76PYJbU7InFeWsSRhpnBwpibWopRjz45AlqojxKo3QeSAYC7w==}
@@ -3710,7 +3675,6 @@ packages:
         optional: true
     dependencies:
       ajv: 8.12.0
-    dev: false
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -3728,7 +3692,6 @@ packages:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
-    dev: false
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3740,7 +3703,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       color-convert: 1.9.3
-    dev: false
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -3814,7 +3776,6 @@ packages:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
       sprintf-js: 1.0.3
-    dev: false
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -3960,7 +3921,6 @@ packages:
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
-    dev: false
 
   /axios@1.4.0:
     resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
@@ -4110,7 +4070,6 @@ packages:
       electron-to-chromium: 1.4.435
       node-releases: 2.0.12
       update-browserslist-db: 1.0.11(browserslist@4.21.9)
-    dev: false
 
   /bson@5.4.0:
     resolution: {integrity: sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==}
@@ -4180,7 +4139,6 @@ packages:
 
   /call-me-maybe@1.0.2:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
-    dev: false
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -4189,7 +4147,6 @@ packages:
 
   /caniuse-lite@1.0.30001506:
     resolution: {integrity: sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==}
-    dev: false
 
   /chai@4.3.7:
     resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
@@ -4211,7 +4168,6 @@ packages:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
-    dev: false
 
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -4269,7 +4225,6 @@ packages:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
       color-name: 1.1.3
-    dev: false
 
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -4280,7 +4235,6 @@ packages:
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-    dev: false
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -4358,7 +4312,6 @@ packages:
 
   /convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
-    dev: false
 
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
@@ -4643,7 +4596,6 @@ packages:
 
   /electron-to-chromium@1.4.435:
     resolution: {integrity: sha512-B0CBWVFhvoQCW/XtjRzgrmqcgVWg6RXOEM/dK59+wFV93BFGR6AeNKc4OyhM+T3IhJaOOG8o/V+33Y2mwJWtzw==}
-    dev: false
 
   /enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
@@ -4757,7 +4709,6 @@ packages:
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
-    dev: false
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -4766,7 +4717,6 @@ packages:
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
-    dev: false
 
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -5074,7 +5024,6 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
   /esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
@@ -5112,7 +5061,6 @@ packages:
 
   /eval-estree-expression@1.1.0:
     resolution: {integrity: sha512-6ZAHSb0wsqxutjk2lXZcW7btSc51I8BhlIetit0wIf5sOb5xDNBrIqe0g8RFyQ/EW6Xwn1szrtButztU7Vdj1Q==}
-    dev: false
 
   /expand-brackets@0.1.5:
     resolution: {integrity: sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==}
@@ -5430,7 +5378,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: false
 
   /fs-extra@11.1.1:
     resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
@@ -5489,7 +5436,6 @@ packages:
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /get-func-name@2.0.0:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
@@ -5570,7 +5516,6 @@ packages:
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-    dev: false
 
   /globals@13.20.0:
     resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
@@ -5637,7 +5582,6 @@ packages:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.17.4
-    dev: false
 
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -5646,7 +5590,6 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
-    dev: false
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -6065,7 +6008,6 @@ packages:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-    dev: false
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -6083,7 +6025,6 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -6091,7 +6032,6 @@ packages:
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-    dev: false
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -6300,7 +6240,6 @@ packages:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
       yallist: 3.1.1
-    dev: false
 
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -6576,7 +6515,6 @@ packages:
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-    dev: false
 
   /node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -6592,7 +6530,6 @@ packages:
 
   /node-releases@2.0.12:
     resolution: {integrity: sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==}
-    dev: false
 
   /normalize-path@2.1.1:
     resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
@@ -6715,7 +6652,6 @@ packages:
 
   /openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
-    dev: false
 
   /openapi-zod-client@1.7.1:
     resolution: {integrity: sha512-ikcQk9pnSMHMJlvwwDlv7rXVoYpUnIJm90xH0bByUz0Z5PN/c7gMHpahdqogdJeHj5tqppqe7zeC+zaIgfZ9pw==}
@@ -6740,13 +6676,11 @@ packages:
       - react
       - supports-color
       - xstate
-    dev: false
 
   /openapi3-ts@3.1.0:
     resolution: {integrity: sha512-1qKTvCCVoV0rkwUh1zq5o8QyghmwYPuhdvtjv1rFjuOnJToXhQyF8eGjNETQ8QmGjr9Jz/tkAKLITIl2s7dw3A==}
     dependencies:
       yaml: 2.3.1
-    dev: false
 
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -6828,7 +6762,6 @@ packages:
       type-fest: 3.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -7215,7 +7148,6 @@ packages:
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -7503,7 +7435,6 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
@@ -7549,7 +7480,6 @@ packages:
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-    dev: false
 
   /ssh-remote-port-forward@1.0.4:
     resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
@@ -7689,7 +7619,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
-    dev: false
 
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -7708,7 +7637,6 @@ packages:
     dependencies:
       tslib: 2.6.2
       typescript: 4.9.5
-    dev: false
 
   /tar-fs@2.0.1:
     resolution: {integrity: sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==}
@@ -7800,7 +7728,6 @@ packages:
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
-    dev: false
 
   /to-object-path@0.3.0:
     resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
@@ -7887,7 +7814,6 @@ packages:
 
   /ts-pattern@4.3.0:
     resolution: {integrity: sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg==}
-    dev: false
 
   /ts-pattern@5.0.1:
     resolution: {integrity: sha512-ZyNm28Lsg34Co5DS3e9DVyjlX2Y+2exkI4jqTKyU+9/OL6Y2fKOOuL8i+7no71o74C6mVS+UFoP3ekM3iCT1HQ==}
@@ -7895,7 +7821,6 @@ packages:
 
   /ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
-    dev: false
 
   /tsc-esm-fix@2.20.15:
     resolution: {integrity: sha512-xkl1jItk5Rp6OW6LnKgy8sCKFncvf96TzCTjN82igNcxWg3tyBainiJk67wl2EPLKnXI58z9alqSP0yqnP37eg==}
@@ -8019,7 +7944,6 @@ packages:
   /type-fest@3.12.0:
     resolution: {integrity: sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==}
     engines: {node: '>=14.16'}
-    dev: false
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -8047,7 +7971,6 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: false
 
   /typescript@5.1.3:
     resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
@@ -8064,7 +7987,6 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true
-    dev: false
     optional: true
 
   /unbox-primitive@1.0.2:
@@ -8112,7 +8034,6 @@ packages:
       browserslist: 4.21.9
       escalade: 3.1.1
       picocolors: 1.0.0
-    dev: false
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -8309,7 +8230,6 @@ packages:
     dependencies:
       '@babel/parser': 7.22.5
       eval-estree-expression: 1.1.0
-    dev: false
 
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -8378,7 +8298,6 @@ packages:
 
   /wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-    dev: false
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -8394,7 +8313,6 @@ packages:
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-    dev: false
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -8429,4 +8347,3 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
-    dev: false


### PR DESCRIPTION
This PR introduces the `AttributeId`, `AgreementId`, `AgreementDocumentId`, and the `DescriptorId` branded type.

Other IDs should be changed into branded type but we decided to split these refactors into multiple PRs.

### Zodios
It would be great if Zodios was able to generate from the open-API specs branded IDs. Currently, it seems impossible so we have to call `unsafeBrandingId` to transform generic `z.string().uuid()` inside the decoder generated by Zodios to get the required branded type. 