### PR TITLE
EService renaming

### DIFF
--- a/packages/agreement-process/src/model/domain/validators.ts
+++ b/packages/agreement-process/src/model/domain/validators.ts
@@ -119,9 +119,9 @@ export function assertAgreementExist(
 
 export function assertEServiceExist(
   eserviceId: EServiceId,
-  eService: WithMetadata<EService> | undefined
-): asserts eService is NonNullable<WithMetadata<EService>> {
-  if (eService === undefined) {
+  eservice: WithMetadata<EService> | undefined
+): asserts eservice is NonNullable<WithMetadata<EService>> {
+  if (eservice === undefined) {
     throw eServiceNotFound(eserviceId);
   }
 }
@@ -221,11 +221,11 @@ const validateDescriptorState = (
 };
 
 const validateLatestDescriptor = (
-  eService: EService,
+  eservice: EService,
   descriptorId: DescriptorId,
   allowedStates: DescriptorState[]
 ): Descriptor => {
-  const recentActiveDescriptors = eService.descriptors
+  const recentActiveDescriptors = eservice.descriptors
     .filter((d) => d.state !== descriptorState.draft)
     .sort((a, b) => Number(b.version) - Number(a.version));
 
@@ -238,7 +238,7 @@ const validateLatestDescriptor = (
 
   const recentActiveDescriptor = recentActiveDescriptors[0];
   validateDescriptorState(
-    eService.id,
+    eservice.id,
     descriptorId,
     recentActiveDescriptor.state,
     allowedStates
@@ -428,10 +428,10 @@ export const failOnActivationFailure = (
 /* ========= MATCHERS ========= */
 
 const matchingAttributes = (
-  eServiceAttributes: EServiceAttribute[][],
+  eserviceAttributes: EServiceAttribute[][],
   consumerAttributes: AttributeId[]
 ): AttributeId[] =>
-  eServiceAttributes
+  eserviceAttributes
     .flatMap((atts) => atts.map((att) => att.id))
     .filter((att) => consumerAttributes.includes(att));
 
@@ -464,12 +464,12 @@ export const matchingDeclaredAttributes = (
 };
 
 export const matchingVerifiedAttributes = (
-  eService: EService,
+  eservice: EService,
   descriptor: Descriptor,
   consumer: Tenant
 ): VerifiedAgreementAttribute[] => {
   const verifiedAttributes = filterVerifiedAttributes(
-    eService.producerId,
+    eservice.producerId,
     consumer
   ).map((a) => a.id);
 

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -89,7 +89,7 @@ export async function activateAgreementLogic(
 
 async function activateAgreement(
   agreementData: WithMetadata<Agreement>,
-  eService: EService,
+  eservice: EService,
   descriptor: Descriptor,
   consumer: Tenant,
   authData: AuthData,
@@ -132,7 +132,7 @@ async function activateAgreement(
         certifiedAttributes: matchingCertifiedAttributes(descriptor, consumer),
         declaredAttributes: matchingDeclaredAttributes(descriptor, consumer),
         verifiedAttributes: matchingVerifiedAttributes(
-          eService,
+          eservice,
           descriptor,
           consumer
         ),
@@ -184,7 +184,7 @@ async function activateAgreement(
     await createContract(
       updatedAgreement,
       updatedAgreementSeed,
-      eService,
+      eservice,
       consumer,
       attributeQuery,
       tenantQuery,
@@ -241,7 +241,7 @@ const archiveRelatedToAgreements = async (
 const createContract = async (
   agreement: Agreement,
   updateSeed: UpdateAgreementSeed,
-  eService: EService,
+  eservice: EService,
   consumer: Tenant,
   attributeQuery: AttributeQuery,
   tenantQuery: TenantQuery,
@@ -252,7 +252,7 @@ const createContract = async (
 
   await contractBuilder(attributeQuery, storeFile).createContract(
     agreement,
-    eService,
+    eservice,
     consumer,
     producer.data,
     updateSeed

--- a/packages/agreement-process/src/services/agreementContractBuilder.ts
+++ b/packages/agreement-process/src/services/agreementContractBuilder.ts
@@ -20,14 +20,14 @@ export const contractBuilder = (
 ) => ({
   createContract: async (
     agreement: Agreement,
-    eService: EService,
+    eservice: EService,
     consumer: Tenant,
     producer: Tenant,
     seed: UpdateAgreementSeed
   ): Promise<ApiAgreementDocumentSeed> =>
     await pdfGenerator.createDocumentSeed(
       agreement,
-      eService,
+      eservice,
       consumer,
       producer,
       seed,

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -298,7 +298,7 @@ export function agreementServiceBuilder(
       return agreementId;
     },
     async getAgreementEServices(
-      eServiceName: string | undefined,
+      eserviceName: string | undefined,
       consumerIds: string[],
       producerIds: string[],
       limit: number,
@@ -309,7 +309,7 @@ export function agreementServiceBuilder(
       );
 
       return await agreementQuery.getEServices(
-        eServiceName,
+        eserviceName,
         consumerIds,
         producerIds,
         limit,

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -112,7 +112,7 @@ export async function submitAgreementLogic(
 
 const submitAgreement = async (
   agreementData: WithMetadata<Agreement>,
-  eService: EService,
+  eservice: EService,
   descriptor: Descriptor,
   consumer: Tenant,
   payload: ApiAgreementSubmissionPayload,
@@ -140,7 +140,7 @@ const submitAgreement = async (
   const updateSeed = getUpdateSeed(
     descriptor,
     consumer,
-    eService,
+    eservice,
     agreement,
     payload,
     stamps,
@@ -209,7 +209,7 @@ const submitAgreement = async (
           await createContract(
             updatedAgreement,
             updatedAgreementEvent.version + 1,
-            eService,
+            eservice,
             consumer,
             updateSeed,
             tenantQuery,
@@ -282,7 +282,7 @@ const validateConsumerEmail = async (
 const getUpdateSeed = (
   descriptor: Descriptor,
   consumer: Tenant,
-  eService: EService,
+  eservice: EService,
   agreement: Agreement,
   payload: ApiAgreementSubmissionPayload,
   stamps: AgreementStamps,
@@ -295,7 +295,7 @@ const getUpdateSeed = (
         certifiedAttributes: matchingCertifiedAttributes(descriptor, consumer),
         declaredAttributes: matchingDeclaredAttributes(descriptor, consumer),
         verifiedAttributes: matchingVerifiedAttributes(
-          eService,
+          eservice,
           descriptor,
           consumer
         ),

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -55,19 +55,19 @@ export async function suspendAgreementLogic({
     agreementSuspendableStates
   );
 
-  const eService = await eserviceQuery.getEServiceById(
+  const eservice = await eserviceQuery.getEServiceById(
     agreement.data.eserviceId
   );
-  assertEServiceExist(agreement.data.eserviceId, eService);
+  assertEServiceExist(agreement.data.eserviceId, eservice);
 
   const consumer = await tenantQuery.getTenantById(agreement.data.consumerId);
   assertTenantExist(agreement.data.consumerId, consumer);
 
-  const descriptor = eService.data.descriptors.find(
+  const descriptor = eservice.data.descriptors.find(
     (d) => d.id === agreement.data.descriptorId
   );
   assertDescriptorExist(
-    eService.data.id,
+    eservice.data.id,
     agreement.data.descriptorId,
     descriptor
   );

--- a/packages/agreement-process/src/services/pdfGenerator.ts
+++ b/packages/agreement-process/src/services/pdfGenerator.ts
@@ -136,7 +136,7 @@ const getActivationInfo = async (
 
 const getPdfPayload = async (
   agreement: Agreement,
-  eService: EService,
+  eservice: EService,
   consumer: Tenant,
   producer: Tenant,
   seed: UpdateAgreementSeed,
@@ -153,7 +153,7 @@ const getPdfPayload = async (
   return {
     today: new Date(),
     agreementId: agreement.id,
-    eService: eService.name,
+    eservice: eservice.name,
     producerName: producer.name,
     producerOrigin: producer.externalId.origin,
     producerIPACode: producer.externalId.value,
@@ -190,7 +190,7 @@ const createAgreementDocumentName = (
 export const pdfGenerator = {
   createDocumentSeed: async (
     agreement: Agreement,
-    eService: EService,
+    eservice: EService,
     consumer: Tenant,
     producer: Tenant,
     seed: UpdateAgreementSeed,
@@ -205,7 +205,7 @@ export const pdfGenerator = {
     );
     const pdfPayload = await getPdfPayload(
       agreement,
-      eService,
+      eservice,
       consumer,
       producer,
       seed,

--- a/packages/agreement-process/src/services/readmodel/agreementQuery.ts
+++ b/packages/agreement-process/src/services/readmodel/agreementQuery.ts
@@ -37,14 +37,14 @@ export function agreementQueryBuilder(readModelService: ReadModelService) {
     ): Promise<ListResult<CompactOrganization>> =>
       readModelService.listProducers(name, limit, offset),
     getEServices: (
-      eServiceName: string | undefined,
+      eserviceName: string | undefined,
       consumerIds: string[],
       producerIds: string[],
       limit: number,
       offset: number
     ): Promise<ListResult<CompactOrganization>> =>
       readModelService.listEServicesAgreements(
-        eServiceName,
+        eserviceName,
         consumerIds,
         producerIds,
         limit,

--- a/packages/agreement-process/src/services/readmodel/readModelService.ts
+++ b/packages/agreement-process/src/services/readmodel/readModelService.ts
@@ -502,7 +502,7 @@ export function readModelServiceBuilder(
       return searchTenantsByName(agreements, name, "producerId", limit, offset);
     },
     async listEServicesAgreements(
-      eServiceName: string | undefined,
+      eserviceName: string | undefined,
       consumerIds: string[],
       producerIds: string[],
       limit: number,
@@ -529,7 +529,7 @@ export function readModelServiceBuilder(
         {
           $match: {
             "eservices.data.name": {
-              $regex: new RegExp(eServiceName || "", "i"),
+              $regex: new RegExp(eserviceName || "", "i"),
             },
             consumerFilter,
             producerFilter,

--- a/packages/catalog-process/src/model/domain/apiConverter.ts
+++ b/packages/catalog-process/src/model/domain/apiConverter.ts
@@ -133,15 +133,15 @@ export function eServiceModeToApiEServiceMode(
 }
 
 export const eServiceToApiEService = (
-  eService: EService
+  eservice: EService
 ): z.infer<typeof api.schemas.EService> => ({
-  id: eService.id,
-  producerId: eService.producerId,
-  name: eService.name,
-  description: eService.description,
-  technology: technologyToApiTechnology(eService.technology),
-  mode: eServiceModeToApiEServiceMode(eService.mode),
-  riskAnalysis: eService.riskAnalysis.map((riskAnalysis) => ({
+  id: eservice.id,
+  producerId: eservice.producerId,
+  name: eservice.name,
+  description: eservice.description,
+  technology: technologyToApiTechnology(eservice.technology),
+  mode: eServiceModeToApiEServiceMode(eservice.mode),
+  riskAnalysis: eservice.riskAnalysis.map((riskAnalysis) => ({
     id: riskAnalysis.id,
     name: riskAnalysis.name,
     createdAt: riskAnalysis.createdAt.toJSON(),
@@ -152,7 +152,7 @@ export const eServiceToApiEService = (
       multiAnswers: riskAnalysis.riskAnalysisForm.multiAnswers,
     },
   })),
-  descriptors: eService.descriptors.map((descriptor) => ({
+  descriptors: eservice.descriptors.map((descriptor) => ({
     id: descriptor.id,
     version: descriptor.version,
     description: descriptor.description,

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -43,9 +43,9 @@ export function eServiceNotFound(eserviceId: EServiceId): ApiError<ErrorCodes> {
   });
 }
 
-export function eServiceDuplicate(eServiceName: string): ApiError<ErrorCodes> {
+export function eServiceDuplicate(eserviceName: string): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `An EService with name ${eServiceName} already exists`,
+    detail: `An EService with name ${eserviceName} already exists`,
     code: "eServiceDuplicate",
     title: "Duplicated service name",
   });

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -107,24 +107,24 @@ export const toRiskAnalysisV2 = (
   createdAt: BigInt(input.createdAt.getTime()),
 });
 
-export const toEServiceV2 = (eService: EService): EServiceV2 => ({
-  ...eService,
-  technology: toEServiceTechnologyV2(eService.technology),
-  descriptors: eService.descriptors.map(toDescriptorV2),
-  createdAt: BigInt(eService.createdAt.getTime()),
-  mode: toEServiceModeV2(eService.mode),
-  riskAnalysis: eService.riskAnalysis.map(toRiskAnalysisV2),
+export const toEServiceV2 = (eservice: EService): EServiceV2 => ({
+  ...eservice,
+  technology: toEServiceTechnologyV2(eservice.technology),
+  descriptors: eservice.descriptors.map(toDescriptorV2),
+  createdAt: BigInt(eservice.createdAt.getTime()),
+  mode: toEServiceModeV2(eservice.mode),
+  riskAnalysis: eservice.riskAnalysis.map(toRiskAnalysisV2),
 });
 
 export const toCreateEventEServiceAdded = (
-  eService: EService
+  eservice: EService
 ): CreateEvent<EServiceEvent> => ({
-  streamId: eService.id,
+  streamId: eservice.id,
   version: 0,
   event: {
     type: "EServiceAdded",
     event_version: 2,
-    data: { eservice: toEServiceV2(eService) },
+    data: { eservice: toEServiceV2(eservice) },
   },
 });
 

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -153,11 +153,11 @@ const eservicesRouter = (
       ]),
       async (req, res) => {
         try {
-          const eService = await catalogService.getEServiceById(
+          const eservice = await catalogService.getEServiceById(
             unsafeBrandId(req.params.eServiceId),
             req.ctx.authData
           );
-          return res.status(200).json(eServiceToApiEService(eService)).end();
+          return res.status(200).json(eServiceToApiEService(eservice)).end();
         } catch (error) {
           const errorRes = makeApiProblem(error, getEServiceErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -86,9 +86,9 @@ import { ReadModelService } from "./readModelService.js";
 
 function assertEServiceExist(
   eserviceId: EServiceId,
-  eService: WithMetadata<EService> | undefined
-): asserts eService is NonNullable<WithMetadata<EService>> {
-  if (eService === undefined) {
+  eservice: WithMetadata<EService> | undefined
+): asserts eservice is NonNullable<WithMetadata<EService>> {
+  if (eservice === undefined) {
     throw eServiceNotFound(eserviceId);
   }
 }
@@ -106,23 +106,23 @@ const retrieveEService = async (
   eserviceId: EServiceId,
   readModelService: ReadModelService
 ): Promise<WithMetadata<EService>> => {
-  const eService = await readModelService.getEServiceById(eserviceId);
-  if (eService === undefined) {
+  const eservice = await readModelService.getEServiceById(eserviceId);
+  if (eservice === undefined) {
     throw eServiceNotFound(eserviceId);
   }
-  return eService;
+  return eservice;
 };
 
 const retrieveDescriptor = (
   descriptorId: DescriptorId,
-  eService: WithMetadata<EService>
+  eservice: WithMetadata<EService>
 ): Descriptor => {
-  const descriptor = eService.data.descriptors.find(
+  const descriptor = eservice.data.descriptors.find(
     (d: Descriptor) => d.id === descriptorId
   );
 
   if (descriptor === undefined) {
-    throw eServiceDescriptorNotFound(eService.data.id, descriptorId);
+    throw eServiceDescriptorNotFound(eservice.data.id, descriptorId);
   }
 
   return descriptor;
@@ -201,12 +201,12 @@ const deprecateDescriptor = (
   return updateDescriptorState(descriptor, descriptorState.deprecated);
 };
 
-const hasNotDraftDescriptor = (eService: EService): void => {
-  const hasDraftDescriptor = eService.descriptors.some(
+const hasNotDraftDescriptor = (eservice: EService): void => {
+  const hasDraftDescriptor = eservice.descriptors.some(
     (d: Descriptor) => d.state === descriptorState.draft
   );
   if (hasDraftDescriptor) {
-    throw draftDescriptorAlreadyExists(eService.id);
+    throw draftDescriptorAlreadyExists(eservice.id);
   }
 };
 
@@ -260,9 +260,9 @@ export function catalogServiceBuilder(
       authData: AuthData
     ): Promise<EService> {
       logger.info(`Retrieving EService ${eserviceId}`);
-      const eService = await retrieveEService(eserviceId, readModelService);
+      const eservice = await retrieveEService(eserviceId, readModelService);
 
-      return applyVisibilityToEService(eService.data, authData);
+      return applyVisibilityToEService(eservice.data, authData);
     },
 
     async getEServices(
@@ -292,13 +292,13 @@ export function catalogServiceBuilder(
     },
 
     async getEServiceConsumers(
-      eServiceId: EServiceId,
+      eserviceId: EServiceId,
       offset: number,
       limit: number
     ): Promise<ListResult<Consumer>> {
-      logger.info(`Retrieving consumers for EService ${eServiceId}`);
+      logger.info(`Retrieving consumers for EService ${eserviceId}`);
       return await readModelService.getEServiceConsumers(
-        eServiceId,
+        eserviceId,
         offset,
         limit
       );
@@ -306,18 +306,18 @@ export function catalogServiceBuilder(
 
     async updateEService(
       eserviceId: EServiceId,
-      eServiceSeed: ApiEServiceSeed,
+      eserviceSeed: ApiEServiceSeed,
       authData: AuthData
     ): Promise<void> {
       logger.info(`Updating EService ${eserviceId}`);
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
         await updateEserviceLogic({
-          eService,
+          eservice,
           eserviceId,
           authData,
-          eServiceSeed,
+          eserviceSeed,
           getEServiceByNameAndProducerId:
             readModelService.getEServiceByNameAndProducerId,
           deleteFile: fileManager.delete,
@@ -330,10 +330,10 @@ export function catalogServiceBuilder(
       authData: AuthData
     ): Promise<void> {
       logger.info(`Deleting EService ${eserviceId}`);
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
-        deleteEserviceLogic({ eserviceId, authData, eService })
+        deleteEserviceLogic({ eserviceId, authData, eservice })
       );
     },
 
@@ -346,7 +346,7 @@ export function catalogServiceBuilder(
       logger.info(
         `Creating EService Document ${document.documentId.toString} of kind ${document.kind}, name ${document.fileName}, path ${document.filePath} for EService ${eserviceId} and Descriptor ${descriptorId}`
       );
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       return await repository.createEvent(
         uploadDocumentLogic({
@@ -354,7 +354,7 @@ export function catalogServiceBuilder(
           descriptorId,
           document,
           authData,
-          eService,
+          eservice,
         })
       );
     },
@@ -372,11 +372,11 @@ export function catalogServiceBuilder(
       logger.info(
         `Retrieving EService document ${documentId} for EService ${eserviceId} and descriptor ${descriptorId}`
       );
-      const eService = await retrieveEService(eserviceId, readModelService);
-      const descriptor = retrieveDescriptor(descriptorId, eService);
+      const eservice = await retrieveEService(eserviceId, readModelService);
+      const descriptor = retrieveDescriptor(descriptorId, eservice);
       const document = retrieveDocument(eserviceId, descriptor, documentId);
       const checkedEService = applyVisibilityToEService(
-        eService.data,
+        eservice.data,
         authData
       );
       if (!checkedEService.descriptors.find((d) => d.id === descriptorId)) {
@@ -393,7 +393,7 @@ export function catalogServiceBuilder(
       logger.info(
         `Deleting Document ${documentId} of Descriptor ${descriptorId} for EService ${eserviceId}`
       );
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
         await deleteDocumentLogic({
@@ -401,7 +401,7 @@ export function catalogServiceBuilder(
           descriptorId,
           documentId,
           authData,
-          eService,
+          eservice,
           deleteFile: fileManager.delete,
         })
       );
@@ -417,7 +417,7 @@ export function catalogServiceBuilder(
       logger.info(
         `Updating Document ${documentId} of Descriptor ${descriptorId} for EService ${eserviceId}`
       );
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
         await updateDocumentLogic({
@@ -426,7 +426,7 @@ export function catalogServiceBuilder(
           documentId,
           apiEServiceDescriptorDocumentUpdateSeed,
           authData,
-          eService,
+          eservice,
         })
       );
     },
@@ -438,14 +438,14 @@ export function catalogServiceBuilder(
     ): Promise<string> {
       logger.info(`Creating Descriptor for EService ${eserviceId}`);
 
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       return await repository.createEvent(
         await createDescriptorLogic({
           eserviceId,
           eserviceDescriptorSeed,
           authData,
-          eService,
+          eservice,
           getAttributesByIds: readModelService.getAttributesByIds,
         })
       );
@@ -460,14 +460,14 @@ export function catalogServiceBuilder(
         `Deleting draft Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
       await repository.createEvent(
         await deleteDraftDescriptorLogic({
           eserviceId,
           descriptorId,
           authData,
           deleteFile: fileManager.delete,
-          eService,
+          eservice,
         })
       );
     },
@@ -481,7 +481,7 @@ export function catalogServiceBuilder(
       logger.info(
         `Updating draft Descriptor ${descriptorId} for EService ${eserviceId}`
       );
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
         updateDraftDescriptorLogic({
@@ -489,7 +489,7 @@ export function catalogServiceBuilder(
           descriptorId,
           seed,
           authData,
-          eService,
+          eservice,
         })
       );
     },
@@ -503,14 +503,14 @@ export function catalogServiceBuilder(
         `Publishing Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
         publishDescriptorLogic({
           eserviceId,
           descriptorId,
           authData,
-          eService,
+          eservice,
         })
       );
     },
@@ -524,14 +524,14 @@ export function catalogServiceBuilder(
         `Suspending Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
         suspendDescriptorLogic({
           eserviceId,
           descriptorId,
           authData,
-          eService,
+          eservice,
         })
       );
     },
@@ -545,14 +545,14 @@ export function catalogServiceBuilder(
         `Activating descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
         activateDescriptorLogic({
           eserviceId,
           descriptorId,
           authData,
-          eService,
+          eservice,
         })
       );
     },
@@ -566,14 +566,14 @@ export function catalogServiceBuilder(
         `Cloning Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
-      const { eService: draftEService, event } = await cloneDescriptorLogic({
+      const { eservice: draftEService, event } = await cloneDescriptorLogic({
         eserviceId,
         descriptorId,
         authData,
         copyFile: fileManager.copy,
-        eService,
+        eservice,
         getEServiceByNameAndProducerId:
           readModelService.getEServiceByNameAndProducerId,
       });
@@ -592,14 +592,14 @@ export function catalogServiceBuilder(
         `Archiving Descriptor ${descriptorId} for EService ${eserviceId}`
       );
 
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       await repository.createEvent(
         archiveDescriptorLogic({
           eserviceId,
           descriptorId,
           authData,
-          eService,
+          eservice,
         })
       );
     },
@@ -613,7 +613,7 @@ export function catalogServiceBuilder(
       logger.info(
         `Updating Descriptor ${descriptorId} for EService ${eserviceId}`
       );
-      const eService = await readModelService.getEServiceById(eserviceId);
+      const eservice = await readModelService.getEServiceById(eserviceId);
 
       return await repository.createEvent(
         updateDescriptorLogic({
@@ -621,7 +621,7 @@ export function catalogServiceBuilder(
           descriptorId,
           seed,
           authData,
-          eService,
+          eservice,
         })
       );
     },
@@ -662,17 +662,17 @@ export function createEserviceLogic({
 }
 
 export async function updateEserviceLogic({
-  eService,
+  eservice,
   eserviceId,
   authData,
-  eServiceSeed,
+  eserviceSeed,
   getEServiceByNameAndProducerId,
   deleteFile,
 }: {
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
   eserviceId: EServiceId;
   authData: AuthData;
-  eServiceSeed: ApiEServiceSeed;
+  eserviceSeed: ApiEServiceSeed;
   getEServiceByNameAndProducerId: ({
     name,
     producerId,
@@ -682,34 +682,34 @@ export async function updateEserviceLogic({
   }) => Promise<WithMetadata<EService> | undefined>;
   deleteFile: (container: string, path: string) => Promise<void>;
 }): Promise<CreateEvent<EServiceEvent>> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
   if (
     !(
-      eService.data.descriptors.length === 0 ||
-      (eService.data.descriptors.length === 1 &&
-        eService.data.descriptors[0].state === descriptorState.draft)
+      eservice.data.descriptors.length === 0 ||
+      (eservice.data.descriptors.length === 1 &&
+        eservice.data.descriptors[0].state === descriptorState.draft)
     )
   ) {
     throw eServiceCannotBeUpdated(eserviceId);
   }
 
-  if (eServiceSeed.name !== eService.data.name) {
-    const eServiceWithSameName = await getEServiceByNameAndProducerId({
-      name: eServiceSeed.name,
+  if (eserviceSeed.name !== eservice.data.name) {
+    const eserviceWithSameName = await getEServiceByNameAndProducerId({
+      name: eserviceSeed.name,
       producerId: authData.organizationId,
     });
-    if (eServiceWithSameName !== undefined) {
-      throw eServiceDuplicate(eServiceSeed.name);
+    if (eserviceWithSameName !== undefined) {
+      throw eServiceDuplicate(eserviceSeed.name);
     }
   }
 
-  const updatedTechnology = apiTechnologyToTechnology(eServiceSeed.technology);
-  if (eService.data.descriptors.length === 1) {
-    const draftDescriptor = eService.data.descriptors[0];
+  const updatedTechnology = apiTechnologyToTechnology(eserviceSeed.technology);
+  if (eservice.data.descriptors.length === 1) {
+    const draftDescriptor = eservice.data.descriptors[0];
     if (
-      updatedTechnology !== eService.data.technology &&
+      updatedTechnology !== eservice.data.technology &&
       draftDescriptor.interface !== undefined
     ) {
       await deleteFile(config.s3Bucket, draftDescriptor.interface.path).catch(
@@ -724,16 +724,16 @@ export async function updateEserviceLogic({
   }
 
   const updatedEService: EService = {
-    ...eService.data,
-    description: eServiceSeed.description,
-    name: eServiceSeed.name,
+    ...eservice.data,
+    description: eserviceSeed.description,
+    name: eserviceSeed.name,
     technology: updatedTechnology,
     producerId: authData.organizationId,
   };
 
   return toCreateEventEServiceUpdated(
     eserviceId,
-    eService.metadata.version,
+    eservice.metadata.version,
     updatedEService
   );
 }
@@ -741,23 +741,23 @@ export async function updateEserviceLogic({
 export function deleteEserviceLogic({
   eserviceId,
   authData,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  if (eService.data.descriptors.length > 0) {
+  if (eservice.data.descriptors.length > 0) {
     throw eServiceCannotBeDeleted(eserviceId);
   }
 
   return toCreateEventEServiceDeleted(
     eserviceId,
-    eService.metadata.version,
-    eService.data
+    eservice.metadata.version,
+    eservice.data
   );
 }
 
@@ -766,18 +766,18 @@ export function uploadDocumentLogic({
   descriptorId,
   document,
   authData,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   document: ApiEServiceDescriptorDocumentSeed;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
 
   if (descriptor.state !== descriptorState.draft) {
     throw notValidDescriptor(descriptor.id, descriptor.state);
@@ -799,8 +799,8 @@ export function uploadDocumentLogic({
   };
 
   const newEservice: EService = {
-    ...eService.data,
-    descriptors: eService.data.descriptors.map((d: Descriptor) =>
+    ...eservice.data,
+    descriptors: eservice.data.descriptors.map((d: Descriptor) =>
       d.id === descriptorId
         ? {
             ...d,
@@ -815,7 +815,7 @@ export function uploadDocumentLogic({
   return document.kind === "INTERFACE"
     ? toCreateEventEServiceInterfaceAdded(
         eserviceId,
-        eService.metadata.version,
+        eservice.metadata.version,
         {
           descriptorId,
           documentId: unsafeBrandId(document.documentId),
@@ -824,7 +824,7 @@ export function uploadDocumentLogic({
       )
     : toCreateEventEServiceDocumentAdded(
         eserviceId,
-        eService.metadata.version,
+        eservice.metadata.version,
         {
           descriptorId,
           documentId: unsafeBrandId(document.documentId),
@@ -838,20 +838,20 @@ export async function deleteDocumentLogic({
   descriptorId,
   documentId,
   authData,
-  eService,
+  eservice,
   deleteFile,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   documentId: EServiceDocumentId;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
   deleteFile: (bucket: string, path: string) => Promise<void>;
 }): Promise<CreateEvent<EServiceEvent>> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
 
   if (descriptor.state !== descriptorState.draft) {
     throw notValidDescriptor(descriptor.id, descriptor.state);
@@ -873,8 +873,8 @@ export async function deleteDocumentLogic({
 
   const isInterface = document.id === descriptor?.interface?.id;
   const newEservice: EService = {
-    ...eService.data,
-    descriptors: eService.data.descriptors.map((d: Descriptor) =>
+    ...eservice.data,
+    descriptors: eservice.data.descriptors.map((d: Descriptor) =>
       d.id === descriptorId
         ? {
             ...d,
@@ -888,7 +888,7 @@ export async function deleteDocumentLogic({
   return isInterface
     ? toCreateEventEServiceInterfaceDeleted(
         eserviceId,
-        eService.metadata.version,
+        eservice.metadata.version,
         {
           descriptorId,
           documentId,
@@ -897,7 +897,7 @@ export async function deleteDocumentLogic({
       )
     : toCreateEventEServiceDocumentDeleted(
         eserviceId,
-        eService.metadata.version,
+        eservice.metadata.version,
         {
           descriptorId,
           documentId,
@@ -912,19 +912,19 @@ export async function updateDocumentLogic({
   documentId,
   apiEServiceDescriptorDocumentUpdateSeed,
   authData,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   documentId: EServiceDocumentId;
   apiEServiceDescriptorDocumentUpdateSeed: ApiEServiceDescriptorDocumentUpdateSeed;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): Promise<CreateEvent<EServiceEvent>> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
 
   if (descriptor.state !== descriptorState.draft) {
     throw notValidDescriptor(descriptor.id, descriptor.state);
@@ -945,8 +945,8 @@ export async function updateDocumentLogic({
 
   const isInterface = document.id === descriptor?.interface?.id;
   const newEservice: EService = {
-    ...eService.data,
-    descriptors: eService.data.descriptors.map((d: Descriptor) =>
+    ...eservice.data,
+    descriptors: eservice.data.descriptors.map((d: Descriptor) =>
       d.id === descriptorId
         ? {
             ...d,
@@ -962,7 +962,7 @@ export async function updateDocumentLogic({
   return isInterface
     ? toCreateEventEServiceInterfaceUpdated(
         eserviceId,
-        eService.metadata.version,
+        eservice.metadata.version,
         {
           descriptorId,
           documentId,
@@ -971,7 +971,7 @@ export async function updateDocumentLogic({
       )
     : toCreateEventEServiceDocumentUpdated(
         eserviceId,
-        eService.metadata.version,
+        eservice.metadata.version,
         {
           descriptorId,
           documentId,
@@ -984,20 +984,20 @@ export async function createDescriptorLogic({
   eserviceId,
   eserviceDescriptorSeed,
   authData,
-  eService,
+  eservice,
   getAttributesByIds,
 }: {
   eserviceId: EServiceId;
   eserviceDescriptorSeed: EServiceDescriptorSeed;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
   getAttributesByIds: (attributesIds: AttributeId[]) => Promise<Attribute[]>;
 }): Promise<CreateEvent<EServiceEvent>> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
-  hasNotDraftDescriptor(eService.data);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
+  hasNotDraftDescriptor(eservice.data);
 
-  const newVersion = nextDescriptorVersion(eService.data);
+  const newVersion = nextDescriptorVersion(eservice.data);
 
   const certifiedAttributes = eserviceDescriptorSeed.attributes.certified;
   const declaredAttributes = eserviceDescriptorSeed.attributes.declared;
@@ -1077,13 +1077,13 @@ export async function createDescriptorLogic({
   };
 
   const newEservice: EService = {
-    ...eService.data,
-    descriptors: [...eService.data.descriptors, newDescriptor],
+    ...eservice.data,
+    descriptors: [...eservice.data.descriptors, newDescriptor],
   };
 
   return toCreateEventEServiceDescriptorAdded(
-    eService.data.id,
-    eService.metadata.version,
+    eservice.data.id,
+    eservice.metadata.version,
     descriptorId,
     newEservice
   );
@@ -1094,18 +1094,18 @@ export async function deleteDraftDescriptorLogic({
   descriptorId,
   authData,
   deleteFile,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   authData: AuthData;
   deleteFile: (bucket: string, path: string) => Promise<void>;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): Promise<CreateEvent<EServiceEvent>> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
 
   if (descriptor.state !== descriptorState.draft) {
     throw notValidDescriptor(descriptorId, descriptor.state.toString());
@@ -1135,15 +1135,15 @@ export async function deleteDraftDescriptorLogic({
   });
 
   const newEservice: EService = {
-    ...eService.data,
-    descriptors: eService.data.descriptors.filter(
+    ...eservice.data,
+    descriptors: eservice.data.descriptors.filter(
       (d: Descriptor) => d.id !== descriptorId
     ),
   };
 
   return toCreateEventEServiceDescriptorDeleted(
-    eService.data.id,
-    eService.metadata.version,
+    eservice.data.id,
+    eservice.metadata.version,
     newEservice,
     descriptorId
   );
@@ -1154,18 +1154,18 @@ export function updateDraftDescriptorLogic({
   descriptorId,
   seed,
   authData,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   seed: UpdateEServiceDescriptorSeed;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
 
   if (descriptor.state !== descriptorState.draft) {
     throw notValidDescriptor(descriptorId, descriptor.state.toString());
@@ -1189,11 +1189,11 @@ export function updateDraftDescriptorLogic({
       ),
   };
 
-  const updatedEService = replaceDescriptor(eService.data, updatedDescriptor);
+  const updatedEService = replaceDescriptor(eservice.data, updatedDescriptor);
 
   return toCreateEventEServiceUpdated(
     eserviceId,
-    eService.metadata.version,
+    eservice.metadata.version,
     updatedEService
   );
 }
@@ -1202,17 +1202,17 @@ export function publishDescriptorLogic({
   eserviceId,
   descriptorId,
   authData,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
   if (descriptor.state !== descriptorState.draft) {
     throw notValidDescriptor(descriptor.id, descriptor.state.toString());
   }
@@ -1221,7 +1221,7 @@ export function publishDescriptorLogic({
     throw eServiceDescriptorWithoutInterface(descriptor.id);
   }
 
-  const currentActiveDescriptor = eService.data.descriptors.find(
+  const currentActiveDescriptor = eservice.data.descriptors.find(
     (d: Descriptor) => d.state === descriptorState.published
   );
 
@@ -1230,24 +1230,24 @@ export function publishDescriptorLogic({
     descriptorState.published
   );
 
-  const newEservice = updateDescriptor(eService.data, updatedDescriptor);
+  const newEservice = updateDescriptor(eservice.data, updatedDescriptor);
 
   if (currentActiveDescriptor !== undefined) {
     const newEserviceWithDeprecation = updateDescriptor(
-      eService.data,
+      eservice.data,
       deprecateDescriptor(eserviceId, currentActiveDescriptor)
     );
 
     return toCreateEventEServiceDescriptorPublished(
       eserviceId,
-      eService.metadata.version + 1,
+      eservice.metadata.version + 1,
       descriptorId,
       newEserviceWithDeprecation
     );
   } else {
     return toCreateEventEServiceDescriptorPublished(
       eserviceId,
-      eService.metadata.version,
+      eservice.metadata.version,
       descriptorId,
       newEservice
     );
@@ -1258,17 +1258,17 @@ export function suspendDescriptorLogic({
   eserviceId,
   descriptorId,
   authData,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
   if (
     descriptor.state !== descriptorState.deprecated &&
     descriptor.state !== descriptorState.published
@@ -1281,11 +1281,11 @@ export function suspendDescriptorLogic({
     descriptorState.suspended
   );
 
-  const newEservice = updateDescriptor(eService.data, updatedDescriptor);
+  const newEservice = updateDescriptor(eservice.data, updatedDescriptor);
 
   return toCreateEventEServiceDescriptorSuspended(
     eserviceId,
-    eService.metadata.version,
+    eservice.metadata.version,
     descriptorId,
     newEservice
   );
@@ -1295,17 +1295,17 @@ export function activateDescriptorLogic({
   eserviceId,
   descriptorId,
   authData,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
   if (descriptor.state !== descriptorState.suspended) {
     throw notValidDescriptor(descriptorId, descriptor.state.toString());
   }
@@ -1314,7 +1314,7 @@ export function activateDescriptorLogic({
     descriptor,
     descriptorState.published
   );
-  const descriptorVersions: number[] = eService.data.descriptors
+  const descriptorVersions: number[] = eservice.data.descriptors
     .filter(
       (d: Descriptor) =>
         d.state === descriptorState.suspended ||
@@ -1328,23 +1328,23 @@ export function activateDescriptorLogic({
     recentDescriptorVersion !== null &&
     parseInt(descriptor.version, 10) === recentDescriptorVersion
   ) {
-    const newEservice = updateDescriptor(eService.data, updatedDescriptor);
+    const newEservice = updateDescriptor(eservice.data, updatedDescriptor);
 
     return toCreateEventEServiceDescriptorActivated(
       eserviceId,
-      eService.metadata.version,
+      eservice.metadata.version,
       descriptorId,
       newEservice
     );
   } else {
     const newEservice = updateDescriptor(
-      eService.data,
+      eservice.data,
       deprecateDescriptor(eserviceId, descriptor)
     );
 
     return toCreateEventEServiceDescriptorActivated(
       eserviceId,
-      eService.metadata.version,
+      eservice.metadata.version,
       descriptorId,
       newEservice
     );
@@ -1356,7 +1356,7 @@ export async function cloneDescriptorLogic({
   descriptorId,
   authData,
   copyFile,
-  eService,
+  eservice,
   getEServiceByNameAndProducerId,
 }: {
   eserviceId: EServiceId;
@@ -1369,7 +1369,7 @@ export async function cloneDescriptorLogic({
     id: string,
     name: string
   ) => Promise<string>;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
   getEServiceByNameAndProducerId: ({
     name,
     producerId,
@@ -1377,12 +1377,12 @@ export async function cloneDescriptorLogic({
     name: string;
     producerId: TenantId;
   }) => Promise<WithMetadata<EService> | undefined>;
-}): Promise<{ eService: EService; event: CreateEvent<EServiceEvent> }> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+}): Promise<{ eservice: EService; event: CreateEvent<EServiceEvent> }> {
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
   const clonedEServiceName = `${
-    eService.data.name
+    eservice.data.name
   } - clone - ${formatClonedEServiceDate(new Date())}`;
 
   if (
@@ -1394,7 +1394,7 @@ export async function cloneDescriptorLogic({
     throw eServiceDuplicate(clonedEServiceName);
   }
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
 
   const clonedInterfaceId = generateId<EServiceDocumentId>();
   const clonedInterfacePath =
@@ -1456,14 +1456,14 @@ export async function cloneDescriptorLogic({
 
   const clonedEservice: EService = {
     id: generateId(),
-    producerId: eService.data.producerId,
+    producerId: eservice.data.producerId,
     name: clonedEServiceName,
-    description: eService.data.description,
-    technology: eService.data.technology,
-    attributes: eService.data.attributes,
+    description: eservice.data.description,
+    technology: eservice.data.technology,
+    attributes: eservice.data.attributes,
     createdAt: new Date(),
-    riskAnalysis: eService.data.riskAnalysis,
-    mode: eService.data.mode,
+    riskAnalysis: eservice.data.riskAnalysis,
+    mode: eservice.data.mode,
     descriptors: [
       {
         ...descriptor,
@@ -1482,10 +1482,10 @@ export async function cloneDescriptorLogic({
   };
 
   return {
-    eService: clonedEservice,
+    eservice: clonedEservice,
     event: toCreateEventClonedEServiceAdded(
       descriptorId,
-      eService.data,
+      eservice.data,
       clonedEservice
     ),
   };
@@ -1495,27 +1495,27 @@ export function archiveDescriptorLogic({
   eserviceId,
   descriptorId,
   authData,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
   const updatedDescriptor = updateDescriptorState(
     descriptor,
     descriptorState.archived
   );
 
-  const newEservice = updateDescriptor(eService.data, updatedDescriptor);
+  const newEservice = updateDescriptor(eservice.data, updatedDescriptor);
 
   return toCreateEventEServiceDescriptorActivated(
     eserviceId,
-    eService.metadata.version,
+    eservice.metadata.version,
     descriptorId,
     newEservice
   );
@@ -1526,18 +1526,18 @@ export function updateDescriptorLogic({
   descriptorId,
   seed,
   authData,
-  eService,
+  eservice,
 }: {
   eserviceId: EServiceId;
   descriptorId: DescriptorId;
   seed: UpdateEServiceDescriptorQuotasSeed;
   authData: AuthData;
-  eService: WithMetadata<EService> | undefined;
+  eservice: WithMetadata<EService> | undefined;
 }): CreateEvent<EServiceEvent> {
-  assertEServiceExist(eserviceId, eService);
-  assertRequesterAllowed(eService.data.producerId, authData.organizationId);
+  assertEServiceExist(eserviceId, eservice);
+  assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
 
-  const descriptor = retrieveDescriptor(descriptorId, eService);
+  const descriptor = retrieveDescriptor(descriptorId, eservice);
 
   if (
     descriptor.state !== descriptorState.published &&
@@ -1561,11 +1561,11 @@ export function updateDescriptorLogic({
     dailyCallsTotal: seed.dailyCallsTotal,
   };
 
-  const updatedEService = replaceDescriptor(eService.data, updatedDescriptor);
+  const updatedEService = replaceDescriptor(eservice.data, updatedDescriptor);
 
   return toCreateEventEServiceUpdated(
     eserviceId,
-    eService.metadata.version,
+    eservice.metadata.version,
     updatedEService
   );
 }

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -281,12 +281,12 @@ export function catalogServiceBuilder(
         limit
       );
 
-      const eServicesToReturn = eservicesList.results.map((eservice) =>
+      const eservicesToReturn = eservicesList.results.map((eservice) =>
         applyVisibilityToEService(eservice, authData)
       );
 
       return {
-        results: eServicesToReturn,
+        results: eservicesToReturn,
         totalCount: eservicesList.totalCount,
       };
     },

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -375,8 +375,8 @@ export function readModelServiceBuilder(
       descriptorId: DescriptorId,
       documentId: EServiceDocumentId
     ): Promise<Document | undefined> {
-      const eService = await this.getEServiceById(eserviceId);
-      return eService?.data.descriptors
+      const eservice = await this.getEServiceById(eserviceId);
+      return eservice?.data.descriptors
         .find((d) => d.id === descriptorId)
         ?.docs.find((d) => d.id === documentId);
     },

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -179,8 +179,8 @@ describe("database test", async () => {
   });
 
   describe("Catalog service", () => {
-    describe("create eService", () => {
-      it("should write on event-store for the creation of an eService", async () => {
+    describe("create eservice", () => {
+      it("should write on event-store for the creation of an eservice", async () => {
         const id = await catalogService.createEService(
           {
             name: mockEService.name,
@@ -202,16 +202,16 @@ describe("database test", async () => {
           payload: writtenEvent.data,
         });
 
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           createdAt: new Date(Number(writtenPayload.eservice!.createdAt)),
           id,
         };
 
-        expect(writtenPayload.eservice).toEqual(toEServiceV2(eService));
+        expect(writtenPayload.eservice).toEqual(toEServiceV2(eservice));
       });
 
-      it("should throw eServiceDuplicate if an eService with the same name already exists", async () => {
+      it("should throw eServiceDuplicate if an eservice with the same name already exists", async () => {
         await addOneEService(mockEService, postgresDB, eservices);
         expect(
           catalogService.createEService(
@@ -247,6 +247,7 @@ describe("database test", async () => {
     describe("update eService", () => {
       it("should write on event-store for the update of an eService (no technology change)", async () => {
         vi.spyOn(fileManager, "delete");
+
         const descriptor: Descriptor = {
           ...mockDescriptor,
           state: descriptorState.draft,
@@ -256,7 +257,7 @@ describe("database test", async () => {
           ...mockEService,
           descriptors: [descriptor],
         };
-        const updatedName = "eService new name";
+        const updatedName = "eservice new name";
         await addOneEService(eservice, postgresDB, eservices);
         await catalogService.updateEService(
           mockEService.id,
@@ -309,7 +310,7 @@ describe("database test", async () => {
           ...mockEService,
           descriptors: [descriptor],
         };
-        const updatedName = "eService new name";
+        const updatedName = "eservice new name";
         await addOneEService(eservice, postgresDB, eservices);
 
         await fileManager.storeBytes(
@@ -395,7 +396,7 @@ describe("database test", async () => {
         ).rejects.toThrowError("Failed to delete file");
       });
       it("should write on event-store for the update of an eService (update description only)", async () => {
-        const updatedDescription = "eService new description";
+        const updatedDescription = "eservice new description";
         await addOneEService(mockEService, postgresDB, eservices);
         await catalogService.updateEService(
           mockEService.id,
@@ -429,13 +430,13 @@ describe("database test", async () => {
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", async () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
         expect(
           catalogService.updateEService(
             mockEService.id,
             {
-              name: "eService new name",
-              description: "eService description",
+              name: "eservice new name",
+              description: "eservice description",
               technology: "REST",
               mode: "DELIVER",
             },
@@ -451,8 +452,8 @@ describe("database test", async () => {
           catalogService.updateEService(
             mockEService.id,
             {
-              name: "eService new name",
-              description: "eService description",
+              name: "eservice new name",
+              description: "eservice description",
               technology: "REST",
               mode: "DELIVER",
             },
@@ -462,139 +463,139 @@ describe("database test", async () => {
       });
 
       it("should throw eServiceDuplicate if the updated name is already in use", async () => {
-        const eService1: EService = {
+        const eservice1: EService = {
           ...mockEService,
           id: generateId(),
           descriptors: [],
         };
-        const eService2: EService = {
+        const eservice2: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService name already in use",
+          name: "eservice name already in use",
           descriptors: [],
         };
-        await addOneEService(eService1, postgresDB, eservices);
-        await addOneEService(eService2, postgresDB, eservices);
+        await addOneEService(eservice1, postgresDB, eservices);
+        await addOneEService(eservice2, postgresDB, eservices);
 
         expect(
           catalogService.updateEService(
-            eService1.id,
+            eservice1.id,
             {
-              name: "eService name already in use",
-              description: "eService description",
+              name: "eservice name already in use",
+              description: "eservice description",
               technology: "REST",
               mode: "DELIVER",
             },
-            getMockAuthData(eService1.producerId)
+            getMockAuthData(eservice1.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDuplicate("eService name already in use")
+          eServiceDuplicate("eservice name already in use")
         );
       });
 
-      it("should throw eServiceCannotBeUpdated if the eService descriptor is in published state", async () => {
+      it("should throw eServiceCannotBeUpdated if the eservice descriptor is in published state", async () => {
         const descriptor: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateEService(
-            eService.id,
+            eservice.id,
             {
-              name: "eService new name",
-              description: "eService description",
+              name: "eservice new name",
+              description: "eservice description",
               technology: "REST",
               mode: "DELIVER",
             },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
-        ).rejects.toThrowError(eServiceCannotBeUpdated(eService.id));
+        ).rejects.toThrowError(eServiceCannotBeUpdated(eservice.id));
       });
 
-      it("should throw eServiceCannotBeUpdated if the eService descriptor is in archived state", async () => {
+      it("should throw eServiceCannotBeUpdated if the eservice descriptor is in archived state", async () => {
         const descriptor: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
           state: descriptorState.archived,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateEService(
-            eService.id,
+            eservice.id,
             {
-              name: "eService new name",
-              description: "eService description",
+              name: "eservice new name",
+              description: "eservice description",
               technology: "REST",
               mode: "DELIVER",
             },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
-        ).rejects.toThrowError(eServiceCannotBeUpdated(eService.id));
+        ).rejects.toThrowError(eServiceCannotBeUpdated(eservice.id));
       });
 
-      it("should throw eServiceCannotBeUpdated if the eService descriptor is in suspended state", async () => {
+      it("should throw eServiceCannotBeUpdated if the eservice descriptor is in suspended state", async () => {
         const descriptor: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
           state: descriptorState.suspended,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateEService(
-            eService.id,
+            eservice.id,
             {
-              name: "eService new name",
-              description: "eService description",
+              name: "eservice new name",
+              description: "eservice description",
               technology: "REST",
               mode: "DELIVER",
             },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
-        ).rejects.toThrowError(eServiceCannotBeUpdated(eService.id));
+        ).rejects.toThrowError(eServiceCannotBeUpdated(eservice.id));
       });
 
-      it("should throw eServiceCannotBeUpdated if the eService descriptor is in deprecated state", async () => {
+      it("should throw eServiceCannotBeUpdated if the eservice descriptor is in deprecated state", async () => {
         const descriptor: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
           state: descriptorState.deprecated,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateEService(
-            eService.id,
+            eservice.id,
             {
-              name: "eService new name",
-              description: "eService description",
+              name: "eservice new name",
+              description: "eservice description",
               technology: "REST",
               mode: "DELIVER",
             },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
-        ).rejects.toThrowError(eServiceCannotBeUpdated(eService.id));
+        ).rejects.toThrowError(eServiceCannotBeUpdated(eservice.id));
       });
     });
 
-    describe("delete eService", () => {
-      it("should write on event-store for the deletion of an eService", async () => {
+    describe("delete eservice", () => {
+      it("should write on event-store for the deletion of an eservice", async () => {
         await addOneEService(mockEService, postgresDB, eservices);
         await catalogService.deleteEService(
           mockEService.id,
@@ -612,10 +613,10 @@ describe("database test", async () => {
           messageType: EServiceDeletedV1,
           payload: writtenEvent.data,
         });
-        expect(writtenPayload.eServiceId).toBe(mockEService.id);
+        expect(writtenPayload.eserviceId).toBe(mockEService.id);
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", () => {
         expect(
           catalogService.deleteEService(
             mockEService.id,
@@ -631,23 +632,23 @@ describe("database test", async () => {
         ).rejects.toThrowError(operationForbidden);
       });
 
-      it("should throw eServiceCannotBeDeleted if the eService has a descriptor", async () => {
+      it("should throw eServiceCannotBeDeleted if the eservice has a descriptor", async () => {
         const descriptor: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.deleteEService(
-            eService.id,
-            getMockAuthData(eService.producerId)
+            eservice.id,
+            getMockAuthData(eservice.producerId)
           )
-        ).rejects.toThrowError(eServiceCannotBeDeleted(eService.id));
+        ).rejects.toThrowError(eServiceCannotBeDeleted(eservice.id));
       });
     });
 
@@ -722,22 +723,22 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
 
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.createDescriptor(
-            eService.id,
+            eservice.id,
             buildDescriptorSeed(descriptor),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
-        ).rejects.toThrowError(draftDescriptorAlreadyExists(eService.id));
+        ).rejects.toThrowError(draftDescriptorAlreadyExists(eservice.id));
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", async () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
         expect(
           catalogService.createDescriptor(
             mockEService.id,
@@ -747,11 +748,11 @@ describe("database test", async () => {
         ).rejects.toThrowError(eServiceNotFound(mockEService.id));
       });
       it("should throw attributeNotFound if at least one of the attributes don't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         const attribute: Attribute = {
           name: "Attribute name",
@@ -786,9 +787,9 @@ describe("database test", async () => {
 
         expect(
           catalogService.createDescriptor(
-            eService.id,
+            eservice.id,
             descriptorSeed,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(attributeNotFound(notExistingId1));
       });
@@ -798,14 +799,14 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.createDescriptor(
-            eService.id,
+            eservice.id,
             buildDescriptorSeed(descriptor),
             getMockAuthData()
           )
@@ -817,17 +818,17 @@ describe("database test", async () => {
           dailyCallsPerConsumer: 100,
           dailyCallsTotal: 50,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
 
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.createDescriptor(
-            eService.id,
+            eservice.id,
             descriptorSeed,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(inconsistentDailyCalls());
       });
@@ -839,11 +840,11 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         const updatedDescriptorSeed: EServiceDescriptorSeed = {
           ...buildDescriptorSeed(descriptor),
@@ -851,7 +852,7 @@ describe("database test", async () => {
         };
 
         const updatedEService: EService = {
-          ...eService,
+          ...eservice,
           descriptors: [
             {
               ...descriptor,
@@ -860,16 +861,16 @@ describe("database test", async () => {
           ],
         };
         await catalogService.updateDraftDescriptor(
-          eService.id,
+          eservice.id,
           descriptor.id,
           updatedDescriptorSeed,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("DraftEServiceUpdated");
         expect(writtenEvent.event_version).toBe(2);
@@ -880,7 +881,7 @@ describe("database test", async () => {
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", () => {
         const descriptor: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
@@ -897,11 +898,11 @@ describe("database test", async () => {
       });
 
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.updateDraftDescriptor(
@@ -911,7 +912,7 @@ describe("database test", async () => {
             getMockAuthData(mockEService.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
 
@@ -921,18 +922,18 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.updateDraftDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildDescriptorSeed(descriptor),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(mockDescriptor.id, descriptorState.published)
@@ -945,18 +946,18 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.deprecated,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.updateDraftDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildDescriptorSeed(descriptor),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(mockDescriptor.id, descriptorState.deprecated)
@@ -969,18 +970,18 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.suspended,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.updateDraftDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildDescriptorSeed(descriptor),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(mockDescriptor.id, descriptorState.suspended)
@@ -993,18 +994,18 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.archived,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.updateDraftDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildDescriptorSeed(descriptor),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(mockDescriptor.id, descriptorState.archived)
@@ -1016,11 +1017,11 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         const updatedDescriptor = {
           ...descriptor,
@@ -1028,7 +1029,7 @@ describe("database test", async () => {
         };
         expect(
           catalogService.updateDraftDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildDescriptorSeed(updatedDescriptor),
             getMockAuthData()
@@ -1040,11 +1041,11 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         const updatedDescriptor: Descriptor = {
           ...descriptor,
@@ -1053,10 +1054,10 @@ describe("database test", async () => {
         };
         expect(
           catalogService.updateDraftDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildDescriptorSeed(updatedDescriptor),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(inconsistentDailyCalls());
       });
@@ -1069,23 +1070,23 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         await catalogService.deleteDraftDescriptor(
-          eService.id,
+          eservice.id,
           descriptor.id,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
 
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorDeleted");
         expect(writtenEvent.event_version).toBe(2);
@@ -1096,7 +1097,7 @@ describe("database test", async () => {
         });
 
         const expectedEservice = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [],
         });
 
@@ -1130,11 +1131,11 @@ describe("database test", async () => {
           interface: interfaceDocument,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         await fileManager.storeBytes(
           config.s3Bucket,
@@ -1171,16 +1172,16 @@ describe("database test", async () => {
         );
 
         await catalogService.deleteDraftDescriptor(
-          eService.id,
+          eservice.id,
           descriptor.id,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
 
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorDeleted");
         expect(writtenEvent.event_version).toBe(2);
@@ -1190,7 +1191,7 @@ describe("database test", async () => {
         });
 
         const expectedEservice = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [],
         });
 
@@ -1231,22 +1232,22 @@ describe("database test", async () => {
           docs: [mockDocument, mockDocument],
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         await expect(
           catalogService.deleteDraftDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError("Failed to delete file");
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", () => {
         expect(
           catalogService.deleteDraftDescriptor(
             mockEService.id,
@@ -1257,11 +1258,11 @@ describe("database test", async () => {
       });
 
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.deleteDraftDescriptor(
             mockEService.id,
@@ -1269,7 +1270,7 @@ describe("database test", async () => {
             getMockAuthData(mockEService.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
 
@@ -1278,14 +1279,14 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.deleteDraftDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             getMockAuthData()
           )
@@ -1308,22 +1309,22 @@ describe("database test", async () => {
             uploadDate: new Date(),
           },
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         await catalogService.publishDescriptor(
-          eService.id,
+          eservice.id,
           descriptor.id,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
 
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorPublished");
         expect(writtenEvent.event_version).toBe(2);
@@ -1333,7 +1334,7 @@ describe("database test", async () => {
         });
 
         const expectedEservice = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [
             {
               ...descriptor,
@@ -1349,7 +1350,7 @@ describe("database test", async () => {
         expect(writtenPayload.eservice).toEqual(expectedEservice);
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", async () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
         await expect(
           catalogService.publishDescriptor(
             mockEService.id,
@@ -1360,19 +1361,19 @@ describe("database test", async () => {
       });
 
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.publishDescriptor(
-            eService.id,
+            eservice.id,
             mockDescriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
 
@@ -1381,14 +1382,14 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.publishDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             getMockAuthData()
           )
@@ -1401,16 +1402,16 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.publishDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.published)
@@ -1423,16 +1424,16 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.deprecated,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.publishDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.deprecated)
@@ -1445,16 +1446,16 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.suspended,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.publishDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.suspended)
@@ -1467,16 +1468,16 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.archived,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.publishDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.archived)
@@ -1488,17 +1489,17 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.publishDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           eServiceDescriptorWithoutInterface(descriptor.id)
@@ -1513,22 +1514,22 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         await catalogService.suspendDescriptor(
-          eService.id,
+          eservice.id,
           descriptor.id,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
 
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorSuspended");
         expect(writtenEvent.event_version).toBe(2);
@@ -1538,7 +1539,7 @@ describe("database test", async () => {
         });
 
         const expectedEservice = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [
             {
               ...descriptor,
@@ -1554,7 +1555,7 @@ describe("database test", async () => {
         expect(writtenPayload.eservice).toEqual(expectedEservice);
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", () => {
         expect(
           catalogService.suspendDescriptor(
             mockEService.id,
@@ -1570,14 +1571,14 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.suspendDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             getMockAuthData()
           )
@@ -1585,20 +1586,20 @@ describe("database test", async () => {
       });
 
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.suspendDescriptor(
-            eService.id,
+            eservice.id,
             mockDescriptor.id,
             getMockAuthData(mockEService.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
 
@@ -1607,16 +1608,16 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.suspendDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.draft)
@@ -1629,16 +1630,16 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.suspended,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.suspendDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.suspended)
@@ -1651,16 +1652,16 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.archived,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.suspendDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.archived)
@@ -1675,15 +1676,15 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.suspended,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         await catalogService.activateDescriptor(
-          eService.id,
+          eservice.id,
           descriptor.id,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
 
         const updatedDescriptor = {
@@ -1692,10 +1693,10 @@ describe("database test", async () => {
         };
 
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorActivated");
         expect(writtenEvent.event_version).toBe(2);
@@ -1705,14 +1706,14 @@ describe("database test", async () => {
         });
 
         const expectedEservice = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [updatedDescriptor],
         });
         expect(writtenPayload.eservice).toEqual(expectedEservice);
         expect(writtenPayload.descriptorId).toEqual(descriptor.id);
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", () => {
         expect(
           catalogService.activateDescriptor(
             mockEService.id,
@@ -1723,20 +1724,20 @@ describe("database test", async () => {
       });
 
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.activateDescriptor(
-            eService.id,
+            eservice.id,
             mockDescriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
 
@@ -1746,14 +1747,14 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.suspended,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.activateDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             getMockAuthData()
           )
@@ -1765,16 +1766,16 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.activateDescriptor(
             mockEService.id,
             mockDescriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.draft)
@@ -1787,16 +1788,16 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.activateDescriptor(
             mockEService.id,
             mockDescriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.published)
@@ -1809,16 +1810,16 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.deprecated,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.activateDescriptor(
             mockEService.id,
             mockDescriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.deprecated)
@@ -1831,16 +1832,16 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.archived,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.activateDescriptor(
             mockEService.id,
             mockDescriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.archived)
@@ -1881,11 +1882,11 @@ describe("database test", async () => {
           interface: interfaceDocument,
           docs: [document1, document2],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         await fileManager.storeBytes(
           config.s3Bucket,
@@ -1922,9 +1923,9 @@ describe("database test", async () => {
 
         const cloneTimestamp = new Date();
         const newEService = await catalogService.cloneDescriptor(
-          eService.id,
+          eservice.id,
           descriptor.id,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
 
         const writtenEvent = await readLastEventByStreamId(
@@ -1983,9 +1984,9 @@ describe("database test", async () => {
         };
 
         const expectedEService: EService = {
-          ...eService,
+          ...eservice,
           id: unsafeBrandId(writtenPayload.clonedEservice!.id),
-          name: `${eService.name} - clone - ${formatClonedEServiceDate(
+          name: `${eservice.name} - clone - ${formatClonedEServiceDate(
             cloneTimestamp
           )}`,
           descriptors: [expectedDescriptor],
@@ -2037,56 +2038,56 @@ describe("database test", async () => {
           interface: mockDocument,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         await expect(
           catalogService.cloneDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError("Failed to copy file");
       });
-      it("should throw eServiceDuplicate if an eService with the same name already exists", async () => {
+      it("should throw eServiceDuplicate if an eservice with the same name already exists", async () => {
         const descriptor: Descriptor = {
           ...mockDescriptor,
           state: descriptorState.draft,
           interface: mockDocument,
           docs: [mockDocument],
         };
-        const eService1: EService = {
+        const eservice1: EService = {
           ...mockEService,
           id: generateId(),
           descriptors: [descriptor],
         };
-        await addOneEService(eService1, postgresDB, eservices);
+        await addOneEService(eservice1, postgresDB, eservices);
 
         const cloneTimestamp = new Date();
         const conflictEServiceName = `${
-          eService1.name
+          eservice1.name
         } - clone - ${formatClonedEServiceDate(cloneTimestamp)}`;
 
-        const eService2: EService = {
+        const eservice2: EService = {
           ...mockEService,
           id: generateId(),
           name: conflictEServiceName,
           descriptors: [descriptor],
         };
-        await addOneEService(eService2, postgresDB, eservices);
+        await addOneEService(eservice2, postgresDB, eservices);
 
         expect(
           catalogService.cloneDescriptor(
-            eService1.id,
+            eservice1.id,
             descriptor.id,
-            getMockAuthData(eService1.producerId)
+            getMockAuthData(eservice1.producerId)
           )
         ).rejects.toThrowError(eServiceDuplicate(conflictEServiceName));
       });
-      it("should throw eServiceNotFound if the eService doesn't exist", () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", () => {
         expect(
           catalogService.cloneDescriptor(
             mockEService.id,
@@ -2100,33 +2101,33 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.cloneDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             getMockAuthData()
           )
         ).rejects.toThrowError(operationForbidden);
       });
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.cloneDescriptor(
             mockEService.id,
             mockDescriptor.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
     });
@@ -2138,22 +2139,22 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.suspended,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         await catalogService.archiveDescriptor(
-          eService.id,
+          eservice.id,
           descriptor.id,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
 
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorActivated");
         expect(writtenEvent.event_version).toBe(2);
@@ -2171,14 +2172,14 @@ describe("database test", async () => {
         };
 
         const expectedEService = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [updatedDescriptor],
         });
         expect(writtenPayload.eservice).toEqual(expectedEService);
         expect(writtenPayload.descriptorId).toEqual(descriptor.id);
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", () => {
         expect(
           catalogService.archiveDescriptor(
             mockEService.id,
@@ -2189,20 +2190,20 @@ describe("database test", async () => {
       });
 
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.archiveDescriptor(
-            eService.id,
+            eservice.id,
             mockDescriptor.id,
             getMockAuthData(mockEService.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
 
@@ -2211,14 +2212,14 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.archiveDescriptor(
-            eService.id,
+            eservice.id,
             descriptor.id,
             getMockAuthData()
           )
@@ -2391,7 +2392,7 @@ describe("database test", async () => {
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", () => {
         const updatedDescriptorQuotasSeed: UpdateEServiceDescriptorQuotasSeed =
           {
             voucherLifespan: 1000,
@@ -2587,24 +2588,24 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         await catalogService.uploadDocument(
-          eService.id,
+          eservice.id,
           descriptor.id,
           buildInterfaceSeed(),
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
 
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorInterfaceAdded");
         expect(writtenEvent.event_version).toBe(2);
@@ -2614,7 +2615,7 @@ describe("database test", async () => {
         });
 
         const expectedEservice = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [
             {
               ...descriptor,
@@ -2636,7 +2637,7 @@ describe("database test", async () => {
         expect(writtenPayload.descriptorId).toEqual(descriptor.id);
         expect(writtenPayload.eservice).toEqual(expectedEservice);
       });
-      it("should throw eServiceNotFound if the eService doesn't exist", () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", () => {
         expect(
           catalogService.uploadDocument(
             mockEService.id,
@@ -2651,15 +2652,15 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.uploadDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildInterfaceSeed(),
             getMockAuthData()
@@ -2667,20 +2668,20 @@ describe("database test", async () => {
         ).rejects.toThrowError(operationForbidden);
       });
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.uploadDocument(
-            eService.id,
+            eservice.id,
             mockDescriptor.id,
             buildInterfaceSeed(),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
       it("should throw notValidDescriptor if the descriptor is in published state", async () => {
@@ -2688,17 +2689,17 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.uploadDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildInterfaceSeed(),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.published)
@@ -2709,17 +2710,17 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.deprecated,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.uploadDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildInterfaceSeed(),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.deprecated)
@@ -2730,17 +2731,17 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.archived,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.uploadDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildInterfaceSeed(),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.archived)
@@ -2751,17 +2752,17 @@ describe("database test", async () => {
           ...mockDescriptor,
           state: descriptorState.suspended,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.uploadDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildInterfaceSeed(),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.suspended)
@@ -2773,17 +2774,17 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.draft,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.uploadDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             buildInterfaceSeed(),
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(interfaceAlreadyExists(descriptor.id));
       });
@@ -2802,12 +2803,12 @@ describe("database test", async () => {
           state: descriptorState.draft,
           docs: [document],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
 
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         await fileManager.storeBytes(
           config.s3Bucket,
@@ -2821,16 +2822,16 @@ describe("database test", async () => {
         );
 
         await catalogService.deleteDocument(
-          eService.id,
+          eservice.id,
           descriptor.id,
           document.id,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorDocumentDeleted");
         expect(writtenEvent.event_version).toBe(2);
@@ -2840,7 +2841,7 @@ describe("database test", async () => {
         });
 
         const expectedEservice = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [
             {
               ...descriptor,
@@ -2874,12 +2875,12 @@ describe("database test", async () => {
           state: descriptorState.draft,
           interface: interfaceDocument,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
 
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         await fileManager.storeBytes(
           config.s3Bucket,
@@ -2893,16 +2894,16 @@ describe("database test", async () => {
         );
 
         await catalogService.deleteDocument(
-          eService.id,
+          eservice.id,
           descriptor.id,
           interfaceDocument.id,
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorInterfaceDeleted");
         expect(writtenEvent.event_version).toBe(2);
@@ -2912,7 +2913,7 @@ describe("database test", async () => {
         });
 
         const expectedEservice = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [
             {
               ...descriptor,
@@ -2944,22 +2945,22 @@ describe("database test", async () => {
           state: descriptorState.draft,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
 
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         await expect(
           catalogService.deleteDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             mockDocument.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError("Failed to delete file");
       });
-      it("should throw eServiceNotFound if the eService doesn't exist", async () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
         expect(
           catalogService.deleteDocument(
             mockEService.id,
@@ -2975,14 +2976,14 @@ describe("database test", async () => {
           state: descriptorState.draft,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.deleteDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             mockDocument.id,
             getMockAuthData()
@@ -2990,21 +2991,21 @@ describe("database test", async () => {
         ).rejects.toThrowError(operationForbidden);
       });
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.deleteDocument(
-            eService.id,
+            eservice.id,
             mockDescriptor.id,
             mockDocument.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
       it("should throw notValidDescriptor if the descriptor is in published state", async () => {
@@ -3013,17 +3014,17 @@ describe("database test", async () => {
           state: descriptorState.published,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.deleteDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             mockDocument.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.published)
@@ -3035,17 +3036,17 @@ describe("database test", async () => {
           state: descriptorState.deprecated,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.deleteDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             mockDocument.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.deprecated)
@@ -3057,17 +3058,17 @@ describe("database test", async () => {
           state: descriptorState.archived,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.deleteDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             mockDocument.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.archived)
@@ -3079,17 +3080,17 @@ describe("database test", async () => {
           state: descriptorState.suspended,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.deleteDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             mockDocument.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.suspended)
@@ -3101,21 +3102,21 @@ describe("database test", async () => {
           state: descriptorState.draft,
           docs: [],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
 
         expect(
           catalogService.deleteDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             mockDocument.id,
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDocumentNotFound(eService.id, descriptor.id, mockDocument.id)
+          eServiceDocumentNotFound(eservice.id, descriptor.id, mockDocument.id)
         );
       });
     });
@@ -3127,24 +3128,24 @@ describe("database test", async () => {
           state: descriptorState.draft,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         await catalogService.updateDocument(
-          eService.id,
+          eservice.id,
           descriptor.id,
           mockDocument.id,
           { prettyName: "updated prettyName" },
-          getMockAuthData(eService.producerId)
+          getMockAuthData(eservice.producerId)
         );
         const writtenEvent = await readLastEventByStreamId(
-          eService.id,
+          eservice.id,
           postgresDB
         );
         const expectedEservice = toEServiceV2({
-          ...eService,
+          ...eservice,
           descriptors: [
             {
               ...descriptor,
@@ -3158,7 +3159,7 @@ describe("database test", async () => {
           ],
         });
 
-        expect(writtenEvent.stream_id).toBe(eService.id);
+        expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
         expect(writtenEvent.type).toBe("EServiceDescriptorDocumentUpdated");
         expect(writtenEvent.event_version).toBe(2);
@@ -3171,7 +3172,7 @@ describe("database test", async () => {
         expect(writtenPayload.documentId).toEqual(mockDocument.id);
         expect(writtenPayload.eservice).toEqual(expectedEservice);
       });
-      it("should throw eServiceNotFound if the eService doesn't exist", async () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
         expect(
           catalogService.updateDocument(
             mockEService.id,
@@ -3188,14 +3189,14 @@ describe("database test", async () => {
           state: descriptorState.draft,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             mockDocument.id,
             { prettyName: "updated prettyName" },
@@ -3204,21 +3205,21 @@ describe("database test", async () => {
         ).rejects.toThrowError(operationForbidden);
       });
       it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateDocument(
-            eService.id,
+            eservice.id,
             mockDescriptor.id,
             generateId(),
             { prettyName: "updated prettyName" },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDescriptorNotFound(eService.id, mockDescriptor.id)
+          eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
         );
       });
       it("should throw notValidDescriptor if the descriptor is in Published state", async () => {
@@ -3227,18 +3228,18 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             generateId(),
             { prettyName: "updated prettyName" },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.published)
@@ -3250,18 +3251,18 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.suspended,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             generateId(),
             { prettyName: "updated prettyName" },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.suspended)
@@ -3273,18 +3274,18 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.archived,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             generateId(),
             { prettyName: "updated prettyName" },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.archived)
@@ -3296,18 +3297,18 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.deprecated,
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             generateId(),
             { prettyName: "updated prettyName" },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
           notValidDescriptor(descriptor.id, descriptorState.deprecated)
@@ -3319,21 +3320,21 @@ describe("database test", async () => {
           state: descriptorState.draft,
           docs: [],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           descriptors: [descriptor],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         expect(
           catalogService.updateDocument(
-            eService.id,
+            eservice.id,
             descriptor.id,
             mockDocument.id,
             { prettyName: "updated prettyName" },
-            getMockAuthData(eService.producerId)
+            getMockAuthData(eservice.producerId)
           )
         ).rejects.toThrowError(
-          eServiceDocumentNotFound(eService.id, descriptor.id, mockDocument.id)
+          eServiceDocumentNotFound(eservice.id, descriptor.id, mockDocument.id)
         );
       });
     });
@@ -3344,12 +3345,12 @@ describe("database test", async () => {
       let organizationId1: TenantId;
       let organizationId2: TenantId;
       let organizationId3: TenantId;
-      let eService1: EService;
-      let eService2: EService;
-      let eService3: EService;
-      let eService4: EService;
-      let eService5: EService;
-      let eService6: EService;
+      let eservice1: EService;
+      let eservice2: EService;
+      let eservice3: EService;
+      let eservice4: EService;
+      let eservice5: EService;
+      let eservice6: EService;
       const attributesForDescriptor1and2 = getMockEServiceAttributes();
       const attributesForDescriptor3 = getMockEServiceAttributes();
       const attributesForDescriptor4 = getMockEServiceAttributes();
@@ -3366,14 +3367,14 @@ describe("database test", async () => {
           state: descriptorState.published,
           attributes: attributesForDescriptor1and2,
         };
-        eService1 = {
+        eservice1 = {
           ...mockEService,
           id: generateId(),
-          name: "eService 001 test",
+          name: "eservice 001 test",
           descriptors: [descriptor1],
           producerId: organizationId1,
         };
-        await addOneEService(eService1, postgresDB, eservices);
+        await addOneEService(eservice1, postgresDB, eservices);
 
         const descriptor2: Descriptor = {
           ...mockDescriptor,
@@ -3382,14 +3383,14 @@ describe("database test", async () => {
           state: descriptorState.published,
           attributes: attributesForDescriptor1and2,
         };
-        eService2 = {
+        eservice2 = {
           ...mockEService,
           id: generateId(),
-          name: "eService 002 test",
+          name: "eservice 002 test",
           descriptors: [descriptor2],
           producerId: organizationId1,
         };
-        await addOneEService(eService2, postgresDB, eservices);
+        await addOneEService(eservice2, postgresDB, eservices);
 
         const descriptor3: Descriptor = {
           ...mockDescriptor,
@@ -3398,14 +3399,14 @@ describe("database test", async () => {
           state: descriptorState.published,
           attributes: attributesForDescriptor3,
         };
-        eService3 = {
+        eservice3 = {
           ...mockEService,
           id: generateId(),
-          name: "eService 003 test",
+          name: "eservice 003 test",
           descriptors: [descriptor3],
           producerId: organizationId1,
         };
-        await addOneEService(eService3, postgresDB, eservices);
+        await addOneEService(eservice3, postgresDB, eservices);
 
         const descriptor4: Descriptor = {
           ...mockDescriptor,
@@ -3414,14 +3415,14 @@ describe("database test", async () => {
           state: descriptorState.archived,
           attributes: attributesForDescriptor4,
         };
-        eService4 = {
+        eservice4 = {
           ...mockEService,
           id: generateId(),
-          name: "eService 004 test",
+          name: "eservice 004 test",
           producerId: organizationId2,
           descriptors: [descriptor4],
         };
-        await addOneEService(eService4, postgresDB, eservices);
+        await addOneEService(eservice4, postgresDB, eservices);
 
         const descriptor5: Descriptor = {
           ...mockDescriptor,
@@ -3429,14 +3430,14 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.published,
         };
-        eService5 = {
+        eservice5 = {
           ...mockEService,
           id: generateId(),
-          name: "eService 005 test",
+          name: "eservice 005 test",
           producerId: organizationId2,
           descriptors: [descriptor5],
         };
-        await addOneEService(eService5, postgresDB, eservices);
+        await addOneEService(eservice5, postgresDB, eservices);
 
         const descriptor6: Descriptor = {
           ...mockDescriptor,
@@ -3444,14 +3445,14 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.archived,
         };
-        eService6 = {
+        eservice6 = {
           ...mockEService,
           id: generateId(),
-          name: "eService 006",
+          name: "eservice 006",
           producerId: organizationId2,
           descriptors: [descriptor6],
         };
-        await addOneEService(eService6, postgresDB, eservices);
+        await addOneEService(eservice6, postgresDB, eservices);
 
         const tenant: Tenant = {
           ...getMockTenant(),
@@ -3459,24 +3460,24 @@ describe("database test", async () => {
         };
         await addOneTenant(tenant, tenants);
         const agreement1 = getMockAgreement({
-          eserviceId: eService1.id,
+          eserviceId: eservice1.id,
           descriptorId: descriptor1.id,
-          producerId: eService1.producerId,
+          producerId: eservice1.producerId,
           consumerId: tenant.id,
         });
         await addOneAgreement(agreement1, agreements);
         const agreement2 = getMockAgreement({
-          eserviceId: eService3.id,
+          eserviceId: eservice3.id,
           descriptorId: descriptor3.id,
-          producerId: eService3.producerId,
+          producerId: eservice3.producerId,
           consumerId: tenant.id,
         });
         await addOneAgreement(agreement2, agreements);
         const agreement3 = {
           ...getMockAgreement({
-            eserviceId: eService4.id,
+            eserviceId: eservice4.id,
             descriptorId: descriptor4.id,
-            producerId: eService4.producerId,
+            producerId: eservice4.producerId,
             consumerId: tenant.id,
           }),
           state: agreementState.draft,
@@ -3487,7 +3488,7 @@ describe("database test", async () => {
         const result = await catalogService.getEServices(
           getMockAuthData(),
           {
-            eservicesIds: [eService1.id, eService2.id],
+            eservicesIds: [eservice1.id, eservice2.id],
             producersIds: [],
             states: [],
             agreementStates: [],
@@ -3497,7 +3498,7 @@ describe("database test", async () => {
           50
         );
         expect(result.totalCount).toBe(2);
-        expect(result.results).toEqual([eService1, eService2]);
+        expect(result.results).toEqual([eservice1, eservice2]);
       });
       it("should get the eServices if they exist (parameters: producersIds)", async () => {
         const result = await catalogService.getEServices(
@@ -3513,7 +3514,7 @@ describe("database test", async () => {
           50
         );
         expect(result.totalCount).toBe(3);
-        expect(result.results).toEqual([eService1, eService2, eService3]);
+        expect(result.results).toEqual([eservice1, eservice2, eservice3]);
       });
       it("should get the eServices if they exist (parameters: states)", async () => {
         const result = await catalogService.getEServices(
@@ -3530,10 +3531,10 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(4);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService5,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice5,
         ]);
       });
       it("should get the eServices if they exist (parameters: agreementStates)", async () => {
@@ -3564,9 +3565,9 @@ describe("database test", async () => {
         );
 
         expect(result1.totalCount).toBe(2);
-        expect(result1.results).toEqual([eService1, eService3]);
+        expect(result1.results).toEqual([eservice1, eservice3]);
         expect(result2.totalCount).toBe(3);
-        expect(result2.results).toEqual([eService1, eService3, eService4]);
+        expect(result2.results).toEqual([eservice1, eservice3, eservice4]);
       });
       it("should get the eServices if they exist (parameters: name)", async () => {
         const result = await catalogService.getEServices(
@@ -3584,11 +3585,11 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(5);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
         ]);
       });
       it("should get the eServices if they exist (parameters: states, agreementStates, name)", async () => {
@@ -3606,7 +3607,7 @@ describe("database test", async () => {
           50
         );
         expect(result.totalCount).toBe(2);
-        expect(result.results).toEqual([eService1, eService3]);
+        expect(result.results).toEqual([eservice1, eservice3]);
       });
       it("should not get the eServices if they don't exist (parameters: states, agreementStates, name)", async () => {
         const result = await catalogService.getEServices(
@@ -3640,7 +3641,7 @@ describe("database test", async () => {
           50
         );
         expect(result.totalCount).toBe(1);
-        expect(result.results).toEqual([eService5]);
+        expect(result.results).toEqual([eservice5]);
       });
       it("should not get the eServices if they don't exist (parameters: producersIds, states, name)", async () => {
         const result = await catalogService.getEServices(
@@ -3710,10 +3711,10 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(4);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
         ]);
       });
 
@@ -3742,14 +3743,14 @@ describe("database test", async () => {
             producersIds: [],
             states: [],
             agreementStates: [],
-            name: eService1.name.slice(-6),
+            name: eservice1.name.slice(-6),
             attributesIds: [attributesForDescriptor1and2.verified[0][1].id],
           },
           0,
           50
         );
         expect(result.totalCount).toBe(1);
-        expect(result.results).toEqual([eService1]);
+        expect(result.results).toEqual([eservice1]);
       });
 
       it("should get the eServices if they exist (parameters: attributesIds, states)", async () => {
@@ -3770,7 +3771,7 @@ describe("database test", async () => {
         );
 
         expect(result.totalCount).toBe(1);
-        expect(result.results).toEqual([eService4]);
+        expect(result.results).toEqual([eservice4]);
       });
 
       it("should get the eServices if they exist (parameters: attributesIds, agreementStates, producersIds)", async () => {
@@ -3787,14 +3788,14 @@ describe("database test", async () => {
           50
         );
         expect(result.totalCount).toBe(1);
-        expect(result.results).toEqual([eService1]);
+        expect(result.results).toEqual([eservice1]);
       });
 
       it("should get the eServices if they exist (parameters: attributesIds, agreementStates, eservicesIds)", async () => {
         const result = await readModelService.getEServices(
           getMockAuthData(organizationId3),
           {
-            eservicesIds: [eService1.id, eService4.id],
+            eservicesIds: [eservice1.id, eservice4.id],
             producersIds: [organizationId1, organizationId2],
             states: [],
             agreementStates: ["Active", "Draft"],
@@ -3807,7 +3808,7 @@ describe("database test", async () => {
           50
         );
         expect(result.totalCount).toBe(2);
-        expect(result.results).toEqual([eService1, eService4]);
+        expect(result.results).toEqual([eservice1, eservice4]);
       });
 
       it("should not get the eServices if they don't exist (parameters: attributesIds, agreementStates)", async () => {
@@ -3831,7 +3832,7 @@ describe("database test", async () => {
         const eService7: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 007",
+          name: "eservice 007",
           producerId: organizationId1,
           descriptors: [],
         };
@@ -3854,12 +3855,12 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(7);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
-          eService6,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
+          eservice6,
           eService7,
         ]);
       });
@@ -3867,7 +3868,7 @@ describe("database test", async () => {
         const eService7: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 007",
+          name: "eservice 007",
           producerId: organizationId1,
           descriptors: [],
         };
@@ -3890,12 +3891,12 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(6);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
-          eService6,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
+          eservice6,
         ]);
       });
       it("should not include eservices with no descriptors (requester is not the producer)", async () => {
@@ -3903,7 +3904,7 @@ describe("database test", async () => {
           ...mockEService,
           id: generateId(),
           producerId: organizationId1,
-          name: "eService 007",
+          name: "eservice 007",
           descriptors: [],
         };
         const authData: AuthData = {
@@ -3925,12 +3926,12 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(6);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
-          eService6,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
+          eservice6,
         ]);
       });
       it("should include eservices whose only descriptor is draft (requester is the producer, admin)", async () => {
@@ -3942,7 +3943,7 @@ describe("database test", async () => {
         const eService8: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 008",
+          name: "eservice 008",
           producerId: organizationId1,
           descriptors: [descriptor8],
         };
@@ -3965,12 +3966,12 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(7);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
-          eService6,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
+          eservice6,
           eService8,
         ]);
       });
@@ -3983,7 +3984,7 @@ describe("database test", async () => {
         const eService8: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 008",
+          name: "eservice 008",
           producerId: organizationId1,
           descriptors: [descriptor8],
         };
@@ -4006,12 +4007,12 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(6);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
-          eService6,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
+          eservice6,
         ]);
       });
       it("should not include eservices whose only descriptor is draft (requester is not the producer)", async () => {
@@ -4023,7 +4024,7 @@ describe("database test", async () => {
         const eService8: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 008",
+          name: "eservice 008",
           producerId: organizationId1,
           descriptors: [descriptor8],
         };
@@ -4046,15 +4047,15 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(6);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
-          eService6,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
+          eservice6,
         ]);
       });
-      it("should not filter out draft descriptors if the eService has both draft and non-draft ones (requester is the producer, admin)", async () => {
+      it("should not filter out draft descriptors if the eservice has both draft and non-draft ones (requester is the producer, admin)", async () => {
         const descriptor9a: Descriptor = {
           ...mockDescriptor,
           id: generateId(),
@@ -4068,10 +4069,10 @@ describe("database test", async () => {
           version: "2",
           state: descriptorState.draft,
         };
-        const eService9: EService = {
+        const eservice9: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 008",
+          name: "eservice 008",
           producerId: organizationId1,
           descriptors: [descriptor9a, descriptor9b],
         };
@@ -4079,7 +4080,7 @@ describe("database test", async () => {
           ...getMockAuthData(organizationId1),
           userRoles: [userRoles.ADMIN_ROLE],
         };
-        await addOneEService(eService9, postgresDB, eservices);
+        await addOneEService(eservice9, postgresDB, eservices);
         const result = await catalogService.getEServices(
           authData,
           {
@@ -4094,16 +4095,16 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(7);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
-          eService6,
-          eService9,
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
+          eservice6,
+          eservice9,
         ]);
       });
-      it("should filter out draft descriptors if the eService has both draft and non-draft ones (requester is the producer, but not admin nor api)", async () => {
+      it("should filter out draft descriptors if the eservice has both draft and non-draft ones (requester is the producer, but not admin nor api)", async () => {
         const descriptor9a: Descriptor = {
           ...mockDescriptor,
           id: generateId(),
@@ -4117,10 +4118,10 @@ describe("database test", async () => {
           version: "2",
           state: descriptorState.draft,
         };
-        const eService9: EService = {
+        const eservice9: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 008",
+          name: "eservice 008",
           producerId: organizationId1,
           descriptors: [descriptor9a, descriptor9b],
         };
@@ -4128,7 +4129,7 @@ describe("database test", async () => {
           ...getMockAuthData(organizationId1),
           userRoles: [userRoles.SUPPORT_ROLE],
         };
-        await addOneEService(eService9, postgresDB, eservices);
+        await addOneEService(eservice9, postgresDB, eservices);
         const result = await catalogService.getEServices(
           authData,
           {
@@ -4143,16 +4144,16 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(7);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
-          eService6,
-          { ...eService9, descriptors: [descriptor9a] },
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
+          eservice6,
+          { ...eservice9, descriptors: [descriptor9a] },
         ]);
       });
-      it("should filter out draft descriptors if the eService has both draft and non-draft ones (requester is not the producer)", async () => {
+      it("should filter out draft descriptors if the eservice has both draft and non-draft ones (requester is not the producer)", async () => {
         const descriptor9a: Descriptor = {
           ...mockDescriptor,
           id: generateId(),
@@ -4166,10 +4167,10 @@ describe("database test", async () => {
           version: "2",
           state: descriptorState.draft,
         };
-        const eService9: EService = {
+        const eservice9: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 008",
+          name: "eservice 008",
           producerId: organizationId1,
           descriptors: [descriptor9a, descriptor9b],
         };
@@ -4177,7 +4178,7 @@ describe("database test", async () => {
           ...getMockAuthData(),
           userRoles: [userRoles.ADMIN_ROLE],
         };
-        await addOneEService(eService9, postgresDB, eservices);
+        await addOneEService(eservice9, postgresDB, eservices);
         const result = await catalogService.getEServices(
           authData,
           {
@@ -4192,68 +4193,68 @@ describe("database test", async () => {
         );
         expect(result.totalCount).toBe(7);
         expect(result.results).toEqual([
-          eService1,
-          eService2,
-          eService3,
-          eService4,
-          eService5,
-          eService6,
-          { ...eService9, descriptors: [descriptor9a] },
+          eservice1,
+          eservice2,
+          eservice3,
+          eservice4,
+          eservice5,
+          eservice6,
+          { ...eservice9, descriptors: [descriptor9a] },
         ]);
       });
     });
 
     describe("getEServiceByNameAndProducerId", () => {
-      it("should get the eService if it matches the name and the producerId", async () => {
+      it("should get the eservice if it matches the name and the producerId", async () => {
         const organizationId1: TenantId = generateId();
         const organizationId2: TenantId = generateId();
-        const eService1: EService = {
+        const eservice1: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 001",
+          name: "eservice 001",
           producerId: organizationId1,
         };
-        await addOneEService(eService1, postgresDB, eservices);
+        await addOneEService(eservice1, postgresDB, eservices);
 
-        const eService2: EService = {
+        const eservice2: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 002",
+          name: "eservice 002",
           producerId: organizationId1,
         };
-        await addOneEService(eService2, postgresDB, eservices);
+        await addOneEService(eservice2, postgresDB, eservices);
 
-        const eService3: EService = {
+        const eservice3: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 001",
+          name: "eservice 001",
           producerId: organizationId2,
         };
-        await addOneEService(eService3, postgresDB, eservices);
+        await addOneEService(eservice3, postgresDB, eservices);
 
         const result = await readModelService.getEServiceByNameAndProducerId({
-          name: "eService 001",
+          name: "eservice 001",
           producerId: organizationId1,
         });
-        expect(result?.data).toEqual(eService1);
+        expect(result?.data).toEqual(eservice1);
       });
-      it("should not get the eService if it doesn't exist", async () => {
+      it("should not get the eservice if it doesn't exist", async () => {
         const organizationId: TenantId = generateId();
-        const eService1: EService = {
+        const eservice1: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 001",
+          name: "eservice 001",
           producerId: organizationId,
         };
-        await addOneEService(eService1, postgresDB, eservices);
+        await addOneEService(eservice1, postgresDB, eservices);
 
-        const eService2: EService = {
+        const eservice2: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 002",
+          name: "eservice 002",
           producerId: organizationId,
         };
-        await addOneEService(eService2, postgresDB, eservices);
+        await addOneEService(eservice2, postgresDB, eservices);
 
         const result = await readModelService.getEServiceByNameAndProducerId({
           name: "not-existing",
@@ -4264,21 +4265,21 @@ describe("database test", async () => {
     });
 
     describe("getEServiceById", () => {
-      it("should get the eService if it exists (requester is the producer, admin)", async () => {
+      it("should get the eservice if it exists (requester is the producer, admin)", async () => {
         const descriptor1: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService1: EService = {
+        const eservice1: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 001",
+          name: "eservice 001",
           descriptors: [descriptor1],
         };
-        await addOneEService(eService1, postgresDB, eservices);
+        await addOneEService(eservice1, postgresDB, eservices);
         const authData: AuthData = {
-          ...getMockAuthData(eService1.producerId),
+          ...getMockAuthData(eservice1.producerId),
           userRoles: [userRoles.ADMIN_ROLE],
         };
 
@@ -4287,35 +4288,35 @@ describe("database test", async () => {
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService2: EService = {
+        const eservice2: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 002",
+          name: "eservice 002",
           descriptors: [descriptor2],
         };
-        await addOneEService(eService2, postgresDB, eservices);
+        await addOneEService(eservice2, postgresDB, eservices);
 
         const descriptor3: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService3: EService = {
+        const eservice3: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 003",
+          name: "eservice 003",
           descriptors: [descriptor3],
         };
-        await addOneEService(eService3, postgresDB, eservices);
+        await addOneEService(eservice3, postgresDB, eservices);
 
         const result = await catalogService.getEServiceById(
-          eService1.id,
+          eservice1.id,
           authData
         );
-        expect(result).toEqual(eService1);
+        expect(result).toEqual(eservice1);
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", async () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
         await addOneEService(mockEService, postgresDB, eservices);
         const notExistingId: EServiceId = generateId();
         expect(
@@ -4383,7 +4384,7 @@ describe("database test", async () => {
           catalogService.getEServiceById(eservice.id, authData)
         ).rejects.toThrowError(eServiceNotFound(eservice.id));
       });
-      it("should filter out the draft descriptors if the eService has both draft and non-draft ones (requester is not the producer)", async () => {
+      it("should filter out the draft descriptors if the eservice has both draft and non-draft ones (requester is not the producer)", async () => {
         const descriptorA: Descriptor = {
           ...mockDescriptor,
           state: descriptorState.draft,
@@ -4409,7 +4410,7 @@ describe("database test", async () => {
         );
         expect(result.descriptors).toEqual([descriptorB]);
       });
-      it("should filter out the draft descriptors if the eService has both draft and non-draft ones (requester is the producer but not admin nor api)", async () => {
+      it("should filter out the draft descriptors if the eservice has both draft and non-draft ones (requester is the producer but not admin nor api)", async () => {
         const descriptorA: Descriptor = {
           ...mockDescriptor,
           state: descriptorState.draft,
@@ -4438,29 +4439,29 @@ describe("database test", async () => {
     });
 
     describe("getEserviceConsumers", () => {
-      it("should get the consumers of the given eService", async () => {
+      it("should get the consumers of the given eservice", async () => {
         const descriptor1: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService1: EService = {
+        const eservice1: EService = {
           ...mockEService,
           descriptors: [descriptor1],
         };
-        await addOneEService(eService1, postgresDB, eservices);
+        await addOneEService(eservice1, postgresDB, eservices);
         const tenant = getMockTenant();
         await addOneTenant(tenant, tenants);
         const agreement = getMockAgreement({
-          eserviceId: eService1.id,
+          eserviceId: eservice1.id,
           descriptorId: descriptor1.id,
-          producerId: eService1.producerId,
+          producerId: eservice1.producerId,
           consumerId: tenant.id,
         });
         await addOneAgreement(agreement, agreements);
 
         const result = await readModelService.getEServiceConsumers(
-          eService1.id,
+          eservice1.id,
           0,
           50
         );
@@ -4468,20 +4469,20 @@ describe("database test", async () => {
         expect(result.results[0].consumerName).toBe(tenant.name);
       });
 
-      it("should not get any consumers, if no one is using the given eService", async () => {
+      it("should not get any consumers, if no one is using the given eservice", async () => {
         const descriptor1: Descriptor = {
           ...mockDescriptor,
           interface: mockDocument,
           state: descriptorState.published,
         };
-        const eService1: EService = {
+        const eservice1: EService = {
           ...mockEService,
           descriptors: [descriptor1],
         };
-        await addOneEService(eService1, postgresDB, eservices);
+        await addOneEService(eservice1, postgresDB, eservices);
 
         const consumers = await readModelService.getEServiceConsumers(
-          eService1.id,
+          eservice1.id,
           0,
           50
         );
@@ -4496,19 +4497,19 @@ describe("database test", async () => {
           ...mockDescriptor,
           docs: [mockDocument],
         };
-        const eService: EService = {
+        const eservice: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 001",
+          name: "eservice 001",
           descriptors: [descriptor],
         };
         const authData: AuthData = {
-          ...getMockAuthData(eService.producerId),
+          ...getMockAuthData(eservice.producerId),
           userRoles: [userRoles.ADMIN_ROLE],
         };
-        await addOneEService(eService, postgresDB, eservices);
+        await addOneEService(eservice, postgresDB, eservices);
         const result = await catalogService.getDocumentById({
-          eserviceId: eService.id,
+          eserviceId: eservice.id,
           descriptorId: descriptor.id,
           documentId: mockDocument.id,
           authData,
@@ -4516,7 +4517,7 @@ describe("database test", async () => {
         expect(result).toEqual(mockDocument);
       });
 
-      it("should throw eServiceNotFound if the eService doesn't exist", async () => {
+      it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
         const authData: AuthData = {
           ...getMockAuthData(),
           userRoles: [userRoles.ADMIN_ROLE],
@@ -4563,7 +4564,7 @@ describe("database test", async () => {
         const eservice: EService = {
           ...mockEService,
           id: generateId(),
-          name: "eService 001",
+          name: "eservice 001",
           descriptors: [descriptor],
         };
         const authData: AuthData = {

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -3829,7 +3829,7 @@ describe("database test", async () => {
       });
 
       it("should include eservices with no descriptors (requester is the producer, admin)", async () => {
-        const eService7: EService = {
+        const eservice7: EService = {
           ...mockEService,
           id: generateId(),
           name: "eservice 007",
@@ -3840,7 +3840,7 @@ describe("database test", async () => {
           ...getMockAuthData(organizationId1),
           userRoles: [userRoles.ADMIN_ROLE],
         };
-        await addOneEService(eService7, postgresDB, eservices);
+        await addOneEService(eservice7, postgresDB, eservices);
         const result = await catalogService.getEServices(
           authData,
           {
@@ -3861,11 +3861,11 @@ describe("database test", async () => {
           eservice4,
           eservice5,
           eservice6,
-          eService7,
+          eservice7,
         ]);
       });
       it("should not include eservices with no descriptors (requester is the producer, not admin nor api)", async () => {
-        const eService7: EService = {
+        const eservice7: EService = {
           ...mockEService,
           id: generateId(),
           name: "eservice 007",
@@ -3876,7 +3876,7 @@ describe("database test", async () => {
           ...getMockAuthData(organizationId1),
           userRoles: [userRoles.SUPPORT_ROLE],
         };
-        await addOneEService(eService7, postgresDB, eservices);
+        await addOneEService(eservice7, postgresDB, eservices);
         const result = await catalogService.getEServices(
           authData,
           {
@@ -3900,7 +3900,7 @@ describe("database test", async () => {
         ]);
       });
       it("should not include eservices with no descriptors (requester is not the producer)", async () => {
-        const eService7: EService = {
+        const eservice7: EService = {
           ...mockEService,
           id: generateId(),
           producerId: organizationId1,
@@ -3911,7 +3911,7 @@ describe("database test", async () => {
           ...getMockAuthData(),
           userRoles: [userRoles.ADMIN_ROLE],
         };
-        await addOneEService(eService7, postgresDB, eservices);
+        await addOneEService(eservice7, postgresDB, eservices);
         const result = await catalogService.getEServices(
           authData,
           {
@@ -3940,7 +3940,7 @@ describe("database test", async () => {
           id: generateId(),
           state: descriptorState.draft,
         };
-        const eService8: EService = {
+        const eservice8: EService = {
           ...mockEService,
           id: generateId(),
           name: "eservice 008",
@@ -3951,7 +3951,7 @@ describe("database test", async () => {
           ...getMockAuthData(organizationId1),
           userRoles: [userRoles.ADMIN_ROLE],
         };
-        await addOneEService(eService8, postgresDB, eservices);
+        await addOneEService(eservice8, postgresDB, eservices);
         const result = await catalogService.getEServices(
           authData,
           {
@@ -3972,7 +3972,7 @@ describe("database test", async () => {
           eservice4,
           eservice5,
           eservice6,
-          eService8,
+          eservice8,
         ]);
       });
       it("should not include eservices whose only descriptor is draft (requester is the producer, not admin nor api)", async () => {
@@ -3981,7 +3981,7 @@ describe("database test", async () => {
           id: generateId(),
           state: descriptorState.draft,
         };
-        const eService8: EService = {
+        const eservice8: EService = {
           ...mockEService,
           id: generateId(),
           name: "eservice 008",
@@ -3992,7 +3992,7 @@ describe("database test", async () => {
           ...getMockAuthData(organizationId1),
           userRoles: [userRoles.SUPPORT_ROLE],
         };
-        await addOneEService(eService8, postgresDB, eservices);
+        await addOneEService(eservice8, postgresDB, eservices);
         const result = await catalogService.getEServices(
           authData,
           {
@@ -4021,7 +4021,7 @@ describe("database test", async () => {
           id: generateId(),
           state: descriptorState.draft,
         };
-        const eService8: EService = {
+        const eservice8: EService = {
           ...mockEService,
           id: generateId(),
           name: "eservice 008",
@@ -4032,7 +4032,7 @@ describe("database test", async () => {
           ...getMockAuthData(),
           userRoles: [userRoles.ADMIN_ROLE],
         };
-        await addOneEService(eService8, postgresDB, eservices);
+        await addOneEService(eservice8, postgresDB, eservices);
         const result = await catalogService.getEServices(
           authData,
           {

--- a/packages/catalog-process/test/utils.ts
+++ b/packages/catalog-process/test/utils.ts
@@ -32,20 +32,20 @@ import { EServiceDescriptorSeed } from "../src/model/domain/models.js";
 import { ApiEServiceDescriptorDocumentSeed } from "../src/model/types.js";
 
 export const writeEServiceInEventstore = async (
-  eService: EService,
+  eservice: EService,
   postgresDB: IDatabase<unknown>
 ): Promise<void> => {
-  const eServiceEvent: EServiceEvent = {
+  const eserviceEvent: EServiceEvent = {
     type: "EServiceAdded",
     event_version: 2,
-    data: { eservice: toEServiceV2(eService) },
+    data: { eservice: toEServiceV2(eservice) },
   };
   const eventToWrite = {
-    stream_id: eServiceEvent.data.eservice?.id,
+    stream_id: eserviceEvent.data.eservice?.id,
     version: 0,
-    type: eServiceEvent.type,
-    event_version: eServiceEvent.event_version,
-    data: Buffer.from(catalogEventToBinaryData(eServiceEvent)),
+    type: eserviceEvent.type,
+    event_version: eserviceEvent.event_version,
+    data: Buffer.from(catalogEventToBinaryData(eserviceEvent)),
   };
 
   await postgresDB.none(
@@ -61,11 +61,11 @@ export const writeEServiceInEventstore = async (
 };
 
 export const writeEServiceInReadmodel = async (
-  eService: EService,
+  eservice: EService,
   eservices: EServiceCollection
 ): Promise<void> => {
   await eservices.insertOne({
-    data: eService,
+    data: eservice,
     metadata: {
       version: 0,
     },
@@ -136,8 +136,8 @@ export const buildDescriptorSeed = (
 
 export const getMockEService = (): EService => ({
   id: generateId(),
-  name: "eService name",
-  description: "eService description",
+  name: "eservice name",
+  description: "eservice description",
   createdAt: new Date(),
   producerId: generateId(),
   technology: technology.rest,
@@ -245,12 +245,12 @@ export const getMockAgreement = ({
 });
 
 export const addOneEService = async (
-  eService: EService,
+  eservice: EService,
   postgresDB: IDatabase<unknown>,
   eservices: EServiceCollection
 ): Promise<void> => {
-  await writeEServiceInEventstore(eService, postgresDB);
-  await writeEServiceInReadmodel(eService, eservices);
+  await writeEServiceInEventstore(eservice, postgresDB);
+  await writeEServiceInReadmodel(eservice, eservices);
 };
 
 export const addOneAttribute = async (

--- a/packages/catalog-readmodel-writer/src/consumerServiceV1.ts
+++ b/packages/catalog-readmodel-writer/src/consumerServiceV1.ts
@@ -20,8 +20,8 @@ export async function handleMessageV1(
         },
         {
           $setOnInsert: {
-            data: msg.data.eService
-              ? fromEServiceV1(msg.data.eService)
+            data: msg.data.eservice
+              ? fromEServiceV1(msg.data.eservice)
               : undefined,
             metadata: {
               version: msg.version,
@@ -38,8 +38,8 @@ export async function handleMessageV1(
           { "data.id": msg.stream_id },
           {
             $setOnInsert: {
-              data: msg.data.eService
-                ? fromEServiceV1(msg.data.eService)
+              data: msg.data.eservice
+                ? fromEServiceV1(msg.data.eservice)
                 : undefined,
               metadata: { version: msg.version },
             },
@@ -57,8 +57,8 @@ export async function handleMessageV1(
           },
           {
             $set: {
-              data: msg.data.eService
-                ? fromEServiceV1(msg.data.eService)
+              data: msg.data.eservice
+                ? fromEServiceV1(msg.data.eservice)
                 : undefined,
               metadata: {
                 version: msg.version,
@@ -302,8 +302,8 @@ export async function handleMessageV1(
           {
             $set: {
               "metadata.version": msg.version,
-              data: msg.data.eService
-                ? fromEServiceV1(msg.data.eService)
+              data: msg.data.eservice
+                ? fromEServiceV1(msg.data.eservice)
                 : undefined,
             },
           }

--- a/packages/catalog-readmodel-writer/src/consumerServiceV1.ts
+++ b/packages/catalog-readmodel-writer/src/consumerServiceV1.ts
@@ -259,8 +259,8 @@ export async function handleMessageV1(
               "metadata.version": msg.version,
             },
             $push: {
-              "data.descriptors": msg.data.eServiceDescriptor
-                ? fromDescriptorV1(msg.data.eServiceDescriptor)
+              "data.descriptors": msg.data.eserviceDescriptor
+                ? fromDescriptorV1(msg.data.eserviceDescriptor)
                 : undefined,
             },
           }
@@ -277,15 +277,15 @@ export async function handleMessageV1(
           {
             $set: {
               "metadata.version": msg.version,
-              "data.descriptors.$[descriptor]": msg.data.eServiceDescriptor
-                ? fromDescriptorV1(msg.data.eServiceDescriptor)
+              "data.descriptors.$[descriptor]": msg.data.eserviceDescriptor
+                ? fromDescriptorV1(msg.data.eserviceDescriptor)
                 : undefined,
             },
           },
           {
             arrayFilters: [
               {
-                "descriptor.id": msg.data.eServiceDescriptor?.id,
+                "descriptor.id": msg.data.eserviceDescriptor?.id,
               },
             ],
           }

--- a/packages/catalog-readmodel-writer/test/catalog-readmodel-writer.integration.test.ts
+++ b/packages/catalog-readmodel-writer/test/catalog-readmodel-writer.integration.test.ts
@@ -43,10 +43,10 @@ describe("database test", async () => {
   });
 
   describe("Handle message for eservice creation", () => {
-    it("should create an eService", async () => {
+    it("should create an eservice", async () => {
       const id = generateId();
       const newEService: EServiceAddedV1 = {
-        eService: {
+        eservice: {
           id,
           producerId: generateId(),
           name: "name",
@@ -73,10 +73,10 @@ describe("database test", async () => {
       });
 
       expect(eservice?.data).toMatchObject({
-        id: newEService.eService?.id,
-        producerId: newEService.eService?.producerId,
-        name: newEService.eService?.name,
-        description: newEService.eService?.description,
+        id: newEService.eservice?.id,
+        producerId: newEService.eservice?.producerId,
+        name: newEService.eservice?.name,
+        description: newEService.eservice?.description,
       });
     });
   });

--- a/packages/models/proto/v1/eservice/events.proto
+++ b/packages/models/proto/v1/eservice/events.proto
@@ -49,12 +49,12 @@ message EServiceDocumentDeletedV1 {
 
 message EServiceDescriptorAddedV1 {
   required string eserviceId = 1;
-  required EServiceDescriptorV1 EServiceDescriptor = 2;
+  required EServiceDescriptorV1 eserviceDescriptor = 2;
 }
 
 message EServiceDescriptorUpdatedV1 {
   required string eserviceId = 1;
-  required EServiceDescriptorV1 EServiceDescriptor = 2;
+  required EServiceDescriptorV1 eserviceDescriptor = 2;
 }
 
 message MovedAttributesFromEserviceToDescriptorsV1 {

--- a/packages/models/proto/v1/eservice/events.proto
+++ b/packages/models/proto/v1/eservice/events.proto
@@ -5,24 +5,24 @@ package eservice;
 import "v1/eservice/eservice.proto";
 
 message EServiceAddedV1 {
-  required EServiceV1 eService = 1;
+  required EServiceV1 eservice = 1;
 }
 
 message ClonedEServiceAddedV1 {
-  required EServiceV1 eService = 1;
+  required EServiceV1 eservice = 1;
 }
 
 message EServiceUpdatedV1 {
-  required EServiceV1 eService = 1;
+  required EServiceV1 eservice = 1;
 }
 
 message EServiceWithDescriptorsDeletedV1 {
-  required EServiceV1 eService = 1;
+  required EServiceV1 eservice = 1;
   required string descriptorId = 2;
 }
 
 message EServiceDocumentUpdatedV1 {
-  required string eServiceId = 1;
+  required string eserviceId = 1;
   required string descriptorId = 2;
   required string documentId = 3;
   required EServiceDocumentV1 updatedDocument = 4;
@@ -30,11 +30,11 @@ message EServiceDocumentUpdatedV1 {
 }
 
 message EServiceDeletedV1 {
-  required string eServiceId = 1;
+  required string eserviceId = 1;
 }
 
 message EServiceDocumentAddedV1 {
-  required string eServiceId = 1;
+  required string eserviceId = 1;
   required string descriptorId = 2;
   required EServiceDocumentV1 document = 3;
   required bool isInterface = 4;
@@ -42,21 +42,21 @@ message EServiceDocumentAddedV1 {
 }
 
 message EServiceDocumentDeletedV1 {
-  required string eServiceId = 1;
+  required string eserviceId = 1;
   required string descriptorId = 2;
   required string documentId = 3;
 }
 
 message EServiceDescriptorAddedV1 {
-  required string eServiceId = 1;
+  required string eserviceId = 1;
   required EServiceDescriptorV1 EServiceDescriptor = 2;
 }
 
 message EServiceDescriptorUpdatedV1 {
-  required string eServiceId = 1;
+  required string eserviceId = 1;
   required EServiceDescriptorV1 EServiceDescriptor = 2;
 }
 
 message MovedAttributesFromEserviceToDescriptorsV1 {
-  required EServiceV1 eService = 1;
+  required EServiceV1 eservice = 1;
 }

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -80,7 +80,7 @@ export type Agreement = z.infer<typeof Agreement>;
 export const PDFPayload = z.object({
   today: z.date(),
   agreementId: AgreementId,
-  eService: z.string(),
+  eservice: z.string(),
   producerName: z.string(),
   producerOrigin: z.string(),
   producerIPACode: z.string(),


### PR DESCRIPTION
This super low-priority PR renames every occurrence of `eService` into `eservice`.

I also renamed the field in the protobuf message, it shouldn't be a problem because protobuf internally uses the index and not the field name.

Some renaming are not included in this PR (primary error codes and some function names that should be changed) and will be changed in a future PR.