### PR TITLE
Reusing commons-test utilities in tenant-process tests and fixing TS errors

### DIFF
--- a/packages/tenant-process/test/tenant.integration.test.ts
+++ b/packages/tenant-process/test/tenant.integration.test.ts
@@ -24,7 +24,6 @@ import {
   descriptorState,
   generateId,
 } from "pagopa-interop-models";
-import { v4 as uuidv4 } from "uuid";
 import { StartedTestContainer } from "testcontainers";
 import { config } from "../src/utilities/config.js";
 import {

--- a/packages/tenant-process/test/utils.ts
+++ b/packages/tenant-process/test/utils.ts
@@ -7,29 +7,26 @@ import {
 import {
   Agreement,
   Descriptor,
+  DescriptorId,
   EService,
+  EServiceId,
   Tenant,
   TenantEvent,
+  TenantId,
   agreementState,
   descriptorState,
+  generateId,
   technology,
   tenantEventToBinaryData,
+  toReadModelEService,
 } from "pagopa-interop-models";
 import { IDatabase } from "pg-promise";
 import { v4 as uuidv4 } from "uuid";
+import {
+  writeInEventstore,
+  writeInReadmodel,
+} from "pagopa-interop-commons-test";
 import { toTenantV1 } from "../src/model/domain/toEvent.js";
-
-export const writeTenantInReadmodel = async (
-  tenant: Tenant,
-  tenants: TenantCollection
-): Promise<void> => {
-  await tenants.insertOne({
-    data: tenant,
-    metadata: {
-      version: 0,
-    },
-  });
-};
 
 export const writeTenantInEventstore = async (
   tenant: Tenant,
@@ -37,30 +34,24 @@ export const writeTenantInEventstore = async (
 ): Promise<void> => {
   const tenantEvent: TenantEvent = {
     type: "TenantCreated",
+    event_version: 1,
     data: { tenant: toTenantV1(tenant) },
   };
   const eventToWrite = {
-    stream_id: tenantEvent.data.tenant?.id,
-    version: 0,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    stream_id: tenantEvent.data.tenant!.id,
+    version: "0",
     type: tenantEvent.type,
-    event_version: 1,
-    data: Buffer.from(tenantEventToBinaryData(tenantEvent)),
+    event_version: tenantEvent.event_version,
+    data: tenantEventToBinaryData(tenantEvent),
   };
-  await postgresDB.none(
-    "INSERT INTO tenant.events(stream_id, version, type, event_version, data) VALUES ($1, $2, $3, $4, $5)",
-    [
-      eventToWrite.stream_id,
-      eventToWrite.version,
-      eventToWrite.type,
-      eventToWrite.event_version,
-      eventToWrite.data,
-    ]
-  );
+
+  await writeInEventstore(eventToWrite, "tenant", postgresDB);
 };
 
 export const getMockTenant = (): Tenant => ({
   name: "A tenant",
-  id: uuidv4(),
+  id: generateId(),
   createdAt: new Date(),
   attributes: [],
   selfcareId: uuidv4(),
@@ -72,8 +63,8 @@ export const getMockTenant = (): Tenant => ({
   mails: [],
 });
 
-export const getMockAuthData = (organizationId?: string): AuthData => ({
-  organizationId: organizationId || uuidv4(),
+export const getMockAuthData = (organizationId?: TenantId): AuthData => ({
+  organizationId: organizationId || generateId(),
   userId: uuidv4(),
   userRoles: [],
   externalId: {
@@ -83,18 +74,20 @@ export const getMockAuthData = (organizationId?: string): AuthData => ({
 });
 
 export const getMockEService = (): EService => ({
-  id: uuidv4(),
+  id: generateId(),
   name: "eService name",
   description: "eService description",
   createdAt: new Date(),
-  producerId: uuidv4(),
+  producerId: generateId(),
   technology: technology.rest,
   descriptors: [],
   attributes: undefined,
+  riskAnalysis: [],
+  mode: "Deliver",
 });
 
 export const getMockDescriptor = (): Descriptor => ({
-  id: uuidv4(),
+  id: generateId(),
   version: "0",
   docs: [],
   state: descriptorState.draft,
@@ -118,12 +111,12 @@ export const getMockAgreement = ({
   producerId,
   consumerId,
 }: {
-  eServiceId: string;
-  descriptorId: string;
-  producerId: string;
-  consumerId: string;
+  eServiceId: EServiceId;
+  descriptorId: DescriptorId;
+  producerId: TenantId;
+  consumerId: TenantId;
 }): Agreement => ({
-  id: uuidv4(),
+  id: generateId(),
   createdAt: new Date(),
   eserviceId: eServiceId,
   descriptorId,
@@ -145,44 +138,18 @@ export const getMockAgreement = ({
   },
 });
 
-export const writeAgreementInReadmodel = async (
-  agreement: Agreement,
-  agreements: AgreementCollection
-): Promise<void> => {
-  await agreements.insertOne({
-    data: agreement,
-    metadata: {
-      version: 0,
-    },
-  });
-};
-
-export const writeEServiceInReadmodel = async (
-  eService: EService,
-  eservices: EServiceCollection
-): Promise<void> => {
-  await eservices.insertOne({
-    data: eService,
-    metadata: {
-      version: 0,
-    },
-  });
-};
-
 export const addOneAgreement = async (
   agreement: Agreement,
   agreements: AgreementCollection
 ): Promise<void> => {
-  await writeAgreementInReadmodel(agreement, agreements);
+  await writeInReadmodel(agreement, agreements);
 };
 
 export const addOneEService = async (
-  eService: EService,
-  // postgresDB: IDatabase<unknown>,
+  eservice: EService,
   eservices: EServiceCollection
 ): Promise<void> => {
-  // await writeEServiceInEventstore(eService, postgresDB);
-  await writeEServiceInReadmodel(eService, eservices);
+  await writeInReadmodel(toReadModelEService(eservice), eservices);
 };
 
 export const addOneTenant = async (
@@ -191,5 +158,5 @@ export const addOneTenant = async (
   tenants: TenantCollection
 ): Promise<void> => {
   await writeTenantInEventstore(tenant, postgresDB);
-  await writeTenantInReadmodel(tenant, tenants);
+  await writeInReadmodel(tenant, tenants);
 };

--- a/packages/tenant-process/test/utils.ts
+++ b/packages/tenant-process/test/utils.ts
@@ -23,6 +23,8 @@ import {
 import { IDatabase } from "pg-promise";
 import { v4 as uuidv4 } from "uuid";
 import {
+  StoredEvent,
+  readLastEventByStreamId,
   writeInEventstore,
   writeInReadmodel,
 } from "pagopa-interop-commons-test";
@@ -160,3 +162,9 @@ export const addOneTenant = async (
   await writeTenantInEventstore(tenant, postgresDB);
   await writeInReadmodel(tenant, tenants);
 };
+
+export const readLastTenantEvent = async (
+  tenantId: TenantId,
+  postgresDB: IDatabase<unknown>
+): Promise<StoredEvent> =>
+  await readLastEventByStreamId(tenantId, "tenant", postgresDB);


### PR DESCRIPTION
Doing what I did in https://github.com/pagopa/interop-be-monorepo/pull/284 also for `tenant-process`.

Tests pass ✅ 