### PR TITLE
Fix kafka message decoder

### DIFF
--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -13,7 +13,7 @@ export type AppContext = {
     eventVersion: number;
     streamId: string;
   };
-  correlationId?: string;
+  correlationId?: string | null | undefined;
 };
 export type ZodiosContext = NonNullable<typeof zodiosCtx>;
 export type ExpressContext = NonNullable<typeof zodiosCtx.context>;

--- a/packages/commons/src/logging/loggerMiddleware.ts
+++ b/packages/commons/src/logging/loggerMiddleware.ts
@@ -10,7 +10,7 @@ import { bigIntReplacer } from "./utils.js";
 export type SessionMetaData = {
   userId: string | undefined;
   organizationId: string | undefined;
-  correlationId: string | undefined;
+  correlationId: string | undefined | null;
   eventType: string | undefined;
   eventVersion: number | undefined;
   streamId: string | undefined;
@@ -59,7 +59,7 @@ const logFormat = (
   }: {
     userId: string | undefined;
     organizationId: string | undefined;
-    correlationId: string | undefined;
+    correlationId: string | undefined | null;
     serviceName: string | undefined;
     eventType: string | undefined;
     eventVersion: number | undefined;

--- a/packages/models/src/events/events.ts
+++ b/packages/models/src/events/events.ts
@@ -9,7 +9,7 @@ export const EventEnvelope = <TEventZodType extends z.ZodType>(
       sequence_num: z.number(),
       stream_id: z.string().uuid(),
       version: z.number(),
-      correlation_id: z.string().optional(),
+      correlation_id: z.string().nullish(),
     }),
     event
   );


### PR DESCRIPTION
This PR changes the decoder for the `correlation_id` field of a kafka message from `.optional()` to `.nullish()` to handle `null` value cases