### PR TITLE
IMN 250 - add Risk Analysis update endpoint in catalog process

### DIFF
--- a/packages/catalog-process/open-api/catalog-service-spec.yml
+++ b/packages/catalog-process/open-api/catalog-service-spec.yml
@@ -923,6 +923,59 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
+/eservices/{eServiceId}/riskAnalysis/{riskAnalysisId}:
+  parameters:
+    - $ref: "#/components/parameters/CorrelationIdHeader"
+  post:
+    security:
+      - bearerAuth: []
+    tags:
+      - process
+    summary: Update an e-service risk analysis
+    operationId: updateRiskAnalysis
+    parameters:
+      - name: eServiceId
+        in: path
+        description: the eservice id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: riskAnalysisId
+        in: path
+        description: the eservice id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    requestBody:
+      description: A payload containing the risk analysis to update
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EServiceRiskAnalysisSeed"
+    responses:
+      "204":
+        description: EService Risk Analysis updated.
+      "403":
+        description: Forbidden
+        content:
+          application/problem+json:
+            schema:
+              $ref: "#/components/schemas/Problem"
+      "404":
+        description: EService not found
+        content:
+          application/problem+json:
+            schema:
+              $ref: "#/components/schemas/Problem"
+      "400":
+        description: Bad request
+        content:
+          application/problem+json:
+            schema:
+              $ref: "#/components/schemas/Problem"
   /status:
     get:
       security: []

--- a/packages/catalog-process/open-api/catalog-service-spec.yml
+++ b/packages/catalog-process/open-api/catalog-service-spec.yml
@@ -923,59 +923,59 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
-/eservices/{eServiceId}/riskAnalysis/{riskAnalysisId}:
-  parameters:
-    - $ref: "#/components/parameters/CorrelationIdHeader"
-  post:
-    security:
-      - bearerAuth: []
-    tags:
-      - process
-    summary: Update an e-service risk analysis
-    operationId: updateRiskAnalysis
+  /eservices/{eServiceId}/riskAnalysis/{riskAnalysisId}:
     parameters:
-      - name: eServiceId
-        in: path
-        description: the eservice id
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: riskAnalysisId
-        in: path
-        description: the eservice id
-        required: true
-        schema:
-          type: string
-          format: uuid
-    requestBody:
-      description: A payload containing the risk analysis to update
-      required: true
-      content:
-        application/json:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - process
+      summary: Update an e-service risk analysis
+      operationId: updateRiskAnalysis
+      parameters:
+        - name: eServiceId
+          in: path
+          description: the eservice id
+          required: true
           schema:
-            $ref: "#/components/schemas/EServiceRiskAnalysisSeed"
-    responses:
-      "204":
-        description: EService Risk Analysis updated.
-      "403":
-        description: Forbidden
+            type: string
+            format: uuid
+        - name: riskAnalysisId
+          in: path
+          description: the eservice id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: A payload containing the risk analysis to update
+        required: true
         content:
-          application/problem+json:
+          application/json:
             schema:
-              $ref: "#/components/schemas/Problem"
-      "404":
-        description: EService not found
-        content:
-          application/problem+json:
-            schema:
-              $ref: "#/components/schemas/Problem"
-      "400":
-        description: Bad request
-        content:
-          application/problem+json:
-            schema:
-              $ref: "#/components/schemas/Problem"
+              $ref: "#/components/schemas/EServiceRiskAnalysisSeed"
+      responses:
+        "204":
+          description: EService Risk Analysis created.
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: EService not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /status:
     get:
       security: []

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -25,6 +25,7 @@ export const errorCodes = {
   tenantNotFound: "0014",
   tenantKindNotFound: "0015",
   riskAnalysisValidationFailed: "0016",
+  eServiceRiskAnalysisNotFound: "0017",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -190,5 +191,16 @@ export function riskAnalysisValidationFailed(
       .join(", ")}]`,
     code: "riskAnalysisValidationFailed",
     title: "Risk analysis validation failed",
+  });
+}
+
+export function eServiceRiskAnalysisNotFound(
+  eserviceId: EServiceId,
+  riskAnalysisId: string
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Risk Analysis ${riskAnalysisId} not found for EService ${eserviceId}`,
+    code: "eServiceRiskAnalysisNotFound",
+    title: "Risk analysis not found",
   });
 }

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -3,6 +3,7 @@ import {
   DescriptorId,
   EServiceDocumentId,
   EServiceId,
+  RiskAnalysisId,
   TenantId,
   makeApiProblemBuilder,
 } from "pagopa-interop-models";
@@ -196,7 +197,7 @@ export function riskAnalysisValidationFailed(
 
 export function eServiceRiskAnalysisNotFound(
   eserviceId: EServiceId,
-  riskAnalysisId: string
+  riskAnalysisId: RiskAnalysisId
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Risk Analysis ${riskAnalysisId} not found for EService ${eserviceId}`,

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -496,3 +496,21 @@ export const toCreateEventEServiceRiskAnalysisAdded = (
     },
   },
 });
+
+export const toCreateEventEServiceRiskAnalysisUpdated = (
+  streamId: string,
+  version: number,
+  riskAnalysisId: RiskAnalysisId,
+  eservice: EService
+): CreateEvent<EServiceEvent> => ({
+  streamId,
+  version,
+  event: {
+    type: "EServiceRiskAnalysisUpdated",
+    event_version: 2,
+    data: {
+      riskAnalysisId,
+      eservice: toEServiceV2(eservice),
+    },
+  },
+});

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -19,7 +19,7 @@ import {
   EServiceDocumentId,
   EServiceMode,
   RiskAnalysis,
-  EServiceRiskAnalysisV1,
+  EServiceRiskAnalysisV2,
   EServiceModeV2,
   RiskAnalysisId,
 } from "pagopa-interop-models";
@@ -103,7 +103,7 @@ export const toDescriptorV2 = (input: Descriptor): EServiceDescriptorV2 => ({
 
 export const toRiskAnalysisV2 = (
   input: RiskAnalysis
-): EServiceRiskAnalysisV1 => ({
+): EServiceRiskAnalysisV2 => ({
   ...input,
   createdAt: BigInt(input.createdAt.getTime()),
 });

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -48,6 +48,7 @@ import {
   updateDescriptorErrorMapper,
   updateDraftDescriptorErrorMapper,
   updateEServiceErrorMapper,
+  updateRiskAnalysisErrorMapper,
 } from "../utilities/errorMappers.js";
 
 const readModelService = readModelServiceBuilder(
@@ -532,6 +533,25 @@ const eservicesRouter = (
           return res.status(204).end();
         } catch (error) {
           const errorRes = makeApiProblem(error, createRiskAnalysisErrorMapper);
+          return res.status(errorRes.status).json(errorRes).end();
+        }
+      }
+    )
+    .post(
+      "/eservices/:eServiceId/riskAnalysis/:riskAnalysisId",
+      authorizationMiddleware([ADMIN_ROLE, API_ROLE]),
+
+      async (req, res) => {
+        try {
+          await catalogService.updateRiskAnalysis(
+            unsafeBrandId(req.params.eServiceId),
+            unsafeBrandId(req.params.riskAnalysisId),
+            req.body,
+            req.ctx.authData
+          );
+          return res.status(204).end();
+        } catch (error) {
+          const errorRes = makeApiProblem(error, updateRiskAnalysisErrorMapper);
           return res.status(errorRes.status).json(errorRes).end();
         }
       }

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1314,6 +1314,18 @@ export function catalogServiceBuilder(
 
       await repository.createEvent(event);
     },
+    async updateRiskAnalysis(
+      eserviceId: EServiceId,
+      riskAnalysisId: RiskAnalysis["id"],
+      _eserviceRiskAnalysisSeed: EServiceRiskAnalysisSeed,
+      _authData: AuthData
+    ): Promise<void> {
+      logger.info(
+        `Updating Risk Analysis ${riskAnalysisId} for EService ${eserviceId}`
+      );
+
+      // TODO unmock
+    },
   };
 }
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -6,6 +6,7 @@ import {
   hasPermission,
   logger,
   riskAnalysisValidatedFormToNewRiskAnalysis,
+  riskAnalysisValidatedFormToNewRiskAnalysisForm,
   userRoles,
 } from "pagopa-interop-commons";
 import {
@@ -28,6 +29,7 @@ import {
   EserviceAttributes,
   Tenant,
   RiskAnalysis,
+  RiskAnalysisId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import {
@@ -62,6 +64,7 @@ import {
   toCreateEventEServiceInterfaceDeleted,
   toCreateEventEServiceInterfaceUpdated,
   toCreateEventEServiceRiskAnalysisAdded,
+  toCreateEventEServiceRiskAnalysisUpdated,
   toCreateEventEServiceUpdated,
 } from "../model/domain/toEvent.js";
 import {
@@ -84,6 +87,7 @@ import {
   inconsistentDailyCalls,
   originNotCompliant,
   tenantNotFound,
+  eServiceRiskAnalysisNotFound,
 } from "../model/domain/errors.js";
 import { formatClonedEServiceDate } from "../utilities/date.js";
 import { ReadModelService } from "./readModelService.js";
@@ -145,6 +149,21 @@ const retrieveTenant = async (
     throw tenantNotFound(tenantId);
   }
   return tenant;
+};
+
+const retrieveRiskAnalysis = (
+  riskAnalysisId: RiskAnalysisId,
+  eservice: WithMetadata<EService>
+): RiskAnalysis => {
+  const riskAnalysis = eservice.data.riskAnalysis.find(
+    (ra: RiskAnalysis) => ra.id === riskAnalysisId
+  );
+
+  if (riskAnalysis === undefined) {
+    throw eServiceRiskAnalysisNotFound(eservice.data.id, riskAnalysisId);
+  }
+
+  return riskAnalysis;
 };
 
 const updateDescriptorState = (
@@ -228,6 +247,20 @@ const replaceDescriptor = (
   return {
     ...eservice,
     descriptors: updatedDescriptors,
+  };
+};
+
+const replaceRiskAnalysis = (
+  eservice: EService,
+  newRiskAnalysis: RiskAnalysis
+): EService => {
+  const updatedRiskAnalysis = eservice.riskAnalysis.map((ra: RiskAnalysis) =>
+    ra.id === newRiskAnalysis.id ? newRiskAnalysis : ra
+  );
+
+  return {
+    ...eservice,
+    riskAnalysis: updatedRiskAnalysis,
   };
 };
 
@@ -1317,14 +1350,57 @@ export function catalogServiceBuilder(
     async updateRiskAnalysis(
       eserviceId: EServiceId,
       riskAnalysisId: RiskAnalysis["id"],
-      _eserviceRiskAnalysisSeed: EServiceRiskAnalysisSeed,
-      _authData: AuthData
+      eserviceRiskAnalysisSeed: EServiceRiskAnalysisSeed,
+      authData: AuthData
     ): Promise<void> {
       logger.info(
         `Updating Risk Analysis ${riskAnalysisId} for EService ${eserviceId}`
       );
 
-      // TODO unmock
+      const eservice = await retrieveEService(eserviceId, readModelService);
+
+      assertRequesterAllowed(eservice.data.producerId, authData.organizationId);
+      assertIsDraftEservice(eservice.data);
+      assertIsReceiveEservice(eservice.data);
+
+      const tenant = await retrieveTenant(
+        authData.organizationId,
+        readModelService
+      );
+      assertTenantKindExists(tenant.data);
+
+      const riskAnalysisToUpdate = retrieveRiskAnalysis(
+        riskAnalysisId,
+        eservice
+      );
+
+      const validatedRiskAnalysisForm = validateRiskAnalysisOrThrow(
+        eserviceRiskAnalysisSeed.riskAnalysisForm,
+        true,
+        tenant.data.kind
+      );
+
+      const updatedRiskAnalysis: RiskAnalysis = {
+        ...riskAnalysisToUpdate,
+        name: eserviceRiskAnalysisSeed.name,
+        riskAnalysisForm: riskAnalysisValidatedFormToNewRiskAnalysisForm(
+          validatedRiskAnalysisForm
+        ),
+      };
+
+      const newEservice = replaceRiskAnalysis(
+        eservice.data,
+        updatedRiskAnalysis
+      );
+
+      const event = toCreateEventEServiceRiskAnalysisUpdated(
+        eservice.data.id,
+        eservice.metadata.version,
+        updatedRiskAnalysis.id,
+        newEservice
+      );
+
+      await repository.createEvent(event);
     },
   };
 }

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -226,3 +226,21 @@ export const createRiskAnalysisErrorMapper = (
     )
     .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const updateRiskAnalysisErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "eServiceNotFound",
+      "eServiceRiskAnalysisNotFound",
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with(
+      "eserviceNotInDraftState",
+      "eserviceNotInReceiveMode",
+      "riskAnalysisValidationFailed",
+      () => HTTP_STATUS_BAD_REQUEST
+    )
+    .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -4379,7 +4379,7 @@ describe("database test", async () => {
           )
         ).rejects.toThrowError(
           riskAnalysisValidationFailed([
-            unexpectedFieldValue(
+            unexpectedFieldValueError(
               "purpose",
               new Set(["INSTITUTIONAL", "OTHER"])
             ),

--- a/packages/catalog-readmodel-writer/src/consumerServiceV1.ts
+++ b/packages/catalog-readmodel-writer/src/consumerServiceV1.ts
@@ -77,6 +77,7 @@ export async function handleMessageV1(
       { type: "EServiceUpdated" },
       { type: "EServiceRiskAnalysisAdded" },
       { type: "MovedAttributesFromEserviceToDescriptors" },
+      { type: "EServiceRiskAnalysisUpdated" },
       async (msg) =>
         await eservices.updateOne(
           {

--- a/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
+++ b/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
@@ -38,6 +38,7 @@ export async function handleMessageV2(
       { type: "EServiceDescriptorInterfaceDeleted" },
       { type: "EServiceDescriptorDocumentDeleted" },
       { type: "EServiceRiskAnalysisAdded" },
+      { type: "EServiceRiskAnalysisUpdated" },
       async (message) =>
         await eservices.updateOne(
           {

--- a/packages/commons/src/risk-analysis/models.ts
+++ b/packages/commons/src/risk-analysis/models.ts
@@ -1,5 +1,6 @@
 import {
   RiskAnalysis,
+  RiskAnalysisForm,
   RiskAnalysisFormId,
   RiskAnalysisId,
   RiskAnalysisMultiAnswerId,
@@ -75,17 +76,24 @@ export function riskAnalysisValidatedFormToNewRiskAnalysis(
     id: generateId<RiskAnalysisId>(),
     name,
     createdAt: new Date(),
-    riskAnalysisForm: {
-      id: generateId<RiskAnalysisFormId>(),
-      version: validatedForm.version,
-      singleAnswers: validatedForm.singleAnswers.map((a) => ({
-        ...a,
-        id: generateId<RiskAnalysisSingleAnswerId>(),
-      })),
-      multiAnswers: validatedForm.multiAnswers.map((a) => ({
-        ...a,
-        id: generateId<RiskAnalysisMultiAnswerId>(),
-      })),
-    },
+    riskAnalysisForm:
+      riskAnalysisValidatedFormToNewRiskAnalysisForm(validatedForm),
+  };
+}
+
+export function riskAnalysisValidatedFormToNewRiskAnalysisForm(
+  validatedForm: RiskAnalysisValidatedForm
+): RiskAnalysisForm {
+  return {
+    id: generateId<RiskAnalysisFormId>(),
+    version: validatedForm.version,
+    singleAnswers: validatedForm.singleAnswers.map((a) => ({
+      ...a,
+      id: generateId<RiskAnalysisSingleAnswerId>(),
+    })),
+    multiAnswers: validatedForm.multiAnswers.map((a) => ({
+      ...a,
+      id: generateId<RiskAnalysisMultiAnswerId>(),
+    })),
   };
 }

--- a/packages/models/proto/v1/eservice/events.proto
+++ b/packages/models/proto/v1/eservice/events.proto
@@ -65,3 +65,8 @@ message EServiceRiskAnalysisAddedV1 {
   required EServiceV1 eservice = 1;
   required string riskAnalysisId = 2;
 }
+
+message EServiceRiskAnalysisUpdatedV1 {
+  required EServiceV1 eservice = 1;
+  required string riskAnalysisId = 2;
+}

--- a/packages/models/proto/v2/eservice/events.proto
+++ b/packages/models/proto/v2/eservice/events.proto
@@ -103,3 +103,8 @@ message EServiceRiskAnalysisAddedV2 {
   string riskAnalysisId = 1;
   EServiceV2 eservice = 2;
 }
+
+message EServiceRiskAnalysisUpdatedV2 {
+  string riskAnalysisId = 1;
+  EServiceV2 eservice = 2;
+}

--- a/packages/models/src/eservice/eserviceEvents.ts
+++ b/packages/models/src/eservice/eserviceEvents.ts
@@ -10,6 +10,7 @@ import {
   EServiceDocumentDeletedV1,
   EServiceDocumentUpdatedV1,
   EServiceRiskAnalysisAddedV1,
+  EServiceRiskAnalysisUpdatedV1,
   EServiceUpdatedV1,
   EServiceWithDescriptorsDeletedV1,
   MovedAttributesFromEserviceToDescriptorsV1,
@@ -35,6 +36,7 @@ import {
   EServiceDraftDescriptorUpdatedV2,
   EServiceRiskAnalysisAddedV2,
   EServiceDescriptorQuotasUpdatedV2,
+  EServiceRiskAnalysisUpdatedV2,
 } from "../gen/v2/eservice/events.js";
 
 export function catalogEventToBinaryData(event: EServiceEvent): Uint8Array {
@@ -81,6 +83,9 @@ export function catalogEventToBinaryDataV1(event: EServiceEventV1): Uint8Array {
     )
     .with({ type: "EServiceRiskAnalysisAdded" }, ({ data }) =>
       EServiceRiskAnalysisAddedV1.toBinary(data)
+    )
+    .with({ type: "EServiceRiskAnalysisUpdated" }, ({ data }) =>
+      EServiceRiskAnalysisUpdatedV1.toBinary(data)
     )
     .exhaustive();
 }
@@ -143,6 +148,9 @@ export function catalogEventToBinaryDataV2(event: EServiceEventV2): Uint8Array {
     )
     .with({ type: "EServiceRiskAnalysisAdded" }, ({ data }) =>
       EServiceRiskAnalysisAddedV2.toBinary(data)
+    )
+    .with({ type: "EServiceRiskAnalysisUpdated" }, ({ data }) =>
+      EServiceRiskAnalysisUpdatedV2.toBinary(data)
     )
     .exhaustive();
 }
@@ -207,6 +215,11 @@ export const EServiceEventV1 = z.discriminatedUnion("type", [
     event_version: z.literal(1),
     type: z.literal("EServiceRiskAnalysisAdded"),
     data: protobufDecoder(EServiceRiskAnalysisAddedV1),
+  }),
+  z.object({
+    event_version: z.literal(1),
+    type: z.literal("EServiceRiskAnalysisUpdated"),
+    data: protobufDecoder(EServiceRiskAnalysisUpdatedV1),
   }),
 ]);
 export type EServiceEventV1 = z.infer<typeof EServiceEventV1>;
@@ -306,6 +319,11 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("EServiceRiskAnalysisAdded"),
     data: protobufDecoder(EServiceRiskAnalysisAddedV2),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceRiskAnalysisUpdated"),
+    data: protobufDecoder(EServiceRiskAnalysisUpdatedV2),
   }),
 ]);
 export type EServiceEventV2 = z.infer<typeof EServiceEventV2>;


### PR DESCRIPTION
Closes [IMN-250](https://pagopa.atlassian.net/browse/IMN-250)

# Tests

## Automated tests ✅ 

<img width="613" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/31735d78-2fbe-43ad-9722-3afde5448b1e">

## Manual tests - failure case

<img width="1232" alt="Screenshot 2024-03-06 at 16 34 35" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/c834ffc3-7ade-43e8-8909-1291a209981e">

## Manual tests - success case

### 1) Before

<img width="874" alt="Screenshot 2024-03-06 at 16 33 13" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/15acb512-22a2-410c-ac32-501993cb0475">

### 2) Update call

<img width="1231" alt="Screenshot 2024-03-06 at 16 35 03" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/9a4f21e3-6ebc-4023-bc4a-8ef037f527c4">

### 3) After

<img width="695" alt="Screenshot 2024-03-06 at 16 33 51" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/4aac8881-11e6-4f94-8da8-07bb4f41c159">


[IMN-250]: https://pagopa.atlassian.net/browse/IMN-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ