### PR TITLE
IMN-209 Fix document delete based on descriptor state

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -634,6 +634,10 @@ export async function deleteDocumentLogic({
 
   const descriptor = retrieveDescriptor(descriptorId, eService);
 
+  if (descriptor.state !== descriptorState.draft) {
+    throw notValidDescriptor(descriptor.id, descriptor.state);
+  }
+
   const document = [...descriptor.docs, descriptor.interface].find(
     (doc) => doc != null && doc.id === documentId
   );

--- a/packages/catalog-process/test/catalogService.test.ts
+++ b/packages/catalog-process/test/catalogService.test.ts
@@ -337,16 +337,25 @@ describe("CatalogService", () => {
   });
   describe("deleteDocument", () => {
     it("delete the document", async () => {
+      const descriptor = {
+        ...mockDescriptor,
+        state: descriptorState.draft,
+        docs: [mockDocument],
+      };
+      const eService = {
+        ...mockEservice,
+        descriptors: [descriptor],
+      };
       const event = await deleteDocumentLogic({
-        eServiceId: mockEservice.id,
-        descriptorId: mockEservice.descriptors[0].id,
+        eServiceId: eService.id,
+        descriptorId: eService.descriptors[0].id,
         documentId: mockDocument.documentId,
         authData,
         eService: addMetadata({
-          ...mockEservice,
+          ...eService,
           descriptors: [
             {
-              ...mockEservice.descriptors[0],
+              ...eService.descriptors[0],
               docs: [
                 {
                   path: mockDocument.filePath,
@@ -365,27 +374,36 @@ describe("CatalogService", () => {
       });
       expect(event.event.type).toBe("EServiceDocumentDeleted");
       expect(event.event.data).toMatchObject({
-        eServiceId: mockEservice.id,
-        descriptorId: mockEservice.descriptors[0].id,
+        eServiceId: eService.id,
+        descriptorId: eService.descriptors[0].id,
         documentId: mockDocument.documentId,
       });
     });
 
-    it("returns an error if the eservice doesn't contains the document", async () => {
+    it("returns an error if the eservice doesn't contain the document", async () => {
+      const descriptor = {
+        ...mockDescriptor,
+        state: descriptorState.draft,
+        docs: [],
+      };
+      const eService = {
+        ...mockEservice,
+        descriptors: [descriptor],
+      };
       const documentId = "document-not-present-id";
       await expect(() =>
         deleteDocumentLogic({
-          eServiceId: mockEservice.id,
-          descriptorId: mockEservice.descriptors[0].id,
+          eServiceId: eService.id,
+          descriptorId: eService.descriptors[0].id,
           documentId,
           authData,
-          eService: addMetadata(mockEservice),
+          eService: addMetadata(eService),
           deleteRemoteFile: () => Promise.resolve(),
         })
       ).rejects.toThrowError(
         eServiceDocumentNotFound(
-          mockEservice.id,
-          mockEservice.descriptors[0].id,
+          eService.id,
+          eService.descriptors[0].id,
           documentId
         )
       );

--- a/packages/catalog-process/test/db.test.ts
+++ b/packages/catalog-process/test/db.test.ts
@@ -1864,6 +1864,94 @@ describe("database test", async () => {
           eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
         );
       });
+      it("should throw notValidDescriptor if the descriptor is in published state", async () => {
+        const descriptor: Descriptor = {
+          ...mockDescriptor,
+          state: descriptorState.published,
+          docs: [mockDocument],
+        };
+        const eService: EService = {
+          ...mockEService,
+          descriptors: [descriptor],
+        };
+        await addOneEService(eService, postgresDB, eservices);
+        expect(
+          catalogService.deleteDocument(
+            eService.id,
+            descriptor.id,
+            mockDocument.id,
+            getMockAuthData(eService.producerId)
+          )
+        ).rejects.toThrowError(
+          notValidDescriptor(descriptor.id, descriptorState.published)
+        );
+      });
+      it("should throw notValidDescriptor if the descriptor is in deprecated state", async () => {
+        const descriptor: Descriptor = {
+          ...mockDescriptor,
+          state: descriptorState.deprecated,
+          docs: [mockDocument],
+        };
+        const eService: EService = {
+          ...mockEService,
+          descriptors: [descriptor],
+        };
+        await addOneEService(eService, postgresDB, eservices);
+        expect(
+          catalogService.deleteDocument(
+            eService.id,
+            descriptor.id,
+            mockDocument.id,
+            getMockAuthData(eService.producerId)
+          )
+        ).rejects.toThrowError(
+          notValidDescriptor(descriptor.id, descriptorState.deprecated)
+        );
+      });
+      it("should throw notValidDescriptor if the descriptor is in archived state", async () => {
+        const descriptor: Descriptor = {
+          ...mockDescriptor,
+          state: descriptorState.archived,
+          docs: [mockDocument],
+        };
+        const eService: EService = {
+          ...mockEService,
+          descriptors: [descriptor],
+        };
+        await addOneEService(eService, postgresDB, eservices);
+        expect(
+          catalogService.deleteDocument(
+            eService.id,
+            descriptor.id,
+            mockDocument.id,
+            getMockAuthData(eService.producerId)
+          )
+        ).rejects.toThrowError(
+          notValidDescriptor(descriptor.id, descriptorState.archived)
+        );
+      });
+      it("should throw notValidDescriptor if the descriptor is in suspended state", async () => {
+        const descriptor: Descriptor = {
+          ...mockDescriptor,
+          state: descriptorState.suspended,
+          docs: [mockDocument],
+        };
+        const eService: EService = {
+          ...mockEService,
+          descriptors: [descriptor],
+        };
+        await addOneEService(eService, postgresDB, eservices);
+        expect(
+          catalogService.deleteDocument(
+            eService.id,
+            descriptor.id,
+            mockDocument.id,
+            getMockAuthData(eService.producerId)
+          )
+        ).rejects.toThrowError(
+          notValidDescriptor(descriptor.id, descriptorState.suspended)
+        );
+      });
       it("should throw eServiceDocumentNotFound if the document doesn't exist", async () => {
         const descriptor: Descriptor = {
           ...mockDescriptor,


### PR DESCRIPTION
[To be merged after #178]

This pull request is for fixing the `documentDelete` operation. With this fix, it's no longer possible to delete a document from a descriptor that is not in draft state.