### PR TITLE
IMN-289 Return eserviceId when the endpoint returns status code 200 in catalog-process

### DIFF
--- a/packages/catalog-process/open-api/catalog-service-spec.yml
+++ b/packages/catalog-process/open-api/catalog-service-spec.yml
@@ -205,6 +205,10 @@ paths:
       responses:
         "200":
           description: E-Service updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceId"
         "404":
           description: E-Service not found
           content:
@@ -410,6 +414,10 @@ paths:
       responses:
         "200":
           description: EService with draft descriptor updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceId"
         "400":
           description: Invalid input
           content:
@@ -847,7 +855,11 @@ paths:
               $ref: "#/components/schemas/UpdateEServiceDescriptorDocumentSeed"
       responses:
         "200":
-          description: EService Descriptor updated.
+          description: EService Document updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceId"
         "404":
           description: EService not found
           content:

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -169,12 +169,12 @@ const eservicesRouter = (
       authorizationMiddleware([ADMIN_ROLE, API_ROLE]),
       async (req, res) => {
         try {
-          await catalogService.updateEService(
+          const eserviceId = await catalogService.updateEService(
             unsafeBrandId(req.params.eServiceId),
             req.body,
             req.ctx.authData
           );
-          return res.status(200).end();
+          return res.status(200).json({ id: eserviceId }).end();
         } catch (error) {
           const errorRes = makeApiProblem(error, updateEServiceErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
@@ -317,14 +317,14 @@ const eservicesRouter = (
       authorizationMiddleware([ADMIN_ROLE, API_ROLE]),
       async (req, res) => {
         try {
-          await catalogService.updateDocument(
+          const eserviceId = await catalogService.updateDocument(
             unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             unsafeBrandId(req.params.documentId),
             req.body,
             req.ctx.authData
           );
-          return res.status(200).end();
+          return res.status(200).json({ id: eserviceId }).end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -376,13 +376,13 @@ const eservicesRouter = (
       authorizationMiddleware([ADMIN_ROLE, API_ROLE]),
       async (req, res) => {
         try {
-          await catalogService.updateDraftDescriptor(
+          const eserviceId = await catalogService.updateDraftDescriptor(
             unsafeBrandId(req.params.eServiceId),
             unsafeBrandId(req.params.descriptorId),
             req.body,
             req.ctx.authData
           );
-          return res.status(200).end();
+          return res.status(200).json({ id: eserviceId }).end();
         } catch (error) {
           const errorRes = makeApiProblem(error, updateDescriptorErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -298,11 +298,11 @@ export function catalogServiceBuilder(
       eserviceId: EServiceId,
       eServiceSeed: ApiEServiceSeed,
       authData: AuthData
-    ): Promise<void> {
+    ): Promise<string> {
       logger.info(`Updating EService ${eserviceId}`);
       const eService = await readModelService.getEServiceById(eserviceId);
 
-      await repository.createEvent(
+      return await repository.createEvent(
         await updateEserviceLogic({
           eService,
           eserviceId,
@@ -403,13 +403,13 @@ export function catalogServiceBuilder(
       documentId: EServiceDocumentId,
       apiEServiceDescriptorDocumentUpdateSeed: ApiEServiceDescriptorDocumentUpdateSeed,
       authData: AuthData
-    ): Promise<void> {
+    ): Promise<string> {
       logger.info(
         `Updating Document ${documentId} of Descriptor ${descriptorId} for EService ${eserviceId}`
       );
       const eService = await readModelService.getEServiceById(eserviceId);
 
-      await repository.createEvent(
+      return await repository.createEvent(
         await updateDocumentLogic({
           eserviceId,
           descriptorId,
@@ -467,13 +467,13 @@ export function catalogServiceBuilder(
       descriptorId: DescriptorId,
       seed: UpdateEServiceDescriptorSeed,
       authData: AuthData
-    ): Promise<void> {
+    ): Promise<string> {
       logger.info(
         `Updating draft Descriptor ${descriptorId} for EService ${eserviceId}`
       );
       const eService = await readModelService.getEServiceById(eserviceId);
 
-      await repository.createEvent(
+      return await repository.createEvent(
         updateDraftDescriptorLogic({
           eserviceId,
           descriptorId,


### PR DESCRIPTION
This pull request is for fixing the returned item in some endpoints.

During the update operations, we were returning a status code 200 without any object. We could not change the status code to 204 because this would break QA tests.
Instead, we could return an id. This id is the `eserviceId`, because the structure of the functions make it easy to retrieve it and return. Otherwise, we will need a refactor to return a more specific id (e.g. return a `documentId` if the update involves a document).