### PR TITLE
Refactoring getAllAgreements

### DIFF
--- a/packages/agreement-process/src/services/readmodel/readModelService.ts
+++ b/packages/agreement-process/src/services/readmodel/readModelService.ts
@@ -162,46 +162,12 @@ const getTenantsByNamePipeline = (
   },
 ];
 
-export const getAllAgreements = async (
+const getAllAgreements = async (
   agreements: AgreementCollection,
   filters: AgreementQueryFilters
 ): Promise<Array<WithMetadata<Agreement>>> => {
-  const limit = 50;
-  let offset = 0;
-  let results: Array<WithMetadata<Agreement>> = [];
-
-  while (true) {
-    const agreementsChunk: Array<WithMetadata<Agreement>> = await getAgreements(
-      agreements,
-      filters,
-      offset,
-      limit
-    );
-
-    results = results.concat(agreementsChunk);
-
-    if (agreementsChunk.length < limit) {
-      break;
-    }
-
-    offset += limit;
-  }
-
-  return results;
-};
-
-const getAgreements = async (
-  agreements: AgreementCollection,
-  filters: AgreementQueryFilters,
-  offset: number,
-  limit: number
-): Promise<Array<WithMetadata<Agreement>>> => {
   const data = await agreements
-    .aggregate([
-      getAgreementsFilters(filters),
-      { $skip: offset },
-      { $limit: limit },
-    ])
+    .aggregate([getAgreementsFilters(filters)])
     .toArray();
 
   const result = z


### PR DESCRIPTION
Closes [IMN-167](https://pagopa.atlassian.net/browse/IMN-167)

* The `getAgreements` function called inside `getAllAgreements` was not used anywhere else: the exposed `getAgreements` functionality is implemented without relying on it and has a different aggregation logic. I removed the function and reimplemented `getAllAgreements` in a simpler way

* Now, after this PR, `getAllAgreements` gets all agreements in one shot instead of doing one query per page of Agreements and then concatenating them

[IMN-167]: https://pagopa.atlassian.net/browse/IMN-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ