### PR TITLE
IMN-212 - Add attributesIds filter to GET /eservices

### DIFF
--- a/packages/catalog-process/open-api/catalog-service-spec.yml
+++ b/packages/catalog-process/open-api/catalog-service-spec.yml
@@ -64,6 +64,16 @@ paths:
             default: []
           explode: false
         - in: query
+          name: attributesIds
+          description: comma separated sequence of attributes IDs
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
+            default: []
+          explode: false
+        - in: query
           name: states
           description: comma separated sequence of states
           schema:

--- a/packages/catalog-process/src/model/types.ts
+++ b/packages/catalog-process/src/model/types.ts
@@ -1,5 +1,11 @@
 import { ZodiosBodyByPath } from "@zodios/core";
-import { AgreementState, DescriptorState } from "pagopa-interop-models";
+import {
+  AgreementState,
+  AttributeId,
+  DescriptorState,
+  EServiceId,
+  TenantId,
+} from "pagopa-interop-models";
 import { api } from "./generated/api.js";
 
 type Api = typeof api.api;
@@ -18,8 +24,9 @@ export type ApiEServiceDescriptorDocumentUpdateSeed = ZodiosBodyByPath<
 >;
 
 export type ApiGetEServicesFilters = {
-  eservicesIds: string[];
-  producersIds: string[];
+  eservicesIds: EServiceId[];
+  producersIds: TenantId[];
+  attributesIds: AttributeId[];
   states: DescriptorState[];
   agreementStates: AgreementState[];
   name?: string;

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -8,7 +8,12 @@ import {
   ReadModelRepository,
   initDB,
 } from "pagopa-interop-commons";
-import { EServiceId, unsafeBrandId } from "pagopa-interop-models";
+import {
+  unsafeBrandId,
+  EServiceId,
+  TenantId,
+  AttributeId,
+} from "pagopa-interop-models";
 import {
   agreementStateToApiAgreementState,
   apiAgreementStateToAgreementState,
@@ -84,6 +89,7 @@ const eservicesRouter = (
             name,
             eservicesIds,
             producersIds,
+            attributesIds,
             states,
             agreementStates,
             offset,
@@ -93,8 +99,9 @@ const eservicesRouter = (
           const catalogs = await catalogService.getEServices(
             req.ctx.authData,
             {
-              eservicesIds,
-              producersIds,
+              eservicesIds: eservicesIds.map<EServiceId>(unsafeBrandId),
+              producersIds: producersIds.map<TenantId>(unsafeBrandId),
+              attributesIds: attributesIds.map<AttributeId>(unsafeBrandId),
               states: states.map(apiDescriptorStateToDescriptorState),
               agreementStates: agreementStates.map(
                 apiAgreementStateToAgreementState
@@ -202,14 +209,10 @@ const eservicesRouter = (
       ]),
       async (req, res) => {
         try {
-          const eServiceId = unsafeBrandId<EServiceId>(req.params.eServiceId);
-          const offset = req.query.offset;
-          const limit = req.query.limit;
-
           const consumers = await catalogService.getEServiceConsumers(
-            eServiceId,
-            offset,
-            limit
+            unsafeBrandId(req.params.eServiceId),
+            req.query.offset,
+            req.query.limit
           );
 
           return res

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -24,6 +24,7 @@ import {
   operationForbidden,
   unsafeBrandId,
   ListResult,
+  AttributeId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import {
@@ -801,7 +802,7 @@ export async function createDescriptorLogic({
   eserviceDescriptorSeed: EServiceDescriptorSeed;
   authData: AuthData;
   eService: WithMetadata<EService> | undefined;
-  getAttributesByIds: (attributesIds: string[]) => Promise<Attribute[]>;
+  getAttributesByIds: (attributesIds: AttributeId[]) => Promise<Attribute[]>;
 }): Promise<CreateEvent<EServiceEvent>> {
   assertEServiceExist(eserviceId, eService);
   assertRequesterAllowed(eService.data.producerId, authData.organizationId);
@@ -820,7 +821,9 @@ export async function createDescriptorLogic({
   ];
 
   if (attributesSeeds.length > 0) {
-    const attributesSeedsIds = attributesSeeds.map((attr) => attr.id);
+    const attributesSeedsIds: AttributeId[] = attributesSeeds.map((attr) =>
+      unsafeBrandId(attr.id)
+    );
     const attributes = await getAttributesByIds(attributesSeedsIds);
     const attributesIds = attributes.map((attr) => attr.id);
     for (const attributeSeedId of attributesSeedsIds) {

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -5,6 +5,7 @@ import {
   EServiceCollection,
 } from "pagopa-interop-commons";
 import {
+  AttributeId,
   Document,
   EService,
   Agreement,
@@ -20,6 +21,7 @@ import {
   EServiceId,
   EServiceDocumentId,
   TenantId,
+  Descriptor,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { z } from "zod";
@@ -72,8 +74,14 @@ export function readModelServiceBuilder(
       offset: number,
       limit: number
     ): Promise<ListResult<EService>> {
-      const { eservicesIds, producersIds, states, agreementStates, name } =
-        filters;
+      const {
+        eservicesIds,
+        producersIds,
+        states,
+        agreementStates,
+        name,
+        attributesIds,
+      } = filters;
       const ids = await match(agreementStates.length)
         .with(0, () => eservicesIds)
         .otherwise(async () =>
@@ -100,19 +108,65 @@ export function readModelServiceBuilder(
           }
         : {};
 
+      const idsFilter: ReadModelFilter<EService> = {
+        "data.id": { $in: ids },
+      };
+
+      const producersIdsFilter: ReadModelFilter<EService> = {
+        "data.producerId": { $in: producersIds },
+      };
+
+      const descriptorsStateFilter: ReadModelFilter<Descriptor> = {
+        state: { $in: states },
+      } as ReadModelFilter<Descriptor>;
+
+      const descriptorsAttributesFilter: ReadModelFilter<Descriptor> = {
+        $or: [
+          {
+            "attributes.certified": {
+              $elemMatch: {
+                $elemMatch: { id: { $in: attributesIds } },
+              },
+            },
+          },
+          {
+            "attributes.declared": {
+              $elemMatch: {
+                $elemMatch: { id: { $in: attributesIds } },
+              },
+            },
+          },
+          {
+            "attributes.verified": {
+              $elemMatch: {
+                $elemMatch: { id: { $in: attributesIds } },
+              },
+            },
+          },
+        ],
+      };
+
       const aggregationPipeline = [
         {
           $match: {
             ...nameFilter,
-            ...ReadModelRepository.arrayToFilter(states, {
-              "data.descriptors": { $elemMatch: { state: { $in: states } } },
-            }),
-            ...ReadModelRepository.arrayToFilter(ids, {
-              "data.id": { $in: ids },
-            }),
-            ...ReadModelRepository.arrayToFilter(producersIds, {
-              "data.producerId": { $in: producersIds },
-            }),
+            ...ReadModelRepository.arrayToFilter(ids, idsFilter),
+            ...ReadModelRepository.arrayToFilter(
+              producersIds,
+              producersIdsFilter
+            ),
+            "data.descriptors": {
+              $elemMatch: {
+                ...ReadModelRepository.arrayToFilter(
+                  states,
+                  descriptorsStateFilter
+                ),
+                ...ReadModelRepository.arrayToFilter(
+                  attributesIds,
+                  descriptorsAttributesFilter
+                ),
+              },
+            },
           } satisfies ReadModelFilter<EService>,
         },
         {
@@ -296,9 +350,9 @@ export function readModelServiceBuilder(
         ?.docs.find((d) => d.id === documentId);
     },
     async listAgreements(
-      eservicesIds: string[],
-      consumersIds: string[],
-      producersIds: string[],
+      eservicesIds: EServiceId[],
+      consumersIds: TenantId[],
+      producersIds: TenantId[],
       states: AgreementState[]
     ): Promise<Agreement[]> {
       const aggregationPipeline = [
@@ -343,7 +397,9 @@ export function readModelServiceBuilder(
       return result.data;
     },
 
-    async getAttributesByIds(attributesIds: string[]): Promise<Attribute[]> {
+    async getAttributesByIds(
+      attributesIds: AttributeId[]
+    ): Promise<Attribute[]> {
       const data = await attributes
         .find({
           "data.id": { $in: attributesIds },

--- a/packages/catalog-process/test/utils.ts
+++ b/packages/catalog-process/test/utils.ts
@@ -14,8 +14,10 @@ import {
   DescriptorId,
   Document,
   EService,
+  EServiceAttribute,
   EServiceEvent,
   EServiceId,
+  EserviceAttributes,
   Tenant,
   TenantId,
   agreementState,
@@ -156,6 +158,17 @@ export const getMockDescriptor = (): Descriptor => ({
     verified: [],
     declared: [],
   },
+});
+
+export const getMockEServiceAttribute = (): EServiceAttribute => ({
+  id: generateId(),
+  explicitAttributeVerification: false,
+});
+
+export const getMockEServiceAttributes = (): EserviceAttributes => ({
+  certified: [[getMockEServiceAttribute(), getMockEServiceAttribute()]],
+  declared: [[getMockEServiceAttribute(), getMockEServiceAttribute()]],
+  verified: [[getMockEServiceAttribute(), getMockEServiceAttribute()]],
 });
 
 export const buildInterfaceSeed = (): ApiEServiceDescriptorDocumentSeed => ({

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -43,7 +43,7 @@ export const EServiceAttribute = z.object({
 });
 export type EServiceAttribute = z.infer<typeof EServiceAttribute>;
 
-const EServiceAttributes = z.object({
+export const EServiceAttributes = z.object({
   certified: z.array(z.array(EServiceAttribute)),
   declared: z.array(z.array(EServiceAttribute)),
   verified: z.array(z.array(EServiceAttribute)),


### PR DESCRIPTION
[to be merged after #156]

Closes [IMN-212](https://pagopa.atlassian.net/browse/IMN-212)

# Tests 

### New automated tests work

<img width="831" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/86ec3131-dca7-4cdc-9bfb-34e94bd13aa8">

### The filter works when added without any other filter:
<img width="1434" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/61ef638a-29e4-46a6-b437-7e567892d7c5">

<img width="1459" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/4ddd9c8a-2ee6-4f60-a628-8ce09cb90088">

<img width="1457" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/cd4cd3a6-2c64-414d-aedc-2f10dd7e73e5">

### The filter works also together with other filters:
<img width="1446" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/4a9d9fba-75b0-464d-be96-85683047d565">
<img width="1459" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/a59f7484-c16e-48d9-b4a3-dcc189af6f90">
<img width="1448" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/adbaf661-a4d5-4290-9af8-53f17d459c1a">
<img width="1460" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/7e86b91a-48fd-4db8-a068-3b2d4d58e52a">


[IMN-212]: https://pagopa.atlassian.net/browse/IMN-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ