### PR TITLE
IMN 358 - agreement read model service methods tests

### DIFF
--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -480,7 +480,7 @@ const agreementRouter = (
             eserviceName: req.query.eServiceName,
             consumerIds: req.query.consumersIds.map(unsafeBrandId<TenantId>),
             producerIds: req.query.producersIds.map(unsafeBrandId<TenantId>),
-            agreeementStates: req.query.states.map(
+            agreementStates: req.query.states.map(
               apiAgreementStateToAgreementState
             ),
           },

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -328,7 +328,7 @@ export function agreementServiceBuilder(
       offset: number
     ): Promise<ListResult<CompactEService>> {
       logger.info(
-        `Retrieving EServices with consumers ${filters.consumerIds}, producers ${filters.producerIds}, states ${filters.agreeementStates}, offset ${offset}, limit ${limit} and name matching ${filters.eserviceName}`
+        `Retrieving EServices with consumers ${filters.consumerIds}, producers ${filters.producerIds}, states ${filters.agreementStates}, offset ${offset}, limit ${limit} and name matching ${filters.eserviceName}`
       );
 
       return await agreementQuery.getEServices(filters, limit, offset);

--- a/packages/agreement-process/src/services/readmodel/readModelService.ts
+++ b/packages/agreement-process/src/services/readmodel/readModelService.ts
@@ -50,7 +50,7 @@ export type AgreementEServicesQueryFilters = {
   eserviceName: string | undefined;
   consumerIds: TenantId[];
   producerIds: TenantId[];
-  agreeementStates: AgreementState[];
+  agreementStates: AgreementState[];
 };
 
 type AgreementDataFields = RemoveDataPrefix<MongoQueryKeys<Agreement>>;
@@ -530,7 +530,7 @@ export function readModelServiceBuilder(
           $match: {
             ...makeFilter("consumerId", filters.consumerIds),
             ...makeFilter("producerId", filters.producerIds),
-            ...makeFilter("state", filters.agreeementStates),
+            ...makeFilter("state", filters.agreementStates),
             ...makeRegexFilter("eservices.data.name", filters.eserviceName),
           },
         },

--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -84,10 +84,7 @@ import {
 import { agreementQueryBuilder } from "../src/services/readmodel/agreementQuery.js";
 import { attributeQueryBuilder } from "../src/services/readmodel/attributeQuery.js";
 import { eserviceQueryBuilder } from "../src/services/readmodel/eserviceQuery.js";
-import {
-  AgreementEServicesQueryFilters,
-  readModelServiceBuilder,
-} from "../src/services/readmodel/readModelService.js";
+import { readModelServiceBuilder } from "../src/services/readmodel/readModelService.js";
 import { tenantQueryBuilder } from "../src/services/readmodel/tenantQuery.js";
 import { config } from "../src/utilities/config.js";
 import { agreementCreationConflictingStates } from "../src/model/domain/validators.js";

--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -1887,6 +1887,8 @@ describe("Agreement service", () => {
           expect(result).toBeUndefined();
         });
       });
+
+      // TODO add a smoke test also for all the other readmodel service methods
     });
   });
 });

--- a/packages/agreement-process/test/utils.ts
+++ b/packages/agreement-process/test/utils.ts
@@ -2,9 +2,11 @@ import {
   Agreement,
   AgreementEvent,
   AgreementId,
+  Attribute,
   EService,
   Tenant,
   agreementEventToBinaryData,
+  toReadModelAttribute,
   toReadModelEService,
 } from "pagopa-interop-models";
 import { IDatabase } from "pg-promise";
@@ -16,6 +18,7 @@ import {
 } from "pagopa-interop-commons-test/index.js";
 import {
   AgreementCollection,
+  AttributeCollection,
   EServiceCollection,
   TenantCollection,
 } from "pagopa-interop-commons";
@@ -63,6 +66,13 @@ export const addOneTenant = async (
   tenants: TenantCollection
 ): Promise<void> => {
   await writeInReadmodel(tenant, tenants);
+};
+
+export const addOneAttribute = async (
+  attribute: Attribute,
+  attributes: AttributeCollection
+): Promise<void> => {
+  await writeInReadmodel(toReadModelAttribute(attribute), attributes);
 };
 
 export const readLastAgreementEvent = async (

--- a/packages/commons-test/src/testUtils.ts
+++ b/packages/commons-test/src/testUtils.ts
@@ -16,7 +16,6 @@ import {
   TenantAttribute,
   TenantId,
   VerifiedTenantAttribute,
-  attributeKind,
   agreementState,
   attributeKind,
   descriptorState,

--- a/packages/commons-test/src/testUtils.ts
+++ b/packages/commons-test/src/testUtils.ts
@@ -4,7 +4,6 @@ import {
   AgreementState,
   Attribute,
   AttributeId,
-  AttributeKind,
   CertifiedTenantAttribute,
   DeclaredTenantAttribute,
   Descriptor,
@@ -16,8 +15,8 @@ import {
   TenantAttribute,
   TenantId,
   VerifiedTenantAttribute,
-  agreementState,
   attributeKind,
+  agreementState,
   descriptorState,
   generateId,
   tenantAttributeType,
@@ -137,10 +136,12 @@ export const buildAgreement = (
   state,
 });
 
-export const getMockAttribute = (
-  kind: AttributeKind = attributeKind.certified
-): Attribute => ({
-  ...generateMock(Attribute),
+export const getMockAttribute = (): Attribute => ({
+  id: generateId(),
+  name: "attribute name",
+  kind: attributeKind.certified,
+  description: "attribute description",
   creationTime: new Date(),
-  kind,
+  code: undefined,
+  origin: undefined,
 });

--- a/packages/commons-test/src/testUtils.ts
+++ b/packages/commons-test/src/testUtils.ts
@@ -4,6 +4,7 @@ import {
   AgreementState,
   Attribute,
   AttributeId,
+  AttributeKind,
   CertifiedTenantAttribute,
   DeclaredTenantAttribute,
   Descriptor,
@@ -17,6 +18,7 @@ import {
   VerifiedTenantAttribute,
   attributeKind,
   agreementState,
+  attributeKind,
   descriptorState,
   generateId,
   tenantAttributeType,
@@ -136,12 +138,10 @@ export const buildAgreement = (
   state,
 });
 
-export const getMockAttribute = (): Attribute => ({
-  id: generateId(),
-  name: "attribute name",
-  kind: attributeKind.certified,
-  description: "attribute description",
+export const getMockAttribute = (
+  kind: AttributeKind = attributeKind.certified
+): Attribute => ({
+  ...generateMock(Attribute),
   creationTime: new Date(),
-  code: undefined,
-  origin: undefined,
+  kind,
 });


### PR DESCRIPTION
[ To be merged after #328 ]

Closes [IMN-358](https://pagopa.atlassian.net/browse/IMN-358)

Adding just smoke tests for all readmodel methods, since their logic is already covered by the service logic tests.

<img width="807" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/a665681b-a394-4621-a508-cec09ff875f3">


[IMN-358]: https://pagopa.atlassian.net/browse/IMN-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ