### PR TITLE
Renovate - removing autodiscover and setting specific repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,6 @@
   "branchPrefix": "renovate-action/",
   "prConcurrentLimit": 2,
   "packageRules": [],
-  "autodiscover": true,
+  "repositories": ["pagopa/interop-be-monorepo"],
   "ignorePaths": ["docker/docker-compose.yml"]
 }


### PR DESCRIPTION
With `autodiscover` set to `true`, Renovate runs on all the repositories it can access with the specified token. 

See the last run here and the screenshot below: https://github.com/pagopa/interop-be-monorepo/actions/runs/8552520446/job/23433780991

**🚨 I stopped it as soon as I saw the repositories discovered, so it should not have created any issues/PRs on other repos.**

<img width="718" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/7ab7a544-4c20-49bb-83b9-4fef27cbaa60">

---

I would keep the `repositories` setting even if it gives the following warning when running - in the future, this will be solved when Renovate is set up for the whole organization.

<img width="1352" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/f897a707-85fb-4446-b510-fa05cb03ec31">
