### PR TITLE
IMN-378 Adjust tenant definition to fix riskAnalysis creation in catalog-process

### DIFF
--- a/packages/attribute-registry-process/src/services/attributeRegistryService.ts
+++ b/packages/attribute-registry-process/src/services/attributeRegistryService.ts
@@ -84,7 +84,7 @@ export function attributeRegistryServiceBuilder(
       }
 
       const certifier = tenant.data.features
-        .filter(({ type }) => type === "Certifier")
+        .filter(({ type }) => type === "PersistentCertifier")
         .find(({ certifierId }) => certifierId.trim().length > 0);
 
       if (certifier) {

--- a/packages/attribute-registry-process/test/attributeRegistryService.integration.test.ts
+++ b/packages/attribute-registry-process/test/attributeRegistryService.integration.test.ts
@@ -214,7 +214,7 @@ describe("database test", () => {
           ...mockTenant,
           features: [
             {
-              type: "Certifier",
+              type: "PersistentCertifier",
               certifierId: uuidv4(),
             },
           ],
@@ -262,7 +262,7 @@ describe("database test", () => {
           ...mockTenant,
           features: [
             {
-              type: "Certifier",
+              type: "PersistentCertifier",
               certifierId: uuidv4(),
             },
           ],
@@ -315,7 +315,7 @@ describe("database test", () => {
           ...mockTenant,
           features: [
             {
-              type: "Certifier",
+              type: "PersistentCertifier",
               certifierId: uuidv4(),
             },
           ],
@@ -362,7 +362,7 @@ describe("database test", () => {
           ...mockTenant,
           features: [
             {
-              type: "Certifier",
+              type: "PersistentCertifier",
               certifierId: uuidv4(),
             },
           ],

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -104,7 +104,7 @@ export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<E
       } catch (error) {
         const problem = makeApiProblem(error, (err) =>
           match(err.code)
-            .with("unauthorizedError", () => 403)
+            .with("unauthorizedError", () => 401)
             .with("operationForbidden", () => 403)
             .with("missingHeader", () => 400)
             .otherwise(() => 500)

--- a/packages/models/proto/v1/tenant/tenant.proto
+++ b/packages/models/proto/v1/tenant/tenant.proto
@@ -13,6 +13,9 @@ message TenantV1 {
   repeated TenantMailV1 mails = 8;
   optional string name = 9;
   optional TenantKindV1 kind = 10;
+  optional int64 onboardedAt = 11;
+  optional TenantUnitTypeV1 subUnitType = 12;
+
 }
 
 enum TenantKindV1 {
@@ -26,10 +29,17 @@ message TenantMailV1 {
   required string address = 2;
   required int64 createdAt = 3;
   optional string description = 4;
+  optional string id = 5;
 }
 
 enum TenantMailKindV1 {
   CONTACT_EMAIL = 1;
+  DIGITAL_ADDRESS = 2;
+}
+
+enum TenantUnitTypeV1 {
+  AOO = 1;
+  UO = 2;
 }
 
 message TenantFeatureV1 {

--- a/packages/models/src/tenant/tenant.ts
+++ b/packages/models/src/tenant/tenant.ts
@@ -22,7 +22,7 @@ export const ExternalId = z.object({
 export type ExternalId = z.infer<typeof ExternalId>;
 
 export const TenantFeatureCertifier = z.object({
-  type: z.literal("Certifier"),
+  type: z.literal("PersistentCertifier"),
   certifierId: z.string(),
 });
 
@@ -97,6 +97,7 @@ export type TenantAttribute = z.infer<typeof TenantAttribute>;
 
 export const tenantMailKind = {
   ContactEmail: "CONTACT_EMAIL",
+  DigitalAddress: "DIGITAL_ADDRESS",
 } as const;
 export const TenantMailKind = z.enum([
   Object.values(tenantMailKind)[0],
@@ -105,12 +106,25 @@ export const TenantMailKind = z.enum([
 export type TenantMailKind = z.infer<typeof TenantMailKind>;
 
 export const TenantMail = z.object({
+  id: z.string(),
   kind: TenantMailKind,
   address: z.string(),
   description: z.string().optional(),
   createdAt: z.coerce.date(),
 });
 export type TenantMail = z.infer<typeof TenantMail>;
+
+export const tenantUnitType = {
+  AOO: "AOO",
+  UO: "UO",
+} as const;
+
+export const TenantUnitType = z.enum([
+  Object.values(tenantUnitType)[0],
+  ...Object.values(tenantUnitType).slice(1),
+]);
+
+export type TenantUnitType = z.infer<typeof TenantUnitType>;
 
 export const Tenant = z.object({
   id: TenantId,
@@ -123,6 +137,8 @@ export const Tenant = z.object({
   updatedAt: z.coerce.date().optional(),
   mails: z.array(TenantMail),
   name: z.string(),
+  onboardedAt: z.coerce.date().optional(),
+  subUnitType: TenantUnitType.optional(),
 });
 
 export type Tenant = z.infer<typeof Tenant>;

--- a/packages/tenant-process/open-api/tenant-service-spec.yml
+++ b/packages/tenant-process/open-api/tenant-service-spec.yml
@@ -1068,6 +1068,7 @@ components:
       type: string
       enum:
         - CONTACT_EMAIL
+        - DIGITAL_ADDRESS
     ResourceId:
       type: object
       required:

--- a/packages/tenant-process/src/model/domain/apiConverter.ts
+++ b/packages/tenant-process/src/model/domain/apiConverter.ts
@@ -43,7 +43,7 @@ export function toApiTenantExternalId(input: ExternalId): ApiExternalId {
 
 export function toApiTenantFeature(input: TenantFeature): ApiTenantFeature {
   return match<TenantFeature, ApiTenantFeature>(input)
-    .with({ type: "Certifier" }, (feature) => ({
+    .with({ type: "PersistentCertifier" }, (feature) => ({
       certifier: {
         certifierId: feature.certifierId,
       },
@@ -103,6 +103,7 @@ export function toApiTenantAttribute(
 export function toApiMailKind(kind: TenantMailKind): ApiMailKind {
   return match<TenantMailKind, ApiMailKind>(kind)
     .with(tenantMailKind.ContactEmail, () => "CONTACT_EMAIL")
+    .with(tenantMailKind.DigitalAddress, () => "DIGITAL_ADDRESS")
     .exhaustive();
 }
 

--- a/packages/tenant-process/src/model/domain/toEvent.ts
+++ b/packages/tenant-process/src/model/domain/toEvent.ts
@@ -20,12 +20,15 @@ import {
   tenantKind,
   TenantEvent,
   tenantAttributeType,
+  TenantUnitTypeV1,
+  tenantUnitType,
+  TenantUnitType,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
 export function toFeatureV1(feature: TenantFeature): TenantFeatureV1 {
   return match<TenantFeature, TenantFeatureV1>(feature)
-    .with({ type: "Certifier" }, (feature) => ({
+    .with({ type: "PersistentCertifier" }, (feature) => ({
       sealedValue: {
         oneofKind: "certifier",
         certifier: {
@@ -112,6 +115,7 @@ export function toTenantMailV1(mail: TenantMail): TenantMailV1 {
 export function toTenantMailKindV1(kind: TenantMailKind): TenantMailKindV1 {
   return match(kind)
     .with(tenantMailKind.ContactEmail, () => TenantMailKindV1.CONTACT_EMAIL)
+    .with(tenantMailKind.DigitalAddress, () => TenantMailKindV1.DIGITAL_ADDRESS)
     .exhaustive();
 }
 
@@ -123,6 +127,13 @@ export function toTenantKindV1(input: TenantKind): TenantKindV1 {
     .exhaustive();
 }
 
+export function toTenantUnitTypeV1(input: TenantUnitType): TenantUnitTypeV1 {
+  return match<TenantUnitType, TenantUnitTypeV1>(input)
+    .with(tenantUnitType.AOO, () => TenantUnitTypeV1.AOO)
+    .with(tenantUnitType.UO, () => TenantUnitTypeV1.UO)
+    .exhaustive();
+}
+
 export const toTenantV1 = (tenant: Tenant): TenantV1 => ({
   ...tenant,
   features: tenant.features.map(toFeatureV1),
@@ -131,6 +142,12 @@ export const toTenantV1 = (tenant: Tenant): TenantV1 => ({
   updatedAt: tenant.updatedAt ? BigInt(tenant.updatedAt.getTime()) : undefined,
   mails: tenant.mails.map(toTenantMailV1),
   kind: tenant.kind ? toTenantKindV1(tenant.kind) : undefined,
+  onboardedAt: tenant.createdAt
+    ? BigInt(tenant.createdAt.getTime())
+    : undefined,
+  subUnitType: tenant.subUnitType
+    ? toTenantUnitTypeV1(tenant.subUnitType)
+    : undefined,
 });
 
 export const toCreateEventTenantAdded = (


### PR DESCRIPTION
This pull request is for adjusting the definition of a `tenant` both in models and in the protobuf definition (most of the changes are due to recent updates in the Scala implementation). The error during the riskAnalysis creation might arise from the unsuccessful parsing of a tenant in `catalog-process`.

Changes:
- the tenant feature is `PersistentCertifier` and not `Certifier`
- tenants have an optional `onboardedAt`
- tenants have an optional `subUnitType` (`AOO` or `UO`)
- tenants `mails` have an `id`
- tenants mail kind can also be `DIGITAL_ADDRESS`