### PR TITLE
 IMN 301 - Add details in consumer logs

### DIFF
--- a/packages/agreement-readmodel-writer/src/index.ts
+++ b/packages/agreement-readmodel-writer/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable functional/immutable-data */
 import { EachMessagePayload } from "kafkajs";
 import {
   ReadModelRepository,
@@ -5,6 +6,7 @@ import {
   agreementTopicConfig,
   decodeKafkaMessage,
   logger,
+  getContext,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
 import { AgreementEvent } from "pagopa-interop-models";
@@ -19,6 +21,16 @@ async function processMessage({
   partition,
 }: EachMessagePayload): Promise<void> {
   try {
+    const msg = decodeKafkaMessage(message, AgreementEvent);
+
+    const ctx = getContext();
+    ctx.messageData = {
+      eventType: msg.type,
+      eventVersion: msg.event_version,
+      streamId: msg.stream_id,
+    };
+    ctx.correlationId = msg.correlation_id;
+
     await handleMessage(
       decodeKafkaMessage(message, AgreementEvent),
       agreements

--- a/packages/attribute-registry-readmodel-writer/src/index.ts
+++ b/packages/attribute-registry-readmodel-writer/src/index.ts
@@ -1,8 +1,10 @@
+/* eslint-disable functional/immutable-data */
 import { Kafka, KafkaMessage } from "kafkajs";
 import {
   ReadModelRepository,
   attributeTopicConfig,
   decodeKafkaMessage,
+  getContext,
   logger,
   readModelWriterConfig,
 } from "pagopa-interop-commons";
@@ -48,10 +50,16 @@ await consumer.subscribe({
 
 async function processMessage(message: KafkaMessage): Promise<void> {
   try {
-    await handleMessage(
-      decodeKafkaMessage(message, AttributeEvent),
-      attributes
-    );
+    const msg = decodeKafkaMessage(message, AttributeEvent);
+    const ctx = getContext();
+    ctx.messageData = {
+      eventType: msg.type,
+      eventVersion: msg.event_version,
+      streamId: msg.stream_id,
+    };
+    ctx.correlationId = msg.correlation_id;
+
+    await handleMessage(msg, attributes);
 
     logger.info("Read model was updated");
   } catch (e) {

--- a/packages/authorization-updater/src/authorizationService.ts
+++ b/packages/authorization-updater/src/authorizationService.ts
@@ -56,7 +56,7 @@ export const authorizationServiceBuilder =
     const getHeaders = () => {
       const appContext = getContext();
       return {
-        "X-Correlation-Id": appContext.correlationId,
+        "X-Correlation-Id": appContext.correlationId || "",
       };
     };
 

--- a/packages/authorization-updater/src/authorizationService.ts
+++ b/packages/authorization-updater/src/authorizationService.ts
@@ -6,6 +6,7 @@ import {
   jwtSeedConfig,
   logger,
 } from "pagopa-interop-commons";
+import { v4 } from "uuid";
 import { DescriptorId, EServiceId } from "pagopa-interop-models";
 import { buildAuthMgmtClient } from "./authorizationManagementClient.js";
 import { ApiClientComponentState } from "./model/models.js";
@@ -56,7 +57,7 @@ export const authorizationServiceBuilder =
     const getHeaders = () => {
       const appContext = getContext();
       return {
-        "X-Correlation-Id": appContext.correlationId || "",
+        "X-Correlation-Id": appContext.correlationId || v4(),
       };
     };
 

--- a/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
+++ b/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
@@ -10,7 +10,11 @@ export async function handleMessageV2(
   message: EServiceEventEnvelopeV2,
   eservices: EServiceCollection
 ): Promise<void> {
-  logger.info(message);
+  logger.info(
+    JSON.stringify(message, (_, v) =>
+      typeof v === "bigint" ? v.toString() : v
+    )
+  );
 
   const eservice = message.data.eservice;
 

--- a/packages/catalog-readmodel-writer/src/index.ts
+++ b/packages/catalog-readmodel-writer/src/index.ts
@@ -8,6 +8,7 @@ import {
   decodeKafkaMessage,
   getContext,
 } from "pagopa-interop-commons";
+import { v4 } from "uuid";
 import { runConsumer } from "kafka-iam-auth";
 import { EServiceEvent } from "pagopa-interop-models";
 import { match } from "ts-pattern";
@@ -30,7 +31,7 @@ async function processMessage({
       eventVersion: decodedMessage.event_version,
       streamId: decodedMessage.stream_id,
     };
-    ctx.correlationId = decodedMessage.correlation_id;
+    ctx.correlationId = decodedMessage.correlation_id || v4();
 
     await match(decodedMessage)
       .with({ event_version: 1 }, (msg) => handleMessageV1(msg, eservices))

--- a/packages/catalog-readmodel-writer/src/index.ts
+++ b/packages/catalog-readmodel-writer/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable functional/immutable-data */
 import { EachMessagePayload } from "kafkajs";
 import {
   logger,
@@ -5,6 +6,7 @@ import {
   readModelWriterConfig,
   catalogTopicConfig,
   decodeKafkaMessage,
+  getContext,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
 import { EServiceEvent } from "pagopa-interop-models";
@@ -22,6 +24,13 @@ async function processMessage({
 }: EachMessagePayload): Promise<void> {
   try {
     const decodedMessage = decodeKafkaMessage(message, EServiceEvent);
+    const ctx = getContext();
+    ctx.messageData = {
+      eventType: decodedMessage.type,
+      eventVersion: decodedMessage.event_version,
+      streamId: decodedMessage.stream_id,
+    };
+    ctx.correlationId = decodedMessage.correlation_id;
 
     await match(decodedMessage)
       .with({ event_version: 1 }, (msg) => handleMessageV1(msg, eservices))

--- a/packages/commons/src/auth/headers.ts
+++ b/packages/commons/src/auth/headers.ts
@@ -13,7 +13,7 @@ export type Headers = z.infer<typeof Headers>;
 
 export const ParsedHeaders = z
   .object({
-    correlationId: z.string().uuid(),
+    correlationId: z.string(),
   })
   .and(AuthData);
 export type ParsedHeaders = z.infer<typeof ParsedHeaders>;

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -20,7 +20,7 @@ export type ExpressContext = NonNullable<typeof zodiosCtx.context>;
 
 export const ctx = z.object({
   authData: AuthData,
-  correlationId: z.string().uuid(),
+  correlationId: z.string(),
 });
 
 export const zodiosCtx = zodiosContext(z.object({ ctx }));

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -6,7 +6,15 @@ import { z } from "zod";
 import { AuthData, defaultAuthData } from "../auth/authData.js";
 import { readHeaders } from "../auth/headers.js";
 
-export type AppContext = z.infer<typeof ctx>;
+export type AppContext = {
+  authData: AuthData;
+  messageData?: {
+    eventType: string;
+    eventVersion: number;
+    streamId: string;
+  };
+  correlationId?: string;
+};
 export type ZodiosContext = NonNullable<typeof zodiosCtx>;
 export type ExpressContext = NonNullable<typeof zodiosCtx.context>;
 
@@ -20,7 +28,6 @@ export const zodiosCtx = zodiosContext(z.object({ ctx }));
 const globalStore = new AsyncLocalStorage<AppContext>();
 const defaultAppContext: AppContext = {
   authData: defaultAuthData,
-  correlationId: "",
 };
 
 export const getContext = (): AppContext => {

--- a/packages/commons/src/logging/loggerMiddleware.ts
+++ b/packages/commons/src/logging/loggerMiddleware.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import * as expressWinston from "express-winston";
 import * as winston from "winston";
+import { v4 } from "uuid";
 import { LoggerConfig } from "../config/commonConfig.js";
 import { getContext } from "../index.js";
 
@@ -27,7 +28,7 @@ const getLoggerMetadata = (): SessionMetaData => {
     ? {
         userId: undefined,
         organizationId: undefined,
-        correlationId: undefined,
+        correlationId: v4(),
         eventType: undefined,
         eventVersion: undefined,
         streamId: undefined,

--- a/packages/commons/src/logging/loggerMiddleware.ts
+++ b/packages/commons/src/logging/loggerMiddleware.ts
@@ -51,19 +51,47 @@ const logFormat = (
     organizationId,
     correlationId,
     serviceName,
+    eventType,
+    eventVersion,
+    streamId,
   }: {
     userId: string | undefined;
     organizationId: string | undefined;
     correlationId: string | undefined;
     serviceName: string | undefined;
+    eventType: string | undefined;
+    eventVersion: number | undefined;
+    streamId: string | undefined;
   }
 ) => {
-  const serviceLogPart = serviceName ? `[${serviceName}]` : "";
-  const userLogPart = userId ? `[UID=${userId}]` : "";
-  const organizationLogPart = organizationId ? `[OID=${organizationId}]` : "";
-  const correlationLogPart = correlationId ? `[CID=${correlationId}]` : "";
+  const serviceLogPart = serviceName ? `[${serviceName}]` : undefined;
+  const userLogPart = userId ? `[UID=${userId}]` : undefined;
+  const organizationLogPart = organizationId
+    ? `[OID=${organizationId}]`
+    : undefined;
+  const correlationLogPart = correlationId
+    ? `[CID=${correlationId}]`
+    : undefined;
+  const eventTypePart = eventType ? `[ET=${eventType}]` : undefined;
+  const eventVersionPart = eventVersion ? `[EV=${eventVersion}]` : undefined;
+  const streamIdPart = streamId ? `[SID=${streamId}]` : undefined;
 
-  return `${timestamp} ${level.toUpperCase()} ${serviceLogPart} - ${userLogPart} ${organizationLogPart} ${correlationLogPart} ${msg}`;
+  const firstPart = [timestamp, level.toUpperCase(), serviceLogPart]
+    .filter((e) => e !== undefined)
+    .join(" ");
+
+  const secondPart = [
+    userLogPart,
+    organizationLogPart,
+    correlationLogPart,
+    eventTypePart,
+    eventVersionPart,
+    streamIdPart,
+  ]
+    .filter((e) => e !== undefined)
+    .join(" ");
+
+  return `${firstPart} - ${secondPart} ${msg}`;
 };
 
 export const customFormat = (serviceName?: string) =>

--- a/packages/commons/src/repositories/EventRepository.ts
+++ b/packages/commons/src/repositories/EventRepository.ts
@@ -30,8 +30,8 @@ export const eventRepository = <T extends Event>(
 
         await t.none(sql.insertEvent, {
           stream_id: createEvent.streamId,
-          correlation_id: createEvent.correlationId,
           version: newVersion,
+          correlation_id: createEvent.correlationId,
           type: createEvent.event.type,
           event_version: createEvent.event.event_version,
           data: Buffer.from(toBinaryData(createEvent.event)),

--- a/packages/commons/src/repositories/sql/insertEvent.sql
+++ b/packages/commons/src/repositories/sql/insertEvent.sql
@@ -1,8 +1,8 @@
 INSERT INTO
   "events"(
     "stream_id",
-    "correlation_id",
     "version",
+    "correlation_id",
     "type",
     "event_version",
     "data"
@@ -10,8 +10,8 @@ INSERT INTO
 VALUES
   (
     $(stream_id),
-    $(correlation_id),
     $(version),
+    $(correlation_id),
     $(type),
     $(event_version),
     $(data)

--- a/packages/models/src/events/events.ts
+++ b/packages/models/src/events/events.ts
@@ -9,7 +9,7 @@ export const EventEnvelope = <TEventZodType extends z.ZodType>(
       sequence_num: z.number(),
       stream_id: z.string().uuid(),
       version: z.number(),
-      correlation_id: z.string().uuid().optional(),
+      correlation_id: z.string().optional(),
     }),
     event
   );

--- a/packages/models/src/events/events.ts
+++ b/packages/models/src/events/events.ts
@@ -9,6 +9,7 @@ export const EventEnvelope = <TEventZodType extends z.ZodType>(
       sequence_num: z.number(),
       stream_id: z.string().uuid(),
       version: z.number(),
+      correlation_id: z.string().uuid().optional(),
     }),
     event
   );

--- a/packages/tenant-readmodel-writer/src/index.ts
+++ b/packages/tenant-readmodel-writer/src/index.ts
@@ -1,9 +1,11 @@
+/* eslint-disable functional/immutable-data */
 import { EachMessagePayload } from "kafkajs";
 import {
   logger,
   readModelWriterConfig,
   tenantTopicConfig,
   decodeKafkaMessage,
+  getContext,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
 import { TenantEvent } from "pagopa-interop-models";
@@ -14,7 +16,17 @@ async function processMessage({
   partition,
 }: EachMessagePayload): Promise<void> {
   try {
-    await handleMessage(decodeKafkaMessage(message, TenantEvent));
+    const decodedMessage = decodeKafkaMessage(message, TenantEvent);
+
+    const ctx = getContext();
+    ctx.messageData = {
+      eventType: decodedMessage.type,
+      eventVersion: decodedMessage.event_version,
+      streamId: decodedMessage.stream_id,
+    };
+    ctx.correlationId = decodedMessage.correlation_id;
+
+    await handleMessage(decodedMessage);
     logger.info(
       `Read model was updated. Partition number: ${partition}. Offset: ${message.offset}`
     );


### PR DESCRIPTION
Closes [IMN-301](https://pagopa.atlassian.net/browse/IMN-301)

In this PR I have partially reverted the changes done in IMN-300. The `correlationId` is now retrieved from the context using the `getContext` function just before saving the event in the event store.

[IMN-301]: https://pagopa.atlassian.net/browse/IMN-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### New log format (consumer)
![image](https://github.com/pagopa/interop-be-monorepo/assets/32327779/7fab3f34-a035-4d6a-b293-cfcadd41fc2d)
 