### PR TITLE
IMN-166 Refactor Branded type - Pt3

### DIFF
--- a/packages/agreement-process/package.json
+++ b/packages/agreement-process/package.json
@@ -43,7 +43,7 @@
     "mongodb": "5.6.0",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "uuid": "^9.0.0",
     "zod": "^3.21.4"
   }

--- a/packages/agreement-process/package.json
+++ b/packages/agreement-process/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^20.3.1",
     "@types/uuid": "^9.0.2",
     "cpx": "^1.5.0",
-    "openapi-zod-client": "^1.7.1",
+    "openapi-zod-client": "1.15.1",
     "pg-promise": "^11.5.0",
     "prettier": "^2.8.8",
     "testcontainers": "^10.2.2",

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -6,6 +6,7 @@ import {
   DescriptorId,
   DescriptorState,
   EServiceId,
+  TenantId,
   makeApiProblemBuilder,
 } from "pagopa-interop-models";
 
@@ -96,7 +97,7 @@ export function descriptorNotInExpectedState(
 
 export function missingCertifiedAttributesError(
   descriptorId: DescriptorId,
-  consumerId: string
+  consumerId: TenantId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Required certified attribute is missing. Descriptor ${descriptorId}, Consumer: ${consumerId}`,
@@ -106,7 +107,7 @@ export function missingCertifiedAttributesError(
 }
 
 export function agreementAlreadyExists(
-  consumerId: string,
+  consumerId: TenantId,
   eserviceId: EServiceId
 ): ApiError<ErrorCodes> {
   return new ApiError({

--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -20,6 +20,7 @@ import {
   DescriptorId,
   EServiceId,
   unsafeBrandId,
+  TenantId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { AuthData } from "pagopa-interop-commons";
@@ -201,7 +202,7 @@ export const validateCreationOnDescriptor = (
 };
 
 export const verifyCreationConflictingAgreements = async (
-  organizationId: string,
+  organizationId: TenantId,
   agreement: ApiAgreementPayload,
   agreementQuery: AgreementQuery
 ): Promise<void> => {
@@ -294,7 +295,7 @@ export const declaredAttributesSatisfied = (
 };
 
 export const verifiedAttributesSatisfied = (
-  producerId: string,
+  producerId: TenantId,
   descriptor: Descriptor,
   tenant: Tenant
 ): boolean => {
@@ -310,7 +311,7 @@ export const verifiedAttributesSatisfied = (
 };
 
 export const verifyConflictingAgreements = async (
-  consumerId: string,
+  consumerId: TenantId,
   eserviceId: EServiceId,
   conflictingStates: AgreementState[],
   agreementQuery: AgreementQuery
@@ -441,7 +442,7 @@ export const matchingVerifiedAttributes = (
 /* ========= FILTERS ========= */
 
 export const filterVerifiedAttributes = (
-  producerId: string,
+  producerId: TenantId,
   tenant: Tenant
 ): VerifiedTenantAttribute[] =>
   tenant.attributes.filter(

--- a/packages/agreement-process/src/services/agreementStampUtils.ts
+++ b/packages/agreement-process/src/services/agreementStampUtils.ts
@@ -3,7 +3,7 @@ import {
   Agreement,
   AgreementStamp,
   AgreementState,
-  Tenant,
+  TenantId,
   agreementState,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
@@ -15,7 +15,7 @@ export const createStamp = (authData: AuthData): AgreementStamp => ({
 
 export const suspendedByConsumerStamp = (
   agreement: Agreement,
-  requesterOrgId: Tenant["id"],
+  requesterOrgId: TenantId,
   destinationState: AgreementState,
   stamp: AgreementStamp
 ): AgreementStamp | undefined =>
@@ -26,7 +26,7 @@ export const suspendedByConsumerStamp = (
 
 export const suspendedByProducerStamp = (
   agreement: Agreement,
-  requesterOrgId: Tenant["id"],
+  requesterOrgId: TenantId,
   destinationState: AgreementState,
   stamp: AgreementStamp
 ): AgreementStamp | undefined =>

--- a/packages/agreement-process/src/services/pdfGenerator.ts
+++ b/packages/agreement-process/src/services/pdfGenerator.ts
@@ -17,6 +17,7 @@ import {
   PDFPayload,
   Tenant,
   TenantAttributeType,
+  TenantId,
   genericError,
   tenantAttributeType,
 } from "pagopa-interop-models";
@@ -180,14 +181,16 @@ const agreementTemplateMock = fs
   .toString();
 
 const createAgreementDocumentName = (
-  consumerId: string,
-  producerId: string
+  // TODO: refine these type to avoid confusion between producer and consumer
+  consumerId: TenantId,
+  producerId: TenantId
 ): string => `${consumerId}_${producerId}_${new Date()}_agreement_contract.pdf`;
 
 export const pdfGenerator = {
   createDocumentSeed: async (
     agreement: Agreement,
     eService: EService,
+    // TODO: refine these types to avoid confusion between producer and consumer
     consumer: Tenant,
     producer: Tenant,
     seed: UpdateAgreementSeed,

--- a/packages/agreement-process/src/services/pdfGenerator.ts
+++ b/packages/agreement-process/src/services/pdfGenerator.ts
@@ -181,7 +181,6 @@ const agreementTemplateMock = fs
   .toString();
 
 const createAgreementDocumentName = (
-  // TODO: refine these type to avoid confusion between producer and consumer
   consumerId: TenantId,
   producerId: TenantId
 ): string => `${consumerId}_${producerId}_${new Date()}_agreement_contract.pdf`;
@@ -190,7 +189,6 @@ export const pdfGenerator = {
   createDocumentSeed: async (
     agreement: Agreement,
     eService: EService,
-    // TODO: refine these types to avoid confusion between producer and consumer
     consumer: Tenant,
     producer: Tenant,
     seed: UpdateAgreementSeed,

--- a/packages/agreement-readmodel-writer/package.json
+++ b/packages/agreement-readmodel-writer/package.json
@@ -32,7 +32,7 @@
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
     "kafka-iam-auth": "workspace:*",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "zod": "^3.21.4"
   }
 }

--- a/packages/agreement-readmodel-writer/src/model/converter.ts
+++ b/packages/agreement-readmodel-writer/src/model/converter.ts
@@ -73,6 +73,8 @@ export const fromAgreementV1 = (input: AgreementV1): Agreement => ({
   id: unsafeBrandId(input.id),
   eserviceId: unsafeBrandId(input.eserviceId),
   descriptorId: unsafeBrandId(input.descriptorId),
+  producerId: unsafeBrandId(input.producerId),
+  consumerId: unsafeBrandId(input.consumerId),
   certifiedAttributes: input.certifiedAttributes.map((a) => ({
     ...a,
     id: unsafeBrandId(a.id),

--- a/packages/attribute-registry-consumer/package.json
+++ b/packages/attribute-registry-consumer/package.json
@@ -32,7 +32,7 @@
     "kafkajs": "^2.2.4",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "zod": "^3.21.4"
   }
 }

--- a/packages/attribute-registry-process/package.json
+++ b/packages/attribute-registry-process/package.json
@@ -14,7 +14,7 @@
     "start": "node --watch --no-warnings --loader ts-node/esm -r 'dotenv-flow/config' ./src/index.ts",
     "build": "tsc",
     "generate-model": "mkdir -p ./src/model/generated && pnpm openapi-zod-client './open-api/attribute-registry-service-spec.yml' -o './src/model/generated/api.ts'",
-    "clean-generated": "pnpm exec rm ./src/models/generated/api.ts"
+    "clean-generated": "pnpm exec rm ./src/model/generated/api.ts"
   },
   "keywords": [],
   "author": "",
@@ -45,7 +45,7 @@
     "dotenv-flow": "^3.2.0",
     "express": "^4.18.2",
     "mongodb": "5.6.0",
-    "openapi-zod-client": "^1.7.1",
+    "openapi-zod-client": "1.15.1",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
     "pg-promise": "^11.5.0",

--- a/packages/attribute-registry-process/package.json
+++ b/packages/attribute-registry-process/package.json
@@ -49,7 +49,7 @@
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
     "pg-promise": "^11.5.0",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "uuid": "^9.0.0",
     "zod": "^3.21.4"
   }

--- a/packages/catalog-process/package.json
+++ b/packages/catalog-process/package.json
@@ -49,7 +49,7 @@
     "openapi-zod-client": "1.15.1",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "uuid": "^9.0.0",
     "zod": "^3.21.4"
   }

--- a/packages/catalog-process/package.json
+++ b/packages/catalog-process/package.json
@@ -14,7 +14,7 @@
     "start": "node --watch --no-warnings --loader ts-node/esm -r 'dotenv-flow/config' ./src/index.ts",
     "build": "tsc",
     "generate-model": "mkdir -p ./src/model/generated && pnpm openapi-zod-client './open-api/catalog-service-spec.yml' -o './src/model/generated/api.ts'",
-    "clean-generated": "pnpm exec rm ./src/models/generated/api.ts"
+    "clean-generated": "pnpm exec rm ./src/model/generated/api.ts"
   },
   "keywords": [],
   "author": "",
@@ -46,7 +46,7 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
     "mongodb": "5.6.0",
-    "openapi-zod-client": "^1.7.1",
+    "openapi-zod-client": "1.15.1",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
     "ts-pattern": "^5.0.1",

--- a/packages/catalog-process/src/model/domain/models.ts
+++ b/packages/catalog-process/src/model/domain/models.ts
@@ -8,12 +8,13 @@ import {
   AgreementState,
   DescriptorId,
   EServiceId,
+  TenantId,
 } from "pagopa-interop-models";
 import * as api from "../generated/api.js";
 import { ApiEServiceDescriptorDocumentSeed } from "../types.js";
 
 export type EServiceSeed = z.infer<typeof api.schemas.EServiceSeed> & {
-  readonly producerId: string;
+  readonly producerId: TenantId;
 };
 
 export type EServiceDocument = {

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -147,7 +147,7 @@ const eservicesRouter = (
       async (req, res) => {
         try {
           const eService = await readModelService.getEServiceById(
-            req.params.eServiceId
+            unsafeBrandId(req.params.eServiceId)
           );
 
           if (eService) {

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -15,6 +15,7 @@ import {
   EServiceDocumentId,
   EServiceEvent,
   EServiceId,
+  TenantId,
   WithMetadata,
   catalogEventToBinaryData,
   descriptorState,
@@ -75,8 +76,8 @@ function assertEServiceExist(
 }
 
 const assertRequesterAllowed = (
-  producerId: string,
-  requesterId: string
+  producerId: TenantId,
+  requesterId: TenantId
 ): void => {
   if (producerId !== requesterId) {
     throw operationForbidden;

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -20,6 +20,7 @@ import {
   DescriptorId,
   EServiceId,
   EServiceDocumentId,
+  TenantId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { z } from "zod";
@@ -166,7 +167,7 @@ export function readModelServiceBuilder(
       producerId,
     }: {
       name: string;
-      producerId: string;
+      producerId: TenantId;
     }): Promise<WithMetadata<EService> | undefined> {
       return getEService(eservices, {
         "data.name": {
@@ -177,7 +178,7 @@ export function readModelServiceBuilder(
       });
     },
     async getEServiceById(
-      id: string
+      id: EServiceId
     ): Promise<WithMetadata<EService> | undefined> {
       return getEService(eservices, { "data.id": id });
     },

--- a/packages/catalog-process/test/utils.ts
+++ b/packages/catalog-process/test/utils.ts
@@ -164,7 +164,6 @@ export const getMockAgreement = ({
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
-  // TODO: refine these types to avoid confusion between producer and consumerc
   producerId: TenantId;
   consumerId: TenantId;
 }): Agreement => ({

--- a/packages/catalog-process/test/utils.ts
+++ b/packages/catalog-process/test/utils.ts
@@ -14,6 +14,7 @@ import {
   EServiceEvent,
   EServiceId,
   Tenant,
+  TenantId,
   agreementState,
   catalogEventToBinaryData,
   descriptorState,
@@ -144,7 +145,7 @@ export const getMockDescriptor = (): Descriptor => ({
 
 export const getMockTenant = (): Tenant => ({
   name: "A tenant",
-  id: uuidv4(),
+  id: generateId(),
   createdAt: new Date(),
   attributes: [],
   externalId: {
@@ -163,8 +164,9 @@ export const getMockAgreement = ({
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
-  producerId: string;
-  consumerId: string;
+  // TODO: refine these types to avoid confusion between producer and consumerc
+  producerId: TenantId;
+  consumerId: TenantId;
 }): Agreement => ({
   id: generateId(),
   createdAt: new Date(),

--- a/packages/catalog-readmodel-writer/package.json
+++ b/packages/catalog-readmodel-writer/package.json
@@ -32,7 +32,7 @@
     "kafkajs": "^2.2.4",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "zod": "^3.21.4"
   }
 }

--- a/packages/catalog-readmodel-writer/src/model/converter.ts
+++ b/packages/catalog-readmodel-writer/src/model/converter.ts
@@ -129,6 +129,7 @@ export const fromDescriptorV1 = (input: EServiceDescriptorV1): Descriptor => ({
 export const fromEServiceV1 = (input: EServiceV1): EService => ({
   ...input,
   id: unsafeBrandId(input.id),
+  producerId: unsafeBrandId(input.producerId),
   technology: fromEServiceTechnologyV1(input.technology),
   attributes:
     input.attributes != null

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -30,7 +30,7 @@
     "mongodb": "5.6.0",
     "pagopa-interop-models": "workspace:*",
     "pg-promise": "^11.5.0",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "winston": "^3.9.0",
     "zod": "^3.21.4"
   },

--- a/packages/commons/src/auth/authData.ts
+++ b/packages/commons/src/auth/authData.ts
@@ -1,4 +1,5 @@
 import { JwtPayload } from "jsonwebtoken";
+import { TenantId } from "pagopa-interop-models";
 import { z } from "zod";
 
 export const userRoles = {
@@ -17,7 +18,7 @@ export const UserRoles = z.enum([
 export type UserRoles = z.infer<typeof UserRoles>;
 
 export const AuthJWTToken = z.object({
-  organizationId: z.string().uuid(),
+  organizationId: TenantId,
   "user-roles": z
     .string()
     .optional()
@@ -42,7 +43,7 @@ export const AuthJWTToken = z.object({
 export type AuthJWTToken = z.infer<typeof AuthJWTToken> & JwtPayload;
 
 export const AuthData = z.object({
-  organizationId: z.string().uuid(),
+  organizationId: TenantId,
   userId: z.string().uuid(),
   userRoles: z.array(z.string()),
   externalId: z.object({

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -22,7 +22,7 @@ const globalStore = new AsyncLocalStorage<AppContext>();
 const defaultAppContext: AppContext = {
   authData: {
     userId: "",
-    // TODO: this is a workaround to avoid to change the type
+    // this is a workaround to avoid to change the type
     // from TenantId to TenantId | undefined
     organizationId: unsafeBrandId(""),
     userRoles: [],

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from "async_hooks";
 import { NextFunction, Request, Response } from "express";
 import { zodiosContext } from "@zodios/express";
 import { z } from "zod";
+import { unsafeBrandId } from "pagopa-interop-models";
 import { AuthData } from "../auth/authData.js";
 import { readHeaders } from "../auth/headers.js";
 
@@ -21,7 +22,9 @@ const globalStore = new AsyncLocalStorage<AppContext>();
 const defaultAppContext: AppContext = {
   authData: {
     userId: "",
-    organizationId: "",
+    // TODO: this is a workaround to avoid to change the type
+    // from TenantId to TenantId | undefined
+    organizationId: unsafeBrandId(""),
     userRoles: [],
     externalId: {
       origin: "",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -26,7 +26,7 @@
     "@protobuf-ts/runtime": "^2.9.1",
     "@types/node": "^20.3.1",
     "@types/uuid": "^9.0.2",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "uuid": "^9.0.0",
     "zod": "^3.21.4"
   },

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -104,7 +104,6 @@ export const Agreement = z.object({
   id: AgreementId,
   eserviceId: EServiceId,
   descriptorId: DescriptorId,
-  // TODO: refine these types to avoid confusion between producer and consumer
   producerId: TenantId,
   consumerId: TenantId,
   state: AgreementState,

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -5,6 +5,7 @@ import {
   AgreementId,
   DescriptorId,
   EServiceId,
+  TenantId,
 } from "./../brandedIds.js";
 
 export const agreementState = {
@@ -103,8 +104,9 @@ export const Agreement = z.object({
   id: AgreementId,
   eserviceId: EServiceId,
   descriptorId: DescriptorId,
-  producerId: z.string().uuid(),
-  consumerId: z.string().uuid(),
+  // TODO: refine these types to avoid confusion between producer and consumer
+  producerId: TenantId,
+  consumerId: TenantId,
   state: AgreementState,
   verifiedAttributes: z.array(AgreementAttribute),
   certifiedAttributes: z.array(AgreementAttribute),

--- a/packages/models/src/brandedIds.ts
+++ b/packages/models/src/brandedIds.ts
@@ -22,13 +22,17 @@ export type AttributeId = z.infer<typeof AttributeId>;
 export const DescriptorId = z.string().uuid().brand("DescriptorId");
 export type DescriptorId = z.infer<typeof DescriptorId>;
 
+export const TenantId = z.string().uuid().brand("TenantId");
+export type TenantId = z.infer<typeof TenantId>;
+
 type IDS =
   | EServiceId
   | EServiceDocumentId
   | AgreementId
   | AgreementDocumentId
   | DescriptorId
-  | AttributeId;
+  | AttributeId
+  | TenantId;
 
 // This function is used to generate a new ID for a new object
 // it infers the type of the ID based on how is used the result

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -4,6 +4,7 @@ import {
   DescriptorId,
   EServiceDocumentId,
   EServiceId,
+  TenantId,
 } from "../brandedIds.js";
 
 export const technology = { rest: "Rest", soap: "Soap" } as const;
@@ -84,7 +85,7 @@ export type Descriptor = z.infer<typeof Descriptor>;
 
 export const EService = z.object({
   id: EServiceId,
-  producerId: z.string().uuid(),
+  producerId: TenantId,
   name: z.string(),
   description: z.string(),
   technology: Technology,

--- a/packages/models/src/tenant/tenant.ts
+++ b/packages/models/src/tenant/tenant.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { AttributeId } from "../brandedIds.js";
+import { AttributeId, TenantId } from "../brandedIds.js";
 
 export const tenantKind = {
   PA: "PA",
@@ -113,7 +113,7 @@ export const TenantMail = z.object({
 export type TenantMail = z.infer<typeof TenantMail>;
 
 export const Tenant = z.object({
-  id: z.string().uuid(),
+  id: TenantId,
   kind: TenantKind.optional(),
   selfcareId: z.string().optional(),
   externalId: ExternalId,

--- a/packages/tenant-consumer/package.json
+++ b/packages/tenant-consumer/package.json
@@ -32,7 +32,7 @@
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
     "kafka-iam-auth": "workspace:*",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "zod": "^3.21.4"
   }
 }

--- a/packages/tenant-consumer/src/model/converter.ts
+++ b/packages/tenant-consumer/src/model/converter.ts
@@ -148,6 +148,7 @@ export const fromTenantV1 = (input: TenantV1): Tenant => {
 
   return {
     ...input,
+    id: unsafeBrandId(input.id),
     name: input.name ?? "",
     createdAt: new Date(Number(input.createdAt)),
     attributes: input.attributes.map(fromTenantAttributesV1),

--- a/packages/tenant-process/package.json
+++ b/packages/tenant-process/package.json
@@ -12,7 +12,7 @@
     "start": "node --watch --no-warnings --loader ts-node/esm -r 'dotenv-flow/config' ./src/index.ts",
     "build": "tsc",
     "generate-model": "mkdir -p ./src/model/generated && pnpm openapi-zod-client './open-api/tenant-service-spec.yml' -o './src/model/generated/api.ts'",
-    "clean-generated": "pnpm exec rm ./src/models/generated/api.ts"
+    "clean-generated": "pnpm exec rm ./src/model/generated/api.ts"
   },
   "keywords": [],
   "author": "",
@@ -33,7 +33,7 @@
     "dotenv-flow": "^3.2.0",
     "express": "^4.18.2",
     "mongodb": "5.6.0",
-    "openapi-zod-client": "^1.7.1",
+    "openapi-zod-client": "1.15.1",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
     "ts-pattern": "^5.0.1",

--- a/packages/tenant-process/package.json
+++ b/packages/tenant-process/package.json
@@ -36,7 +36,7 @@
     "openapi-zod-client": "1.15.1",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
-    "ts-pattern": "^5.0.1",
+    "ts-pattern": "^5.0.6",
     "uuid": "^9.0.0",
     "zod": "^3.21.4"
   }

--- a/packages/tenant-process/src/model/domain/errors.ts
+++ b/packages/tenant-process/src/model/domain/errors.ts
@@ -57,6 +57,17 @@ export function tenantNotFound(tenantId: TenantId): ApiError<ErrorCodes> {
   });
 }
 
+export function tenantFromExternalIdNotFound(
+  origin: string,
+  code: string
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Tenant with externalId ${origin}/${code} not found`,
+    code: "tenantNotFound",
+    title: "Tenant not found",
+  });
+}
+
 export function eServiceNotFound(eserviceId: EServiceId): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `EService ${eserviceId} not found`,

--- a/packages/tenant-process/src/model/domain/errors.ts
+++ b/packages/tenant-process/src/model/domain/errors.ts
@@ -2,6 +2,7 @@ import {
   ApiError,
   AttributeId,
   EServiceId,
+  TenantId,
   makeApiProblemBuilder,
 } from "pagopa-interop-models";
 
@@ -48,7 +49,7 @@ export function tenantDuplicate(teanantName: string): ApiError<ErrorCodes> {
   });
 }
 
-export function tenantNotFound(tenantId: string): ApiError<ErrorCodes> {
+export function tenantNotFound(tenantId: TenantId): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Tenant ${tenantId} not found`,
     code: "tenantNotFound",
@@ -65,7 +66,7 @@ export function eServiceNotFound(eserviceId: EServiceId): ApiError<ErrorCodes> {
 }
 
 export function verifiedAttributeNotFoundInTenant(
-  tenantId: string,
+  tenantId: TenantId,
   attributeId: AttributeId
 ): ApiError<ErrorCodes> {
   return new ApiError({
@@ -87,7 +88,7 @@ export function expirationDateCannotBeInThePast(
 
 export function organizationNotFoundInVerifiers(
   requesterId: string,
-  tenantId: string,
+  tenantId: TenantId,
   attributeId: AttributeId
 ): ApiError<ErrorCodes> {
   return new ApiError({
@@ -110,7 +111,7 @@ export function tenantBySelfcareIdNotFound(
 export function expirationDateNotFoundInVerifier(
   verifierId: string,
   attributeId: string,
-  tenantId: string
+  tenantId: TenantId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `ExpirationDate not found in verifier ${verifierId} for Tenant ${tenantId} and attribute ${attributeId}`,
@@ -123,7 +124,7 @@ export function selfcareIdConflict({
   existingSelfcareId,
   newSelfcareId,
 }: {
-  tenantId: string;
+  tenantId: TenantId;
   existingSelfcareId: string;
   newSelfcareId: string;
 }): ApiError<ErrorCodes> {

--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -133,7 +133,9 @@ const tenantsRouter = (
       ]),
       async (req, res) => {
         try {
-          const tenant = await readModelService.getTenantById(req.params.id);
+          const tenant = await readModelService.getTenantById(
+            unsafeBrandId(req.params.id)
+          );
 
           if (tenant) {
             return res.status(200).json(toApiTenant(tenant.data)).end();
@@ -142,7 +144,7 @@ const tenantsRouter = (
               .status(404)
               .json(
                 makeApiProblem(
-                  tenantNotFound(req.params.id),
+                  tenantNotFound(unsafeBrandId(req.params.id)),
                   getTenantByIdErrorMapper
                 )
               )
@@ -178,7 +180,8 @@ const tenantsRouter = (
               .status(404)
               .json(
                 makeApiProblem(
-                  tenantNotFound(`${origin}/${code}`),
+                  // TODO create a dedicated error. origin/code is not a valid TenantId
+                  tenantNotFound(unsafeBrandId(`${origin}/${code}`)),
                   getTenantByExternalIdErrorMapper
                 )
               )
@@ -285,7 +288,7 @@ const tenantsRouter = (
           const { tenantId, attributeId } = req.params;
           await tenantService.updateTenantVerifiedAttribute({
             verifierId: req.ctx.authData.organizationId,
-            tenantId,
+            tenantId: unsafeBrandId(tenantId),
             attributeId: unsafeBrandId(attributeId),
             updateVerifiedTenantAttributeSeed: req.body,
           });
@@ -306,7 +309,7 @@ const tenantsRouter = (
         try {
           const { tenantId, attributeId, verifierId } = req.params;
           await tenantService.updateVerifiedAttributeExtensionDate(
-            tenantId,
+            unsafeBrandId(tenantId),
             unsafeBrandId(attributeId),
             verifierId
           );

--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -12,6 +12,7 @@ import { toApiTenant } from "../model/domain/apiConverter.js";
 import {
   makeApiProblem,
   tenantBySelfcareIdNotFound,
+  tenantFromExternalIdNotFound,
   tenantNotFound,
 } from "../model/domain/errors.js";
 import {
@@ -180,8 +181,7 @@ const tenantsRouter = (
               .status(404)
               .json(
                 makeApiProblem(
-                  // TODO create a dedicated error. origin/code is not a valid TenantId
-                  tenantNotFound(unsafeBrandId(`${origin}/${code}`)),
+                  tenantFromExternalIdNotFound(origin, code),
                   getTenantByExternalIdErrorMapper
                 )
               )

--- a/packages/tenant-process/src/services/readModelService.ts
+++ b/packages/tenant-process/src/services/readModelService.ts
@@ -14,6 +14,8 @@ import {
   ListResult,
   agreementState,
   AttributeId,
+  TenantId,
+  EServiceId,
 } from "pagopa-interop-models";
 import { z } from "zod";
 import { Filter, WithId } from "mongodb";
@@ -180,7 +182,9 @@ export function readModelServiceBuilder(config: TenantProcessConfig) {
       });
     },
 
-    async getTenantById(id: string): Promise<WithMetadata<Tenant> | undefined> {
+    async getTenantById(
+      id: TenantId
+    ): Promise<WithMetadata<Tenant> | undefined> {
       return getTenant(tenants, { "data.id": id });
     },
 
@@ -217,7 +221,7 @@ export function readModelServiceBuilder(config: TenantProcessConfig) {
       limit,
     }: {
       name: string | undefined;
-      producerId: string;
+      producerId: TenantId;
       offset: number;
       limit: number;
     }): Promise<ListResult<Tenant>> {
@@ -329,7 +333,7 @@ export function readModelServiceBuilder(config: TenantProcessConfig) {
     },
 
     async getEServiceById(
-      id: string
+      id: EServiceId
     ): Promise<WithMetadata<EService> | undefined> {
       const data = await eservices.findOne(
         { "data.id": id },

--- a/packages/tenant-process/src/services/tenantService.ts
+++ b/packages/tenant-process/src/services/tenantService.ts
@@ -12,13 +12,14 @@ import {
   TenantAttribute,
   TenantEvent,
   TenantFeature,
+  TenantId,
   TenantKind,
   TenantMail,
   WithMetadata,
+  generateId,
   tenantAttributeType,
   tenantEventToBinaryData,
 } from "pagopa-interop-models";
-import { v4 as uuidv4 } from "uuid";
 import { TenantProcessConfig } from "../utilities/config.js";
 import {
   toCreateEventTenantAdded,
@@ -64,7 +65,7 @@ export function tenantServiceBuilder(
   );
   return {
     async updateVerifiedAttributeExtensionDate(
-      tenantId: string,
+      tenantId: TenantId,
       attributeId: AttributeId,
       verifierId: string
     ): Promise<string> {
@@ -109,7 +110,7 @@ export function tenantServiceBuilder(
       updateVerifiedTenantAttributeSeed,
     }: {
       verifierId: string;
-      tenantId: string;
+      tenantId: TenantId;
       attributeId: AttributeId;
       updateVerifiedTenantAttributeSeed: UpdateVerifiedTenantAttributeSeed;
     }): Promise<void> {
@@ -166,7 +167,7 @@ export function tenantServiceBuilder(
         );
       } else {
         const newTenant: Tenant = {
-          id: uuidv4(),
+          id: generateId(),
           name: tenantSeed.name,
           attributes: [],
           externalId: tenantSeed.externalId,
@@ -193,7 +194,7 @@ async function updateTenantVerifiedAttributeLogic({
 }: {
   verifierId: string;
   tenant: WithMetadata<Tenant> | undefined;
-  tenantId: string;
+  tenantId: TenantId;
   attributeId: AttributeId;
   updateVerifiedTenantAttributeSeed: UpdateVerifiedTenantAttributeSeed;
 }): Promise<CreateEvent<TenantEvent>> {
@@ -294,7 +295,7 @@ export function createTenantLogic({
   }));
 
   const newTenant: Tenant = {
-    id: uuidv4(),
+    id: generateId(),
     name: apiTenantSeed.name,
     attributes: tenantAttributes,
     externalId: apiTenantSeed.externalId,
@@ -314,7 +315,7 @@ export async function updateVerifiedAttributeExtensionDateLogic({
   verifierId,
   tenant,
 }: {
-  tenantId: string;
+  tenantId: TenantId;
   attributeId: AttributeId;
   verifierId: string;
   tenant: WithMetadata<Tenant> | undefined;

--- a/packages/tenant-process/src/services/validators.ts
+++ b/packages/tenant-process/src/services/validators.ts
@@ -5,6 +5,7 @@ import {
   ExternalId,
   Tenant,
   TenantAttribute,
+  TenantId,
   TenantKind,
   TenantVerifier,
   WithMetadata,
@@ -25,7 +26,7 @@ import {
 import { ReadModelService } from "./readModelService.js";
 
 export function assertTenantExists(
-  tenantId: string,
+  tenantId: TenantId,
   tenant: WithMetadata<Tenant> | undefined
 ): asserts tenant is NonNullable<WithMetadata<Tenant>> {
   if (tenant === undefined) {
@@ -47,7 +48,7 @@ export function assertVerifiedAttributeExistsInTenant(
 
 export function assertOrganizationVerifierExist(
   verifierId: string,
-  tenantId: string,
+  tenantId: TenantId,
   attributeId: AttributeId,
   tenantVerifier: TenantVerifier | undefined
 ): asserts tenantVerifier is NonNullable<TenantVerifier> {
@@ -57,13 +58,13 @@ export function assertOrganizationVerifierExist(
 }
 
 export function assertExpirationDateExist(
-  tenantId: string,
+  tenantId: TenantId,
   attributeId: string,
   verifierId: string,
   expirationDate: Date | undefined
 ): asserts expirationDate is Date {
   if (expirationDate === undefined) {
-    expirationDateNotFoundInVerifier(tenantId, attributeId, verifierId);
+    expirationDateNotFoundInVerifier(verifierId, attributeId, tenantId);
   }
 }
 
@@ -165,7 +166,7 @@ export function assertValidExpirationDate(
 
 export function assertOrganizationIsInAttributeVerifiers(
   verifierId: string,
-  tenantId: string,
+  tenantId: TenantId,
   attribute: Extract<TenantAttribute, { type: "verified" }>
 ): void {
   if (!attribute.verifiedBy.some((v) => v.id === verifierId)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       openapi-zod-client:
-        specifier: ^1.7.1
-        version: 1.7.1
+        specifier: 1.15.1
+        version: 1.15.1
       pg-promise:
         specifier: ^11.5.0
         version: 11.5.0
@@ -216,8 +216,8 @@ importers:
         specifier: 5.6.0
         version: 5.6.0
       openapi-zod-client:
-        specifier: ^1.7.1
-        version: 1.7.1
+        specifier: 1.15.1
+        version: 1.15.1
       pagopa-interop-commons:
         specifier: workspace:*
         version: link:../commons
@@ -307,8 +307,8 @@ importers:
         specifier: 5.6.0
         version: 5.6.0
       openapi-zod-client:
-        specifier: ^1.7.1
-        version: 1.7.1
+        specifier: 1.15.1
+        version: 1.15.1
       pagopa-interop-commons:
         specifier: workspace:*
         version: link:../commons
@@ -634,8 +634,8 @@ importers:
         specifier: 5.6.0
         version: 5.6.0
       openapi-zod-client:
-        specifier: ^1.7.1
-        version: 1.7.1
+        specifier: 1.15.1
+        version: 1.15.1
       pagopa-interop-commons:
         specifier: workspace:*
         version: link:../commons
@@ -3596,15 +3596,6 @@ packages:
       pretty-format: 29.6.1
     dev: true
 
-  /@zodios/core@10.9.2(axios@0.27.2)(zod@3.21.4):
-    resolution: {integrity: sha512-aY8FgE6Y+91oBaMfTnqibGoHO62OiKKHoiQAq76PYJbU7InFeWsSRhpnBwpibWopRjz45AlqojxKo3QeSAYC7w==}
-    peerDependencies:
-      axios: ^0.x || ^1.0.0
-      zod: ^3.x
-    dependencies:
-      axios: 0.27.2
-      zod: 3.21.4
-
   /@zodios/core@10.9.2(axios@1.4.0)(zod@3.21.4):
     resolution: {integrity: sha512-aY8FgE6Y+91oBaMfTnqibGoHO62OiKKHoiQAq76PYJbU7InFeWsSRhpnBwpibWopRjz45AlqojxKo3QeSAYC7w==}
     peerDependencies:
@@ -3614,6 +3605,15 @@ packages:
       axios: 1.4.0
       zod: 3.21.4
     dev: false
+
+  /@zodios/core@10.9.2(axios@1.6.5)(zod@3.21.4):
+    resolution: {integrity: sha512-aY8FgE6Y+91oBaMfTnqibGoHO62OiKKHoiQAq76PYJbU7InFeWsSRhpnBwpibWopRjz45AlqojxKo3QeSAYC7w==}
+    peerDependencies:
+      axios: ^0.x || ^1.0.0
+      zod: ^3.x
+    dependencies:
+      axios: 1.6.5
+      zod: 3.21.4
 
   /@zodios/express@10.6.1(@zodios/core@10.9.2)(express@4.18.2)(zod@3.21.4):
     resolution: {integrity: sha512-FNgOq8mvwvWP5B2howMKGm6EPp6i/0XFAsQnX5Ov3MLbanzD1oE4WJtBkTL3cmJYvD0nyykbWSeHOh51bCmhUA==}
@@ -3914,18 +3914,19 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-    dependencies:
-      follow-redirects: 1.15.2
-      form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
-
   /axios@1.4.0:
     resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
     dependencies:
       follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  /axios@1.6.5:
+    resolution: {integrity: sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==}
+    dependencies:
+      follow-redirects: 1.15.5
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -5324,6 +5325,15 @@ packages:
       debug:
         optional: true
 
+  /follow-redirects@1.15.5:
+    resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
@@ -6653,22 +6663,22 @@ packages:
   /openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
-  /openapi-zod-client@1.7.1:
-    resolution: {integrity: sha512-ikcQk9pnSMHMJlvwwDlv7rXVoYpUnIJm90xH0bByUz0Z5PN/c7gMHpahdqogdJeHj5tqppqe7zeC+zaIgfZ9pw==}
+  /openapi-zod-client@1.15.1:
+    resolution: {integrity: sha512-2WWy3O28KGHE1+HKY49RUs1XFXCeOIwXY+6NsmoGlBn5N2LrZUfPMN/B6EW60U5Xt2O535TYMT+5SYfRqTvDBQ==}
     hasBin: true
     dependencies:
       '@apidevtools/swagger-parser': 10.1.0(openapi-types@12.1.3)
       '@liuli-util/fs-extra': 0.1.0
-      '@zodios/core': 10.9.2(axios@0.27.2)(zod@3.21.4)
-      axios: 0.27.2
+      '@zodios/core': 10.9.2(axios@1.6.5)(zod@3.21.4)
+      axios: 1.6.5
       cac: 6.7.14
       handlebars: 4.7.7
       openapi-types: 12.1.3
       openapi3-ts: 3.1.0
-      pastable: 2.2.0
+      pastable: 2.2.1
       prettier: 2.8.8
       tanu: 0.1.13
-      ts-pattern: 4.3.0
+      ts-pattern: 5.0.1
       whence: 2.0.0
       zod: 3.21.4
     transitivePeerDependencies:
@@ -6745,8 +6755,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /pastable@2.2.0:
-    resolution: {integrity: sha512-VW3BlFr4aqazNaHOdf2Yg/GY8JRiMDnGExFCHXN+dm6yz8b5uZk9WuJk3YwhRPyzFjuZPnoxt8aFe5fX4gAStw==}
+  /pastable@2.2.1:
+    resolution: {integrity: sha512-K4ClMxRKpgN4sXj6VIPPrvor/TMp2yPNCGtfhvV106C73SwefQ3FuegURsH7AQHpqu0WwbvKXRl1HQxF6qax9w==}
     engines: {node: '>=14.x'}
     peerDependencies:
       react: '>=17'
@@ -7812,12 +7822,8 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-pattern@4.3.0:
-    resolution: {integrity: sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg==}
-
   /ts-pattern@5.0.1:
     resolution: {integrity: sha512-ZyNm28Lsg34Co5DS3e9DVyjlX2Y+2exkI4jqTKyU+9/OL6Y2fKOOuL8i+7no71o74C6mVS+UFoP3ekM3iCT1HQ==}
-    dev: false
 
   /ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
     dependencies:
       '@zodios/core':
         specifier: ^10.9.2
-        version: 10.9.2(axios@1.4.0)(zod@3.21.4)
+        version: 10.9.2(axios@1.6.5)(zod@3.21.4)
       '@zodios/express':
         specifier: ^10.6.1
         version: 10.6.1(@zodios/core@10.9.2)(express@4.18.2)(zod@3.21.4)
@@ -39,8 +39,8 @@ importers:
         specifier: workspace:*
         version: link:../models
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -115,8 +115,8 @@ importers:
         specifier: workspace:*
         version: link:../models
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -164,8 +164,8 @@ importers:
         specifier: workspace:*
         version: link:../models
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -228,8 +228,8 @@ importers:
         specifier: ^11.5.0
         version: 11.5.0
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -316,8 +316,8 @@ importers:
         specifier: workspace:*
         version: link:../models
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -401,8 +401,8 @@ importers:
         specifier: workspace:*
         version: link:../models
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -433,7 +433,7 @@ importers:
         version: 3.367.0
       '@zodios/core':
         specifier: ^10.9.2
-        version: 10.9.2(axios@1.4.0)(zod@3.21.4)
+        version: 10.9.2(axios@1.6.5)(zod@3.21.4)
       '@zodios/express':
         specifier: ^10.6.1
         version: 10.6.1(@zodios/core@10.9.2)(express@4.18.2)(zod@3.21.4)
@@ -462,8 +462,8 @@ importers:
         specifier: ^11.5.0
         version: 11.5.0
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       winston:
         specifier: ^3.9.0
         version: 3.9.0
@@ -539,8 +539,8 @@ importers:
         specifier: ^9.0.2
         version: 9.0.2
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -588,8 +588,8 @@ importers:
         specifier: workspace:*
         version: link:../models
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -620,7 +620,7 @@ importers:
         version: 9.0.2
       '@zodios/core':
         specifier: ^10.9.2
-        version: 10.9.2(axios@1.4.0)(zod@3.21.4)
+        version: 10.9.2(axios@1.6.5)(zod@3.21.4)
       '@zodios/express':
         specifier: ^10.6.1
         version: 10.6.1(@zodios/core@10.9.2)(express@4.18.2)(zod@3.21.4)
@@ -643,8 +643,8 @@ importers:
         specifier: workspace:*
         version: link:../models
       ts-pattern:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.6
+        version: 5.0.6
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -3622,7 +3622,7 @@ packages:
       express: 4.x
       zod: ^3.x
     dependencies:
-      '@zodios/core': 10.9.2(axios@1.4.0)(zod@3.21.4)
+      '@zodios/core': 10.9.2(axios@1.6.5)(zod@3.21.4)
       express: 4.18.2
       zod: 3.21.4
     dev: false
@@ -6678,7 +6678,7 @@ packages:
       pastable: 2.2.1
       prettier: 2.8.8
       tanu: 0.1.13
-      ts-pattern: 5.0.1
+      ts-pattern: 5.0.6
       whence: 2.0.0
       zod: 3.21.4
     transitivePeerDependencies:
@@ -7822,8 +7822,8 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-pattern@5.0.1:
-    resolution: {integrity: sha512-ZyNm28Lsg34Co5DS3e9DVyjlX2Y+2exkI4jqTKyU+9/OL6Y2fKOOuL8i+7no71o74C6mVS+UFoP3ekM3iCT1HQ==}
+  /ts-pattern@5.0.6:
+    resolution: {integrity: sha512-Y+jOjihlFriWzcBjncPCf2/am+Hgz7LtsWs77pWg5vQQKLQj07oNrJryo/wK2G0ndNaoVn2ownFMeoeAuReu3Q==}
 
   /ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}


### PR DESCRIPTION
This PR introduces the TenantId branded types.

<del>I left a bunch of TODOs because in some situations is very easy to misuse a `producerId` instead of a `consumerId` (and vice versa)</del>. I explored possible solutions but adds too much complexity  

I had to update `ts-pattern` to resolve this bug https://github.com/gvergnaud/ts-pattern/issues/167
