### PR TITLE
IMN-166 Refactor Branded type - Pt2

### DIFF
--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -5,6 +5,7 @@ import {
   ApiError,
   DescriptorId,
   DescriptorState,
+  EServiceId,
   makeApiProblemBuilder,
 } from "pagopa-interop-models";
 
@@ -40,9 +41,9 @@ export type ErrorCodes = keyof typeof errorCodes;
 
 export const makeApiProblem = makeApiProblemBuilder(errorCodes);
 
-export function eServiceNotFound(eServiceId: string): ApiError<ErrorCodes> {
+export function eServiceNotFound(eserviceId: EServiceId): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `EService ${eServiceId} not found`,
+    detail: `EService ${eserviceId} not found`,
     code: "eServiceNotFound",
     title: "EService not found",
   });
@@ -69,23 +70,23 @@ export function notLatestEServiceDescriptor(
 }
 
 export function descriptorNotFound(
-  eServiceId: string,
+  eserviceId: EServiceId,
   descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `Descriptor ${descriptorId} not found in EService ${eServiceId}`,
+    detail: `Descriptor ${descriptorId} not found in EService ${eserviceId}`,
     code: "descriptorNotFound",
     title: "Descriptor not found",
   });
 }
 
 export function descriptorNotInExpectedState(
-  eServiceId: string,
+  eserviceId: EServiceId,
   descriptorId: DescriptorId,
   allowedStates: DescriptorState[]
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `Descriptor ${descriptorId} of EService ${eServiceId} has not status in ${allowedStates.join(
+    detail: `Descriptor ${descriptorId} of EService ${eserviceId} has not status in ${allowedStates.join(
       ","
     )}`,
     code: "descriptorNotInExpectedState",
@@ -106,10 +107,10 @@ export function missingCertifiedAttributesError(
 
 export function agreementAlreadyExists(
   consumerId: string,
-  eServiceId: string
+  eserviceId: EServiceId
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `Agreement already exists for Consumer = ${consumerId}, EService = ${eServiceId}`,
+    detail: `Agreement already exists for Consumer = ${consumerId}, EService = ${eserviceId}`,
     code: "agreementAlreadyExists",
     title: "Agreement already exists",
   });
@@ -241,7 +242,7 @@ export function agreementSelfcareIdNotFound(
 }
 
 export function publishedDescriptorNotFound(
-  eserviceId: string
+  eserviceId: EServiceId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Published descriptor not found in EService ${eserviceId}`,
@@ -251,7 +252,7 @@ export function publishedDescriptorNotFound(
 }
 
 export function unexpectedVersionFormat(
-  eserviceId: string,
+  eserviceId: EServiceId,
   descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({
@@ -262,7 +263,7 @@ export function unexpectedVersionFormat(
 }
 
 export function noNewerDescriptor(
-  eserviceId: string,
+  eserviceId: EServiceId,
   descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -18,6 +18,8 @@ import {
   agreementActivationFailureStates,
   AgreementId,
   DescriptorId,
+  EServiceId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { AuthData } from "pagopa-interop-commons";
@@ -61,11 +63,11 @@ export function assertAgreementExist(
 }
 
 export function assertEServiceExist(
-  eServiceId: string,
+  eserviceId: EServiceId,
   eService: WithMetadata<EService> | undefined
 ): asserts eService is NonNullable<WithMetadata<EService>> {
   if (eService === undefined) {
-    throw eServiceNotFound(eServiceId);
+    throw eServiceNotFound(eserviceId);
   }
 }
 
@@ -141,7 +143,7 @@ export const assertActivableState = (agreement: Agreement): void => {
 };
 
 export function assertDescriptorExist(
-  eserviceId: string,
+  eserviceId: EServiceId,
   descriptorId: DescriptorId,
   descriptor: Descriptor | undefined
 ): asserts descriptor is NonNullable<Descriptor> {
@@ -153,8 +155,8 @@ export function assertDescriptorExist(
 /* =========  VALIDATIONS ========= */
 
 const validateDescriptorState = (
-  eserviceId: EService["id"],
-  descriptorId: Descriptor["id"],
+  eserviceId: EServiceId,
+  descriptorId: DescriptorId,
   descriptorState: DescriptorState,
   allowedStates: DescriptorState[]
 ): void => {
@@ -212,7 +214,7 @@ export const verifyCreationConflictingAgreements = async (
   ];
   await verifyConflictingAgreements(
     organizationId,
-    agreement.eserviceId,
+    unsafeBrandId(agreement.eserviceId),
     conflictingStates,
     agreementQuery
   );
@@ -228,7 +230,7 @@ export const verifySubmissionConflictingAgreements = async (
   ];
   await verifyConflictingAgreements(
     agreement.consumerId,
-    agreement.eserviceId,
+    unsafeBrandId(agreement.eserviceId),
     conflictingStates,
     agreementQuery
   );
@@ -309,7 +311,7 @@ export const verifiedAttributesSatisfied = (
 
 export const verifyConflictingAgreements = async (
   consumerId: string,
-  eserviceId: string,
+  eserviceId: EServiceId,
   conflictingStates: AgreementState[],
   agreementQuery: AgreementQuery
 ): Promise<void> => {

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -8,7 +8,12 @@ import {
   initDB,
   ReadModelRepository,
 } from "pagopa-interop-commons";
-import { Agreement, DescriptorId, unsafeBrandId } from "pagopa-interop-models";
+import {
+  Agreement,
+  DescriptorId,
+  EServiceId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
 import {
   agreementDocumentToApiAgreementDocument,
@@ -256,7 +261,7 @@ const agreementRouter = (
       try {
         const agreements = await agreementService.getAgreements(
           {
-            eserviceId: req.query.eservicesIds,
+            eserviceId: req.query.eservicesIds.map(unsafeBrandId<EServiceId>),
             consumerId: req.query.consumersIds,
             producerId: req.query.producersIds,
             descriptorId: req.query.descriptorsIds.map(

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -467,7 +467,7 @@ export async function createAgreementLogic(
     `Creating agreement for EService ${agreement.eserviceId} and Descriptor ${agreement.descriptorId}`
   );
   const eservice = await eserviceQuery.getEServiceById(agreement.eserviceId);
-  assertEServiceExist(agreement.eserviceId, eservice);
+  assertEServiceExist(unsafeBrandId(agreement.eserviceId), eservice);
 
   const descriptor = validateCreationOnDescriptor(
     eservice.data,
@@ -488,7 +488,7 @@ export async function createAgreementLogic(
 
   const agreementSeed: Agreement = {
     id: generateId(),
-    eserviceId: agreement.eserviceId,
+    eserviceId: unsafeBrandId(agreement.eserviceId),
     descriptorId: unsafeBrandId(agreement.descriptorId),
     producerId: eservice.data.producerId,
     consumerId: authData.organizationId,

--- a/packages/agreement-process/src/services/readmodel/readModelService.ts
+++ b/packages/agreement-process/src/services/readmodel/readModelService.ts
@@ -24,6 +24,7 @@ import {
   agreementState,
   descriptorState,
   genericError,
+  EServiceId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { z } from "zod";
@@ -36,7 +37,7 @@ import {
 export type AgreementQueryFilters = {
   producerId?: string | string[];
   consumerId?: string | string[];
-  eserviceId?: string | string[];
+  eserviceId?: EServiceId | EServiceId[];
   descriptorId?: DescriptorId | DescriptorId[];
   agreementStates?: AgreementState[];
   attributeId?: AttributeId | AttributeId[];

--- a/packages/agreement-readmodel-writer/src/model/converter.ts
+++ b/packages/agreement-readmodel-writer/src/model/converter.ts
@@ -71,6 +71,7 @@ export const fromAgreementState = (input: AgreementStateV1): AgreementState => {
 export const fromAgreementV1 = (input: AgreementV1): Agreement => ({
   ...input,
   id: unsafeBrandId(input.id),
+  eserviceId: unsafeBrandId(input.eserviceId),
   descriptorId: unsafeBrandId(input.descriptorId),
   certifiedAttributes: input.certifiedAttributes.map((a) => ({
     ...a,

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -1,6 +1,7 @@
 import {
   ApiError,
   DescriptorId,
+  EServiceId,
   makeApiProblemBuilder,
 } from "pagopa-interop-models";
 
@@ -27,9 +28,9 @@ const eserviceCannotBeUpdatedOrDeleted: {
   title: "EService cannot be updated or deleted",
 };
 
-export function eServiceNotFound(eServiceId: string): ApiError<ErrorCodes> {
+export function eServiceNotFound(eserviceId: EServiceId): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `EService ${eServiceId} not found`,
+    detail: `EService ${eserviceId} not found`,
     code: "eServiceNotFound",
     title: "EService not found",
   });
@@ -46,41 +47,41 @@ export function eServiceDuplicate(
 }
 
 export function eServiceCannotBeUpdated(
-  eServiceId: string
+  eserviceId: EServiceId
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `EService ${eServiceId} contains valid descriptors and cannot be updated`,
+    detail: `EService ${eserviceId} contains valid descriptors and cannot be updated`,
     ...eserviceCannotBeUpdatedOrDeleted,
   });
 }
 
 export function eServiceCannotBeDeleted(
-  eServiceId: string
+  eserviceId: EServiceId
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `EService ${eServiceId} contains descriptors and cannot be deleted`,
+    detail: `EService ${eserviceId} contains descriptors and cannot be deleted`,
     ...eserviceCannotBeUpdatedOrDeleted,
   });
 }
 
 export function eServiceDescriptorNotFound(
-  eServiceId: string,
+  eserviceId: EServiceId,
   descriptorId: DescriptorId
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `Descriptor ${descriptorId} for EService ${eServiceId} not found`,
+    detail: `Descriptor ${descriptorId} for EService ${eserviceId} not found`,
     code: "eServiceDescriptorNotFound",
     title: "EService descriptor not found",
   });
 }
 
 export function eServiceDocumentNotFound(
-  eServiceId: string,
+  eserviceId: EServiceId,
   descriptorId: DescriptorId,
   documentId: string
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `Document with id ${documentId} not found in EService ${eServiceId} / Descriptor ${descriptorId}`,
+    detail: `Document with id ${documentId} not found in EService ${eserviceId} / Descriptor ${descriptorId}`,
     code: "eServiceDocumentNotFound",
     title: "EService document not found",
   });
@@ -108,10 +109,10 @@ export function eServiceDescriptorWithoutInterface(
 }
 
 export function draftDescriptorAlreadyExists(
-  eServiceId: string
+  eserviceId: EServiceId
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `EService ${eServiceId} already contains a draft descriptor`,
+    detail: `EService ${eserviceId} already contains a draft descriptor`,
     code: "draftDescriptorAlreadyExists",
     title: "EService already contains a draft descriptor",
   });

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -1,6 +1,7 @@
 import {
   ApiError,
   DescriptorId,
+  EServiceDocumentId,
   EServiceId,
   makeApiProblemBuilder,
 } from "pagopa-interop-models";
@@ -78,7 +79,7 @@ export function eServiceDescriptorNotFound(
 export function eServiceDocumentNotFound(
   eserviceId: EServiceId,
   descriptorId: DescriptorId,
-  documentId: string
+  documentId: EServiceDocumentId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Document with id ${documentId} not found in EService ${eserviceId} / Descriptor ${descriptorId}`,

--- a/packages/catalog-process/src/model/domain/models.ts
+++ b/packages/catalog-process/src/model/domain/models.ts
@@ -7,6 +7,7 @@ import {
   DescriptorState,
   AgreementState,
   DescriptorId,
+  EServiceId,
 } from "pagopa-interop-models";
 import * as api from "../generated/api.js";
 import { ApiEServiceDescriptorDocumentSeed } from "../types.js";
@@ -16,7 +17,7 @@ export type EServiceSeed = z.infer<typeof api.schemas.EServiceSeed> & {
 };
 
 export type EServiceDocument = {
-  readonly eServiceId: string;
+  readonly eserviceId: EServiceId;
   readonly descriptorId: DescriptorId;
   readonly document: {
     readonly name: string;
@@ -66,11 +67,11 @@ export const consumer = z.object({
 export type Consumer = z.infer<typeof consumer>;
 
 export const convertToDocumentEServiceEventData = (
-  eServiceId: string,
+  eserviceId: EServiceId,
   descriptorId: DescriptorId,
   apiEServiceDescriptorDocumentSeed: ApiEServiceDescriptorDocumentSeed
 ): EServiceDocument => ({
-  eServiceId,
+  eserviceId,
   descriptorId,
   document: {
     name: apiEServiceDescriptorDocumentSeed.fileName,

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -17,6 +17,7 @@ import {
   WithMetadata,
   EServiceEvent,
   DescriptorId,
+  EServiceDocumentId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 
@@ -194,7 +195,7 @@ export const toCreateEventEServiceDocumentUpdated = ({
   streamId: string;
   version: number;
   descriptorId: DescriptorId;
-  documentId: string;
+  documentId: EServiceDocumentId;
   updatedDocument: Document;
   serverUrls: string[];
 }): CreateEvent<EServiceEvent> => ({
@@ -246,7 +247,7 @@ export const toCreateEventEServiceDocumentDeleted = (
   streamId: string,
   version: number,
   descriptorId: DescriptorId,
-  documentId: string
+  documentId: EServiceDocumentId
 ): CreateEvent<EServiceEvent> => ({
   streamId,
   version,

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -259,7 +259,7 @@ const eservicesRouter = (
           const document = await readModelService.getDocumentById(
             unsafeBrandId(eServiceId),
             unsafeBrandId(descriptorId),
-            documentId
+            unsafeBrandId(documentId)
           );
 
           if (document) {
@@ -281,7 +281,7 @@ const eservicesRouter = (
                   eServiceDocumentNotFound(
                     unsafeBrandId(eServiceId),
                     unsafeBrandId(descriptorId),
-                    documentId
+                    unsafeBrandId(documentId)
                   ),
                   () => 404
                 )
@@ -320,7 +320,7 @@ const eservicesRouter = (
           await catalogService.deleteDocument(
             unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
-            req.params.documentId,
+            unsafeBrandId(req.params.documentId),
             req.ctx.authData
           );
           return res.status(204).end();
@@ -341,7 +341,7 @@ const eservicesRouter = (
           await catalogService.updateDocument(
             unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
-            req.params.documentId,
+            unsafeBrandId(req.params.documentId),
             req.body,
             req.ctx.authData
           );

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -8,7 +8,7 @@ import {
   ReadModelRepository,
   initDB,
 } from "pagopa-interop-commons";
-import { unsafeBrandId } from "pagopa-interop-models";
+import { EServiceId, unsafeBrandId } from "pagopa-interop-models";
 import {
   agreementStateToApiAgreementState,
   apiAgreementStateToAgreementState,
@@ -160,7 +160,7 @@ const eservicesRouter = (
               .status(404)
               .json(
                 makeApiProblem(
-                  eServiceNotFound(req.params.eServiceId),
+                  eServiceNotFound(unsafeBrandId(req.params.eServiceId)),
                   () => 404
                 )
               )
@@ -178,7 +178,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.updateEService(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             req.body,
             req.ctx.authData
           );
@@ -195,7 +195,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.deleteEService(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             req.ctx.authData
           );
           return res.status(204).end();
@@ -216,7 +216,7 @@ const eservicesRouter = (
       ]),
       async (req, res) => {
         try {
-          const eServiceId = req.params.eServiceId;
+          const eServiceId = unsafeBrandId<EServiceId>(req.params.eServiceId);
           const offset = req.query.offset;
           const limit = req.query.limit;
 
@@ -257,7 +257,7 @@ const eservicesRouter = (
           const { eServiceId, descriptorId, documentId } = req.params;
 
           const document = await readModelService.getDocumentById(
-            eServiceId,
+            unsafeBrandId(eServiceId),
             unsafeBrandId(descriptorId),
             documentId
           );
@@ -279,7 +279,7 @@ const eservicesRouter = (
               .json(
                 makeApiProblem(
                   eServiceDocumentNotFound(
-                    eServiceId,
+                    unsafeBrandId(eServiceId),
                     unsafeBrandId(descriptorId),
                     documentId
                   ),
@@ -300,7 +300,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           const id = await catalogService.uploadDocument(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.body,
             req.ctx.authData
@@ -318,7 +318,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.deleteDocument(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.params.documentId,
             req.ctx.authData
@@ -339,7 +339,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.updateDocument(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.params.documentId,
             req.body,
@@ -361,7 +361,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           const id = await catalogService.createDescriptor(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             req.body,
             req.ctx.authData
           );
@@ -378,7 +378,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.deleteDraftDescriptor(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );
@@ -398,7 +398,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.updateDescriptor(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.body,
             req.ctx.authData
@@ -416,7 +416,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.publishDescriptor(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );
@@ -433,7 +433,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.suspendDescriptor(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );
@@ -450,7 +450,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.activateDescriptor(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );
@@ -468,7 +468,7 @@ const eservicesRouter = (
         try {
           const clonedEserviceByDescriptor =
             await catalogService.cloneDescriptor(
-              req.params.eServiceId,
+              unsafeBrandId(req.params.eServiceId),
               unsafeBrandId(req.params.descriptorId),
               req.ctx.authData
             );
@@ -488,7 +488,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           await catalogService.archiveDescriptor(
-            req.params.eServiceId,
+            unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.ctx.authData
           );

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -18,6 +18,7 @@ import {
   emptyListResult,
   genericError,
   DescriptorId,
+  EServiceId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { z } from "zod";
@@ -180,14 +181,14 @@ export function readModelServiceBuilder(
       return getEService(eservices, { "data.id": id });
     },
     async getEServiceConsumers(
-      eServiceId: string,
+      eserviceId: EServiceId,
       offset: number,
       limit: number
     ): Promise<ListResult<Consumer>> {
       const aggregationPipeline = [
         {
           $match: {
-            "data.id": eServiceId,
+            "data.id": eserviceId,
             "data.descriptors": {
               $elemMatch: {
                 state: {
@@ -292,11 +293,11 @@ export function readModelServiceBuilder(
       };
     },
     async getDocumentById(
-      eServiceId: string,
+      eserviceId: EServiceId,
       descriptorId: DescriptorId,
       documentId: string
     ): Promise<Document | undefined> {
-      const eService = await this.getEServiceById(eServiceId);
+      const eService = await this.getEServiceById(eserviceId);
       return eService?.data.descriptors
         .find((d) => d.id === descriptorId)
         ?.docs.find((d) => d.id === documentId);

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -19,6 +19,7 @@ import {
   genericError,
   DescriptorId,
   EServiceId,
+  EServiceDocumentId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { z } from "zod";
@@ -295,7 +296,7 @@ export function readModelServiceBuilder(
     async getDocumentById(
       eserviceId: EServiceId,
       descriptorId: DescriptorId,
-      documentId: string
+      documentId: EServiceDocumentId
     ): Promise<Document | undefined> {
       const eService = await this.getEServiceById(eserviceId);
       return eService?.data.descriptors

--- a/packages/catalog-process/test/catalogService.test.ts
+++ b/packages/catalog-process/test/catalogService.test.ts
@@ -6,6 +6,10 @@ import {
   descriptorState,
   WithMetadata,
   operationForbidden,
+  unsafeBrandId,
+  EServiceId,
+  DescriptorId,
+  AttributeId,
 } from "pagopa-interop-models";
 import { AuthData } from "pagopa-interop-commons";
 import {
@@ -127,7 +131,7 @@ describe("CatalogService", () => {
 
       const event = updateEserviceLogic({
         eService: addMetadata(eService),
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         eServiceSeed: mockEserviceSeed,
         authData,
       });
@@ -152,7 +156,7 @@ describe("CatalogService", () => {
             ...mockEservice,
             descriptors: [{ ...mockDescriptor, state: "Archived" }],
           }),
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           authData,
           eServiceSeed: mockEserviceSeed,
         })
@@ -166,7 +170,7 @@ describe("CatalogService", () => {
             ...mockEservice,
             producerId: "some-org-id",
           }),
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           eServiceSeed: mockEserviceSeed,
           authData: {
             ...authData,
@@ -177,37 +181,37 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         updateEserviceLogic({
           eService: undefined,
-          eServiceId,
+          eserviceId,
           eServiceSeed: mockEserviceSeed,
           authData: {
             ...authData,
             organizationId: "organizationId",
           },
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("deleteEService", () => {
     it("delete the eservice", async () => {
       const event = deleteEserviceLogic({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         authData,
         eService: addMetadata({ ...mockEservice, descriptors: [] }),
       });
       expect(event.event.type).toBe("EServiceDeleted");
       expect(event.event.data).toMatchObject({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
       });
     });
 
     it("returns an error if the eservice contains descriptors", async () => {
       expect(() =>
         deleteEserviceLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           authData,
           eService: addMetadata({
             ...mockEservice,
@@ -220,7 +224,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       expect(() =>
         deleteEserviceLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           authData: {
             ...authData,
             organizationId: "other-org-id",
@@ -234,23 +238,23 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         deleteEserviceLogic({
-          eServiceId,
+          eserviceId,
           authData: {
             ...authData,
             organizationId: "organizationId",
           },
           eService: undefined,
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("uploadDocument", () => {
     it("uploads the document", async () => {
       const event = uploadDocumentLogic({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
         document: mockDocument,
         authData,
@@ -258,7 +262,7 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDocumentAdded");
       expect(event.event.data).toMatchObject({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
         document: {
           id: mockDocument.documentId,
@@ -276,10 +280,12 @@ describe("CatalogService", () => {
     });
 
     it("returns an error if the eservice doesn't contains the descriptor", async () => {
-      const descriptorId = "descriptor-not-present-id";
+      const descriptorId = unsafeBrandId<DescriptorId>(
+        "descriptor-not-present-id"
+      );
       expect(() =>
         uploadDocumentLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId,
           document: mockDocument,
           authData,
@@ -291,7 +297,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       expect(() =>
         uploadDocumentLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           document: mockDocument,
           authData: {
@@ -307,10 +313,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         uploadDocumentLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           document: mockDocument,
           authData: {
@@ -319,13 +325,13 @@ describe("CatalogService", () => {
           },
           eService: undefined,
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("deleteDocument", () => {
     it("delete the document", async () => {
       const event = await deleteDocumentLogic({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
         documentId: mockDocument.documentId,
         authData,
@@ -352,17 +358,17 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDocumentDeleted");
       expect(event.event.data).toMatchObject({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
         documentId: mockDocument.documentId,
       });
     });
 
     it("returns an error if the eservice doesn't contains the document", async () => {
-      const documentId = "document-not-present-id";
+      const documentId = unsafeBrandId("document-not-present-id");
       await expect(() =>
         deleteDocumentLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           documentId,
           authData,
@@ -381,7 +387,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       await expect(() =>
         deleteDocumentLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           documentId: mockDocument.documentId,
           authData: {
@@ -398,10 +404,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       await expect(() =>
         deleteDocumentLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           documentId: mockDocument.documentId,
           authData: {
@@ -411,14 +417,14 @@ describe("CatalogService", () => {
           eService: undefined,
           deleteRemoteFile: () => Promise.resolve(),
         })
-      ).rejects.toThrowError(eServiceNotFound(eServiceId));
+      ).rejects.toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("updateDocument", () => {
     it("update the document", async () => {
       const refDate = new Date();
       const event = await updateDocumentLogic({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
         documentId: mockDocument.documentId,
         apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
@@ -445,7 +451,7 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDocumentUpdated");
       expect(event.event.data).toMatchObject({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
         documentId: mockDocument.documentId,
         updatedDocument: {
@@ -462,10 +468,12 @@ describe("CatalogService", () => {
     });
 
     it("returns an error if the eservice doesn't contains the descriptor", async () => {
-      const descriptorId = "descriptor-not-present-id";
+      const descriptorId = unsafeBrandId<DescriptorId>(
+        "descriptor-not-present-id"
+      );
       await expect(() =>
         updateDocumentLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId,
           documentId: mockDocument.documentId,
           apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
@@ -478,10 +486,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error if the eservice doesn't contains the document", async () => {
-      const documentId = "document-not-present-id";
+      const documentId = unsafeBrandId("document-not-present-id");
       await expect(() =>
         updateDocumentLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           documentId,
           apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
@@ -500,7 +508,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       await expect(() =>
         updateDocumentLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           documentId: mockDocument.documentId,
           apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
@@ -517,10 +525,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       await expect(() =>
         updateDocumentLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           documentId: mockDocument.documentId,
           apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
@@ -530,7 +538,7 @@ describe("CatalogService", () => {
           },
           eService: undefined,
         })
-      ).rejects.toThrowError(eServiceNotFound(eServiceId));
+      ).rejects.toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("createDescriptor", () => {
@@ -543,14 +551,14 @@ describe("CatalogService", () => {
         }))
       );
       const event = createDescriptorLogic({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         eserviceDescriptorSeed: mockEserviceDescriptorSeed,
         authData,
         eService: addMetadata({ ...mockEservice, descriptors }),
       });
       expect(event.event.type).toBe("EServiceDescriptorAdded");
       expect(event.event.data).toMatchObject({
-        eServiceId: mockEservice.id,
+        eserviceId: mockEservice.id,
         eServiceDescriptor: {
           id: (event.event.data as { eServiceDescriptor: { id: string } })
             .eServiceDescriptor.id,
@@ -578,9 +586,11 @@ describe("CatalogService", () => {
             event.event.data as { eServiceDescriptor: { createdAt: Date } }
           ).eServiceDescriptor.createdAt,
           attributes: {
-            certified: mockEserviceDescriptorSeed.attributes.certified.map(
-              toEServiceAttributeV1
-            ),
+            certified: mockEserviceDescriptorSeed.attributes.certified
+              .map((a) =>
+                a.map((a) => ({ ...a, id: unsafeBrandId<AttributeId>(a.id) }))
+              )
+              .map(toEServiceAttributeV1),
             declared: [],
             verified: [],
           },
@@ -591,7 +601,7 @@ describe("CatalogService", () => {
     it("returns an error if the eservice doesn't contains a draft descriptor", async () => {
       expect(() =>
         createDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           eserviceDescriptorSeed: mockEserviceDescriptorSeed,
           authData,
           eService: addMetadata({
@@ -605,7 +615,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       expect(() =>
         createDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           eserviceDescriptorSeed: mockEserviceDescriptorSeed,
           authData: {
             ...authData,
@@ -620,10 +630,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         createDescriptorLogic({
-          eServiceId,
+          eserviceId,
           eserviceDescriptorSeed: mockEserviceDescriptorSeed,
           authData: {
             ...authData,
@@ -631,7 +641,7 @@ describe("CatalogService", () => {
           },
           eService: undefined,
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("deleteDraftDescriptor", () => {
@@ -641,7 +651,7 @@ describe("CatalogService", () => {
         descriptors: [{ ...mockDescriptor, state: "Draft" }],
       };
       const event = await deleteDraftDescriptorLogic({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         descriptorId: eService.descriptors[0].id,
         authData,
         deleteFile: () => Promise.resolve(),
@@ -655,10 +665,12 @@ describe("CatalogService", () => {
     });
 
     it("returns an error if the eservice doesn't contains the descriptor", async () => {
-      const descriptorId = "descriptor-not-present-id";
+      const descriptorId = unsafeBrandId<DescriptorId>(
+        "descriptor-not-present-id"
+      );
       await expect(() =>
         deleteDraftDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId,
           authData,
           deleteFile: () => Promise.resolve(),
@@ -672,7 +684,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       await expect(() =>
         deleteDraftDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -688,10 +700,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       await expect(() =>
         deleteDraftDescriptorLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -700,7 +712,7 @@ describe("CatalogService", () => {
           deleteFile: () => Promise.resolve(),
           eService: undefined,
         })
-      ).rejects.toThrowError(eServiceNotFound(eServiceId));
+      ).rejects.toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("updateDescriptor", () => {
@@ -711,7 +723,7 @@ describe("CatalogService", () => {
         descriptors: [descriptor],
       };
       const event = updateDescriptorLogic({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         descriptorId: eService.descriptors[0].id,
         seed: mockUpdateDescriptorSeed,
         authData,
@@ -748,10 +760,12 @@ describe("CatalogService", () => {
         ...mockEservice,
         descriptors: [descriptor],
       };
-      const descriptorId = "descriptor-not-present-id";
+      const descriptorId = unsafeBrandId<DescriptorId>(
+        "descriptor-not-present-id"
+      );
       expect(() =>
         updateDescriptorLogic({
-          eServiceId: eService.id,
+          eserviceId: eService.id,
           descriptorId,
           seed: mockEserviceDescriptorSeed,
           authData,
@@ -768,7 +782,7 @@ describe("CatalogService", () => {
       };
       expect(() =>
         updateDescriptorLogic({
-          eServiceId: eService.id,
+          eserviceId: eService.id,
           descriptorId: eService.descriptors[0].id,
           seed: mockEserviceDescriptorSeed,
           authData,
@@ -782,7 +796,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       expect(() =>
         updateDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           seed: mockEserviceDescriptorSeed,
           authData: {
@@ -798,10 +812,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         updateDescriptorLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           seed: mockEserviceDescriptorSeed,
           authData: {
@@ -810,7 +824,7 @@ describe("CatalogService", () => {
           },
           eService: undefined,
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("publishDescriptor", () => {
@@ -820,14 +834,14 @@ describe("CatalogService", () => {
         descriptors: [{ ...mockDescriptor, state: "Draft" }],
       };
       const event = publishDescriptorLogic({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         descriptorId: eService.descriptors[0].id,
         authData,
         eService: addMetadata(eService),
       });
       expect(event[0].event.type).toBe("EServiceDescriptorUpdated");
       expect(event[0].event.data).toMatchObject({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           publishedAt: (
@@ -839,7 +853,9 @@ describe("CatalogService", () => {
     });
 
     it("publish the descriptor and deprecate the current published descriptor", async () => {
-      const publishedDescriptorId = "published-descriptor-id";
+      const publishedDescriptorId = unsafeBrandId<DescriptorId>(
+        "published-descriptor-id"
+      );
       const eService: EService = {
         ...mockEservice,
         descriptors: [
@@ -852,14 +868,14 @@ describe("CatalogService", () => {
         ],
       };
       const event = publishDescriptorLogic({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         descriptorId: eService.descriptors[1].id,
         authData,
         eService: addMetadata(eService),
       });
       expect(event[0].event.type).toBe("EServiceDescriptorUpdated");
       expect(event[0].event.data).toMatchObject({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           id: publishedDescriptorId,
@@ -873,7 +889,7 @@ describe("CatalogService", () => {
       });
       expect(event[1].event.type).toBe("EServiceDescriptorUpdated");
       expect(event[1].event.data).toMatchObject({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           publishedAt: (
@@ -885,10 +901,12 @@ describe("CatalogService", () => {
     });
 
     it("returns an error if the eservice doesn't contains the descriptor", async () => {
-      const descriptorId = "descriptor-not-present-id";
+      const descriptorId = unsafeBrandId<DescriptorId>(
+        "descriptor-not-present-id"
+      );
       expect(() =>
         publishDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId,
           authData,
           eService: addMetadata(mockEservice),
@@ -904,7 +922,7 @@ describe("CatalogService", () => {
       };
       expect(() =>
         publishDescriptorLogic({
-          eServiceId: eService.id,
+          eserviceId: eService.id,
           descriptorId: eService.descriptors[0].id,
           authData,
           eService: addMetadata(eService),
@@ -917,7 +935,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       expect(() =>
         publishDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -932,10 +950,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         publishDescriptorLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -943,7 +961,7 @@ describe("CatalogService", () => {
           },
           eService: undefined,
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("suspendDescriptor", () => {
@@ -961,20 +979,20 @@ describe("CatalogService", () => {
         descriptors: [publishedDescriptor, deprecatedDescriptor],
       };
       const event1 = suspendDescriptorLogic({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         descriptorId: eService.descriptors[0].id,
         authData,
         eService: addMetadata(eService),
       });
       const event2 = suspendDescriptorLogic({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         descriptorId: eService.descriptors[1].id,
         authData,
         eService: addMetadata(eService),
       });
       expect(event1.event.type).toBe("EServiceDescriptorUpdated");
       expect(event1.event.data).toMatchObject({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(publishedDescriptor),
           state: toEServiceDescriptorStateV1("Suspended"),
@@ -985,7 +1003,7 @@ describe("CatalogService", () => {
       });
       expect(event2.event.type).toBe("EServiceDescriptorUpdated");
       expect(event2.event.data).toMatchObject({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(deprecatedDescriptor),
           state: toEServiceDescriptorStateV1("Suspended"),
@@ -1002,10 +1020,12 @@ describe("CatalogService", () => {
         ...mockEservice,
         descriptors: [descriptor],
       };
-      const descriptorId = "descriptor-not-present-id";
+      const descriptorId = unsafeBrandId<DescriptorId>(
+        "descriptor-not-present-id"
+      );
       expect(() =>
         suspendDescriptorLogic({
-          eServiceId: eService.id,
+          eserviceId: eService.id,
           descriptorId,
           authData,
           eService: addMetadata(eService),
@@ -1024,7 +1044,7 @@ describe("CatalogService", () => {
       };
       expect(() =>
         suspendDescriptorLogic({
-          eServiceId: eService.id,
+          eserviceId: eService.id,
           descriptorId: eService.descriptors[0].id,
           authData,
           eService: addMetadata(eService),
@@ -1035,7 +1055,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       expect(() =>
         suspendDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -1050,10 +1070,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         suspendDescriptorLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -1061,7 +1081,7 @@ describe("CatalogService", () => {
           },
           eService: undefined,
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("activateDescriptor", () => {
@@ -1071,14 +1091,14 @@ describe("CatalogService", () => {
         descriptors: [{ ...mockDescriptor, state: "Suspended", version: "1" }],
       };
       const event = activateDescriptorLogic({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         descriptorId: eService.descriptors[0].id,
         authData,
         eService: addMetadata(eService),
       });
       expect(event.event.type).toBe("EServiceDescriptorUpdated");
       expect(event.event.data).toMatchObject({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           state: toEServiceDescriptorStateV1("Published"),
@@ -1101,7 +1121,7 @@ describe("CatalogService", () => {
       };
       expect(() =>
         activateDescriptorLogic({
-          eServiceId: eService.id,
+          eserviceId: eService.id,
           descriptorId: eService.descriptors[0].id,
           authData,
           eService: addMetadata(eService),
@@ -1112,7 +1132,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       expect(() =>
         activateDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -1127,10 +1147,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         activateDescriptorLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -1138,7 +1158,7 @@ describe("CatalogService", () => {
           },
           eService: undefined,
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("cloneDescriptor", () => {
@@ -1150,7 +1170,7 @@ describe("CatalogService", () => {
       const mockEserviceV1 = toEServiceV1(mockEservice);
       const mockDescriptorV1 = toDescriptorV1(mockDescriptor);
       const { event } = await cloneDescriptorLogic({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         descriptorId: eService.descriptors[0].id,
         authData,
         copyFile: () => Promise.resolve(""),
@@ -1207,10 +1227,12 @@ describe("CatalogService", () => {
         ...mockEservice,
         descriptors: [mockDescriptor],
       };
-      const descriptorId = "descriptor-not-present-id";
+      const descriptorId = unsafeBrandId<DescriptorId>(
+        "descriptor-not-present-id"
+      );
       expect(() =>
         archiveDescriptorLogic({
-          eServiceId: eService.id,
+          eserviceId: eService.id,
           descriptorId,
           authData,
           eService: addMetadata(eService),
@@ -1221,7 +1243,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       expect(() =>
         suspendDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -1236,10 +1258,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         suspendDescriptorLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -1247,7 +1269,7 @@ describe("CatalogService", () => {
           },
           eService: undefined,
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
   describe("archiveDescriptor", () => {
@@ -1257,14 +1279,14 @@ describe("CatalogService", () => {
         descriptors: [mockDescriptor],
       };
       const event = archiveDescriptorLogic({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         descriptorId: eService.descriptors[0].id,
         authData,
         eService: addMetadata(eService),
       });
       expect(event.event.type).toBe("EServiceDescriptorUpdated");
       expect(event.event.data).toMatchObject({
-        eServiceId: eService.id,
+        eserviceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           state: toEServiceDescriptorStateV1("Archived"),
@@ -1283,10 +1305,12 @@ describe("CatalogService", () => {
         ...mockEservice,
         descriptors: [mockDescriptor],
       };
-      const descriptorId = "descriptor-not-present-id";
+      const descriptorId = unsafeBrandId<DescriptorId>(
+        "descriptor-not-present-id"
+      );
       expect(() =>
         archiveDescriptorLogic({
-          eServiceId: eService.id,
+          eserviceId: eService.id,
           descriptorId,
           authData,
           eService: addMetadata(eService),
@@ -1297,7 +1321,7 @@ describe("CatalogService", () => {
     it("returns an error if the authenticated organization is not the producer", async () => {
       expect(() =>
         suspendDescriptorLogic({
-          eServiceId: mockEservice.id,
+          eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -1312,10 +1336,10 @@ describe("CatalogService", () => {
     });
 
     it("returns an error when the service does not exist", async () => {
-      const eServiceId = "not-existing-id";
+      const eserviceId = unsafeBrandId<EServiceId>("not-existing-id");
       expect(() =>
         suspendDescriptorLogic({
-          eServiceId,
+          eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
           authData: {
             ...authData,
@@ -1323,7 +1347,7 @@ describe("CatalogService", () => {
           },
           eService: undefined,
         })
-      ).toThrowError(eServiceNotFound(eServiceId));
+      ).toThrowError(eServiceNotFound(eserviceId));
     });
   });
 });

--- a/packages/catalog-process/test/catalogService.test.ts
+++ b/packages/catalog-process/test/catalogService.test.ts
@@ -204,7 +204,7 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDeleted");
       expect(event.event.data).toMatchObject({
-        eserviceId: mockEservice.id,
+        eServiceId: mockEservice.id,
       });
     });
 
@@ -262,7 +262,7 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDocumentAdded");
       expect(event.event.data).toMatchObject({
-        eserviceId: mockEservice.id,
+        eServiceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
         document: {
           id: mockDocument.documentId,
@@ -358,7 +358,7 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDocumentDeleted");
       expect(event.event.data).toMatchObject({
-        eserviceId: mockEservice.id,
+        eServiceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
         documentId: mockDocument.documentId,
       });
@@ -451,7 +451,7 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDocumentUpdated");
       expect(event.event.data).toMatchObject({
-        eserviceId: mockEservice.id,
+        eServiceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
         documentId: mockDocument.documentId,
         updatedDocument: {
@@ -558,7 +558,7 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDescriptorAdded");
       expect(event.event.data).toMatchObject({
-        eserviceId: mockEservice.id,
+        eServiceId: mockEservice.id,
         eServiceDescriptor: {
           id: (event.event.data as { eServiceDescriptor: { id: string } })
             .eServiceDescriptor.id,
@@ -841,7 +841,7 @@ describe("CatalogService", () => {
       });
       expect(event[0].event.type).toBe("EServiceDescriptorUpdated");
       expect(event[0].event.data).toMatchObject({
-        eserviceId: eService.id,
+        eServiceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           publishedAt: (
@@ -875,7 +875,7 @@ describe("CatalogService", () => {
       });
       expect(event[0].event.type).toBe("EServiceDescriptorUpdated");
       expect(event[0].event.data).toMatchObject({
-        eserviceId: eService.id,
+        eServiceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           id: publishedDescriptorId,
@@ -889,7 +889,7 @@ describe("CatalogService", () => {
       });
       expect(event[1].event.type).toBe("EServiceDescriptorUpdated");
       expect(event[1].event.data).toMatchObject({
-        eserviceId: eService.id,
+        eServiceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           publishedAt: (
@@ -992,7 +992,7 @@ describe("CatalogService", () => {
       });
       expect(event1.event.type).toBe("EServiceDescriptorUpdated");
       expect(event1.event.data).toMatchObject({
-        eserviceId: eService.id,
+        eServiceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(publishedDescriptor),
           state: toEServiceDescriptorStateV1("Suspended"),
@@ -1003,7 +1003,7 @@ describe("CatalogService", () => {
       });
       expect(event2.event.type).toBe("EServiceDescriptorUpdated");
       expect(event2.event.data).toMatchObject({
-        eserviceId: eService.id,
+        eServiceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(deprecatedDescriptor),
           state: toEServiceDescriptorStateV1("Suspended"),
@@ -1098,7 +1098,7 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDescriptorUpdated");
       expect(event.event.data).toMatchObject({
-        eserviceId: eService.id,
+        eServiceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           state: toEServiceDescriptorStateV1("Published"),
@@ -1286,7 +1286,7 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDescriptorUpdated");
       expect(event.event.data).toMatchObject({
-        eserviceId: eService.id,
+        eServiceId: eService.id,
         eServiceDescriptor: {
           ...toDescriptorV1(mockDescriptor),
           state: toEServiceDescriptorStateV1("Archived"),

--- a/packages/catalog-process/test/catalogService.test.ts
+++ b/packages/catalog-process/test/catalogService.test.ts
@@ -333,7 +333,7 @@ describe("CatalogService", () => {
       const event = await deleteDocumentLogic({
         eserviceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
-        documentId: mockDocument.documentId,
+        documentId: unsafeBrandId(mockDocument.documentId),
         authData,
         eService: addMetadata({
           ...mockEservice,
@@ -343,7 +343,7 @@ describe("CatalogService", () => {
               docs: [
                 {
                   path: mockDocument.filePath,
-                  id: mockDocument.documentId,
+                  id: unsafeBrandId(mockDocument.documentId),
                   name: mockDocument.fileName,
                   contentType: mockDocument.contentType,
                   prettyName: mockDocument.prettyName,
@@ -370,7 +370,7 @@ describe("CatalogService", () => {
         deleteDocumentLogic({
           eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
-          documentId,
+          documentId: unsafeBrandId(documentId),
           authData,
           eService: addMetadata(mockEservice),
           deleteRemoteFile: () => Promise.resolve(),
@@ -379,7 +379,7 @@ describe("CatalogService", () => {
         eServiceDocumentNotFound(
           mockEservice.id,
           mockEservice.descriptors[0].id,
-          documentId
+          unsafeBrandId(documentId)
         )
       );
     });
@@ -389,7 +389,7 @@ describe("CatalogService", () => {
         deleteDocumentLogic({
           eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
-          documentId: mockDocument.documentId,
+          documentId: unsafeBrandId(mockDocument.documentId),
           authData: {
             ...authData,
             organizationId: "other-org-id",
@@ -409,7 +409,7 @@ describe("CatalogService", () => {
         deleteDocumentLogic({
           eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
-          documentId: mockDocument.documentId,
+          documentId: unsafeBrandId(mockDocument.documentId),
           authData: {
             ...authData,
             organizationId: "organizationId",
@@ -426,7 +426,7 @@ describe("CatalogService", () => {
       const event = await updateDocumentLogic({
         eserviceId: mockEservice.id,
         descriptorId: mockEservice.descriptors[0].id,
-        documentId: mockDocument.documentId,
+        documentId: unsafeBrandId(mockDocument.documentId),
         apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
         authData,
         eService: addMetadata({
@@ -437,7 +437,7 @@ describe("CatalogService", () => {
               docs: [
                 {
                   path: mockDocument.filePath,
-                  id: mockDocument.documentId,
+                  id: unsafeBrandId(mockDocument.documentId),
                   name: mockDocument.fileName,
                   contentType: mockDocument.contentType,
                   prettyName: mockDocument.prettyName,
@@ -475,7 +475,7 @@ describe("CatalogService", () => {
         updateDocumentLogic({
           eserviceId: mockEservice.id,
           descriptorId,
-          documentId: mockDocument.documentId,
+          documentId: unsafeBrandId(mockDocument.documentId),
           apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
           authData,
           eService: addMetadata(mockEservice),
@@ -491,7 +491,7 @@ describe("CatalogService", () => {
         updateDocumentLogic({
           eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
-          documentId,
+          documentId: unsafeBrandId(documentId),
           apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
           authData,
           eService: addMetadata(mockEservice),
@@ -500,7 +500,7 @@ describe("CatalogService", () => {
         eServiceDocumentNotFound(
           mockEservice.id,
           mockEservice.descriptors[0].id,
-          documentId
+          unsafeBrandId(documentId)
         )
       );
     });
@@ -510,7 +510,7 @@ describe("CatalogService", () => {
         updateDocumentLogic({
           eserviceId: mockEservice.id,
           descriptorId: mockEservice.descriptors[0].id,
-          documentId: mockDocument.documentId,
+          documentId: unsafeBrandId(mockDocument.documentId),
           apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
           authData: {
             ...authData,
@@ -530,7 +530,7 @@ describe("CatalogService", () => {
         updateDocumentLogic({
           eserviceId,
           descriptorId: mockEservice.descriptors[0].id,
-          documentId: mockDocument.documentId,
+          documentId: unsafeBrandId(mockDocument.documentId),
           apiEServiceDescriptorDocumentUpdateSeed: mockUpdateDocumentSeed,
           authData: {
             ...authData,

--- a/packages/catalog-process/test/db.test.ts
+++ b/packages/catalog-process/test/db.test.ts
@@ -19,7 +19,9 @@ import {
   EServiceUpdatedV1,
   EServiceWithDescriptorsDeletedV1,
   descriptorState,
+  generateId,
   operationForbidden,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { v4 as uuidv4 } from "uuid";
 import { PostgreSqlContainer } from "@testcontainers/postgresql";
@@ -337,7 +339,7 @@ describe("database test", async () => {
             Number(writtenPayload.eServiceDescriptor?.createdAt)
           ),
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          id: writtenPayload.eServiceDescriptor!.id,
+          id: unsafeBrandId(writtenPayload.eServiceDescriptor!.id),
         };
 
         expect(writtenPayload.eServiceId).toEqual(mockEService.id);
@@ -554,7 +556,7 @@ describe("database test", async () => {
           interface: {
             name: "interface name",
             path: "pagopa.it",
-            id: uuidv4(),
+            id: generateId(),
             prettyName: "",
             contentType: "json",
             checksum: uuidv4(),
@@ -958,12 +960,12 @@ describe("database test", async () => {
         const [organizationId1, organizationId2] = [uuidv4(), uuidv4()];
         const descriptor1: Descriptor = {
           ...mockDescriptor,
-          id: uuidv4(),
+          id: generateId(),
           state: descriptorState.published,
         };
         const eService1: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 001",
           descriptors: [descriptor1],
           producerId: organizationId1,
@@ -972,12 +974,12 @@ describe("database test", async () => {
 
         const descriptor2: Descriptor = {
           ...mockDescriptor,
-          id: uuidv4(),
+          id: generateId(),
           state: descriptorState.draft,
         };
         const eService2: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 002",
           descriptors: [descriptor2],
           producerId: organizationId1,
@@ -986,12 +988,12 @@ describe("database test", async () => {
 
         const descriptor3: Descriptor = {
           ...mockDescriptor,
-          id: uuidv4(),
+          id: generateId(),
           state: descriptorState.published,
         };
         const eService3: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 003",
           descriptors: [descriptor3],
           producerId: organizationId1,
@@ -1000,12 +1002,12 @@ describe("database test", async () => {
 
         const descriptor4: Descriptor = {
           ...mockDescriptor,
-          id: uuidv4(),
+          id: generateId(),
           state: descriptorState.draft,
         };
         const eService4: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 004",
           producerId: organizationId2,
           descriptors: [descriptor4],
@@ -1014,12 +1016,12 @@ describe("database test", async () => {
 
         const descriptor5: Descriptor = {
           ...mockDescriptor,
-          id: uuidv4(),
+          id: generateId(),
           state: descriptorState.published,
         };
         const eService5: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 005",
           producerId: organizationId2,
           descriptors: [descriptor5],
@@ -1028,12 +1030,12 @@ describe("database test", async () => {
 
         const descriptor6: Descriptor = {
           ...mockDescriptor,
-          id: uuidv4(),
+          id: generateId(),
           state: descriptorState.draft,
         };
         const eService6: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 006",
           producerId: organizationId2,
           descriptors: [descriptor6],
@@ -1102,7 +1104,7 @@ describe("database test", async () => {
         const organizationId2 = uuidv4();
         const eService1: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 001",
           producerId: organizationId1,
         };
@@ -1110,7 +1112,7 @@ describe("database test", async () => {
 
         const eService2: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 002",
           producerId: organizationId1,
         };
@@ -1118,7 +1120,7 @@ describe("database test", async () => {
 
         const eService3: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 001",
           producerId: organizationId2,
         };
@@ -1134,7 +1136,7 @@ describe("database test", async () => {
         const organizationId = uuidv4();
         const eService1: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 001",
           producerId: organizationId,
         };
@@ -1142,7 +1144,7 @@ describe("database test", async () => {
 
         const eService2: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 002",
           producerId: organizationId,
         };
@@ -1164,7 +1166,7 @@ describe("database test", async () => {
         };
         const eService1: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 001",
           descriptors: [descriptor1],
         };
@@ -1176,7 +1178,7 @@ describe("database test", async () => {
         };
         const eService2: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 002",
           descriptors: [descriptor2],
         };
@@ -1188,7 +1190,7 @@ describe("database test", async () => {
         };
         const eService3: EService = {
           ...mockEService,
-          id: uuidv4(),
+          id: generateId(),
           name: "eService 003",
           descriptors: [descriptor3],
         };
@@ -1220,7 +1222,7 @@ describe("database test", async () => {
         const tenant = getMockTenant();
         await addOneTenant(tenant, tenants);
         const agreement = getMockAgreement({
-          eServiceId: eService1.id,
+          eserviceId: eService1.id,
           descriptorId: descriptor1.id,
           producerId: eService1.producerId,
           consumerId: tenant.id,

--- a/packages/catalog-process/test/utils.ts
+++ b/packages/catalog-process/test/utils.ts
@@ -12,6 +12,7 @@ import {
   DescriptorId,
   EService,
   EServiceEvent,
+  EServiceId,
   Tenant,
   agreementState,
   catalogEventToBinaryData,
@@ -112,7 +113,7 @@ export const buildDescriptorSeed = (
 });
 
 export const getMockEService = (): EService => ({
-  id: uuidv4(),
+  id: generateId(),
   name: "eService name",
   description: "eService description",
   createdAt: new Date(),
@@ -155,19 +156,19 @@ export const getMockTenant = (): Tenant => ({
 });
 
 export const getMockAgreement = ({
-  eServiceId,
+  eserviceId,
   descriptorId,
   producerId,
   consumerId,
 }: {
-  eServiceId: string;
+  eserviceId: EServiceId;
   descriptorId: DescriptorId;
   producerId: string;
   consumerId: string;
 }): Agreement => ({
   id: generateId(),
   createdAt: new Date(),
-  eserviceId: eServiceId,
+  eserviceId,
   descriptorId,
   producerId,
   consumerId,
@@ -221,10 +222,10 @@ export const addOneAgreement = async (
 };
 
 export const readLastEventByStreamId = async (
-  eServiceId: string,
+  eserviceId: EServiceId,
   postgresDB: IDatabase<unknown>
 ): Promise<any> => // eslint-disable-line @typescript-eslint/no-explicit-any
   await postgresDB.one(
     "SELECT * FROM catalog.events WHERE stream_id = $1 ORDER BY sequence_num DESC LIMIT 1",
-    [eServiceId]
+    [eserviceId]
   );

--- a/packages/catalog-readmodel-writer/src/model/converter.ts
+++ b/packages/catalog-readmodel-writer/src/model/converter.ts
@@ -85,6 +85,7 @@ export const fromEServiceAttributeV1 = (
 
 export const fromDocumentV1 = (input: EServiceDocumentV1): Document => ({
   ...input,
+  id: unsafeBrandId(input.id),
   uploadDate: new Date(input.uploadDate),
 });
 

--- a/packages/catalog-readmodel-writer/src/model/converter.ts
+++ b/packages/catalog-readmodel-writer/src/model/converter.ts
@@ -127,6 +127,7 @@ export const fromDescriptorV1 = (input: EServiceDescriptorV1): Descriptor => ({
 
 export const fromEServiceV1 = (input: EServiceV1): EService => ({
   ...input,
+  id: unsafeBrandId(input.id),
   technology: fromEServiceTechnologyV1(input.technology),
   attributes:
     input.attributes != null

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -4,6 +4,7 @@ import {
   AgreementDocumentId,
   AgreementId,
   DescriptorId,
+  EServiceId,
 } from "./../brandedIds.js";
 
 export const agreementState = {
@@ -100,7 +101,7 @@ export type AgreementStamps = z.infer<typeof AgreementStamps>;
 
 export const Agreement = z.object({
   id: AgreementId,
-  eserviceId: z.string().uuid(),
+  eserviceId: EServiceId,
   descriptorId: DescriptorId,
   producerId: z.string().uuid(),
   consumerId: z.string().uuid(),

--- a/packages/models/src/brandedIds.ts
+++ b/packages/models/src/brandedIds.ts
@@ -4,6 +4,9 @@ import { v4 as uuidv4 } from "uuid";
 export const EServiceId = z.string().uuid().brand("EServiceId");
 export type EServiceId = z.infer<typeof EServiceId>;
 
+export const EServiceDocumentId = z.string().uuid().brand("EServiceDocumentId");
+export type EServiceDocumentId = z.infer<typeof EServiceDocumentId>;
+
 export const AgreementId = z.string().uuid().brand("AgreementId");
 export type AgreementId = z.infer<typeof AgreementId>;
 
@@ -21,6 +24,7 @@ export type DescriptorId = z.infer<typeof DescriptorId>;
 
 type IDS =
   | EServiceId
+  | EServiceDocumentId
   | AgreementId
   | AgreementDocumentId
   | DescriptorId

--- a/packages/models/src/brandedIds.ts
+++ b/packages/models/src/brandedIds.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { v4 as uuidv4 } from "uuid";
 
+export const EServiceId = z.string().uuid().brand("EServiceId");
+export type EServiceId = z.infer<typeof EServiceId>;
+
 export const AgreementId = z.string().uuid().brand("AgreementId");
 export type AgreementId = z.infer<typeof AgreementId>;
 
@@ -16,7 +19,12 @@ export type AttributeId = z.infer<typeof AttributeId>;
 export const DescriptorId = z.string().uuid().brand("DescriptorId");
 export type DescriptorId = z.infer<typeof DescriptorId>;
 
-type IDS = AgreementId | AgreementDocumentId | DescriptorId | AttributeId;
+type IDS =
+  | EServiceId
+  | AgreementId
+  | AgreementDocumentId
+  | DescriptorId
+  | AttributeId;
 
 // This function is used to generate a new ID for a new object
 // it infers the type of the ID based on how is used the result

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { AttributeId, DescriptorId } from "../brandedIds.js";
+import { AttributeId, DescriptorId, EServiceId } from "../brandedIds.js";
 
 export const technology = { rest: "Rest", soap: "Soap" } as const;
 export const Technology = z.enum([
@@ -78,7 +78,7 @@ export const Descriptor = z.object({
 export type Descriptor = z.infer<typeof Descriptor>;
 
 export const EService = z.object({
-  id: z.string().uuid(),
+  id: EServiceId,
   producerId: z.string().uuid(),
   name: z.string(),
   description: z.string(),

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -1,5 +1,10 @@
 import z from "zod";
-import { AttributeId, DescriptorId, EServiceId } from "../brandedIds.js";
+import {
+  AttributeId,
+  DescriptorId,
+  EServiceDocumentId,
+  EServiceId,
+} from "../brandedIds.js";
 
 export const technology = { rest: "Rest", soap: "Soap" } as const;
 export const Technology = z.enum([
@@ -45,7 +50,7 @@ const EServiceAttributes = z.object({
 export type EserviceAttributes = z.infer<typeof EServiceAttributes>;
 
 export const Document = z.object({
-  id: z.string().uuid(),
+  id: EServiceDocumentId,
   name: z.string(),
   contentType: z.string(),
   prettyName: z.string(),

--- a/packages/tenant-process/src/model/domain/errors.ts
+++ b/packages/tenant-process/src/model/domain/errors.ts
@@ -1,6 +1,7 @@
 import {
   ApiError,
   AttributeId,
+  EServiceId,
   makeApiProblemBuilder,
 } from "pagopa-interop-models";
 
@@ -55,9 +56,9 @@ export function tenantNotFound(tenantId: string): ApiError<ErrorCodes> {
   });
 }
 
-export function eServiceNotFound(eServiceId: string): ApiError<ErrorCodes> {
+export function eServiceNotFound(eserviceId: EServiceId): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `EService ${eServiceId} not found`,
+    detail: `EService ${eserviceId} not found`,
     code: "eServiceNotFound",
     title: "EService not found",
   });


### PR DESCRIPTION
This PR introduces the EServiceId and EServiceDocumentId branded types.

Other IDs should be changed into branded type but we decided to split these refactors into multiple PRs.