### PR TITLE
IMN-361 Adjust tenant attributes type in models and tenant packages

### DIFF
--- a/packages/models/src/tenant/tenant.ts
+++ b/packages/models/src/tenant/tenant.ts
@@ -33,9 +33,9 @@ export const TenantFeature = TenantFeatureCertifier; // It will be extended with
 export type TenantFeature = z.infer<typeof TenantFeature>;
 
 export const tenantAttributeType = {
-  CERTIFIED: "certified",
-  DECLARED: "declared",
-  VERIFIED: "verified",
+  CERTIFIED: "PersistentCertifiedAttribute",
+  DECLARED: "PersistentDeclaredAttribute",
+  VERIFIED: "PersistentVerifiedAttribute",
 } as const;
 
 export const TenantAttributeType = z.enum([

--- a/packages/tenant-process/src/model/domain/apiConverter.ts
+++ b/packages/tenant-process/src/model/domain/apiConverter.ts
@@ -10,6 +10,7 @@ import {
   TenantMailKind,
   tenantMailKind,
   TenantFeature,
+  tenantAttributeType,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
@@ -75,14 +76,14 @@ export function toApiTenantAttribute(
   input: TenantAttribute
 ): ApiTenantAttribute {
   return match<TenantAttribute, ApiTenantAttribute>(input)
-    .with({ type: "certified" }, (attribute) => ({
+    .with({ type: tenantAttributeType.CERTIFIED }, (attribute) => ({
       certified: {
         id: attribute.id,
         assignmentTimestamp: attribute.assignmentTimestamp.toJSON(),
         revocationTimestamp: attribute.revocationTimestamp?.toJSON(),
       },
     }))
-    .with({ type: "verified" }, (attribute) => ({
+    .with({ type: tenantAttributeType.VERIFIED }, (attribute) => ({
       verified: {
         id: attribute.id,
         assignmentTimestamp: attribute.assignmentTimestamp.toJSON(),
@@ -90,7 +91,7 @@ export function toApiTenantAttribute(
         revokedBy: attribute.revokedBy.map(toApiTenantRevoker),
       },
     }))
-    .with({ type: "declared" }, (attribute) => ({
+    .with({ type: tenantAttributeType.DECLARED }, (attribute) => ({
       declared: {
         id: attribute.id,
         assignmentTimestamp: attribute.assignmentTimestamp.toJSON(),

--- a/packages/tenant-process/src/model/domain/toEvent.ts
+++ b/packages/tenant-process/src/model/domain/toEvent.ts
@@ -19,6 +19,7 @@ import {
   tenantMailKind,
   tenantKind,
   TenantEvent,
+  tenantAttributeType,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
@@ -64,7 +65,7 @@ export function toTenantRevokerV1(revoker: TenantRevoker): TenantRevokerV1 {
 
 export function toAttributeV1(input: TenantAttribute): TenantAttributeV1 {
   return match<TenantAttribute, TenantAttributeV1>(input)
-    .with({ type: "certified" }, (attribute) => ({
+    .with({ type: tenantAttributeType.CERTIFIED }, (attribute) => ({
       sealedValue: {
         oneofKind: "certifiedAttribute",
         certifiedAttribute: {
@@ -76,7 +77,7 @@ export function toAttributeV1(input: TenantAttribute): TenantAttributeV1 {
         },
       },
     }))
-    .with({ type: "verified" }, (attribute) => ({
+    .with({ type: tenantAttributeType.VERIFIED }, (attribute) => ({
       sealedValue: {
         oneofKind: "verifiedAttribute",
         verifiedAttribute: {
@@ -87,7 +88,7 @@ export function toAttributeV1(input: TenantAttribute): TenantAttributeV1 {
         },
       },
     }))
-    .with({ type: "declared" }, (attribute) => ({
+    .with({ type: tenantAttributeType.DECLARED }, (attribute) => ({
       sealedValue: {
         oneofKind: "declaredAttribute",
         declaredAttribute: {

--- a/packages/tenant-process/src/services/validators.ts
+++ b/packages/tenant-process/src/services/validators.ts
@@ -8,6 +8,7 @@ import {
   TenantId,
   TenantKind,
   TenantVerifier,
+  VerifiedTenantAttribute,
   WithMetadata,
   operationForbidden,
   tenantAttributeType,
@@ -38,9 +39,7 @@ export function assertVerifiedAttributeExistsInTenant(
   attributeId: AttributeId,
   attribute: TenantAttribute | undefined,
   tenant: WithMetadata<Tenant>
-): asserts attribute is NonNullable<
-  Extract<TenantAttribute, { type: "verified" }>
-> {
+): asserts attribute is NonNullable<VerifiedTenantAttribute> {
   if (!attribute || attribute.type !== tenantAttributeType.VERIFIED) {
     throw verifiedAttributeNotFoundInTenant(tenant.data.id, attributeId);
   }
@@ -123,7 +122,7 @@ export async function getTenantKindLoadingCertifiedAttributes(
     attributes: TenantAttribute[]
   ): AttributeId[] {
     return attributes.flatMap((attr) =>
-      attr.type === "certified" ? attr.id : []
+      attr.type === tenantAttributeType.CERTIFIED ? attr.id : []
     );
   }
 
@@ -167,7 +166,7 @@ export function assertValidExpirationDate(
 export function assertOrganizationIsInAttributeVerifiers(
   verifierId: string,
   tenantId: TenantId,
-  attribute: Extract<TenantAttribute, { type: "verified" }>
+  attribute: VerifiedTenantAttribute
 ): void {
   if (!attribute.verifiedBy.some((v) => v.id === verifierId)) {
     throw organizationNotFoundInVerifiers(verifierId, tenantId, attribute.id);

--- a/packages/tenant-readmodel-writer/src/model/converter.ts
+++ b/packages/tenant-readmodel-writer/src/model/converter.ts
@@ -20,6 +20,7 @@ import {
   ExternalId,
   genericError,
   unsafeBrandId,
+  tenantAttributeType,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
@@ -106,7 +107,7 @@ export const fromTenantAttributesV1 = (
         assignmentTimestamp: new Date(
           Number(certifiedAttribute.assignmentTimestamp)
         ),
-        type: "certified",
+        type: tenantAttributeType.CERTIFIED,
       };
     case "verifiedAttribute":
       const { verifiedAttribute } = sealedValue;
@@ -117,7 +118,7 @@ export const fromTenantAttributesV1 = (
         ),
         verifiedBy: verifiedAttribute.verifiedBy.map(fromTenantVerifierV1),
         revokedBy: verifiedAttribute.revokedBy.map(fromTenantRevokerV1),
-        type: "verified",
+        type: tenantAttributeType.VERIFIED,
       };
     case "declaredAttribute":
       const { declaredAttribute } = sealedValue;
@@ -126,7 +127,7 @@ export const fromTenantAttributesV1 = (
         assignmentTimestamp: new Date(
           Number(declaredAttribute.assignmentTimestamp)
         ),
-        type: "declared",
+        type: tenantAttributeType.DECLARED,
       };
     case undefined:
       throw genericError("Undefined attribute kind");


### PR DESCRIPTION
This pull request is for changing the type of the attributes of a tenant. This change is required to read tenants that are already in readmodel (as we are doing in `catalog-process`).
To keep the change simple, for now we will be also writing tenants in readmodel with the "older" labels.