### PR TITLE
IMN-312 Fix descriptors versions numbering in catalog-process

### DIFF
--- a/packages/catalog-process/src/utilities/versionGenerator.ts
+++ b/packages/catalog-process/src/utilities/versionGenerator.ts
@@ -14,7 +14,7 @@ export const nextDescriptorVersion = (eservice: EService): string => {
     }
 
     return currentVersionNumber.data > max ? currentVersionNumber.data : max;
-  }, 1);
+  }, 0);
 
   return (currentVersion + 1).toString();
 };

--- a/packages/catalog-process/src/utilities/versionGenerator.ts
+++ b/packages/catalog-process/src/utilities/versionGenerator.ts
@@ -16,5 +16,5 @@ export const nextDescriptorVersion = (eservice: EService): string => {
     return currentVersionNumber.data > max ? currentVersionNumber.data : max;
   }, 1);
 
-  return currentVersion.toString();
+  return (currentVersion + 1).toString();
 };

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -727,8 +727,10 @@ describe("database test", async () => {
           ],
         });
 
-        expect(writtenPayload.descriptorId).toEqual(newDescriptorId);
-        expect(writtenPayload.eservice).toEqual(expectedEservice);
+        expect(writtenPayload).toEqual({
+          descriptorId: newDescriptorId,
+          eservice: expectedEservice,
+        });
       });
 
       it("should write on event-store for the creation of a descriptor (eservice already had one descriptor)", async () => {
@@ -804,8 +806,10 @@ describe("database test", async () => {
           descriptors: [...eservice.descriptors, newDescriptor],
         });
 
-        expect(writtenPayload.descriptorId).toEqual(newDescriptorId);
-        expect(writtenPayload.eservice).toEqual(expectedEservice);
+        expect(writtenPayload).toEqual({
+          descriptorId: newDescriptorId,
+          eservice: expectedEservice,
+        });
       });
 
       it("should throw draftDescriptorAlreadyExists if a draft descriptor already exists", async () => {

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -63,7 +63,6 @@ import {
   postgreSQLContainer,
 } from "pagopa-interop-commons-test";
 import { StartedTestContainer } from "testcontainers";
-import { E } from "vitest/dist/types-198fd1d9.js";
 import { config } from "../src/utilities/config.js";
 import { toEServiceV2 } from "../src/model/domain/toEvent.js";
 import {

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -693,10 +693,12 @@ describe("database test", async () => {
           eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(eservice.id);
-        expect(writtenEvent.version).toBe("1");
-        expect(writtenEvent.type).toBe("EServiceDescriptorAdded");
-        expect(writtenEvent.event_version).toBe(2);
+        expect(writtenEvent).toMatchObject({
+          stream_id: eservice.id,
+          version: "1",
+          type: "EServiceDescriptorAdded",
+          event_version: 2,
+        });
         const writtenPayload = decodeProtobufPayload({
           messageType: EServiceDescriptorAddedV2,
           payload: writtenEvent.data,
@@ -768,10 +770,12 @@ describe("database test", async () => {
           eservice.id,
           postgresDB
         );
-        expect(writtenEvent.stream_id).toBe(mockEService.id);
-        expect(writtenEvent.version).toBe("1");
-        expect(writtenEvent.type).toBe("EServiceDescriptorAdded");
-        expect(writtenEvent.event_version).toBe(2);
+        expect(writtenEvent).toMatchObject({
+          stream_id: eservice.id,
+          version: "1",
+          type: "EServiceDescriptorAdded",
+          event_version: 2,
+        });
         const writtenPayload = decodeProtobufPayload({
           messageType: EServiceDescriptorAddedV2,
           payload: writtenEvent.data,

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -749,9 +749,14 @@ describe("database test", async () => {
             verified: [],
           },
         };
+        const descriptor: Descriptor = {
+          ...mockDescriptor,
+          interface: mockDocument,
+          state: descriptorState.published,
+        };
         const eservice: EService = {
           ...mockEService,
-          descriptors: [],
+          descriptors: [descriptor],
         };
         await addOneEService(eservice, postgresDB, eservices);
         await catalogService.createDescriptor(
@@ -776,9 +781,9 @@ describe("database test", async () => {
           ...mockDescriptor,
           version: "2",
           createdAt: new Date(
-            Number(writtenPayload.eservice!.descriptors[0]!.createdAt)
+            Number(writtenPayload.eservice!.descriptors[1]!.createdAt)
           ),
-          id: unsafeBrandId(writtenPayload.eservice!.descriptors[0]!.id),
+          id: unsafeBrandId(writtenPayload.eservice!.descriptors[1]!.id),
           serverUrls: [],
           attributes: {
             certified: [],
@@ -790,12 +795,12 @@ describe("database test", async () => {
         };
 
         const expectedEservice = toEServiceV2({
-          ...mockEService,
+          ...eservice,
           descriptors: [...eservice.descriptors, newDescriptor],
         });
 
         expect(writtenPayload.descriptorId).toEqual(
-          expectedEservice.descriptors[0].id
+          expectedEservice.descriptors[1].id
         );
         expect(writtenPayload.eservice).toEqual(expectedEservice);
       });

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -683,11 +683,13 @@ describe("database test", async () => {
           descriptors: [],
         };
         await addOneEService(eservice, postgresDB, eservices);
-        await catalogService.createDescriptor(
-          eservice.id,
-          descriptorSeed,
-          getMockAuthData(eservice.producerId)
-        );
+        const newDescriptorId = (
+          await catalogService.createDescriptor(
+            eservice.id,
+            descriptorSeed,
+            getMockAuthData(eservice.producerId)
+          )
+        ).id;
         const writtenEvent = await readLastEventByStreamId(
           eservice.id,
           postgresDB
@@ -712,7 +714,7 @@ describe("database test", async () => {
               createdAt: new Date(
                 Number(writtenPayload.eservice!.descriptors[0]!.createdAt)
               ),
-              id: unsafeBrandId(writtenPayload.eservice!.descriptors[0]!.id),
+              id: newDescriptorId,
               serverUrls: [],
               attributes: {
                 certified: [],
@@ -725,9 +727,7 @@ describe("database test", async () => {
           ],
         });
 
-        expect(writtenPayload.descriptorId).toEqual(
-          expectedEservice.descriptors[0].id
-        );
+        expect(writtenPayload.descriptorId).toEqual(newDescriptorId);
         expect(writtenPayload.eservice).toEqual(expectedEservice);
       });
 
@@ -760,11 +760,13 @@ describe("database test", async () => {
           descriptors: [descriptor],
         };
         await addOneEService(eservice, postgresDB, eservices);
-        await catalogService.createDescriptor(
-          eservice.id,
-          descriptorSeed,
-          getMockAuthData(eservice.producerId)
-        );
+        const newDescriptorId = (
+          await catalogService.createDescriptor(
+            eservice.id,
+            descriptorSeed,
+            getMockAuthData(eservice.producerId)
+          )
+        ).id;
         const writtenEvent = await readLastEventByStreamId(
           eservice.id,
           postgresDB
@@ -786,7 +788,7 @@ describe("database test", async () => {
           createdAt: new Date(
             Number(writtenPayload.eservice!.descriptors[1]!.createdAt)
           ),
-          id: unsafeBrandId(writtenPayload.eservice!.descriptors[1]!.id),
+          id: newDescriptorId,
           serverUrls: [],
           attributes: {
             certified: [],
@@ -802,9 +804,7 @@ describe("database test", async () => {
           descriptors: [...eservice.descriptors, newDescriptor],
         });
 
-        expect(writtenPayload.descriptorId).toEqual(
-          expectedEservice.descriptors[1].id
-        );
+        expect(writtenPayload.descriptorId).toEqual(newDescriptorId);
         expect(writtenPayload.eservice).toEqual(expectedEservice);
       });
 


### PR DESCRIPTION
This pull request is for fixing the numbering of new descriptors.

It seems every new descriptor was being numbered `"1"` because of a bug in the version generator.