### PR TITLE
IMN 218 - Adding tests for get agreement producers and consumers

### DIFF
--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -85,6 +85,7 @@ import { readModelServiceBuilder } from "../src/services/readmodel/readModelServ
 import { tenantQueryBuilder } from "../src/services/readmodel/tenantQuery.js";
 import { config } from "../src/utilities/config.js";
 import { agreementCreationConflictingStates } from "../src/model/domain/validators.js";
+import { CompactOrganization } from "../src/model/domain/models.js";
 import {
   addOneAgreement,
   addOneEService,
@@ -598,13 +599,8 @@ describe("Agreement service", () => {
         ...buildAgreement(
           eservice.id,
           consumer.id,
-          randomArrayItem(
-            Object.values(agreementState).filter(
-              (state) => !agreementCreationConflictingStates.includes(state)
-            )
-          )
+          randomArrayItem(agreementCreationConflictingStates)
         ),
-        state: randomArrayItem(agreementCreationConflictingStates),
       };
 
       await addOneTenant(consumer, tenants);
@@ -1207,21 +1203,9 @@ describe("Agreement service", () => {
   });
   describe("get agreement", () => {
     it("should get an agreement", async () => {
-      const agreement: Agreement = buildAgreement(
-        generateId<EServiceId>(),
-        generateId<TenantId>(),
-        agreementState.draft
-      );
+      const agreement: Agreement = buildAgreement();
       await addOneAgreement(agreement, postgresDB, agreements);
-      await addOneAgreement(
-        buildAgreement(
-          generateId<EServiceId>(),
-          generateId<TenantId>(),
-          agreementState.pending
-        ),
-        postgresDB,
-        agreements
-      );
+      await addOneAgreement(buildAgreement(), postgresDB, agreements);
 
       const result = await agreementService.getAgreementById(agreement.id);
       expect(result).toEqual(agreement);
@@ -1230,19 +1214,204 @@ describe("Agreement service", () => {
     it("should throw an agreementNotFound error when the agreement does not exist", async () => {
       const agreementId = generateId<AgreementId>();
 
-      await addOneAgreement(
-        buildAgreement(
-          generateId<EServiceId>(),
-          generateId<TenantId>(),
-          agreementState.pending
-        ),
-        postgresDB,
-        agreements
-      );
+      await addOneAgreement(buildAgreement(), postgresDB, agreements);
 
       await expect(
         agreementService.getAgreementById(agreementId)
       ).rejects.toThrowError(agreementNotFound(agreementId));
+    });
+  });
+  describe("get agreement consumers / producers", () => {
+    let tenant1: Tenant;
+    let tenant2: Tenant;
+    let tenant3: Tenant;
+    let tenant4: Tenant;
+    let tenant5: Tenant;
+    let tenant6: Tenant;
+
+    const toCompactOrganization = (tenant: Tenant): CompactOrganization => ({
+      id: tenant.id,
+      name: tenant.name,
+    });
+
+    beforeEach(async () => {
+      tenant1 = { ...buildTenant(), name: "Tenant 1 Foo" };
+      tenant2 = { ...buildTenant(), name: "Tenant 2 Bar" };
+      tenant3 = { ...buildTenant(), name: "Tenant 3 FooBar" };
+      tenant4 = { ...buildTenant(), name: "Tenant 4 Baz" };
+      tenant5 = { ...buildTenant(), name: "Tenant 5 BazBar" };
+      tenant6 = { ...buildTenant(), name: "Tenant 6 BazFoo" };
+
+      await addOneTenant(tenant1, tenants);
+      await addOneTenant(tenant2, tenants);
+      await addOneTenant(tenant3, tenants);
+      await addOneTenant(tenant4, tenants);
+      await addOneTenant(tenant5, tenants);
+      await addOneTenant(tenant6, tenants);
+
+      const agreement1 = {
+        ...buildAgreement(),
+        producerId: tenant1.id,
+        consumerId: tenant2.id,
+      };
+
+      const agreement2 = {
+        ...buildAgreement(),
+        producerId: tenant1.id,
+        consumerId: tenant3.id,
+      };
+
+      const agreement3 = {
+        ...buildAgreement(),
+        producerId: tenant2.id,
+        consumerId: tenant4.id,
+      };
+
+      const agreement4 = {
+        ...buildAgreement(),
+        producerId: tenant2.id,
+        consumerId: tenant5.id,
+      };
+
+      const agreement5 = {
+        ...buildAgreement(),
+        producerId: tenant3.id,
+        consumerId: tenant6.id,
+      };
+
+      await addOneAgreement(agreement1, postgresDB, agreements);
+      await addOneAgreement(agreement2, postgresDB, agreements);
+      await addOneAgreement(agreement3, postgresDB, agreements);
+      await addOneAgreement(agreement4, postgresDB, agreements);
+      await addOneAgreement(agreement5, postgresDB, agreements);
+    });
+    describe("get agreement consumers", () => {
+      it("should get all agreement consumers", async () => {
+        const consumers = await agreementService.getAgreementConsumers(
+          undefined,
+          10,
+          0
+        );
+
+        expect(consumers.totalCount).toEqual(5);
+        expect(consumers.results).toEqual(
+          expect.arrayContaining(
+            [tenant2, tenant3, tenant4, tenant5, tenant6].map(
+              toCompactOrganization
+            )
+          )
+        );
+      });
+      it("should get agreement consumers filtered by name", async () => {
+        const consumers = await agreementService.getAgreementConsumers(
+          "Foo",
+          10,
+          0
+        );
+        expect(consumers.totalCount).toEqual(2);
+        expect(consumers.results).toEqual(
+          expect.arrayContaining([tenant3, tenant6].map(toCompactOrganization))
+        );
+      });
+      it("should get agreeement consumers with limit", async () => {
+        const consumers = await agreementService.getAgreementConsumers(
+          undefined,
+          2,
+          0
+        );
+        expect(consumers.totalCount).toEqual(5);
+        expect(consumers.results.length).toEqual(2);
+        expect(consumers.results).toEqual(
+          expect.arrayContaining([tenant2, tenant3].map(toCompactOrganization))
+        );
+      });
+      it("should get agreement consumers with offset and limit", async () => {
+        const consumers = await agreementService.getAgreementConsumers(
+          undefined,
+          2,
+          1
+        );
+        expect(consumers.totalCount).toEqual(5);
+        expect(consumers.results.length).toEqual(2);
+        expect(consumers.results).toEqual(
+          expect.arrayContaining([tenant3, tenant4].map(toCompactOrganization))
+        );
+      });
+      it("should get agreement consumers with offset, limit, and name filter", async () => {
+        const consumers = await agreementService.getAgreementConsumers(
+          "Foo",
+          1,
+          1
+        );
+        expect(consumers.totalCount).toEqual(2);
+        expect(consumers.results.length).toEqual(1);
+        expect(consumers.results).toEqual(
+          expect.arrayContaining([tenant6].map(toCompactOrganization))
+        );
+      });
+    });
+    describe("get agreement producers", () => {
+      it("should get all agreement producers", async () => {
+        const producers = await agreementService.getAgreementProducers(
+          undefined,
+          10,
+          0
+        );
+
+        expect(producers.totalCount).toEqual(3);
+        expect(producers.results).toEqual(
+          expect.arrayContaining(
+            [tenant1, tenant2, tenant3].map(toCompactOrganization)
+          )
+        );
+      });
+      it("should get agreement producers filtered by name", async () => {
+        const producers = await agreementService.getAgreementProducers(
+          "Bar",
+          10,
+          0
+        );
+        expect(producers.totalCount).toEqual(2);
+        expect(producers.results).toEqual(
+          expect.arrayContaining([tenant2, tenant3].map(toCompactOrganization))
+        );
+      });
+      it("should get agreeement producers with limit", async () => {
+        const producers = await agreementService.getAgreementProducers(
+          undefined,
+          2,
+          0
+        );
+        expect(producers.totalCount).toEqual(3);
+        expect(producers.results.length).toEqual(2);
+        expect(producers.results).toEqual(
+          expect.arrayContaining([tenant1, tenant2].map(toCompactOrganization))
+        );
+      });
+      it("should get agreement producers with offset and limit", async () => {
+        const producers = await agreementService.getAgreementProducers(
+          undefined,
+          2,
+          1
+        );
+        expect(producers.totalCount).toEqual(3);
+        expect(producers.results.length).toEqual(2);
+        expect(producers.results).toEqual(
+          expect.arrayContaining([tenant2, tenant3].map(toCompactOrganization))
+        );
+      });
+      it("should get agreement producers with offset, limit, and name filter", async () => {
+        const producers = await agreementService.getAgreementProducers(
+          "Bar",
+          1,
+          1
+        );
+        expect(producers.totalCount).toEqual(2);
+        expect(producers.results.length).toEqual(1);
+        expect(producers.results).toEqual(
+          expect.arrayContaining([tenant3].map(toCompactOrganization))
+        );
+      });
     });
   });
 });

--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -927,10 +927,16 @@ describe("Agreement service", () => {
         10,
         0
       );
-      expect(agreements2.totalCount).toEqual(4);
-      expect(agreements2.results).toEqual(
-        expect.arrayContaining([agreement1, agreement2, agreement3, agreement4])
-      );
+
+      expect(agreements2).toEqual({
+        totalCount: 4,
+        results: expect.arrayContaining([
+          agreement1,
+          agreement2,
+          agreement3,
+          agreement4,
+        ]),
+      });
     });
 
     it("should get agreements with filters: consumerId", async () => {
@@ -1293,14 +1299,14 @@ describe("Agreement service", () => {
           0
         );
 
-        expect(consumers.totalCount).toEqual(5);
-        expect(consumers.results).toEqual(
-          expect.arrayContaining(
+        expect(consumers).toEqual({
+          totalCount: 5,
+          results: expect.arrayContaining(
             [tenant2, tenant3, tenant4, tenant5, tenant6].map(
               toCompactOrganization
             )
-          )
-        );
+          ),
+        });
       });
       it("should get agreement consumers filtered by name", async () => {
         const consumers = await agreementService.getAgreementConsumers(
@@ -1308,10 +1314,13 @@ describe("Agreement service", () => {
           10,
           0
         );
-        expect(consumers.totalCount).toEqual(2);
-        expect(consumers.results).toEqual(
-          expect.arrayContaining([tenant3, tenant6].map(toCompactOrganization))
-        );
+
+        expect(consumers).toEqual({
+          totalCount: 2,
+          results: expect.arrayContaining(
+            [tenant3, tenant6].map(toCompactOrganization)
+          ),
+        });
       });
       it("should get agreeement consumers with limit", async () => {
         const consumers = await agreementService.getAgreementConsumers(
@@ -1319,11 +1328,13 @@ describe("Agreement service", () => {
           2,
           0
         );
-        expect(consumers.totalCount).toEqual(5);
-        expect(consumers.results.length).toEqual(2);
-        expect(consumers.results).toEqual(
-          expect.arrayContaining([tenant2, tenant3].map(toCompactOrganization))
-        );
+
+        expect(consumers).toEqual({
+          totalCount: 5,
+          results: expect.arrayContaining(
+            [tenant2, tenant3].map(toCompactOrganization)
+          ),
+        });
       });
       it("should get agreement consumers with offset and limit", async () => {
         const consumers = await agreementService.getAgreementConsumers(
@@ -1331,11 +1342,13 @@ describe("Agreement service", () => {
           2,
           1
         );
-        expect(consumers.totalCount).toEqual(5);
-        expect(consumers.results.length).toEqual(2);
-        expect(consumers.results).toEqual(
-          expect.arrayContaining([tenant3, tenant4].map(toCompactOrganization))
-        );
+
+        expect(consumers).toEqual({
+          totalCount: 5,
+          results: expect.arrayContaining(
+            [tenant3, tenant4].map(toCompactOrganization)
+          ),
+        });
       });
       it("should get agreement consumers with offset, limit, and name filter", async () => {
         const consumers = await agreementService.getAgreementConsumers(
@@ -1343,11 +1356,11 @@ describe("Agreement service", () => {
           1,
           1
         );
-        expect(consumers.totalCount).toEqual(2);
-        expect(consumers.results.length).toEqual(1);
-        expect(consumers.results).toEqual(
-          expect.arrayContaining([tenant6].map(toCompactOrganization))
-        );
+
+        expect(consumers).toEqual({
+          totalCount: 2,
+          results: expect.arrayContaining([tenant6].map(toCompactOrganization)),
+        });
       });
     });
     describe("get agreement producers", () => {
@@ -1358,12 +1371,12 @@ describe("Agreement service", () => {
           0
         );
 
-        expect(producers.totalCount).toEqual(3);
-        expect(producers.results).toEqual(
-          expect.arrayContaining(
+        expect(producers).toEqual({
+          totalCount: 3,
+          results: expect.arrayContaining(
             [tenant1, tenant2, tenant3].map(toCompactOrganization)
-          )
-        );
+          ),
+        });
       });
       it("should get agreement producers filtered by name", async () => {
         const producers = await agreementService.getAgreementProducers(
@@ -1371,10 +1384,13 @@ describe("Agreement service", () => {
           10,
           0
         );
-        expect(producers.totalCount).toEqual(2);
-        expect(producers.results).toEqual(
-          expect.arrayContaining([tenant2, tenant3].map(toCompactOrganization))
-        );
+
+        expect(producers).toEqual({
+          totalCount: 2,
+          results: expect.arrayContaining(
+            [tenant2, tenant3].map(toCompactOrganization)
+          ),
+        });
       });
       it("should get agreeement producers with limit", async () => {
         const producers = await agreementService.getAgreementProducers(
@@ -1382,11 +1398,13 @@ describe("Agreement service", () => {
           2,
           0
         );
-        expect(producers.totalCount).toEqual(3);
-        expect(producers.results.length).toEqual(2);
-        expect(producers.results).toEqual(
-          expect.arrayContaining([tenant1, tenant2].map(toCompactOrganization))
-        );
+
+        expect(producers).toEqual({
+          totalCount: 3,
+          results: expect.arrayContaining(
+            [tenant1, tenant2].map(toCompactOrganization)
+          ),
+        });
       });
       it("should get agreement producers with offset and limit", async () => {
         const producers = await agreementService.getAgreementProducers(
@@ -1394,11 +1412,13 @@ describe("Agreement service", () => {
           2,
           1
         );
-        expect(producers.totalCount).toEqual(3);
-        expect(producers.results.length).toEqual(2);
-        expect(producers.results).toEqual(
-          expect.arrayContaining([tenant2, tenant3].map(toCompactOrganization))
-        );
+
+        expect(producers).toEqual({
+          totalCount: 3,
+          results: expect.arrayContaining(
+            [tenant2, tenant3].map(toCompactOrganization)
+          ),
+        });
       });
       it("should get agreement producers with offset, limit, and name filter", async () => {
         const producers = await agreementService.getAgreementProducers(
@@ -1406,11 +1426,11 @@ describe("Agreement service", () => {
           1,
           1
         );
-        expect(producers.totalCount).toEqual(2);
-        expect(producers.results.length).toEqual(1);
-        expect(producers.results).toEqual(
-          expect.arrayContaining([tenant3].map(toCompactOrganization))
-        );
+
+        expect(producers).toEqual({
+          totalCount: 2,
+          results: expect.arrayContaining([tenant3].map(toCompactOrganization)),
+        });
       });
     });
   });

--- a/packages/commons-test/src/testUtils.ts
+++ b/packages/commons-test/src/testUtils.ts
@@ -16,6 +16,7 @@ import {
   TenantId,
   VerifiedTenantAttribute,
   attributeKind,
+  agreementState,
   descriptorState,
   generateId,
   tenantAttributeType,
@@ -127,7 +128,7 @@ export const buildTenant = (
 export const buildAgreement = (
   eserviceId: EServiceId = generateId<EServiceId>(),
   consumerId: TenantId = generateId<TenantId>(),
-  state: AgreementState
+  state: AgreementState = agreementState.draft
 ): Agreement => ({
   ...generateMock(Agreement),
   eserviceId,


### PR DESCRIPTION
[ To be merged after #324 ]

Closes [IMN-218](https://pagopa.atlassian.net/browse/IMN-218)

# Tests

## New automated tests work ✅
<img width="601" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/07b20188-978a-43c4-a96e-e87d80e688ca">


## Manual tests 
<img width="1298" alt="Screenshot 2024-04-02 at 15 49 37" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/6d329ee7-2aac-43b1-a245-3b6343e6f15b">

---

<img width="1301" alt="Screenshot 2024-04-02 at 15 49 26" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/772b5d8a-b232-4253-bb7a-1f1fad098d94">

---

<img width="1300" alt="Screenshot 2024-04-02 at 15 49 12" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/4da0ee74-2f87-4f5b-8b2d-0067775eaa85">

---

<img width="1300" alt="Screenshot 2024-04-02 at 15 49 02" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/cd2adfba-52ad-4616-a364-40a583aec45c">


[IMN-218]: https://pagopa.atlassian.net/browse/IMN-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ