### PR TITLE
IMN-269 - GET /eservice - Adding descriptors filter only if corresponding params are present

### DIFF
--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -111,13 +111,15 @@ export function readModelServiceBuilder(
           }
         : {};
 
-      const idsFilter: ReadModelFilter<EService> = {
-        "data.id": { $in: ids },
-      };
+      const idsFilter: ReadModelFilter<EService> =
+        ReadModelRepository.arrayToFilter(ids, {
+          "data.id": { $in: ids },
+        });
 
-      const producersIdsFilter: ReadModelFilter<EService> = {
-        "data.producerId": { $in: producersIds },
-      };
+      const producersIdsFilter: ReadModelFilter<EService> =
+        ReadModelRepository.arrayToFilter(producersIds, {
+          "data.producerId": { $in: producersIds },
+        });
 
       const descriptorsStateFilter: ReadModelFilter<Descriptor> = {
         state: { $in: states },
@@ -148,6 +150,24 @@ export function readModelServiceBuilder(
           },
         ],
       };
+
+      const descriptorsFilter =
+        states.length === 0 && attributesIds.length === 0
+          ? {}
+          : {
+              "data.descriptors": {
+                $elemMatch: {
+                  ...ReadModelRepository.arrayToFilter(
+                    states,
+                    descriptorsStateFilter
+                  ),
+                  ...ReadModelRepository.arrayToFilter(
+                    attributesIds,
+                    descriptorsAttributesFilter
+                  ),
+                },
+              },
+            };
 
       const visibilityFilter = (): ReadModelFilter<EService> => {
         if (
@@ -197,23 +217,9 @@ export function readModelServiceBuilder(
         {
           $match: {
             ...nameFilter,
-            ...ReadModelRepository.arrayToFilter(ids, idsFilter),
-            ...ReadModelRepository.arrayToFilter(
-              producersIds,
-              producersIdsFilter
-            ),
-            "data.descriptors": {
-              $elemMatch: {
-                ...ReadModelRepository.arrayToFilter(
-                  states,
-                  descriptorsStateFilter
-                ),
-                ...ReadModelRepository.arrayToFilter(
-                  attributesIds,
-                  descriptorsAttributesFilter
-                ),
-              },
-            },
+            ...idsFilter,
+            ...producersIdsFilter,
+            ...descriptorsFilter,
             ...visibilityFilter(),
           } satisfies ReadModelFilter<EService>,
         },


### PR DESCRIPTION
Closes [IMN-269](https://pagopa.atlassian.net/browse/IMN-269)

# Tests

✅ Automated test `should include eservices with no descriptors (requester is the producer, admin)` now works
✅ Manual test: GET /eservices now returns also EServices without Descriptors:

<img width="1341" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/0a46f1a8-704e-4f09-bd2f-09ed90797349">


[IMN-269]: https://pagopa.atlassian.net/browse/IMN-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ