### PR TITLE
IMN 373 - Multistep docker build

### DIFF
--- a/packages/agreement-process/Dockerfile
+++ b/packages/agreement-process/Dockerfile
@@ -19,7 +19,19 @@ COPY ./packages/agreement-process /app/packages/agreement-process
 COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 
-RUN pnpm build
+RUN pnpm build && \
+    rm -rf /app/node_modules/.modules.yaml && \
+    rm -rf /app/node_modules/.cache && \
+    mkdir /out && \
+    cp -a --parents -t /out \
+      node_modules packages/agreement-process/node_modules \
+      package*.json packages/agreement-process/package*.json \
+      packages/agreement-process/dist && \
+    find /out -exec touch -h --date=@0 {} \;
+
+FROM node:18.17.1-slim as final 
+
+COPY --from=build /out /app
 
 WORKDIR /app/packages/agreement-process
 EXPOSE 3000

--- a/packages/agreement-readmodel-writer/Dockerfile
+++ b/packages/agreement-readmodel-writer/Dockerfile
@@ -21,9 +21,21 @@ COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 COPY ./packages/kafka-iam-auth /app/packages/kafka-iam-auth
 
-RUN pnpm build
+RUN pnpm build && \
+    rm -rf /app/node_modules/.modules.yaml && \
+    rm -rf /app/node_modules/.cache && \
+    mkdir /out && \
+    cp -a --parents -t /out \
+      node_modules packages/agreement-readmodel-writer/node_modules \
+      package*.json packages/agreement-readmodel-writer/package*.json \
+      packages/agreement-readmodel-writer/dist && \
+    find /out -exec touch -h --date=@0 {} \;
+
+FROM node:18.17.1-slim as final 
+
+COPY --from=build /out /app
 
 WORKDIR /app/packages/agreement-readmodel-writer
 EXPOSE 3000
 
-CMD ["node", "."]
+CMD [ "node", "." ]

--- a/packages/attribute-registry-process/Dockerfile
+++ b/packages/attribute-registry-process/Dockerfile
@@ -19,7 +19,19 @@ COPY ./packages/attribute-registry-process /app/packages/attribute-registry-proc
 COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 
-RUN pnpm build
+RUN pnpm build && \
+    rm -rf /app/node_modules/.modules.yaml && \
+    rm -rf /app/node_modules/.cache && \
+    mkdir /out && \
+    cp -a --parents -t /out \
+      node_modules packages/attribute-registry-process/node_modules \
+      package*.json packages/attribute-registry-process/package*.json \
+      packages/attribute-registry-process/dist && \
+    find /out -exec touch -h --date=@0 {} \;
+
+FROM node:18.17.1-slim as final 
+
+COPY --from=build /out /app
 
 WORKDIR /app/packages/attribute-registry-process
 EXPOSE 3000

--- a/packages/attribute-registry-readmodel-writer/Dockerfile
+++ b/packages/attribute-registry-readmodel-writer/Dockerfile
@@ -21,9 +21,21 @@ COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 COPY ./packages/kafka-iam-auth /app/packages/kafka-iam-auth
 
-RUN pnpm build
+RUN pnpm build && \
+    rm -rf /app/node_modules/.modules.yaml && \
+    rm -rf /app/node_modules/.cache && \
+    mkdir /out && \
+    cp -a --parents -t /out \
+      node_modules packages/attribute-registry-readmodel-writer/node_modules \
+      package*.json packages/attribute-registry-readmodel-writer/package*.json \
+      packages/attribute-registry-readmodel-writer/dist && \
+    find /out -exec touch -h --date=@0 {} \;
+
+FROM node:18.17.1-slim as final 
+
+COPY --from=build /out /app
 
 WORKDIR /app/packages/attribute-registry-readmodel-writer
 EXPOSE 3000
 
-CMD ["node", "."]
+CMD [ "node", "." ]

--- a/packages/catalog-process/Dockerfile
+++ b/packages/catalog-process/Dockerfile
@@ -19,10 +19,21 @@ COPY ./packages/catalog-process /app/packages/catalog-process
 COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 
-RUN pnpm build
+RUN pnpm build && \
+    rm -rf /app/node_modules/.modules.yaml && \
+    rm -rf /app/node_modules/.cache && \
+    mkdir /out && \
+    cp -a --parents -t /out \
+      node_modules packages/catalog-process/node_modules \
+      package*.json packages/catalog-process/package*.json \
+      packages/catalog-process/dist && \
+    find /out -exec touch -h --date=@0 {} \;
+
+FROM node:18.17.1-slim as final 
+
+COPY --from=build /out /app
 
 WORKDIR /app/packages/catalog-process
 EXPOSE 3000
 
 CMD [ "node", "." ]
-

--- a/packages/catalog-readmodel-writer/Dockerfile
+++ b/packages/catalog-readmodel-writer/Dockerfile
@@ -21,7 +21,19 @@ COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 COPY ./packages/kafka-iam-auth /app/packages/kafka-iam-auth
 
-RUN pnpm build
+RUN pnpm build && \
+    rm -rf /app/node_modules/.modules.yaml && \
+    rm -rf /app/node_modules/.cache && \
+    mkdir /out && \
+    cp -a --parents -t /out \
+      node_modules packages/catalog-readmodel-writer/node_modules \
+      package*.json packages/catalog-readmodel-writer/package*.json \
+      packages/catalog-readmodel-writer/dist && \
+    find /out -exec touch -h --date=@0 {} \;
+
+FROM node:18.17.1-slim as final 
+
+COPY --from=build /out /app
 
 WORKDIR /app/packages/catalog-readmodel-writer
 EXPOSE 3000

--- a/packages/tenant-process/Dockerfile
+++ b/packages/tenant-process/Dockerfile
@@ -19,9 +19,21 @@ COPY ./packages/tenant-process /app/packages/tenant-process
 COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 
-RUN pnpm build
+RUN pnpm build && \
+    rm -rf /app/node_modules/.modules.yaml && \
+    rm -rf /app/node_modules/.cache && \
+    mkdir /out && \
+    cp -a --parents -t /out \
+      node_modules packages/tenant-process/node_modules \
+      package*.json packages/tenant-process/package*.json \
+      packages/tenant-process/dist && \
+    find /out -exec touch -h --date=@0 {} \;
+
+FROM node:18.17.1-slim as final 
+
+COPY --from=build /out /app
 
 WORKDIR /app/packages/tenant-process
 EXPOSE 3000
 
-CMD ["node", "."]
+CMD [ "node", "." ]

--- a/packages/tenant-readmodel-writer/Dockerfile
+++ b/packages/tenant-readmodel-writer/Dockerfile
@@ -21,9 +21,21 @@ COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 COPY ./packages/kafka-iam-auth /app/packages/kafka-iam-auth
 
-RUN pnpm build
+RUN pnpm build && \
+    rm -rf /app/node_modules/.modules.yaml && \
+    rm -rf /app/node_modules/.cache && \
+    mkdir /out && \
+    cp -a --parents -t /out \
+      node_modules packages/tenant-readmodel-writer/node_modules \
+      package*.json packages/tenant-readmodel-writer/package*.json \
+      packages/tenant-readmodel-writer/dist && \
+    find /out -exec touch -h --date=@0 {} \;
+
+FROM node:18.17.1-slim as final 
+
+COPY --from=build /out /app
 
 WORKDIR /app/packages/tenant-readmodel-writer
 EXPOSE 3000
 
-CMD ["node", "."]
+CMD [ "node", "." ]


### PR DESCRIPTION
Modify and merge after [IMN-161](https://github.com/pagopa/interop-be-monorepo/pull/161)

Closes [IMN-373](https://pagopa.atlassian.net/browse/IMN-373)
Related [IMN-73](https://pagopa.atlassian.net/browse/IMN-73)

[IMN-373]: https://pagopa.atlassian.net/browse/IMN-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IMN-73]: https://pagopa.atlassian.net/browse/IMN-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Test
Without changing the code I generated the catalog-process image twice using `--no-cache --build-arg SOURCE_DATE_EPOCH=0` obtaining the same hash `sha256:892b6e48a9c073bbfa58c4c2e8b5abc21243357a119cbaa2e3cc04cb11080c51`

![image](https://github.com/pagopa/interop-be-monorepo/assets/32327779/a4bbf86d-ee5c-4a9e-a694-a5cffd307fa2)
![image](https://github.com/pagopa/interop-be-monorepo/assets/32327779/88973a92-21c9-4946-ba29-b8363e511af7)


[IMN-161]: https://pagopa.atlassian.net/browse/IMN-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ