### PR TITLE
IMN 147 - Kafka primary key

### DIFF
--- a/register-connector-postgres.json
+++ b/register-connector-postgres.json
@@ -18,6 +18,7 @@
         "transforms": "PartitionRouting",
         "transforms.PartitionRouting.type": "io.debezium.transforms.partitions.PartitionRouting",
         "transforms.PartitionRouting.partition.topic.num": 3,
-        "transforms.PartitionRouting.partition.payload.fields": "change.stream_id"
+        "transforms.PartitionRouting.partition.payload.fields": "change.stream_id",
+        "message.key.columns": "(.*).events:stream_id"
     }
 }


### PR DESCRIPTION
Closes [IMN-147](https://pagopa.atlassian.net/browse/IMN-147)

By default, Debezium uses the Postgres table primary key as kafka message primary key. For this reason, until now our kafka messages show `sequence_num` as key.

Kafka uses this key to select the correct partition for a message if a target partition is not specified. We tell Debezium to use a custom route to select the correct partition for a message so each message is routed to a specific partition.

This change sets the `stream_id` as Kafka message key. Now the `stream_id` will be used as a fallback value to decide which partition to route a message.


![image](https://github.com/pagopa/interop-be-monorepo/assets/32327779/956aa7c6-3e0e-41c0-b5de-1f27b6a067ae)


[IMN-147]: https://pagopa.atlassian.net/browse/IMN-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ