### PR TITLE
IMN-294 Refactor logic functions in attribute-registry-process

### DIFF
--- a/packages/attribute-registry-process/open-api/attribute-registry-service-spec.yml
+++ b/packages/attribute-registry-process/open-api/attribute-registry-service-spec.yml
@@ -41,7 +41,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResourceId'
+                $ref: '#/components/schemas/Attribute'
         '400':
           description: Bad Request
           content:
@@ -82,7 +82,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResourceId'
+                $ref: '#/components/schemas/Attribute'
         '400':
           description: Bad Request
           content:
@@ -123,7 +123,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResourceId'
+                $ref: '#/components/schemas/Attribute'
         '400':
           description: Bad Request
           content:
@@ -164,7 +164,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResourceId'
+                $ref: '#/components/schemas/Attribute'
         '400':
           description: Bad Request
           content:
@@ -392,14 +392,6 @@ components:
       schema:
         type: string
   schemas:
-    ResourceId:
-        type: object
-        required:
-          - id
-        properties:
-          id:
-            type: string
-            format: uuid
     Problem:
       properties:
         type:

--- a/packages/attribute-registry-process/src/routers/AttributeRouter.ts
+++ b/packages/attribute-registry-process/src/routers/AttributeRouter.ts
@@ -200,11 +200,12 @@ const attributeRouter = (
       authorizationMiddleware([ADMIN_ROLE, API_ROLE, M2M_ROLE]),
       async (req, res) => {
         try {
-          const id = await attributeRegistryService.createCertifiedAttribute(
-            req.body,
-            req.ctx.authData
-          );
-          return res.status(200).json({ id }).end();
+          const attribute =
+            await attributeRegistryService.createCertifiedAttribute(
+              req.body,
+              req.ctx.authData
+            );
+          return res.status(200).json(toApiAttribute(attribute)).end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -219,11 +220,12 @@ const attributeRouter = (
       authorizationMiddleware([ADMIN_ROLE, API_ROLE, M2M_ROLE]),
       async (req, res) => {
         try {
-          const id = await attributeRegistryService.createDeclaredAttribute(
-            req.body,
-            req.ctx.authData
-          );
-          return res.status(200).json({ id }).end();
+          const attribute =
+            await attributeRegistryService.createDeclaredAttribute(
+              req.body,
+              req.ctx.authData
+            );
+          return res.status(200).json(toApiAttribute(attribute)).end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -238,11 +240,12 @@ const attributeRouter = (
       authorizationMiddleware([ADMIN_ROLE, API_ROLE, M2M_ROLE]),
       async (req, res) => {
         try {
-          const id = await attributeRegistryService.createVerifiedAttribute(
-            req.body,
-            req.ctx.authData
-          );
-          return res.status(200).json({ id }).end();
+          const attribute =
+            await attributeRegistryService.createVerifiedAttribute(
+              req.body,
+              req.ctx.authData
+            );
+          return res.status(200).json(toApiAttribute(attribute)).end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -257,11 +260,11 @@ const attributeRouter = (
       authorizationMiddleware([INTERNAL_ROLE]),
       async (req, res) => {
         try {
-          const id =
+          const attribute =
             await attributeRegistryService.createInternalCertifiedAttribute(
               req.body
             );
-          return res.status(200).json({ id }).end();
+          return res.status(200).json(toApiAttribute(attribute)).end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/attribute-registry-process/src/services/attributeRegistryService.ts
+++ b/packages/attribute-registry-process/src/services/attributeRegistryService.ts
@@ -1,19 +1,11 @@
+import { AuthData, DB, eventRepository, logger } from "pagopa-interop-commons";
 import {
-  AuthData,
-  CreateEvent,
-  DB,
-  eventRepository,
-  logger,
-} from "pagopa-interop-commons";
-import {
-  AttributeEvent,
   Attribute,
   WithMetadata,
   attributeEventToBinaryData,
   attributeKind,
   generateId,
   TenantId,
-  unsafeBrandId,
   AttributeId,
   AttributeKind,
   ListResult,
@@ -42,112 +34,6 @@ export function attributeRegistryServiceBuilder(
   const repository = eventRepository(dbInstance, attributeEventToBinaryData);
 
   return {
-    async createDeclaredAttribute(
-      apiDeclaredAttributeSeed: ApiDeclaredAttributeSeed,
-      authData: AuthData
-    ): Promise<AttributeId> {
-      logger.info(
-        `Creating declared attribute with name ${apiDeclaredAttributeSeed.name}}`
-      );
-      if (authData.externalId.origin !== "IPA") {
-        throw originNotCompliant("IPA");
-      }
-
-      return unsafeBrandId<AttributeId>(
-        await repository.createEvent(
-          createDeclaredAttributeLogic({
-            attribute: await readModelService.getAttributeByName(
-              apiDeclaredAttributeSeed.name
-            ),
-            apiDeclaredAttributeSeed,
-          })
-        )
-      );
-    },
-
-    async createVerifiedAttribute(
-      apiVerifiedAttributeSeed: ApiVerifiedAttributeSeed,
-      authData: AuthData
-    ): Promise<AttributeId> {
-      logger.info(
-        `Creating verified attribute with name ${apiVerifiedAttributeSeed.name}`
-      );
-      if (authData.externalId.origin !== "IPA") {
-        throw originNotCompliant("IPA");
-      }
-
-      return unsafeBrandId<AttributeId>(
-        await repository.createEvent(
-          createVerifiedAttributeLogic({
-            attribute: await readModelService.getAttributeByName(
-              apiVerifiedAttributeSeed.name
-            ),
-            apiVerifiedAttributeSeed,
-          })
-        )
-      );
-    },
-    async getCertifierId(tenantId: TenantId): Promise<string> {
-      const tenant = await readModelService.getTenantById(tenantId);
-      if (!tenant) {
-        throw tenantNotFound(tenantId);
-      }
-
-      const certifier = tenant.data.features
-        .filter(({ type }) => type === "Certifier")
-        .find(({ certifierId }) => certifierId.trim().length > 0);
-
-      if (certifier) {
-        return certifier.certifierId;
-      }
-      throw OrganizationIsNotACertifier(tenantId);
-    },
-    async createCertifiedAttribute(
-      apiCertifiedAttributeSeed: ApiCertifiedAttributeSeed,
-      authData: AuthData
-    ): Promise<AttributeId> {
-      logger.info(
-        `Creating certified attribute with code ${apiCertifiedAttributeSeed.code}`
-      );
-      const certifierPromise = this.getCertifierId(authData.organizationId);
-      const attributePromise = readModelService.getAttributeByCodeAndName(
-        apiCertifiedAttributeSeed.code,
-        apiCertifiedAttributeSeed.name
-      );
-
-      const [certifier, attribute] = await Promise.all([
-        certifierPromise,
-        attributePromise,
-      ]);
-
-      return unsafeBrandId<AttributeId>(
-        await repository.createEvent(
-          createCertifiedAttributeLogic({
-            attribute,
-            apiCertifiedAttributeSeed,
-            certifier,
-          })
-        )
-      );
-    },
-    async createInternalCertifiedAttribute(
-      apiInternalCertifiedAttributeSeed: ApiInternalCertifiedAttributeSeed
-    ): Promise<AttributeId> {
-      logger.info(
-        `Creating certified attribute with origin ${apiInternalCertifiedAttributeSeed.origin} and code ${apiInternalCertifiedAttributeSeed.code} - Internal Request`
-      );
-      return unsafeBrandId<AttributeId>(
-        await repository.createEvent(
-          createInternalCertifiedAttributeLogic({
-            attribute: await readModelService.getAttributeByCodeAndName(
-              apiInternalCertifiedAttributeSeed.code,
-              apiInternalCertifiedAttributeSeed.name
-            ),
-            apiInternalCertifiedAttributeSeed,
-          })
-        )
-      );
-    },
     async getAttributesByKindsNameOrigin({
       kinds,
       name,
@@ -172,6 +58,7 @@ export function attributeRegistryServiceBuilder(
         limit,
       });
     },
+
     async getAttributeByName(name: string): Promise<WithMetadata<Attribute>> {
       logger.info(`Retrieving attribute with name ${name}`);
       const attribute = await readModelService.getAttributeByName(name);
@@ -180,6 +67,7 @@ export function attributeRegistryServiceBuilder(
       }
       return attribute;
     },
+
     async getAttributeByOriginAndCode({
       origin,
       code,
@@ -197,6 +85,7 @@ export function attributeRegistryServiceBuilder(
       }
       return attribute;
     },
+
     async getAttributeById(id: AttributeId): Promise<WithMetadata<Attribute>> {
       logger.info(`Retrieving attribute with ID ${id}`);
       const attribute = await readModelService.getAttributeById(id);
@@ -205,6 +94,7 @@ export function attributeRegistryServiceBuilder(
       }
       return attribute;
     },
+
     async getAttributesByIds({
       ids,
       offset,
@@ -217,115 +107,185 @@ export function attributeRegistryServiceBuilder(
       logger.info(`Retrieving attributes in bulk by id in [${ids}]`);
       return await readModelService.getAttributesByIds({ ids, offset, limit });
     },
+
+    async createDeclaredAttribute(
+      apiDeclaredAttributeSeed: ApiDeclaredAttributeSeed,
+      authData: AuthData
+    ): Promise<Attribute> {
+      logger.info(
+        `Creating declared attribute with name ${apiDeclaredAttributeSeed.name}}`
+      );
+      if (authData.externalId.origin !== "IPA") {
+        throw originNotCompliant("IPA");
+      }
+
+      const attributeWithSameName = await readModelService.getAttributeByName(
+        apiDeclaredAttributeSeed.name
+      );
+      if (attributeWithSameName) {
+        throw attributeDuplicate(apiDeclaredAttributeSeed.name);
+      }
+
+      const newDeclaredAttribute: Attribute = {
+        id: generateId(),
+        kind: attributeKind.declared,
+        name: apiDeclaredAttributeSeed.name,
+        description: apiDeclaredAttributeSeed.description,
+        creationTime: new Date(),
+        code: undefined,
+        origin: undefined,
+      };
+
+      logger.info(
+        `Declared attribute created with id ${newDeclaredAttribute.id}`
+      );
+
+      const event = toCreateEventAttributeAdded(newDeclaredAttribute);
+      await repository.createEvent(event);
+
+      return newDeclaredAttribute;
+    },
+
+    async createVerifiedAttribute(
+      apiVerifiedAttributeSeed: ApiVerifiedAttributeSeed,
+      authData: AuthData
+    ): Promise<Attribute> {
+      logger.info(
+        `Creating verified attribute with name ${apiVerifiedAttributeSeed.name}`
+      );
+      if (authData.externalId.origin !== "IPA") {
+        throw originNotCompliant("IPA");
+      }
+
+      const attributeWithSameName = await readModelService.getAttributeByName(
+        apiVerifiedAttributeSeed.name
+      );
+      if (attributeWithSameName) {
+        throw attributeDuplicate(apiVerifiedAttributeSeed.name);
+      }
+
+      const newVerifiedAttribute: Attribute = {
+        id: generateId(),
+        kind: attributeKind.verified,
+        name: apiVerifiedAttributeSeed.name,
+        description: apiVerifiedAttributeSeed.description,
+        creationTime: new Date(),
+        code: undefined,
+        origin: undefined,
+      };
+
+      logger.info(
+        `Verified attribute created with id ${newVerifiedAttribute.id}`
+      );
+
+      const event = toCreateEventAttributeAdded(newVerifiedAttribute);
+      await repository.createEvent(event);
+
+      return newVerifiedAttribute;
+    },
+
+    async createCertifiedAttribute(
+      apiCertifiedAttributeSeed: ApiCertifiedAttributeSeed,
+      authData: AuthData
+    ): Promise<Attribute> {
+      logger.info(
+        `Creating certified attribute with code ${apiCertifiedAttributeSeed.code}`
+      );
+      const certifierPromise = getCertifierId(
+        authData.organizationId,
+        readModelService
+      );
+      const attributePromise = readModelService.getAttributeByCodeAndName(
+        apiCertifiedAttributeSeed.code,
+        apiCertifiedAttributeSeed.name
+      );
+
+      const [certifier, attributeWithSameName] = await Promise.all([
+        certifierPromise,
+        attributePromise,
+      ]);
+
+      if (attributeWithSameName) {
+        throw attributeDuplicate(apiCertifiedAttributeSeed.name);
+      }
+
+      const newCertifiedAttribute: Attribute = {
+        id: generateId(),
+        kind: attributeKind.certified,
+        name: apiCertifiedAttributeSeed.name,
+        description: apiCertifiedAttributeSeed.description,
+        creationTime: new Date(),
+        code: apiCertifiedAttributeSeed.code,
+        origin: certifier,
+      };
+
+      logger.info(
+        `Certified attribute created with id ${newCertifiedAttribute.id}`
+      );
+
+      const event = toCreateEventAttributeAdded(newCertifiedAttribute);
+      await repository.createEvent(event);
+
+      return newCertifiedAttribute;
+    },
+
+    async createInternalCertifiedAttribute(
+      apiInternalCertifiedAttributeSeed: ApiInternalCertifiedAttributeSeed
+    ): Promise<Attribute> {
+      logger.info(
+        `Creating certified attribute with origin ${apiInternalCertifiedAttributeSeed.origin} and code ${apiInternalCertifiedAttributeSeed.code} - Internal Request`
+      );
+
+      const attributeWithSameNameAndCode =
+        await readModelService.getAttributeByCodeAndName(
+          apiInternalCertifiedAttributeSeed.code,
+          apiInternalCertifiedAttributeSeed.name
+        );
+      if (attributeWithSameNameAndCode) {
+        throw attributeDuplicate(apiInternalCertifiedAttributeSeed.name);
+      }
+
+      const newInternalCertifiedAttribute: Attribute = {
+        id: generateId(),
+        kind: attributeKind.certified,
+        name: apiInternalCertifiedAttributeSeed.name,
+        description: apiInternalCertifiedAttributeSeed.description,
+        creationTime: new Date(),
+        code: apiInternalCertifiedAttributeSeed.code,
+        origin: apiInternalCertifiedAttributeSeed.origin,
+      };
+
+      logger.info(
+        `Certified attribute created with id ${newInternalCertifiedAttribute.id} - Internal Request`
+      );
+
+      const event = toCreateEventAttributeAdded(newInternalCertifiedAttribute);
+      await repository.createEvent(event);
+
+      return newInternalCertifiedAttribute;
+    },
   };
+}
+
+async function getCertifierId(
+  tenantId: TenantId,
+  readModelService: ReadModelService
+): Promise<string> {
+  const tenant = await readModelService.getTenantById(tenantId);
+  if (!tenant) {
+    throw tenantNotFound(tenantId);
+  }
+
+  const certifier = tenant.data.features
+    .filter(({ type }) => type === "Certifier")
+    .find(({ certifierId }) => certifierId.trim().length > 0);
+
+  if (certifier) {
+    return certifier.certifierId;
+  }
+  throw OrganizationIsNotACertifier(tenantId);
 }
 
 export type AttributeRegistryService = ReturnType<
   typeof attributeRegistryServiceBuilder
 >;
-
-export function createDeclaredAttributeLogic({
-  attribute,
-  apiDeclaredAttributeSeed,
-}: {
-  attribute: WithMetadata<Attribute> | undefined;
-  apiDeclaredAttributeSeed: ApiDeclaredAttributeSeed;
-}): CreateEvent<AttributeEvent> {
-  if (attribute) {
-    throw attributeDuplicate(apiDeclaredAttributeSeed.name);
-  }
-
-  const newDeclaredAttribute: Attribute = {
-    id: generateId(),
-    kind: attributeKind.declared,
-    name: apiDeclaredAttributeSeed.name,
-    description: apiDeclaredAttributeSeed.description,
-    creationTime: new Date(),
-    code: undefined,
-    origin: undefined,
-  };
-
-  logger.info(`Declared attribute created with id ${newDeclaredAttribute.id}`);
-  return toCreateEventAttributeAdded(newDeclaredAttribute);
-}
-
-export function createVerifiedAttributeLogic({
-  attribute,
-  apiVerifiedAttributeSeed,
-}: {
-  attribute: WithMetadata<Attribute> | undefined;
-  apiVerifiedAttributeSeed: ApiVerifiedAttributeSeed;
-}): CreateEvent<AttributeEvent> {
-  if (attribute) {
-    throw attributeDuplicate(apiVerifiedAttributeSeed.name);
-  }
-
-  const newVerifiedAttribute: Attribute = {
-    id: generateId(),
-    kind: attributeKind.verified,
-    name: apiVerifiedAttributeSeed.name,
-    description: apiVerifiedAttributeSeed.description,
-    creationTime: new Date(),
-    code: undefined,
-    origin: undefined,
-  };
-
-  logger.info(`Verified attribute created with id ${newVerifiedAttribute.id}`);
-  return toCreateEventAttributeAdded(newVerifiedAttribute);
-}
-
-export function createCertifiedAttributeLogic({
-  attribute,
-  apiCertifiedAttributeSeed,
-  certifier,
-}: {
-  attribute: WithMetadata<Attribute> | undefined;
-  apiCertifiedAttributeSeed: ApiCertifiedAttributeSeed;
-  certifier: string;
-}): CreateEvent<AttributeEvent> {
-  if (attribute) {
-    throw attributeDuplicate(apiCertifiedAttributeSeed.name);
-  }
-
-  const newCertifiedAttribute: Attribute = {
-    id: generateId(),
-    kind: attributeKind.certified,
-    name: apiCertifiedAttributeSeed.name,
-    description: apiCertifiedAttributeSeed.description,
-    creationTime: new Date(),
-    code: apiCertifiedAttributeSeed.code,
-    origin: certifier,
-  };
-
-  logger.info(
-    `Certified attribute created with id ${newCertifiedAttribute.id}`
-  );
-  return toCreateEventAttributeAdded(newCertifiedAttribute);
-}
-
-export function createInternalCertifiedAttributeLogic({
-  attribute,
-  apiInternalCertifiedAttributeSeed,
-}: {
-  attribute: WithMetadata<Attribute> | undefined;
-  apiInternalCertifiedAttributeSeed: ApiInternalCertifiedAttributeSeed;
-}): CreateEvent<AttributeEvent> {
-  if (attribute) {
-    throw attributeDuplicate(apiInternalCertifiedAttributeSeed.name);
-  }
-
-  const newInternalCertifiedAttribute: Attribute = {
-    id: generateId(),
-    kind: attributeKind.certified,
-    name: apiInternalCertifiedAttributeSeed.name,
-    description: apiInternalCertifiedAttributeSeed.description,
-    creationTime: new Date(),
-    code: apiInternalCertifiedAttributeSeed.code,
-    origin: apiInternalCertifiedAttributeSeed.origin,
-  };
-
-  logger.info(
-    `Certified attribute created with id ${newInternalCertifiedAttribute.id} - Internal Request`
-  );
-  return toCreateEventAttributeAdded(newInternalCertifiedAttribute);
-}


### PR DESCRIPTION
[To be merged after #237]

This pull request is for refactoring the logic functions in `attribute-registry-process`, as it has been done in `catalog-process`.
The payload returned by the endpoints has been adjusted to be the same as the Scala implementation.