### PR TITLE
IMN-268 - Fixing readmodel writer DELETE & UPDATE Descriptor document

### DIFF
--- a/packages/catalog-readmodel-writer/src/consumerService.ts
+++ b/packages/catalog-readmodel-writer/src/consumerService.ts
@@ -98,7 +98,6 @@ export async function handleMessage(
         { "data.id": msg.stream_id, "metadata.version": { $lt: msg.version } },
         {
           $set: {
-            "metadata.version": msg.version,
             "data.descriptors.$[descriptor].docs.$[doc]": msg.data
               .updatedDocument
               ? fromDocumentV1(msg.data.updatedDocument)
@@ -109,7 +108,30 @@ export async function handleMessage(
           arrayFilters: [
             {
               "descriptor.id": msg.data.descriptorId,
+            },
+            {
               "doc.id": msg.data.documentId,
+            },
+          ],
+        }
+      );
+      await eservices.updateOne(
+        {
+          "data.id": msg.stream_id,
+        },
+        {
+          $set: {
+            "data.descriptors.$[descriptor].interface": msg.data.updatedDocument
+              ? fromDocumentV1(msg.data.updatedDocument)
+              : undefined,
+            "data.descriptors.$[descriptor].serverUrls": msg.data.serverUrls,
+          },
+        },
+        {
+          arrayFilters: [
+            {
+              "descriptor.id": msg.data.descriptorId,
+              "descriptor.interface.id": msg.data.documentId,
             },
           ],
         }
@@ -121,23 +143,8 @@ export async function handleMessage(
         },
         {
           $set: {
-            "data.descriptors.$[descriptor].interface": msg.data.updatedDocument
-              ? fromDocumentV1(msg.data.updatedDocument)
-              : undefined,
-            "data.descriptors.$[descriptor].serverUrls": msg.data.serverUrls,
             "metadata.version": msg.version,
           },
-        },
-        {
-          arrayFilters: [
-            {
-              "descriptor.id": msg.data.descriptorId,
-              $or: [
-                { "descriptor.interface": { $exists: true } },
-                { "descriptor.interface.id": msg.data.documentId },
-              ],
-            },
-          ],
         }
       );
     })
@@ -208,9 +215,6 @@ export async function handleMessage(
               id: msg.data.documentId,
             },
           },
-          $set: {
-            "metadata.version": msg.version,
-          },
         },
         {
           arrayFilters: [
@@ -228,7 +232,6 @@ export async function handleMessage(
           },
           $set: {
             "data.descriptors.$[descriptor].serverUrls": [],
-            "metadata.version": msg.version,
           },
         },
         {
@@ -238,6 +241,14 @@ export async function handleMessage(
               "descriptor.interface.id": msg.data.documentId,
             },
           ],
+        }
+      );
+      await eservices.updateOne(
+        { "data.id": msg.stream_id, "metadata.version": { $lt: msg.version } },
+        {
+          $set: {
+            "metadata.version": msg.version,
+          },
         }
       );
     })


### PR DESCRIPTION
Closes [IMN-268](https://pagopa.atlassian.net/browse/IMN-268)

The issues were happening for two reasons:
1. both UPDATE and DELETE are implemented using more than one subsequent MongoDB `updateOne` operations. With the first operation updating the version to the new `msg.version` and the second operation using the same filter `"metadata.version": { $lt: msg.version }`, the second operation was not being executed.
2. one of the `arrayFilters` was causing an error as shown in the Jira card: being a filter on two different top-level fields, it must be separated into two different filters

# Tests

Manually tested.

### Starting model:

<img width="673" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/271f5c3f-8b37-4f31-91b7-c76c1e18603d">

### 1) Updating document

<img width="654" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/58fbe894-0ea6-41f9-8e48-fc8801e1ddf2">

### 2) Updating interface

<img width="670" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/6dce3885-4bda-4770-840e-e848630b285d">

### 3) Deleting interface

<img width="678" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/7e460cce-9337-46bb-b1d0-88e72977a7cc">

### 4) Deleting document

<img width="491" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/2b0ed221-8753-44fa-aa02-1d022c0fdf8d">


[IMN-268]: https://pagopa.atlassian.net/browse/IMN-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ