### PR TITLE
IMN-314 Assign attributes during updateDraftDescriptor in catalog-process

### DIFF
--- a/packages/catalog-process/src/model/domain/models.ts
+++ b/packages/catalog-process/src/model/domain/models.ts
@@ -53,6 +53,8 @@ export type ApiAttribute = z.infer<typeof api.schemas.Attribute>;
 
 export type EServiceDescriptor = z.infer<typeof api.schemas.EServiceDescriptor>;
 
+export type EServiceAttributesSeed = z.infer<typeof api.schemas.AttributesSeed>;
+
 export type UpdateEServiceDescriptorSeed = z.infer<
   typeof api.schemas.UpdateEServiceDescriptorSeed
 >;

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -44,6 +44,7 @@ import {
   publishDescriptorErrorMapper,
   suspendDescriptorErrorMapper,
   updateDescriptorErrorMapper,
+  updateDraftDescriptorErrorMapper,
   updateEServiceErrorMapper,
 } from "../utilities/errorMappers.js";
 
@@ -400,7 +401,10 @@ const eservicesRouter = (
             .json(eServiceToApiEService(updatedEService))
             .end();
         } catch (error) {
-          const errorRes = makeApiProblem(error, updateDescriptorErrorMapper);
+          const errorRes = makeApiProblem(
+            error,
+            updateDraftDescriptorErrorMapper
+          );
           return res.status(errorRes.status).json(errorRes).end();
         }
       }

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -25,6 +25,7 @@ import {
   ListResult,
   AttributeId,
   agreementState,
+  EserviceAttributes,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import {
@@ -37,6 +38,7 @@ import {
   EServiceDescriptorSeed,
   UpdateEServiceDescriptorSeed,
   UpdateEServiceDescriptorQuotasSeed,
+  EServiceAttributesSeed,
 } from "../model/domain/models.js";
 import {
   toCreateEventClonedEServiceAdded,
@@ -220,6 +222,59 @@ const replaceDescriptor = (
     descriptors: updatedDescriptors,
   };
 };
+
+async function parseAndCheckAttributes(
+  attributesSeed: EServiceAttributesSeed,
+  readModelService: ReadModelService
+): Promise<EserviceAttributes> {
+  const certifiedAttributes = attributesSeed.certified;
+  const declaredAttributes = attributesSeed.declared;
+  const verifiedAttributes = attributesSeed.verified;
+
+  const attributesSeeds = [
+    ...certifiedAttributes.flat(),
+    ...declaredAttributes.flat(),
+    ...verifiedAttributes.flat(),
+  ];
+
+  if (attributesSeeds.length > 0) {
+    const attributesSeedsIds: AttributeId[] = attributesSeeds.map((attr) =>
+      unsafeBrandId(attr.id)
+    );
+    const attributes = await readModelService.getAttributesByIds(
+      attributesSeedsIds
+    );
+    const attributesIds = attributes.map((attr) => attr.id);
+    for (const attributeSeedId of attributesSeedsIds) {
+      if (!attributesIds.includes(unsafeBrandId(attributeSeedId))) {
+        throw attributeNotFound(attributeSeedId);
+      }
+    }
+  }
+
+  return {
+    certified: certifiedAttributes.map((a) =>
+      a.map((a) => ({
+        ...a,
+        id: unsafeBrandId(a.id),
+      }))
+    ),
+    // eslint-disable-next-line sonarjs/no-identical-functions
+    declared: declaredAttributes.map((a) =>
+      a.map((a) => ({
+        ...a,
+        id: unsafeBrandId(a.id),
+      }))
+    ),
+    // eslint-disable-next-line sonarjs/no-identical-functions
+    verified: verifiedAttributes.map((a) =>
+      a.map((a) => ({
+        ...a,
+        id: unsafeBrandId(a.id),
+      }))
+    ),
+  };
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function catalogServiceBuilder(
@@ -667,30 +722,10 @@ export function catalogServiceBuilder(
 
       const newVersion = nextDescriptorVersion(eservice.data);
 
-      const certifiedAttributes = eserviceDescriptorSeed.attributes.certified;
-      const declaredAttributes = eserviceDescriptorSeed.attributes.declared;
-      const verifiedAttributes = eserviceDescriptorSeed.attributes.verified;
-
-      const attributesSeeds = [
-        ...certifiedAttributes.flat(),
-        ...declaredAttributes.flat(),
-        ...verifiedAttributes.flat(),
-      ];
-
-      if (attributesSeeds.length > 0) {
-        const attributesSeedsIds: AttributeId[] = attributesSeeds.map((attr) =>
-          unsafeBrandId(attr.id)
-        );
-        const attributes = await readModelService.getAttributesByIds(
-          attributesSeedsIds
-        );
-        const attributesIds = attributes.map((attr) => attr.id);
-        for (const attributeSeedId of attributesSeedsIds) {
-          if (!attributesIds.includes(unsafeBrandId(attributeSeedId))) {
-            throw attributeNotFound(attributeSeedId);
-          }
-        }
-      }
+      const parsedAttributes = await parseAndCheckAttributes(
+        eserviceDescriptorSeed.attributes,
+        readModelService
+      );
 
       if (
         eserviceDescriptorSeed.dailyCallsPerConsumer >
@@ -722,28 +757,7 @@ export function catalogServiceBuilder(
         deprecatedAt: undefined,
         archivedAt: undefined,
         createdAt: new Date(),
-        attributes: {
-          certified: certifiedAttributes.map((a) =>
-            a.map((a) => ({
-              ...a,
-              id: unsafeBrandId(a.id),
-            }))
-          ),
-          // eslint-disable-next-line sonarjs/no-identical-functions
-          declared: declaredAttributes.map((a) =>
-            a.map((a) => ({
-              ...a,
-              id: unsafeBrandId(a.id),
-            }))
-          ),
-          // eslint-disable-next-line sonarjs/no-identical-functions
-          verified: verifiedAttributes.map((a) =>
-            a.map((a) => ({
-              ...a,
-              id: unsafeBrandId(a.id),
-            }))
-          ),
-        },
+        attributes: parsedAttributes,
       };
 
       const newEservice: EService = {

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -853,6 +853,11 @@ export function catalogServiceBuilder(
         throw inconsistentDailyCalls();
       }
 
+      const parsedAttributes = await parseAndCheckAttributes(
+        seed.attributes,
+        readModelService
+      );
+
       const updatedDescriptor: Descriptor = {
         ...descriptor,
         description: seed.description,
@@ -865,6 +870,7 @@ export function catalogServiceBuilder(
           apiAgreementApprovalPolicyToAgreementApprovalPolicy(
             seed.agreementApprovalPolicy
           ),
+        attributes: parsedAttributes,
       };
 
       const updatedEService = replaceDescriptor(

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -113,6 +113,24 @@ export const deleteDraftDescriptorErrorMapper = (
     .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
+export const updateDraftDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "eServiceNotFound",
+      "eServiceDescriptorNotFound",
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
+    .with(
+      "notValidDescriptor",
+      "inconsistentDailyCalls",
+      "attributeNotFound",
+      () => HTTP_STATUS_BAD_REQUEST
+    )
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
 export const updateDescriptorErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>

--- a/packages/catalog-process/test/catalogService.integration.test.ts
+++ b/packages/catalog-process/test/catalogService.integration.test.ts
@@ -752,7 +752,7 @@ describe("database test", async () => {
           )
         ).rejects.toThrowError(eServiceNotFound(mockEService.id));
       });
-      it("should throw attributeNotFound if at least one of the attributes don't exist", async () => {
+      it("should throw attributeNotFound if at least one of the attributes doesn't exist", async () => {
         const eservice: EService = {
           ...mockEService,
           descriptors: [],
@@ -1092,7 +1092,7 @@ describe("database test", async () => {
         ).rejects.toThrowError(inconsistentDailyCalls());
       });
 
-      it("should throw attributeNotFound if at least one of the attributes don't exist", async () => {
+      it("should throw attributeNotFound if at least one of the attributes doesn't exist", async () => {
         const descriptor: Descriptor = {
           ...mockDescriptor,
           state: descriptorState.draft,


### PR DESCRIPTION
This pull request is for fixing a bug related to the assignment of the `attributes` during the `updateDraftDescriptor` operation. We were just not assigning attributes at all in that endpoint.

The implementation include a refactor to reuse the code that performs the same actions during the `createDescriptor` operation.