### PR TITLE
Operational logs consistency - Part 1 - Agreement and Catalog

### DIFF
--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-params */
-import { AuthData, CreateEvent, logger } from "pagopa-interop-commons";
+import { AuthData, CreateEvent } from "pagopa-interop-commons";
 import {
   Agreement,
   Descriptor,
@@ -53,8 +53,6 @@ export async function activateAgreementLogic(
   attributeQuery: AttributeQuery,
   authData: AuthData
 ): Promise<Array<CreateEvent<AgreementEvent>>> {
-  logger.info(`Activating agreement ${agreementId}`);
-
   const agreement = await agreementQuery.getAgreementById(agreementId);
   assertAgreementExist(agreementId, agreement);
 

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -119,6 +119,9 @@ export function agreementServiceBuilder(
       agreement: ApiAgreementPayload,
       authData: AuthData
     ): Promise<string> {
+      logger.info(
+        `Creating agreement for EService ${agreement.eserviceId} and Descriptor ${agreement.descriptorId}`
+      );
       const createAgreementEvent = await createAgreementLogic(
         agreement,
         authData,
@@ -153,6 +156,7 @@ export function agreementServiceBuilder(
       agreement: ApiAgreementUpdatePayload,
       authData: AuthData
     ): Promise<void> {
+      logger.info(`Updating agreement ${agreementId}`);
       const agreementToBeUpdated = await agreementQuery.getAgreementById(
         agreementId
       );
@@ -170,6 +174,7 @@ export function agreementServiceBuilder(
       agreementId: AgreementId,
       authData: AuthData
     ): Promise<void> {
+      logger.info(`Deleting agreement ${agreementId}`);
       const agreement = await agreementQuery.getAgreementById(agreementId);
 
       await repository.createEvent(
@@ -355,6 +360,7 @@ export function agreementServiceBuilder(
       agreementId: Agreement["id"],
       authData: AuthData
     ): Promise<Agreement["id"]> {
+      logger.info(`Activating agreement ${agreementId}`);
       const updatesEvents = await activateAgreementLogic(
         agreementId,
         agreementQuery,
@@ -463,9 +469,6 @@ export async function createAgreementLogic(
   eserviceQuery: EserviceQuery,
   tenantQuery: TenantQuery
 ): Promise<CreateEvent<AgreementEvent>> {
-  logger.info(
-    `Creating agreement for EService ${agreement.eserviceId} and Descriptor ${agreement.descriptorId}`
-  );
   const eservice = await eserviceQuery.getEServiceById(agreement.eserviceId);
   assertEServiceExist(unsafeBrandId(agreement.eserviceId), eservice);
 

--- a/packages/catalog-process/src/model/types.ts
+++ b/packages/catalog-process/src/model/types.ts
@@ -1,4 +1,5 @@
 import { ZodiosBodyByPath } from "@zodios/core";
+import { AgreementState, DescriptorState } from "pagopa-interop-models";
 import { api } from "./generated/api.js";
 
 type Api = typeof api.api;
@@ -15,3 +16,11 @@ export type ApiEServiceDescriptorDocumentUpdateSeed = ZodiosBodyByPath<
   "post",
   "/eservices/:eServiceId/descriptors/:descriptorId/documents/:documentId/update"
 >;
+
+export type ApiGetEServicesFilters = {
+  eservicesIds: string[];
+  producersIds: string[];
+  states: DescriptorState[];
+  agreementStates: AgreementState[];
+  name?: string;
+};

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -20,11 +20,7 @@ import { api } from "../model/generated/api.js";
 import { config } from "../utilities/config.js";
 import { readModelServiceBuilder } from "../services/readModelService.js";
 import { catalogServiceBuilder } from "../services/catalogService.js";
-import {
-  makeApiProblem,
-  eServiceNotFound,
-  eServiceDocumentNotFound,
-} from "../model/domain/errors.js";
+import { makeApiProblem } from "../model/domain/errors.js";
 import {
   activateDescriptorErrorMapper,
   archiveDescriptorErrorMapper,
@@ -34,7 +30,9 @@ import {
   deleteDraftDescriptorErrorMapper,
   deleteEServiceErrorMapper,
   documentCreateErrorMapper,
+  documentGetErrorMapper,
   documentUpdateDeleteErrorMapper,
+  getEServiceErrorMapper,
   publishDescriptorErrorMapper,
   suspendDescriptorErrorMapper,
   updateDescriptorErrorMapper,
@@ -92,7 +90,7 @@ const eservicesRouter = (
             limit,
           } = req.query;
 
-          const catalogs = await readModelService.getEServices(
+          const catalogs = await catalogService.getEServices(
             req.ctx.authData,
             {
               eservicesIds,
@@ -146,28 +144,16 @@ const eservicesRouter = (
       ]),
       async (req, res) => {
         try {
-          const eService = await readModelService.getEServiceById(
+          const eService = await catalogService.getEServiceById(
             unsafeBrandId(req.params.eServiceId)
           );
 
-          if (eService) {
-            return res
-              .status(200)
-              .json(eServiceToApiEService(eService.data))
-              .end();
-          } else {
-            return res
-              .status(404)
-              .json(
-                makeApiProblem(
-                  eServiceNotFound(unsafeBrandId(req.params.eServiceId)),
-                  () => 404
-                )
-              )
-              .end();
-          }
+          return res
+            .status(200)
+            .json(eServiceToApiEService(eService.data))
+            .end();
         } catch (error) {
-          const errorRes = makeApiProblem(error, () => 500);
+          const errorRes = makeApiProblem(error, getEServiceErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }
@@ -220,7 +206,7 @@ const eservicesRouter = (
           const offset = req.query.offset;
           const limit = req.query.limit;
 
-          const consumers = await readModelService.getEServiceConsumers(
+          const consumers = await catalogService.getEServiceConsumers(
             eServiceId,
             offset,
             limit
@@ -262,40 +248,24 @@ const eservicesRouter = (
         try {
           const { eServiceId, descriptorId, documentId } = req.params;
 
-          const document = await readModelService.getDocumentById(
+          const document = await catalogService.getDocumentById(
             unsafeBrandId(eServiceId),
             unsafeBrandId(descriptorId),
             unsafeBrandId(documentId)
           );
 
-          if (document) {
-            return res
-              .status(200)
-              .json({
-                id: document.id,
-                name: document.name,
-                contentType: document.contentType,
-                prettyName: document.prettyName,
-                path: document.path,
-              })
-              .end();
-          } else {
-            return res
-              .status(404)
-              .json(
-                makeApiProblem(
-                  eServiceDocumentNotFound(
-                    unsafeBrandId(eServiceId),
-                    unsafeBrandId(descriptorId),
-                    unsafeBrandId(documentId)
-                  ),
-                  () => 404
-                )
-              )
-              .end();
-          }
+          return res
+            .status(200)
+            .json({
+              id: document.id,
+              name: document.name,
+              contentType: document.contentType,
+              prettyName: document.prettyName,
+              path: document.path,
+            })
+            .end();
         } catch (error) {
-          const errorRes = makeApiProblem(error, () => 500);
+          const errorRes = makeApiProblem(error, documentGetErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -87,6 +87,17 @@ const assertRequesterAllowed = (
   }
 };
 
+export const retrieveEService = async (
+  eserviceId: EServiceId,
+  readModelService: ReadModelService
+): Promise<WithMetadata<EService>> => {
+  const eService = await readModelService.getEServiceById(eserviceId);
+  if (eService === undefined) {
+    throw eServiceNotFound(eserviceId);
+  }
+  return eService;
+};
+
 const retrieveDescriptor = (
   descriptorId: DescriptorId,
   eService: WithMetadata<EService>

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -22,6 +22,7 @@ import {
   generateId,
   operationForbidden,
   unsafeBrandId,
+  ListResult,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import {
@@ -29,6 +30,7 @@ import {
   apiTechnologyToTechnology,
 } from "../model/domain/apiConverter.js";
 import {
+  Consumer,
   EServiceDescriptorSeed,
   UpdateEServiceDescriptorSeed,
 } from "../model/domain/models.js";
@@ -48,6 +50,7 @@ import {
   ApiEServiceDescriptorDocumentSeed,
   ApiEServiceDescriptorDocumentUpdateSeed,
   ApiEServiceSeed,
+  ApiGetEServicesFilters,
 } from "../model/types.js";
 import { config } from "../utilities/config.js";
 import { nextDescriptorVersion } from "../utilities/versionGenerator.js";
@@ -82,17 +85,6 @@ const assertRequesterAllowed = (
   if (producerId !== requesterId) {
     throw operationForbidden;
   }
-};
-
-export const retrieveEService = async (
-  eserviceId: EServiceId,
-  readModelService: ReadModelService
-): Promise<WithMetadata<EService>> => {
-  const eService = await readModelService.getEServiceById(eserviceId);
-  if (eService === undefined) {
-    throw eServiceNotFound(eserviceId);
-  }
-  return eService;
 };
 
 const retrieveDescriptor = (
@@ -200,6 +192,9 @@ export function catalogServiceBuilder(
       apiEServicesSeed: ApiEServiceSeed,
       authData: AuthData
     ): Promise<EServiceId> {
+      logger.info(
+        `Creating EService with service name ${apiEServicesSeed.name}`
+      );
       return unsafeBrandId<EServiceId>(
         await repository.createEvent(
           createEserviceLogic({
@@ -213,12 +208,49 @@ export function catalogServiceBuilder(
         )
       );
     },
-
+    async getEServiceById(
+      eserviceId: EServiceId
+    ): Promise<WithMetadata<EService>> {
+      logger.info(`Retrieving EService ${eserviceId}`);
+      const eService = await readModelService.getEServiceById(eserviceId);
+      assertEServiceExist(eserviceId, eService);
+      return eService;
+    },
+    async getEServices(
+      authData: AuthData,
+      filters: ApiGetEServicesFilters,
+      offset: number,
+      limit: number
+    ): Promise<ListResult<EService>> {
+      // "Getting e-service with name = $name, ids = $eServicesIds, producers = $producersIds, states = $states, agreementStates = $agreementStates, limit = $limit, offset = $offset"
+      logger.info(
+        `Getting EServices with name = ${filters.name}, ids = ${filters.eservicesIds}, producers = ${filters.producersIds}, states = ${filters.states}, agreementStates = ${filters.agreementStates}, limit = ${limit}, offset = ${offset}`
+      );
+      return await readModelService.getEServices(
+        authData.organizationId,
+        filters,
+        offset,
+        limit
+      );
+    },
+    async getEServiceConsumers(
+      eServiceId: EServiceId,
+      offset: number,
+      limit: number
+    ): Promise<ListResult<Consumer>> {
+      logger.info(`Retrieving consumers for EService ${eServiceId}`);
+      return await readModelService.getEServiceConsumers(
+        eServiceId,
+        offset,
+        limit
+      );
+    },
     async updateEService(
       eserviceId: EServiceId,
       eServiceSeed: ApiEServiceSeed,
       authData: AuthData
     ): Promise<void> {
+      logger.info(`Updating EService ${eserviceId}`);
       const eService = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
@@ -230,6 +262,7 @@ export function catalogServiceBuilder(
       eserviceId: EServiceId,
       authData: AuthData
     ): Promise<void> {
+      logger.info(`Deleting EService ${eserviceId}`);
       const eService = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
@@ -243,6 +276,9 @@ export function catalogServiceBuilder(
       document: ApiEServiceDescriptorDocumentSeed,
       authData: AuthData
     ): Promise<string> {
+      logger.info(
+        `Creating EService Document ${document.documentId.toString} of kind ${document.kind}, name ${document.fileName}, path ${document.filePath} for EService ${eserviceId} and Descriptor ${descriptorId}`
+      );
       const eService = await readModelService.getEServiceById(eserviceId);
 
       return await repository.createEvent(
@@ -255,13 +291,34 @@ export function catalogServiceBuilder(
         })
       );
     },
+    async getDocumentById(
+      eServiceId: EServiceId,
+      descriptorId: DescriptorId,
+      documentId: EServiceDocumentId
+    ): Promise<Document> {
+      logger.info(
+        `Retrieving EService document ${documentId} for EService ${eServiceId} and descriptor ${descriptorId}`
+      );
+      const document = await readModelService.getDocumentById(
+        eServiceId,
+        descriptorId,
+        documentId
+      );
 
+      if (document === undefined) {
+        throw eServiceDocumentNotFound(eServiceId, descriptorId, documentId);
+      }
+      return document;
+    },
     async deleteDocument(
       eserviceId: EServiceId,
       descriptorId: DescriptorId,
       documentId: EServiceDocumentId,
       authData: AuthData
     ): Promise<void> {
+      logger.info(
+        `Deleting Document ${documentId} of Descriptor ${descriptorId} for EService ${eserviceId}`
+      );
       const eService = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
@@ -283,6 +340,9 @@ export function catalogServiceBuilder(
       apiEServiceDescriptorDocumentUpdateSeed: ApiEServiceDescriptorDocumentUpdateSeed,
       authData: AuthData
     ): Promise<void> {
+      logger.info(
+        `Updating Document ${documentId} of Descriptor ${descriptorId} for EService ${eserviceId}`
+      );
       const eService = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
@@ -322,7 +382,7 @@ export function catalogServiceBuilder(
       authData: AuthData
     ): Promise<void> {
       logger.info(
-        `Deleting draft Descriptor ${descriptorId} of EService ${eserviceId}`
+        `Deleting draft Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
       const eService = await readModelService.getEServiceById(eserviceId);
@@ -343,6 +403,9 @@ export function catalogServiceBuilder(
       seed: UpdateEServiceDescriptorSeed,
       authData: AuthData
     ): Promise<void> {
+      logger.info(
+        `Updating draft Descriptor ${descriptorId} for EService ${eserviceId}`
+      );
       const eService = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
@@ -362,7 +425,7 @@ export function catalogServiceBuilder(
       authData: AuthData
     ): Promise<void> {
       logger.info(
-        `Publishing Descriptor $descriptorId of EService ${eserviceId}`
+        `Publishing Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
       const eService = await readModelService.getEServiceById(eserviceId);
@@ -383,7 +446,7 @@ export function catalogServiceBuilder(
       authData: AuthData
     ): Promise<void> {
       logger.info(
-        `Suspending Descriptor ${descriptorId} of EService ${eserviceId}`
+        `Suspending Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
       const eService = await readModelService.getEServiceById(eserviceId);
@@ -425,7 +488,7 @@ export function catalogServiceBuilder(
       authData: AuthData
     ): Promise<EService> {
       logger.info(
-        `Cloning Descriptor ${descriptorId} of EService ${eserviceId}`
+        `Cloning Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
       const eService = await readModelService.getEServiceById(eserviceId);
@@ -449,7 +512,7 @@ export function catalogServiceBuilder(
       authData: AuthData
     ): Promise<void> {
       logger.info(
-        `Archiving descriptor ${descriptorId} of EService ${eserviceId}`
+        `Archiving Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
       const eService = await readModelService.getEServiceById(eserviceId);
@@ -967,10 +1030,6 @@ export function activateDescriptorLogic({
     recentDescriptorVersion !== null &&
     parseInt(descriptor.version, 10) === recentDescriptorVersion
   ) {
-    logger.info(
-      `Publishing Descriptor ${descriptorId} of EService ${eserviceId}`
-    );
-
     return toCreateEventEServiceDescriptorUpdated(
       eserviceId,
       eService.metadata.version,

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -1,12 +1,10 @@
 import {
-  AuthData,
   logger,
   ReadModelRepository,
   ReadModelFilter,
   EServiceCollection,
 } from "pagopa-interop-commons";
 import {
-  DescriptorState,
   Document,
   EService,
   Agreement,
@@ -26,6 +24,7 @@ import { match } from "ts-pattern";
 import { z } from "zod";
 import { Filter, WithId } from "mongodb";
 import { Consumer, consumer } from "../model/domain/models.js";
+import { ApiGetEServicesFilters } from "../model/types.js";
 
 async function getEService(
   eservices: EServiceCollection,
@@ -66,30 +65,20 @@ export function readModelServiceBuilder(
   const agreements = readModelRepository.agreements;
   return {
     async getEServices(
-      authData: AuthData,
-      {
-        eservicesIds,
-        producersIds,
-        states,
-        agreementStates,
-        name,
-      }: {
-        eservicesIds: string[];
-        producersIds: string[];
-        states: DescriptorState[];
-        agreementStates: AgreementState[];
-        name?: string;
-      },
+      organizationId: TenantId,
+      filters: ApiGetEServicesFilters,
       offset: number,
       limit: number
     ): Promise<ListResult<EService>> {
+      const { eservicesIds, producersIds, states, agreementStates, name } =
+        filters;
       const ids = await match(agreementStates.length)
         .with(0, () => eservicesIds)
         .otherwise(async () =>
           (
             await this.listAgreements(
               eservicesIds,
-              [authData.organizationId],
+              [organizationId],
               [],
               agreementStates
             )

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -14,6 +14,11 @@ const {
   HTTP_STATUS_CONFLICT,
 } = constants;
 
+export const getEServiceErrorMapper = (error: ApiError<ErrorCodes>): number =>
+  match(error.code)
+    .with("eServiceNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
 export const createEServiceErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
@@ -48,6 +53,11 @@ export const documentCreateErrorMapper = (
       () => HTTP_STATUS_NOT_FOUND
     )
     .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const documentGetErrorMapper = (error: ApiError<ErrorCodes>): number =>
+  match(error.code)
+    .with("eServiceDocumentNotFound", () => HTTP_STATUS_NOT_FOUND)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
 export const documentUpdateDeleteErrorMapper = (


### PR DESCRIPTION
First PR to close [IMN-241](https://pagopa.atlassian.net/browse/IMN-241). 
**The same should then be done for `tenant` and `attribute-registry`.**

# Description

After this PR:
1. Operational logs correspond to the ones in the Scala codebase
2. Operational logs are performed at the beginning of each operation in `*Service.ts` modules (`catalogService`, `agreementService`)

For point 2, I had to perform a few small refactors: in the Catalog Router, some operations were calling `catalogService`, while some others were directly calling `readModelService` - I made all calls pass by the `catalogService`.

[IMN-241]: https://pagopa.atlassian.net/browse/IMN-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ