### PR TITLE
IMN 270 - Proposal to use AWS CLI internals and env var instead of custom logic to override local AWS config

### DIFF
--- a/packages/agreement-process/.env
+++ b/packages/agreement-process/.env
@@ -18,10 +18,8 @@ READMODEL_DB_PORT=27017
 
 SKIP_JWT_VERIFICATION=true
 
+AWS_CONFIG_FILE=aws.config.local
 S3_BUCKET=interop-local-bucket
-S3_ACCESS_KEY_ID=minioadmin
-S3_SECRET_ACCESS_KEY=minioadmin
-AWS_REGION=eu-central-1
 S3_CUSTOM_SERVER=true
 S3_SERVER_HOST=http://localhost
 S3_SERVER_PORT=9000

--- a/packages/agreement-process/aws.config.local
+++ b/packages/agreement-process/aws.config.local
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id=minioadmin
+aws_secret_access_key=minioadmin
+region=eu-central-1

--- a/packages/catalog-process/.env
+++ b/packages/catalog-process/.env
@@ -18,10 +18,8 @@ READMODEL_DB_PORT=27017
 
 SKIP_JWT_VERIFICATION=true
 
+AWS_CONFIG_FILE=aws.config.local
 S3_BUCKET=interop-local-bucket
-S3_ACCESS_KEY_ID=minioadmin
-S3_SECRET_ACCESS_KEY=minioadmin
-AWS_REGION=eu-central-1
 S3_CUSTOM_SERVER=true
 S3_SERVER_HOST=http://localhost
 S3_SERVER_PORT=9000

--- a/packages/catalog-process/aws.config.local
+++ b/packages/catalog-process/aws.config.local
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id=minioadmin
+aws_secret_access_key=minioadmin
+region=eu-central-1

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -142,9 +142,9 @@ describe("database test", async () => {
       "quay.io/minio/minio:RELEASE.2024-02-06T21-36-22Z"
     )
       .withEnvironment({
-        MINIO_ROOT_USER: config.s3AccessKeyId,
-        MINIO_ROOT_PASSWORD: config.s3SecretAccessKey,
-        MINIO_SITE_REGION: config.s3Region,
+        MINIO_ROOT_USER: "minioadmin",
+        MINIO_ROOT_PASSWORD: "minioadmin",
+        MINIO_SITE_REGION: "eu-central-1",
       })
       .withEntrypoint(["sh", "-c"])
       .withCommand([

--- a/packages/commons-test/aws.config.local
+++ b/packages/commons-test/aws.config.local
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id=minioadmin
+aws_secret_access_key=minioadmin
+region=eu-central-1

--- a/packages/commons-test/test/fileManager.test.ts
+++ b/packages/commons-test/test/fileManager.test.ts
@@ -10,10 +10,9 @@ import {
 } from "pagopa-interop-commons";
 
 describe("FileManager tests", async () => {
+  process.env.AWS_CONFIG_FILE = "aws.config.local";
+
   const config: FileManagerConfig & LoggerConfig = {
-    s3AccessKeyId: "minioadmin",
-    s3SecretAccessKey: "minioadmin",
-    s3Region: "eu-central-1",
     s3CustomServer: true,
     s3ServerHost: "http://127.0.0.1",
     s3ServerPort: 9000,
@@ -29,9 +28,9 @@ describe("FileManager tests", async () => {
       "quay.io/minio/minio:RELEASE.2024-02-06T21-36-22Z"
     )
       .withEnvironment({
-        MINIO_ROOT_USER: config.s3AccessKeyId,
-        MINIO_ROOT_PASSWORD: config.s3SecretAccessKey,
-        MINIO_SITE_REGION: config.s3Region,
+        MINIO_ROOT_USER: "minioadmin",
+        MINIO_ROOT_PASSWORD: "minioadmin",
+        MINIO_SITE_REGION: "eu-central-1",
       })
       .withEntrypoint(["sh", "-c"])
       .withCommand([

--- a/packages/commons/src/config/fileManagerConfig.ts
+++ b/packages/commons/src/config/fileManagerConfig.ts
@@ -6,8 +6,6 @@ const S3CustomServerConfig = z
       S3_CUSTOM_SERVER: z.literal("true"),
       S3_SERVER_HOST: z.string(),
       S3_SERVER_PORT: z.coerce.number().min(1001),
-      S3_ACCESS_KEY_ID: z.string(),
-      S3_SECRET_ACCESS_KEY: z.string(),
     }),
     z.object({
       S3_CUSTOM_SERVER: z.literal("false"),
@@ -19,21 +17,11 @@ const S3CustomServerConfig = z
           s3CustomServer: true as const,
           s3ServerHost: c.S3_SERVER_HOST,
           s3ServerPort: c.S3_SERVER_PORT,
-          s3AccessKeyId: c.S3_ACCESS_KEY_ID,
-          s3SecretAccessKey: c.S3_SECRET_ACCESS_KEY,
         }
       : {
           s3CustomServer: false as const,
         }
   );
 
-const S3Config = z
-  .object({
-    AWS_REGION: z.string(),
-  })
-  .transform((c) => ({
-    s3Region: c.AWS_REGION,
-  }));
-
-export const FileManagerConfig = z.intersection(S3CustomServerConfig, S3Config);
+export const FileManagerConfig = S3CustomServerConfig;
 export type FileManagerConfig = z.infer<typeof FileManagerConfig>;

--- a/packages/commons/src/fileManager.ts
+++ b/packages/commons/src/fileManager.ts
@@ -32,15 +32,6 @@ export function initFileManager(
   config: FileManagerConfig & LoggerConfig
 ): FileManager {
   const s3ClientConfig: S3ClientConfig = {
-    ...(config.s3CustomServer
-      ? {
-          credentials: {
-            accessKeyId: config.s3AccessKeyId,
-            secretAccessKey: config.s3SecretAccessKey,
-          },
-        }
-      : undefined),
-    region: config.s3Region,
     endpoint: config.s3CustomServer
       ? `${config.s3ServerHost}:${config.s3ServerPort}`
       : undefined,


### PR DESCRIPTION
# Tests

### 1) Automated tests using minio work ✅ (`fileManager` tests, `catalogProcess` tests, etc.)

### 2) Manual testing of document delete with path `testfile`

**Before**
<img width="720" alt="Screenshot 2024-02-19 at 16 58 43" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/6aa1db67-54ca-4ff4-802e-9590c0b37951">

**After**  -- doc is correctly deleted meaning the integration is working
<img width="721" alt="Screenshot 2024-02-19 at 16 59 23" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/c675471c-a25d-417f-917e-55478a253faf">
