### PR TITLE
IMN-247 - EService Risk Analysis - adding new fields + updating createAgreement

### DIFF
--- a/packages/catalog-process/open-api/catalog-service-spec.yml
+++ b/packages/catalog-process/open-api/catalog-service-spec.yml
@@ -1057,6 +1057,8 @@ components:
         - description
         - technology
         - descriptors
+        - riskAnalysis
+        - mode
       properties:
         id:
           type: string
@@ -1074,6 +1076,86 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/EServiceDescriptor"
+        riskAnalysis:
+          type: array
+          items:
+            $ref: "#/components/schemas/EServiceRiskAnalysis"
+        mode:
+          $ref: "#/components/schemas/EServiceMode"
+    EServiceMode:
+      type: string
+      description: Risk Analysis Mode
+      enum:
+        - RECEIVE
+        - DELIVER
+    EServiceRiskAnalysis:
+      type: object
+      required:
+        - id
+        - name
+        - riskAnalysisForm
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        riskAnalysisForm:
+          $ref: "#/components/schemas/EServiceRiskAnalysisForm"
+        createdAt:
+          type: string
+          format: date-time
+    EServiceRiskAnalysisForm:
+      type: object
+      required:
+        - id
+        - version
+        - singleAnswers
+        - multiAnswers
+      properties:
+        id:
+          type: string
+          format: uuid
+        version:
+          type: string
+        singleAnswers:
+          type: array
+          items:
+            $ref: "#/components/schemas/EServiceRiskAnalysisSingleAnswer"
+        multiAnswers:
+          type: array
+          items:
+            $ref: "#/components/schemas/EServiceRiskAnalysisMultiAnswer"
+    EServiceRiskAnalysisSingleAnswer:
+      type: object
+      required:
+        - id
+        - key
+      properties:
+        id:
+          type: string
+          format: uuid
+        key:
+          type: string
+        value:
+          type: string
+    EServiceRiskAnalysisMultiAnswer:
+      type: object
+      required:
+        - id
+        - key
+        - values
+      properties:
+        id:
+          type: string
+          format: uuid
+        key:
+          type: string
+        values:
+          type: array
+          items:
+            type: string
     EServiceConsumers:
       type: object
       properties:

--- a/packages/catalog-process/open-api/catalog-service-spec.yml
+++ b/packages/catalog-process/open-api/catalog-service-spec.yml
@@ -847,6 +847,7 @@ components:
         - name
         - description
         - technology
+        - mode
       properties:
         name:
           type: string
@@ -858,12 +859,15 @@ components:
           maxLength: 250
         technology:
           $ref: "#/components/schemas/EServiceTechnology"
+        mode:
+          $ref: "#/components/schemas/EServiceMode"
     UpdateEServiceSeed:
       type: object
       required:
         - name
         - description
         - technology
+        - mode
       properties:
         name:
           type: string
@@ -875,6 +879,8 @@ components:
           maxLength: 250
         technology:
           $ref: "#/components/schemas/EServiceTechnology"
+        mode:
+          $ref: "#/components/schemas/EServiceMode"
     EServiceDescriptorSeed:
       required:
         - audience

--- a/packages/catalog-process/src/model/domain/apiConverter.ts
+++ b/packages/catalog-process/src/model/domain/apiConverter.ts
@@ -8,6 +8,8 @@ import {
   agreementApprovalPolicy,
   descriptorState,
   technology,
+  EServiceMode,
+  eserviceMode,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { z } from "zod";
@@ -16,6 +18,7 @@ import {
   ApiAgreementApprovalPolicy,
   ApiAgreementState,
   ApiEServiceDescriptorState,
+  ApiEServiceMode,
   ApiTechnology,
 } from "./models.js";
 
@@ -111,6 +114,24 @@ export function apiAgreementStateToAgreementState(
     .exhaustive();
 }
 
+export function apiEServiceModeToEServiceMode(
+  input: ApiEServiceMode
+): EServiceMode {
+  return match<ApiEServiceMode, EServiceMode>(input)
+    .with("RECEIVE", () => eserviceMode.receive)
+    .with("DELIVER", () => eserviceMode.deliver)
+    .exhaustive();
+}
+
+export function eServiceModeToApiEServiceMode(
+  input: EServiceMode
+): ApiEServiceMode {
+  return match<EServiceMode, ApiEServiceMode>(input)
+    .with(eserviceMode.receive, () => "RECEIVE")
+    .with(eserviceMode.deliver, () => "DELIVER")
+    .exhaustive();
+}
+
 export const eServiceToApiEService = (
   eService: EService
 ): z.infer<typeof api.schemas.EService> => ({
@@ -119,6 +140,18 @@ export const eServiceToApiEService = (
   name: eService.name,
   description: eService.description,
   technology: technologyToApiTechnology(eService.technology),
+  mode: eServiceModeToApiEServiceMode(eService.mode),
+  riskAnalysis: eService.riskAnalysis.map((riskAnalysis) => ({
+    id: riskAnalysis.id,
+    name: riskAnalysis.name,
+    createdAt: riskAnalysis.createdAt.toJSON(),
+    riskAnalysisForm: {
+      id: riskAnalysis.riskAnalysisForm.id,
+      version: riskAnalysis.riskAnalysisForm.version,
+      singleAnswers: riskAnalysis.riskAnalysisForm.singleAnswers,
+      multiAnswers: riskAnalysis.riskAnalysisForm.multiAnswers,
+    },
+  })),
   descriptors: eService.descriptors.map((descriptor) => ({
     id: descriptor.id,
     version: descriptor.version,

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -16,9 +16,10 @@ export const errorCodes = {
   draftDescriptorAlreadyExists: "0008",
   eserviceCannotBeUpdatedOrDeleted: "0009",
   eServiceDuplicate: "0010",
-  interfaceAlreadyExists: "0011",
+  originNotCompliant: "0011",
   attributeNotFound: "0012",
   inconsistentDailyCalls: "0013",
+  interfaceAlreadyExists: "0022",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -156,5 +157,13 @@ export function inconsistentDailyCalls(): ApiError<ErrorCodes> {
     detail: `dailyCallsPerConsumer can't be greater than dailyCallsTotal`,
     code: "inconsistentDailyCalls",
     title: "Inconsistent daily calls",
+  });
+}
+
+export function originNotCompliant(origin: string): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Requester has not origin ${origin}`,
+    code: "originNotCompliant",
+    title: "Origin is not compliant",
   });
 }

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -42,11 +42,9 @@ export function eServiceNotFound(eserviceId: EServiceId): ApiError<ErrorCodes> {
   });
 }
 
-export function eServiceDuplicate(
-  eServiceNameSeed: string
-): ApiError<ErrorCodes> {
+export function eServiceDuplicate(eServiceName: string): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `ApiError during EService creation with name ${eServiceNameSeed}`,
+    detail: `EService with name: ${eServiceName} already in use`,
     code: "eServiceDuplicate",
     title: "Duplicated service name",
   });

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -44,7 +44,7 @@ export function eServiceNotFound(eserviceId: EServiceId): ApiError<ErrorCodes> {
 
 export function eServiceDuplicate(eServiceName: string): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `EService with name: ${eServiceName} already in use`,
+    detail: `An EService with name ${eServiceName} already exists`,
     code: "eServiceDuplicate",
     title: "Duplicated service name",
   });

--- a/packages/catalog-process/src/model/domain/models.ts
+++ b/packages/catalog-process/src/model/domain/models.ts
@@ -109,3 +109,5 @@ export const convertToDescriptorEServiceEventData = (
   archivedAt: undefined,
   attributes: eserviceDescriptorSeed.attributes,
 });
+
+export type ApiEServiceMode = z.infer<typeof api.schemas.EServiceMode>;

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -18,6 +18,10 @@ import {
   EServiceEvent,
   DescriptorId,
   EServiceDocumentId,
+  EServiceMode,
+  EServiceModeV1,
+  RiskAnalysis,
+  EServiceRiskAnalysisV1,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 
@@ -47,6 +51,12 @@ export const toEServiceTechnologyV1 = (
   match(input)
     .with("Rest", () => EServiceTechnologyV1.REST)
     .with("Soap", () => EServiceTechnologyV1.SOAP)
+    .exhaustive();
+
+export const toEServiceModeV1 = (input: EServiceMode): EServiceModeV1 =>
+  match(input)
+    .with("Deliver", () => EServiceModeV1.DELIVER)
+    .with("Receive", () => EServiceModeV1.RECEIVE)
     .exhaustive();
 
 export const toEServiceAttributeV1 = (
@@ -90,6 +100,13 @@ export const toDescriptorV1 = (input: Descriptor): EServiceDescriptorV1 => ({
   archivedAt: input.archivedAt ? BigInt(input.archivedAt.getTime()) : undefined,
 });
 
+export const toRiskAnalysisV1 = (
+  input: RiskAnalysis
+): EServiceRiskAnalysisV1 => ({
+  ...input,
+  createdAt: BigInt(input.createdAt.getTime()),
+});
+
 export const toEServiceV1 = (eService: EService): EServiceV1 => ({
   ...eService,
   technology: toEServiceTechnologyV1(eService.technology),
@@ -103,6 +120,8 @@ export const toEServiceV1 = (eService: EService): EServiceV1 => ({
       : undefined,
   descriptors: eService.descriptors.map(toDescriptorV1),
   createdAt: BigInt(eService.createdAt.getTime()),
+  mode: toEServiceModeV1(eService.mode),
+  riskAnalysis: eService.riskAnalysis.map(toRiskAnalysisV1),
 });
 
 export const toCreateEventEServiceAdded = (

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -72,6 +72,7 @@ import {
   interfaceAlreadyExists,
   attributeNotFound,
   inconsistentDailyCalls,
+  originNotCompliant,
 } from "../model/domain/errors.js";
 import { formatClonedEServiceDate } from "../utilities/date.js";
 import { ReadModelService } from "./readModelService.js";
@@ -602,11 +603,13 @@ export function createEserviceLogic({
   apiEServicesSeed: ApiEServiceSeed;
   authData: AuthData;
 }): CreateEvent<EServiceEvent> {
+  if (authData.externalId.origin !== "IPA") {
+    throw originNotCompliant("IPA");
+  }
+
   if (eserviceWithSameName) {
     throw eServiceDuplicate(apiEServicesSeed.name);
   }
-
-  // TODO missing IPA origin check? https://github.com/pagopa/interop-be-catalog-process/blob/19b60ff8bc4994dec501b6f1b4a81de5ee225cd5/src/main/scala/it/pagopa/interop/catalogprocess/api/impl/ProcessApiServiceImpl.scala#L73
 
   const newEService: EService = {
     id: generateId(),

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -31,6 +31,7 @@ import {
 import { match } from "ts-pattern";
 import {
   apiAgreementApprovalPolicyToAgreementApprovalPolicy,
+  apiEServiceModeToEServiceMode,
   apiTechnologyToTechnology,
 } from "../model/domain/apiConverter.js";
 import {
@@ -225,13 +226,16 @@ export function catalogServiceBuilder(
       logger.info(
         `Creating EService with service name ${apiEServicesSeed.name}`
       );
+
+      const eserviceWithSameName =
+        await readModelService.getEServiceByNameAndProducerId({
+          name: apiEServicesSeed.name,
+          producerId: authData.organizationId,
+        });
       return unsafeBrandId<EServiceId>(
         await repository.createEvent(
           createEserviceLogic({
-            eService: await readModelService.getEServiceByNameAndProducerId({
-              name: apiEServicesSeed.name,
-              producerId: authData.organizationId,
-            }),
+            eserviceWithSameName,
             apiEServicesSeed,
             authData,
           })
@@ -590,17 +594,19 @@ export function catalogServiceBuilder(
 }
 
 export function createEserviceLogic({
-  eService,
+  eserviceWithSameName,
   apiEServicesSeed,
   authData,
 }: {
-  eService: WithMetadata<EService> | undefined;
+  eserviceWithSameName: WithMetadata<EService> | undefined;
   apiEServicesSeed: ApiEServiceSeed;
   authData: AuthData;
 }): CreateEvent<EServiceEvent> {
-  if (eService) {
+  if (eserviceWithSameName) {
     throw eServiceDuplicate(apiEServicesSeed.name);
   }
+
+  // TODO missing IPA origin check? https://github.com/pagopa/interop-be-catalog-process/blob/19b60ff8bc4994dec501b6f1b4a81de5ee225cd5/src/main/scala/it/pagopa/interop/catalogprocess/api/impl/ProcessApiServiceImpl.scala#L73
 
   const newEService: EService = {
     id: generateId(),
@@ -608,9 +614,11 @@ export function createEserviceLogic({
     name: apiEServicesSeed.name,
     description: apiEServicesSeed.description,
     technology: apiTechnologyToTechnology(apiEServicesSeed.technology),
+    mode: apiEServiceModeToEServiceMode(apiEServicesSeed.mode),
     attributes: undefined,
     descriptors: [],
     createdAt: new Date(),
+    riskAnalysis: [],
   };
 
   return toCreateEventEServiceAdded(newEService);
@@ -1308,6 +1316,8 @@ export async function cloneDescriptorLogic({
     technology: eService.data.technology,
     attributes: eService.data.attributes,
     createdAt: new Date(),
+    riskAnalysis: eService.data.riskAnalysis,
+    mode: eService.data.mode,
     descriptors: [
       {
         ...descriptor,

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -23,6 +23,7 @@ export const createEServiceErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)
+    .with("originNotCompliant", () => HTTP_STATUS_FORBIDDEN)
     .with("eServiceDuplicate", () => HTTP_STATUS_CONFLICT)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -307,6 +307,7 @@ describe("database test", async () => {
             name: updatedName,
             description: mockEService.description,
             technology: "SOAP",
+            mode: "RECEIVE",
           },
           getMockAuthData(mockEService.producerId)
         );

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -88,6 +88,7 @@ import {
   inconsistentDailyCalls,
   interfaceAlreadyExists,
   notValidDescriptor,
+  originNotCompliant,
 } from "../src/model/domain/errors.js";
 import { formatClonedEServiceDate } from "../src/utilities/date.js";
 import {
@@ -221,6 +222,23 @@ describe("database test", async () => {
             getMockAuthData(mockEService.producerId)
           )
         ).rejects.toThrowError(eServiceDuplicate(mockEService.name));
+      });
+
+      it("should throw originNotCompliant if the requester externalId origin is not IPA", async () => {
+        expect(
+          catalogService.createEService(
+            {
+              name: mockEService.name,
+              description: mockEService.description,
+              technology: "REST",
+              mode: "DELIVER",
+            },
+            {
+              ...getMockAuthData(mockEService.producerId),
+              externalId: { ...getMockAuthData().externalId, origin: "" },
+            }
+          )
+        ).rejects.toThrowError(originNotCompliant("IPA"));
       });
     });
 

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -183,6 +183,7 @@ describe("database test", async () => {
             name: mockEService.name,
             description: mockEService.description,
             technology: "REST",
+            mode: "DELIVER",
           },
           getMockAuthData(mockEService.producerId)
         );
@@ -215,6 +216,7 @@ describe("database test", async () => {
               name: mockEService.name,
               description: mockEService.description,
               technology: "REST",
+              mode: "DELIVER",
             },
             getMockAuthData(mockEService.producerId)
           )
@@ -242,6 +244,7 @@ describe("database test", async () => {
             name: updatedName,
             description: mockEService.description,
             technology: "REST",
+            mode: "DELIVER",
           },
           getMockAuthData(mockEService.producerId)
         );
@@ -324,6 +327,7 @@ describe("database test", async () => {
             name: mockEService.name,
             description: updatedDescription,
             technology: "REST",
+            mode: "DELIVER",
           },
           getMockAuthData(mockEService.producerId)
         );
@@ -356,6 +360,7 @@ describe("database test", async () => {
               name: "eService new name",
               description: "eService description",
               technology: "REST",
+              mode: "DELIVER",
             },
             getMockAuthData(mockEService.producerId)
           )
@@ -372,6 +377,7 @@ describe("database test", async () => {
               name: "eService new name",
               description: "eService description",
               technology: "REST",
+              mode: "DELIVER",
             },
             getMockAuthData()
           )
@@ -400,6 +406,7 @@ describe("database test", async () => {
               name: "eService name already in use",
               description: "eService description",
               technology: "REST",
+              mode: "DELIVER",
             },
             getMockAuthData(eService1.producerId)
           )
@@ -426,6 +433,7 @@ describe("database test", async () => {
               name: "eService new name",
               description: "eService description",
               technology: "REST",
+              mode: "DELIVER",
             },
             getMockAuthData(eService.producerId)
           )
@@ -450,6 +458,7 @@ describe("database test", async () => {
               name: "eService new name",
               description: "eService description",
               technology: "REST",
+              mode: "DELIVER",
             },
             getMockAuthData(eService.producerId)
           )
@@ -474,6 +483,7 @@ describe("database test", async () => {
               name: "eService new name",
               description: "eService description",
               technology: "REST",
+              mode: "DELIVER",
             },
             getMockAuthData(eService.producerId)
           )
@@ -498,6 +508,7 @@ describe("database test", async () => {
               name: "eService new name",
               description: "eService description",
               technology: "REST",
+              mode: "DELIVER",
             },
             getMockAuthData(eService.producerId)
           )

--- a/packages/catalog-process/test/utils.ts
+++ b/packages/catalog-process/test/utils.ts
@@ -5,6 +5,8 @@ import {
   EServiceCollection,
   TenantCollection,
 } from "pagopa-interop-commons";
+import { IDatabase } from "pg-promise";
+import { v4 as uuidv4 } from "uuid";
 import {
   Agreement,
   Attribute,
@@ -25,10 +27,8 @@ import {
   generateId,
   technology,
 } from "pagopa-interop-models";
-import { IDatabase } from "pg-promise";
-import { v4 as uuidv4 } from "uuid";
-import { EServiceDescriptorSeed } from "../src/model/domain/models.js";
 import { toEServiceV1 } from "../src/model/domain/toEvent.js";
+import { EServiceDescriptorSeed } from "../src/model/domain/models.js";
 import { ApiEServiceDescriptorDocumentSeed } from "../src/model/types.js";
 
 export const writeEServiceInEventstore = async (

--- a/packages/catalog-process/test/utils.ts
+++ b/packages/catalog-process/test/utils.ts
@@ -5,8 +5,6 @@ import {
   EServiceCollection,
   TenantCollection,
 } from "pagopa-interop-commons";
-import { IDatabase } from "pg-promise";
-import { v4 as uuidv4 } from "uuid";
 import {
   Agreement,
   Attribute,
@@ -23,11 +21,14 @@ import {
   agreementState,
   catalogEventToBinaryData,
   descriptorState,
+  eserviceMode,
   generateId,
   technology,
 } from "pagopa-interop-models";
-import { toEServiceV1 } from "../src/model/domain/toEvent.js";
+import { IDatabase } from "pg-promise";
+import { v4 as uuidv4 } from "uuid";
 import { EServiceDescriptorSeed } from "../src/model/domain/models.js";
+import { toEServiceV1 } from "../src/model/domain/toEvent.js";
 import { ApiEServiceDescriptorDocumentSeed } from "../src/model/types.js";
 
 export const writeEServiceInEventstore = async (
@@ -142,6 +143,8 @@ export const getMockEService = (): EService => ({
   technology: technology.rest,
   descriptors: [],
   attributes: undefined,
+  mode: eserviceMode.deliver,
+  riskAnalysis: [],
 });
 
 export const getMockDescriptor = (): Descriptor => ({
@@ -178,7 +181,7 @@ export const buildInterfaceSeed = (): ApiEServiceDescriptorDocumentSeed => ({
   contentType: "json",
   prettyName: "prettyName",
   serverUrls: ["pagopa.it"],
-  documentId: uuidv4(),
+  documentId: generateId(),
   kind: "INTERFACE",
   filePath: "filePath",
   fileName: "fileName",
@@ -191,7 +194,7 @@ export const getMockDocument = (): Document => ({
   id: generateId(),
   prettyName: "prettyName",
   contentType: "json",
-  checksum: uuidv4(),
+  checksum: generateId(),
   uploadDate: new Date(),
 });
 

--- a/packages/catalog-readmodel-writer/src/model/converterV1.ts
+++ b/packages/catalog-readmodel-writer/src/model/converterV1.ts
@@ -1,20 +1,27 @@
 import {
   AgreementApprovalPolicy,
   AgreementApprovalPolicyV1,
-  EServiceAttribute,
   Descriptor,
   DescriptorState,
   Document,
   EService,
+  EServiceAttribute,
   EServiceAttributeV1,
   EServiceDescriptorStateV1,
   EServiceDescriptorV1,
   EServiceDocumentV1,
+  EServiceMode,
+  EServiceModeV1,
+  EServiceRiskAnalysisFormV1,
+  EServiceRiskAnalysisV1,
   EServiceTechnologyV1,
   EServiceV1,
+  RiskAnalysis,
+  RiskAnalysisForm,
   Technology,
   agreementApprovalPolicy,
   descriptorState,
+  eserviceMode,
   technology,
   unsafeBrandId,
 } from "pagopa-interop-models";
@@ -67,6 +74,23 @@ export const fromEServiceTechnologyV1 = (
       return technology.soap;
     case EServiceTechnologyV1.UNSPECIFIED$:
       throw new Error("Unspecified technology");
+  }
+};
+
+export const fromEServiceModeV1 = (
+  input: EServiceModeV1 | undefined
+): EServiceMode => {
+  switch (input) {
+    case EServiceModeV1.RECEIVE:
+      return eserviceMode.receive;
+    case EServiceModeV1.DELIVER:
+      return eserviceMode.deliver;
+    case EServiceModeV1.UNSPECIFIED$:
+    case undefined:
+      throw new Error("Unspecified mode");
+
+    // the undefiend case is becauese mode is required in EService definition but not in protobuf
+    // tracked in: https://pagopa.atlassian.net/browse/IMN-171
   }
 };
 
@@ -127,6 +151,40 @@ export const fromDescriptorV1 = (input: EServiceDescriptorV1): Descriptor => ({
   archivedAt: input.archivedAt ? new Date(Number(input.archivedAt)) : undefined,
 });
 
+export const fromRiskAnalysisFormV1 = (
+  input: EServiceRiskAnalysisFormV1 | undefined
+): RiskAnalysisForm => {
+  if (!input) {
+    // riskAnalysisForm is required in EService definition but not in protobuf
+    // tracked in https://pagopa.atlassian.net/browse/IMN-171
+    throw new Error(
+      "riskAnalysisForm field is required in EService definition but is not provided in serialized byte array events"
+    );
+  }
+
+  return {
+    ...input,
+    id: unsafeBrandId(input.id),
+    singleAnswers: input.singleAnswers.map((a) => ({
+      ...a,
+      id: unsafeBrandId(a.id),
+    })),
+    multiAnswers: input.multiAnswers.map((a) => ({
+      ...a,
+      id: unsafeBrandId(a.id),
+    })),
+  };
+};
+
+export const fromRiskAnalysisV1 = (
+  input: EServiceRiskAnalysisV1
+): RiskAnalysis => ({
+  ...input,
+  id: unsafeBrandId(input.id),
+  createdAt: new Date(Number(input.createdAt)),
+  riskAnalysisForm: fromRiskAnalysisFormV1(input.riskAnalysisForm),
+});
+
 export const fromEServiceV1 = (input: EServiceV1): EService => ({
   ...input,
   id: unsafeBrandId(input.id),
@@ -141,7 +199,9 @@ export const fromEServiceV1 = (input: EServiceV1): EService => ({
         }
       : undefined,
   descriptors: input.descriptors.map(fromDescriptorV1),
-  // createdAt is required in EService definition but not in protobuf,
-  // this bug is handled with ISSUE https://pagopa.atlassian.net/browse/IMN-171
+  // createdAt is required in EService definition but not in protobuf
+  // tracked in https://pagopa.atlassian.net/browse/IMN-171
   createdAt: parseDateOrThrow(input.createdAt),
+  riskAnalysis: input.riskAnalysis.map(fromRiskAnalysisV1),
+  mode: fromEServiceModeV1(input.mode),
 });

--- a/packages/catalog-readmodel-writer/src/model/converterV2.ts
+++ b/packages/catalog-readmodel-writer/src/model/converterV2.ts
@@ -17,6 +17,13 @@ import {
   descriptorState,
   technology,
   unsafeBrandId,
+  EServiceModeV2,
+  EServiceMode,
+  eserviceMode,
+  EServiceRiskAnalysisV2,
+  RiskAnalysis,
+  EServiceRiskAnalysisFormV2,
+  RiskAnalysisForm,
 } from "pagopa-interop-models";
 
 export const fromAgreementApprovalPolicyV2 = (
@@ -55,6 +62,15 @@ export const fromEServiceTechnologyV2 = (
       return technology.rest;
     case EServiceTechnologyV2.SOAP:
       return technology.soap;
+  }
+};
+
+export const fromEServiceModeV2 = (input: EServiceModeV2): EServiceMode => {
+  switch (input) {
+    case EServiceModeV2.RECEIVE:
+      return eserviceMode.receive;
+    case EServiceModeV2.DELIVER:
+      return eserviceMode.deliver;
   }
 };
 
@@ -105,6 +121,40 @@ export const fromDescriptorV2 = (input: EServiceDescriptorV2): Descriptor => ({
   archivedAt: input.archivedAt ? new Date(Number(input.archivedAt)) : undefined,
 });
 
+export const fromRiskAnalysisFormV2 = (
+  input: EServiceRiskAnalysisFormV2 | undefined
+): RiskAnalysisForm => {
+  if (!input) {
+    // riskAnalysisForm is required in EService definition but not in protobuf
+    // tracked in https://pagopa.atlassian.net/browse/IMN-171
+    throw new Error(
+      "riskAnalysisForm field is required in EService definition but is not provided in serialized byte array events"
+    );
+  }
+
+  return {
+    ...input,
+    id: unsafeBrandId(input.id),
+    singleAnswers: input.singleAnswers.map((a) => ({
+      ...a,
+      id: unsafeBrandId(a.id),
+    })),
+    multiAnswers: input.multiAnswers.map((a) => ({
+      ...a,
+      id: unsafeBrandId(a.id),
+    })),
+  };
+};
+
+export const fromRiskAnalysisV2 = (
+  input: EServiceRiskAnalysisV2
+): RiskAnalysis => ({
+  ...input,
+  id: unsafeBrandId(input.id),
+  createdAt: new Date(Number(input.createdAt)),
+  riskAnalysisForm: fromRiskAnalysisFormV2(input.riskAnalysisForm),
+});
+
 export const fromEServiceV2 = (input: EServiceV2): EService => ({
   ...input,
   id: unsafeBrandId(input.id),
@@ -112,4 +162,6 @@ export const fromEServiceV2 = (input: EServiceV2): EService => ({
   technology: fromEServiceTechnologyV2(input.technology),
   descriptors: input.descriptors.map(fromDescriptorV2),
   createdAt: new Date(Number(input.createdAt)),
+  riskAnalysis: input.riskAnalysis.map(fromRiskAnalysisV2),
+  mode: fromEServiceModeV2(input.mode),
 });

--- a/packages/catalog-readmodel-writer/test/catalog-readmodel-writer.integration.test.ts
+++ b/packages/catalog-readmodel-writer/test/catalog-readmodel-writer.integration.test.ts
@@ -12,6 +12,7 @@ import { mongoDBContainer } from "pagopa-interop-commons-test";
 import {
   EServiceAddedV1,
   EServiceEventEnvelope,
+  EServiceModeV1,
   EServiceTechnologyV1,
   generateId,
 } from "pagopa-interop-models";
@@ -53,6 +54,8 @@ describe("database test", async () => {
           technology: EServiceTechnologyV1.REST,
           descriptors: [],
           createdAt: BigInt(new Date().getTime()),
+          mode: EServiceModeV1.RECEIVE,
+          riskAnalysis: [],
         },
       };
       const message: EServiceEventEnvelope = {

--- a/packages/models/proto/v1/eservice/eservice.proto
+++ b/packages/models/proto/v1/eservice/eservice.proto
@@ -11,6 +11,34 @@ message EServiceV1 {
   optional EServiceAttributesV1 attributes = 6;
   repeated EServiceDescriptorV1 descriptors = 7;
   optional int64 createdAt = 8;
+  repeated EServiceRiskAnalysisV1 riskAnalysis = 9;
+  optional EServiceModeV1 mode = 10;
+}
+
+message EServiceRiskAnalysisV1 {
+  required string id = 1;
+  required string name = 2;
+  required EServiceRiskAnalysisFormV1 riskAnalysisForm = 3;
+  required int64 createdAt = 4;
+}
+
+message EServiceRiskAnalysisFormV1 {
+  required string id = 1;
+  required string version = 2;
+  repeated EServiceRiskAnalysisSingleAnswerV1 singleAnswers = 3;
+  repeated EServiceRiskAnalysisMultiAnswerV1 multiAnswers = 4;
+}
+
+message EServiceRiskAnalysisSingleAnswerV1 {
+  required string id = 1;
+  required string key = 2;
+  optional string value = 3;
+}
+
+message EServiceRiskAnalysisMultiAnswerV1 {
+  required string id = 1;
+  required string key = 2;
+  repeated string values = 3;
 }
 
 message EServiceAttributeValueV1 {
@@ -76,4 +104,9 @@ enum EServiceTechnologyV1 {
 enum AgreementApprovalPolicyV1 {
   AUTOMATIC = 1;
   MANUAL = 2;
+}
+
+enum EServiceModeV1 {
+  RECEIVE = 1;
+  DELIVER = 2;
 }

--- a/packages/models/proto/v2/eservice/eservice.proto
+++ b/packages/models/proto/v2/eservice/eservice.proto
@@ -10,6 +10,35 @@ message EServiceV2 {
   EServiceTechnologyV2 technology = 5;
   repeated EServiceDescriptorV2 descriptors = 6;
   int64 createdAt = 7;
+  repeated EServiceRiskAnalysisV2 riskAnalysis = 8;
+  EServiceModeV2 mode = 9;
+}
+
+
+message EServiceRiskAnalysisV2 {
+  string id = 1;
+  string name = 2;
+  EServiceRiskAnalysisFormV2 riskAnalysisForm = 3;
+  int64 createdAt = 4;
+}
+
+message EServiceRiskAnalysisFormV2 {
+  string id = 1;
+  string version = 2;
+  repeated EServiceRiskAnalysisSingleAnswerV2 singleAnswers = 3;
+  repeated EServiceRiskAnalysisMultiAnswerV2 multiAnswers = 4;
+}
+
+message EServiceRiskAnalysisSingleAnswerV2 {
+  string id = 1;
+  string key = 2;
+  optional string value = 3;
+}
+
+message EServiceRiskAnalysisMultiAnswerV2 {
+  string id = 1;
+  string key = 2;
+  repeated string values = 3;
 }
 
 message EServiceAttributeValueV2 {
@@ -74,4 +103,9 @@ enum EServiceTechnologyV2 {
 enum AgreementApprovalPolicyV2 {
   AUTOMATIC = 0;
   MANUAL = 1;
+}
+
+enum EServiceModeV2 {
+  RECEIVE = 0;
+  DELIVER = 1;
 }

--- a/packages/models/src/brandedIds.ts
+++ b/packages/models/src/brandedIds.ts
@@ -25,6 +25,28 @@ export type DescriptorId = z.infer<typeof DescriptorId>;
 export const TenantId = z.string().uuid().brand("TenantId");
 export type TenantId = z.infer<typeof TenantId>;
 
+export const RiskAnalysisSingleAnswerId = z
+  .string()
+  .uuid()
+  .brand("RiskAnalysisSingleAnswerId");
+export type RiskAnalysisSingleAnswerId = z.infer<
+  typeof RiskAnalysisSingleAnswerId
+>;
+
+export const RiskAnalysisMultiAnswerId = z
+  .string()
+  .uuid()
+  .brand("RiskAnalysisMultiAnswerId");
+export type RiskAnalysisMultiAnswerId = z.infer<
+  typeof RiskAnalysisMultiAnswerId
+>;
+
+export const RiskAnalysisFormId = z.string().uuid().brand("RiskAnalysisFormId");
+export type RiskAnalysisFormId = z.infer<typeof RiskAnalysisFormId>;
+
+export const RiskAnalysisId = z.string().uuid().brand("RiskAnalysisId");
+export type RiskAnalysisId = z.infer<typeof RiskAnalysisId>;
+
 type IDS =
   | EServiceId
   | EServiceDocumentId
@@ -32,7 +54,11 @@ type IDS =
   | AgreementDocumentId
   | DescriptorId
   | AttributeId
-  | TenantId;
+  | TenantId
+  | RiskAnalysisSingleAnswerId
+  | RiskAnalysisMultiAnswerId
+  | RiskAnalysisFormId
+  | RiskAnalysisId;
 
 // This function is used to generate a new ID for a new object
 // it infers the type of the ID based on how is used the result

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -4,6 +4,10 @@ import {
   DescriptorId,
   EServiceDocumentId,
   EServiceId,
+  RiskAnalysisFormId,
+  RiskAnalysisId,
+  RiskAnalysisMultiAnswerId,
+  RiskAnalysisSingleAnswerId,
   TenantId,
 } from "../brandedIds.js";
 
@@ -83,6 +87,45 @@ export const Descriptor = z.object({
 });
 export type Descriptor = z.infer<typeof Descriptor>;
 
+export const eserviceMode = {
+  manual: "Receive",
+  automatic: "Deliver",
+} as const;
+export const EServiceMode = z.enum([
+  Object.values(eserviceMode)[0],
+  ...Object.values(eserviceMode).slice(1),
+]);
+export type EServiceMode = z.infer<typeof EServiceMode>;
+
+export const RiskAnalysisSingleAnswer = z.object({
+  id: RiskAnalysisSingleAnswerId,
+  key: z.string(),
+  value: z.string().optional(),
+});
+export type RiskAnalysisSingleAnswer = z.infer<typeof RiskAnalysisSingleAnswer>;
+
+export const RiskAnalysisMultiAnswer = z.object({
+  id: RiskAnalysisMultiAnswerId,
+  key: z.string(),
+  value: z.array(z.string()),
+});
+export type RiskAnalysisMultiAnswer = z.infer<typeof RiskAnalysisMultiAnswer>;
+
+export const RiskAnalysisForm = z.object({
+  id: RiskAnalysisFormId,
+  version: z.string(),
+  singleAnswers: z.array(RiskAnalysisSingleAnswer),
+  multiAnswers: z.array(RiskAnalysisMultiAnswer),
+});
+export type RiskAnalysisForm = z.infer<typeof RiskAnalysisForm>;
+
+export const RiskAnalysis = z.object({
+  id: RiskAnalysisId,
+  name: z.string(),
+  riskAnalysisForm: RiskAnalysisForm,
+  createdAt: z.coerce.date(),
+});
+
 export const EService = z.object({
   id: EServiceId,
   producerId: TenantId,
@@ -92,5 +135,7 @@ export const EService = z.object({
   attributes: EServiceAttributes.optional(),
   descriptors: z.array(Descriptor),
   createdAt: z.coerce.date(),
+  riskAnalysis: z.array(RiskAnalysis),
+  mode: EServiceMode,
 });
 export type EService = z.infer<typeof EService>;

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -88,8 +88,8 @@ export const Descriptor = z.object({
 export type Descriptor = z.infer<typeof Descriptor>;
 
 export const eserviceMode = {
-  manual: "Receive",
-  automatic: "Deliver",
+  receive: "Receive",
+  deliver: "Deliver",
 } as const;
 export const EServiceMode = z.enum([
   Object.values(eserviceMode)[0],
@@ -107,7 +107,7 @@ export type RiskAnalysisSingleAnswer = z.infer<typeof RiskAnalysisSingleAnswer>;
 export const RiskAnalysisMultiAnswer = z.object({
   id: RiskAnalysisMultiAnswerId,
   key: z.string(),
-  value: z.array(z.string()),
+  values: z.array(z.string()),
 });
 export type RiskAnalysisMultiAnswer = z.infer<typeof RiskAnalysisMultiAnswer>;
 
@@ -125,6 +125,7 @@ export const RiskAnalysis = z.object({
   riskAnalysisForm: RiskAnalysisForm,
   createdAt: z.coerce.date(),
 });
+export type RiskAnalysis = z.infer<typeof RiskAnalysis>;
 
 export const EService = z.object({
   id: EServiceId,


### PR DESCRIPTION
Closes [IMN-247](https://pagopa.atlassian.net/browse/IMN-247)

# Tests

### 1) Automated tests work ✅

### 2) Manual testing of createEService + manual check on new fields
<img width="882" alt="Screenshot 2024-02-21 at 17 11 55" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/fc81716b-b0e8-4e1f-b034-229aadfb9776">

<img width="881" alt="Screenshot 2024-02-21 at 17 12 14" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/047272a6-f4a9-4674-80bb-a020c4481a77">

<img width="917" alt="Screenshot 2024-02-21 at 17 14 11" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/8da66648-d949-430d-80ab-89b1c837ef65">


<img width="1221" alt="Screenshot 2024-02-21 at 17 14 44" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/83eace4e-d6be-4703-a307-f07467862f92">

<img width="1227" alt="Screenshot 2024-02-21 at 17 15 01" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/60cfdd75-fdfa-4696-bac5-06246ee562b0">



[IMN-247]: https://pagopa.atlassian.net/browse/IMN-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ