### PR TITLE
IMN-236 Avoid showing draft descriptors to consumer in catalog-process

### DIFF
--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -146,15 +146,13 @@ const eservicesRouter = (
       ]),
       async (req, res) => {
         try {
-          const eService = await readModelService.getEServiceById(
-            req.params.eServiceId
+          const eService = await catalogService.getEServiceById(
+            req.params.eServiceId,
+            req.ctx.authData
           );
 
           if (eService) {
-            return res
-              .status(200)
-              .json(eServiceToApiEService(eService.data))
-              .end();
+            return res.status(200).json(eServiceToApiEService(eService)).end();
           } else {
             return res
               .status(404)

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -459,6 +459,36 @@ export function catalogServiceBuilder(
         })
       );
     },
+
+    async getEServiceById(
+      eServiceId: string,
+      authData: AuthData
+    ): Promise<EService> {
+      const eServiceAndMetadata = await readModelService.getEServiceById(
+        eServiceId
+      );
+      if (eServiceAndMetadata === undefined) {
+        throw eServiceNotFound(eServiceId);
+      }
+      const eService = eServiceAndMetadata.data;
+
+      if (authData.organizationId !== eService.producerId) {
+        const eServiceForConsumer: EService = {
+          ...eService,
+          descriptors: eService.descriptors.filter(
+            (d) => d.state !== descriptorState.draft
+          ),
+        };
+
+        if (eServiceForConsumer.descriptors.length === 0) {
+          throw eServiceNotFound(eService.id);
+        }
+
+        return eServiceForConsumer;
+      }
+
+      return eService;
+    },
   };
 }
 


### PR DESCRIPTION
[To be merged after #156]

This pull request is for implementing new checks on the `getEServiceById` endpoint.
- If the eService has both `draft` and `non-draft` descriptors: the consumer should only get the `non-draft` ones.
- If the eService has only one descriptor, which is in draft: the consumer should get `404`.
- If the eService has no descriptors: the consumer should get `404`.