### PR TITLE
IMN-176 Fix events v2 in catalog-process

### DIFF
--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -302,6 +302,25 @@ export const toCreateEventEServiceDraftDescriptorUpdated = (
   },
 });
 
+export const toCreateEventEServiceDescriptorUpdated = (
+  streamId: string,
+  version: number,
+  descriptorId: DescriptorId,
+  eservice: EService
+  // eslint-disable-next-line sonarjs/no-identical-functions
+): CreateEvent<EServiceEvent> => ({
+  streamId,
+  version,
+  event: {
+    type: "EServiceDescriptorUpdated",
+    event_version: 2,
+    data: {
+      descriptorId,
+      eservice: toEServiceV2(eservice),
+    },
+  },
+});
+
 export const toCreateEventEServiceDescriptorActivated = (
   streamId: string,
   version: number,

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -141,7 +141,7 @@ export const toCreateEventClonedEServiceAdded = (
     data: {
       sourceDescriptorId,
       sourceEservice: toEServiceV2(sourceEservice),
-      clonedEservice: toEServiceV2(clonedEservice),
+      eservice: toEServiceV2(clonedEservice),
     },
   },
 });

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -307,7 +307,6 @@ export const toCreateEventEServiceDescriptorUpdated = (
   version: number,
   descriptorId: DescriptorId,
   eservice: EService
-  // eslint-disable-next-line sonarjs/no-identical-functions
 ): CreateEvent<EServiceEvent> => ({
   streamId,
   version,

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -302,7 +302,7 @@ export const toCreateEventEServiceDraftDescriptorUpdated = (
   },
 });
 
-export const toCreateEventEServiceDescriptorUpdated = (
+export const toCreateEventEServiceDescriptorQuotasUpdated = (
   streamId: string,
   version: number,
   descriptorId: DescriptorId,
@@ -311,7 +311,7 @@ export const toCreateEventEServiceDescriptorUpdated = (
   streamId,
   version,
   event: {
-    type: "EServiceDescriptorUpdated",
+    type: "EServiceDescriptorQuotasUpdated",
     event_version: 2,
     data: {
       descriptorId,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -44,12 +44,15 @@ import {
   toCreateEventEServiceDeleted,
   toCreateEventEServiceDescriptorActivated,
   toCreateEventEServiceDescriptorAdded,
+  toCreateEventEServiceDescriptorArchived,
   toCreateEventEServiceDescriptorDeleted,
   toCreateEventEServiceDescriptorPublished,
   toCreateEventEServiceDescriptorSuspended,
+  toCreateEventEServiceDescriptorUpdated,
   toCreateEventEServiceDocumentAdded,
   toCreateEventEServiceDocumentDeleted,
   toCreateEventEServiceDocumentUpdated,
+  toCreateEventEServiceDraftDescriptorUpdated,
   toCreateEventEServiceInterfaceAdded,
   toCreateEventEServiceInterfaceDeleted,
   toCreateEventEServiceInterfaceUpdated,
@@ -859,9 +862,10 @@ export function catalogServiceBuilder(
         updatedDescriptor
       );
 
-      const event = toCreateEventEServiceUpdated(
+      const event = toCreateEventEServiceDraftDescriptorUpdated(
         eserviceId,
         eservice.metadata.version,
+        descriptorId,
         updatedEService
       );
       await repository.createEvent(event);
@@ -1199,7 +1203,7 @@ export function catalogServiceBuilder(
 
       const newEservice = replaceDescriptor(eservice.data, updatedDescriptor);
 
-      const event = toCreateEventEServiceDescriptorActivated(
+      const event = toCreateEventEServiceDescriptorArchived(
         eserviceId,
         eservice.metadata.version,
         descriptorId,
@@ -1251,9 +1255,10 @@ export function catalogServiceBuilder(
         updatedDescriptor
       );
 
-      const event = toCreateEventEServiceUpdated(
+      const event = toCreateEventEServiceDescriptorUpdated(
         eserviceId,
         eservice.metadata.version,
+        descriptorId,
         updatedEService
       );
       await repository.createEvent(event);

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -49,8 +49,8 @@ import {
   toCreateEventEServiceDescriptorArchived,
   toCreateEventEServiceDescriptorDeleted,
   toCreateEventEServiceDescriptorPublished,
+  toCreateEventEServiceDescriptorQuotasUpdated,
   toCreateEventEServiceDescriptorSuspended,
-  toCreateEventEServiceDescriptorUpdated,
   toCreateEventEServiceDocumentAdded,
   toCreateEventEServiceDocumentDeleted,
   toCreateEventEServiceDocumentUpdated,
@@ -1271,7 +1271,7 @@ export function catalogServiceBuilder(
         updatedDescriptor
       );
 
-      const event = toCreateEventEServiceDescriptorUpdated(
+      const event = toCreateEventEServiceDescriptorQuotasUpdated(
         eserviceId,
         eservice.metadata.version,
         descriptorId,

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -2256,57 +2256,51 @@ describe("database test", async () => {
         const expectedInterface: Document = {
           ...interfaceDocument,
           id: unsafeBrandId(
-            writtenPayload.clonedEservice!.descriptors[0].interface!.id
+            writtenPayload.eservice!.descriptors[0].interface!.id
           ),
           uploadDate: new Date(
-            writtenPayload.clonedEservice!.descriptors[0].interface!.uploadDate
+            writtenPayload.eservice!.descriptors[0].interface!.uploadDate
           ),
-          path: writtenPayload.clonedEservice!.descriptors[0].interface!.path,
+          path: writtenPayload.eservice!.descriptors[0].interface!.path,
         };
         const expectedDocument1: Document = {
           ...document1,
-          id: unsafeBrandId(
-            writtenPayload.clonedEservice!.descriptors[0].docs[0].id
-          ),
+          id: unsafeBrandId(writtenPayload.eservice!.descriptors[0].docs[0].id),
           uploadDate: new Date(
-            writtenPayload.clonedEservice!.descriptors[0].docs[0].uploadDate
+            writtenPayload.eservice!.descriptors[0].docs[0].uploadDate
           ),
-          path: writtenPayload.clonedEservice!.descriptors[0].docs[0].path,
+          path: writtenPayload.eservice!.descriptors[0].docs[0].path,
         };
         const expectedDocument2: Document = {
           ...document2,
-          id: unsafeBrandId(
-            writtenPayload.clonedEservice!.descriptors[0].docs[1].id
-          ),
+          id: unsafeBrandId(writtenPayload.eservice!.descriptors[0].docs[1].id),
           uploadDate: new Date(
-            writtenPayload.clonedEservice!.descriptors[0].docs[1].uploadDate
+            writtenPayload.eservice!.descriptors[0].docs[1].uploadDate
           ),
-          path: writtenPayload.clonedEservice!.descriptors[0].docs[1].path,
+          path: writtenPayload.eservice!.descriptors[0].docs[1].path,
         };
 
         const expectedDescriptor: Descriptor = {
           ...descriptor,
-          id: unsafeBrandId(writtenPayload.clonedEservice!.descriptors[0].id),
+          id: unsafeBrandId(writtenPayload.eservice!.descriptors[0].id),
           version: "1",
           interface: expectedInterface,
           createdAt: new Date(
-            Number(writtenPayload.clonedEservice?.descriptors[0].createdAt)
+            Number(writtenPayload.eservice?.descriptors[0].createdAt)
           ),
           docs: [expectedDocument1, expectedDocument2],
         };
 
         const expectedEService: EService = {
           ...eservice,
-          id: unsafeBrandId(writtenPayload.clonedEservice!.id),
+          id: unsafeBrandId(writtenPayload.eservice!.id),
           name: `${eservice.name} - clone - ${formatClonedEServiceDate(
             cloneTimestamp
           )}`,
           descriptors: [expectedDescriptor],
-          createdAt: new Date(Number(writtenPayload.clonedEservice?.createdAt)),
+          createdAt: new Date(Number(writtenPayload.eservice?.createdAt)),
         };
-        expect(writtenPayload.clonedEservice).toEqual(
-          toEServiceV2(expectedEService)
-        );
+        expect(writtenPayload.eservice).toEqual(toEServiceV2(expectedEService));
 
         expect(fileManager.copy).toHaveBeenCalledWith(
           config.s3Bucket,

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -43,6 +43,8 @@ import {
   EServiceDescriptorInterfaceDeletedV2,
   EServiceDescriptorPublishedV2,
   EServiceDescriptorSuspendedV2,
+  EServiceDescriptorUpdatedV2,
+  EServiceDraftDescriptorUpdatedV2,
   EServiceId,
   Tenant,
   TenantId,
@@ -878,10 +880,10 @@ describe("database test", async () => {
         );
         expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
-        expect(writtenEvent.type).toBe("DraftEServiceUpdated");
+        expect(writtenEvent.type).toBe("EServiceDraftDescriptorUpdated");
         expect(writtenEvent.event_version).toBe(2);
         const writtenPayload = decodeProtobufPayload({
-          messageType: DraftEServiceUpdatedV2,
+          messageType: EServiceDraftDescriptorUpdatedV2,
           payload: writtenEvent.data,
         });
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
@@ -2296,7 +2298,7 @@ describe("database test", async () => {
         );
         expect(writtenEvent.stream_id).toBe(eservice.id);
         expect(writtenEvent.version).toBe("1");
-        expect(writtenEvent.type).toBe("EServiceDescriptorActivated");
+        expect(writtenEvent.type).toBe("EServiceDescriptorArchived");
         expect(writtenEvent.event_version).toBe(2);
         const writtenPayload = decodeProtobufPayload({
           messageType: EServiceDescriptorActivatedV2,
@@ -2412,11 +2414,11 @@ describe("database test", async () => {
         expect(writtenEvent).toMatchObject({
           stream_id: eservice.id,
           version: "1",
-          type: "DraftEServiceUpdated",
+          type: "EServiceDescriptorUpdated",
           event_version: 2,
         });
         const writtenPayload = decodeProtobufPayload({
-          messageType: DraftEServiceUpdatedV2,
+          messageType: EServiceDescriptorUpdatedV2,
           payload: writtenEvent.data,
         });
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
@@ -2467,11 +2469,11 @@ describe("database test", async () => {
         expect(writtenEvent).toMatchObject({
           stream_id: eservice.id,
           version: "1",
-          type: "DraftEServiceUpdated",
+          type: "EServiceDescriptorUpdated",
           event_version: 2,
         });
         const writtenPayload = decodeProtobufPayload({
-          messageType: DraftEServiceUpdatedV2,
+          messageType: EServiceDescriptorUpdatedV2,
           payload: writtenEvent.data,
         });
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
@@ -2522,11 +2524,11 @@ describe("database test", async () => {
         expect(writtenEvent).toMatchObject({
           stream_id: eservice.id,
           version: "1",
-          type: "DraftEServiceUpdated",
+          type: "EServiceDescriptorUpdated",
           event_version: 2,
         });
         const writtenPayload = decodeProtobufPayload({
-          messageType: DraftEServiceUpdatedV2,
+          messageType: EServiceDescriptorUpdatedV2,
           payload: writtenEvent.data,
         });
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -42,8 +42,8 @@ import {
   EServiceDescriptorDocumentUpdatedV2,
   EServiceDescriptorInterfaceDeletedV2,
   EServiceDescriptorPublishedV2,
+  EServiceDescriptorQuotasUpdatedV2,
   EServiceDescriptorSuspendedV2,
-  EServiceDescriptorUpdatedV2,
   EServiceDraftDescriptorUpdatedV2,
   EServiceId,
   Tenant,
@@ -2578,11 +2578,11 @@ describe("database test", async () => {
         expect(writtenEvent).toMatchObject({
           stream_id: eservice.id,
           version: "1",
-          type: "EServiceDescriptorUpdated",
+          type: "EServiceDescriptorQuotasUpdated",
           event_version: 2,
         });
         const writtenPayload = decodeProtobufPayload({
-          messageType: EServiceDescriptorUpdatedV2,
+          messageType: EServiceDescriptorQuotasUpdatedV2,
           payload: writtenEvent.data,
         });
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
@@ -2633,11 +2633,11 @@ describe("database test", async () => {
         expect(writtenEvent).toMatchObject({
           stream_id: eservice.id,
           version: "1",
-          type: "EServiceDescriptorUpdated",
+          type: "EServiceDescriptorQuotasUpdated",
           event_version: 2,
         });
         const writtenPayload = decodeProtobufPayload({
-          messageType: EServiceDescriptorUpdatedV2,
+          messageType: EServiceDescriptorQuotasUpdatedV2,
           payload: writtenEvent.data,
         });
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
@@ -2688,11 +2688,11 @@ describe("database test", async () => {
         expect(writtenEvent).toMatchObject({
           stream_id: eservice.id,
           version: "1",
-          type: "EServiceDescriptorUpdated",
+          type: "EServiceDescriptorQuotasUpdated",
           event_version: 2,
         });
         const writtenPayload = decodeProtobufPayload({
-          messageType: EServiceDescriptorUpdatedV2,
+          messageType: EServiceDescriptorQuotasUpdatedV2,
           payload: writtenEvent.data,
         });
         expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -990,7 +990,7 @@ describe("database test", async () => {
         expect(writtenEvent).toMatchObject({
           stream_id: eservice.id,
           version: "1",
-          type: "DraftEServiceUpdated",
+          type: "EServiceDraftDescriptorUpdated",
           event_version: 2,
         });
         const writtenPayload = decodeProtobufPayload({

--- a/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
+++ b/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
@@ -26,6 +26,7 @@ export async function handleMessageV2(
       { type: "EServiceCloned" },
       { type: "EServiceDescriptorAdded" },
       { type: "EServiceDraftDescriptorUpdated" },
+      { type: "EServiceDescriptorUpdated" },
       { type: "EServiceDescriptorActivated" },
       { type: "EServiceDescriptorArchived" },
       { type: "EServiceDescriptorPublished" },

--- a/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
+++ b/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
@@ -24,7 +24,7 @@ export async function handleMessageV2(
       { type: "EServiceCloned" },
       { type: "EServiceDescriptorAdded" },
       { type: "EServiceDraftDescriptorUpdated" },
-      { type: "EServiceDescriptorUpdated" },
+      { type: "EServiceDescriptorQuotasUpdated" },
       { type: "EServiceDescriptorActivated" },
       { type: "EServiceDescriptorArchived" },
       { type: "EServiceDescriptorPublished" },

--- a/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
+++ b/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
@@ -9,9 +9,7 @@ export async function handleMessageV2(
 ): Promise<void> {
   logger.info(message);
 
-  const eservice = match(message)
-    .with({ type: "EServiceCloned" }, (msg) => msg.data.clonedEservice)
-    .otherwise((msg) => msg.data.eservice);
+  const eservice = message.data.eservice;
 
   await match(message)
     .with({ type: "EServiceDeleted" }, async (message) => {

--- a/packages/models/proto/v2/eservice/events.proto
+++ b/packages/models/proto/v2/eservice/events.proto
@@ -33,7 +33,7 @@ message EServiceDraftDescriptorUpdatedV2 {
   EServiceV2 eservice = 2;
 }
 
-message EServiceDescriptorUpdatedV2 {
+message EServiceDescriptorQuotasUpdatedV2 {
   string descriptorId = 1;
   EServiceV2 eservice = 2;
 }

--- a/packages/models/proto/v2/eservice/events.proto
+++ b/packages/models/proto/v2/eservice/events.proto
@@ -33,6 +33,11 @@ message EServiceDraftDescriptorUpdatedV2 {
   EServiceV2 eservice = 2;
 }
 
+message EServiceDescriptorUpdatedV2 {
+  string descriptorId = 1;
+  EServiceV2 eservice = 2;
+}
+
 message EServiceDescriptorActivatedV2 {
   string descriptorId = 1;
   EServiceV2 eservice = 2;

--- a/packages/models/proto/v2/eservice/events.proto
+++ b/packages/models/proto/v2/eservice/events.proto
@@ -20,7 +20,7 @@ message EServiceDeletedV2 {
 message EServiceClonedV2 {
   EServiceV2 sourceEservice = 1;
   string sourceDescriptorId = 2;
-  EServiceV2 clonedEservice = 3;
+  EServiceV2 eservice = 3;
 }
 
 message EServiceDescriptorAddedV2 {

--- a/packages/models/src/eservice/eserviceEvents.ts
+++ b/packages/models/src/eservice/eserviceEvents.ts
@@ -32,6 +32,7 @@ import {
   EServiceDescriptorPublishedV2,
   EServiceDescriptorSuspendedV2,
   EServiceDraftDescriptorUpdatedV2,
+  EServiceDescriptorUpdatedV2,
 } from "../gen/v2/eservice/events.js";
 
 export function catalogEventToBinaryData(event: EServiceEvent): Uint8Array {
@@ -98,6 +99,9 @@ export function catalogEventToBinaryDataV2(event: EServiceEventV2): Uint8Array {
     )
     .with({ type: "EServiceDraftDescriptorUpdated" }, ({ data }) =>
       EServiceDraftDescriptorUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceDescriptorUpdated" }, ({ data }) =>
+      EServiceDescriptorUpdatedV2.toBinary(data)
     )
     .with({ type: "EServiceDescriptorActivated" }, ({ data }) =>
       EServiceDescriptorActivatedV2.toBinary(data)
@@ -223,6 +227,11 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
   z.object({
     event_version: z.literal(2),
     type: z.literal("EServiceDraftDescriptorUpdated"),
+    data: protobufDecoder(EServiceDraftDescriptorUpdatedV2),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorUpdated"),
     data: protobufDecoder(EServiceDraftDescriptorUpdatedV2),
   }),
   z.object({

--- a/packages/models/src/eservice/eserviceEvents.ts
+++ b/packages/models/src/eservice/eserviceEvents.ts
@@ -32,7 +32,7 @@ import {
   EServiceDescriptorPublishedV2,
   EServiceDescriptorSuspendedV2,
   EServiceDraftDescriptorUpdatedV2,
-  EServiceDescriptorUpdatedV2,
+  EServiceDescriptorQuotasUpdatedV2,
 } from "../gen/v2/eservice/events.js";
 
 export function catalogEventToBinaryData(event: EServiceEvent): Uint8Array {
@@ -100,8 +100,8 @@ export function catalogEventToBinaryDataV2(event: EServiceEventV2): Uint8Array {
     .with({ type: "EServiceDraftDescriptorUpdated" }, ({ data }) =>
       EServiceDraftDescriptorUpdatedV2.toBinary(data)
     )
-    .with({ type: "EServiceDescriptorUpdated" }, ({ data }) =>
-      EServiceDescriptorUpdatedV2.toBinary(data)
+    .with({ type: "EServiceDescriptorQuotasUpdated" }, ({ data }) =>
+      EServiceDescriptorQuotasUpdatedV2.toBinary(data)
     )
     .with({ type: "EServiceDescriptorActivated" }, ({ data }) =>
       EServiceDescriptorActivatedV2.toBinary(data)
@@ -231,7 +231,7 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceDescriptorUpdated"),
+    type: z.literal("EServiceDescriptorQuotasUpdated"),
     data: protobufDecoder(EServiceDraftDescriptorUpdatedV2),
   }),
   z.object({


### PR DESCRIPTION
This pull request is for adding minor changes related to events v2:
- the `archiveDescription` operation was generating an `EServiceDescriptorActivated` event. This bug was unintendedly added [here](https://github.com/pagopa/interop-be-monorepo/pull/207/files#diff-77a5bad1f3b877e7bfc968a9b423c16649fca358d54286d743fe34fa555564ceR1516)
- the `updateDraftDescriptor` operation was generating a `DraftEServiceUpdated` event, even though we do have an `EServiceDraftDescriptorUpdated` event
- the `updateDescriptor` operation was generating a `DraftEServiceUpdated` event, so I added a new `EServiceDescriptorQuotasUpdated` event. I forgot to add the event during the implementation of that new endpoint [here](https://github.com/pagopa/interop-be-monorepo/pull/216/files#diff-77a5bad1f3b877e7bfc968a9b423c16649fca358d54286d743fe34fa555564ceR1433).
- [IMN-329] the `clonedEservice` field in `EServiceClonedV2` has been renamed to eservice, to avoid a custom parser in `catalog-readmodel-writer`

[IMN-329]: https://pagopa.atlassian.net/browse/IMN-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ