### PR TITLE
IMN-225 - adding tests for GET agreement consumer document

### DIFF
--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -1771,7 +1771,6 @@ describe("Agreement service", () => {
   });
   describe("get agreement consumer document", () => {
     let agreement1: Agreement;
-    let agreement2: Agreement;
 
     beforeEach(async () => {
       agreement1 = {
@@ -1782,12 +1781,8 @@ describe("Agreement service", () => {
         ],
       };
 
-      agreement2 = {
-        ...buildAgreement(),
-        consumerDocuments: [],
-      };
       await addOneAgreement(agreement1, postgresDB, agreements);
-      await addOneAgreement(agreement2, postgresDB, agreements);
+      await addOneAgreement(buildAgreement(), postgresDB, agreements);
     });
 
     it("should get an agreement consumer document when the requester is the consumer or producer", async () => {
@@ -1817,7 +1812,7 @@ describe("Agreement service", () => {
     });
 
     it("should throw operationNotAllowed error when the requester is not the consumer or producer", async () => {
-      const authData = getRandomAuthData(agreement2.consumerId);
+      const authData = getRandomAuthData(generateId<TenantId>());
 
       await expect(
         agreementService.getAgreementConsumerDocument(

--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -1771,20 +1771,23 @@ describe("Agreement service", () => {
   });
   describe("get agreement consumer document", () => {
     let agreement1: Agreement;
+    let agreement2: Agreement;
 
     beforeEach(async () => {
       agreement1 = {
-        ...getMockAgreement(),
-        producerId: generateId<TenantId>(),
-        consumerId: generateId<TenantId>(),
+        ...buildAgreement(),
         consumerDocuments: [
           generateMock(AgreementDocument),
           generateMock(AgreementDocument),
         ],
       };
 
+      agreement2 = {
+        ...buildAgreement(),
+        consumerDocuments: [],
+      };
       await addOneAgreement(agreement1, postgresDB, agreements);
-      await addOneAgreement(getMockAgreement(), postgresDB, agreements);
+      await addOneAgreement(agreement2, postgresDB, agreements);
     });
 
     it("should get an agreement consumer document when the requester is the consumer or producer", async () => {
@@ -1814,7 +1817,7 @@ describe("Agreement service", () => {
     });
 
     it("should throw operationNotAllowed error when the requester is not the consumer or producer", async () => {
-      const authData = getRandomAuthData(generateId<TenantId>());
+      const authData = getRandomAuthData(agreement2.consumerId);
 
       await expect(
         agreementService.getAgreementConsumerDocument(

--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -1811,7 +1811,7 @@ describe("Agreement service", () => {
       ).rejects.toThrowError(agreementNotFound(agreementId));
     });
 
-    it("should throw operationNotAllowed error when the requester is not the consumer or producer", async () => {
+    it("should throw an operationNotAllowed error when the requester is not the consumer or producer", async () => {
       const authData = getRandomAuthData(generateId<TenantId>());
 
       await expect(
@@ -1823,7 +1823,7 @@ describe("Agreement service", () => {
       ).rejects.toThrowError(operationNotAllowed(authData.organizationId));
     });
 
-    it("should throw agreementDocumentNotFound error when the document does not exist", async () => {
+    it("should throw an agreementDocumentNotFound error when the document does not exist", async () => {
       const authData = getRandomAuthData(agreement1.consumerId);
       const agreementDocumentId = generateId<AgreementDocumentId>();
       await expect(

--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable functional/immutable-data */
 
 import { fail } from "assert";
+import { generateMock } from "@anatine/zod-mock";
 import {
   AgreementCollection,
   EServiceCollection,
@@ -35,6 +36,8 @@ import {
   Agreement,
   AgreementAddedV1,
   AgreementAttribute,
+  AgreementDocument,
+  AgreementDocumentId,
   AgreementId,
   AgreementV1,
   AttributeId,
@@ -65,11 +68,13 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import {
   agreementAlreadyExists,
+  agreementDocumentNotFound,
   agreementNotFound,
   descriptorNotInExpectedState,
   eServiceNotFound,
   missingCertifiedAttributesError,
   notLatestEServiceDescriptor,
+  operationNotAllowed,
   tenantIdNotFound,
 } from "../src/model/domain/errors.js";
 import { toAgreementStateV1 } from "../src/model/domain/toEvent.js";
@@ -1764,7 +1769,76 @@ describe("Agreement service", () => {
       });
     });
   });
+  describe("get agreement consumer document", () => {
+    let agreement1: Agreement;
 
-  testUpdateAgreement();
+    beforeEach(async () => {
+      agreement1 = {
+        ...getMockAgreement(),
+        producerId: generateId<TenantId>(),
+        consumerId: generateId<TenantId>(),
+        consumerDocuments: [
+          generateMock(AgreementDocument),
+          generateMock(AgreementDocument),
+        ],
+      };
+
+      await addOneAgreement(agreement1, postgresDB, agreements);
+      await addOneAgreement(getMockAgreement(), postgresDB, agreements);
+    });
+
+    it("should get an agreement consumer document when the requester is the consumer or producer", async () => {
+      const authData = getRandomAuthData(
+        randomArrayItem([agreement1.consumerId, agreement1.producerId])
+      );
+      const result = await agreementService.getAgreementConsumerDocument(
+        agreement1.id,
+        agreement1.consumerDocuments[0].id,
+        authData
+      );
+
+      expect(result).toEqual(agreement1.consumerDocuments[0]);
+    });
+
+    it("should throw an agreementNotFound error when the agreement does not exist", async () => {
+      const agreementId = generateId<AgreementId>();
+      const authData = getRandomAuthData(agreement1.consumerId);
+
+      await expect(
+        agreementService.getAgreementConsumerDocument(
+          agreementId,
+          agreement1.consumerDocuments[0].id,
+          authData
+        )
+      ).rejects.toThrowError(agreementNotFound(agreementId));
+    });
+
+    it("should throw operationNotAllowed error when the requester is not the consumer or producer", async () => {
+      const authData = getRandomAuthData(generateId<TenantId>());
+
+      await expect(
+        agreementService.getAgreementConsumerDocument(
+          agreement1.id,
+          agreement1.consumerDocuments[0].id,
+          authData
+        )
+      ).rejects.toThrowError(operationNotAllowed(authData.organizationId));
+    });
+
+    it("should throw agreementDocumentNotFound error when the document does not exist", async () => {
+      const authData = getRandomAuthData(agreement1.consumerId);
+      const agreementDocumentId = generateId<AgreementDocumentId>();
+      await expect(
+        agreementService.getAgreementConsumerDocument(
+          agreement1.id,
+          agreementDocumentId,
+          authData
+        )
+      ).rejects.toThrowError(
+        agreementDocumentNotFound(agreementDocumentId, agreement1.id)
+      );
+    });
+  });
   testDeleteAgreement();
+  testUpdateAgreement();
 });

--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -1774,7 +1774,7 @@ describe("Agreement service", () => {
 
     beforeEach(async () => {
       agreement1 = {
-        ...buildAgreement(),
+        ...getMockAgreement(),
         consumerDocuments: [
           generateMock(AgreementDocument),
           generateMock(AgreementDocument),
@@ -1782,7 +1782,7 @@ describe("Agreement service", () => {
       };
 
       await addOneAgreement(agreement1, postgresDB, agreements);
-      await addOneAgreement(buildAgreement(), postgresDB, agreements);
+      await addOneAgreement(getMockAgreement(), postgresDB, agreements);
     });
 
     it("should get an agreement consumer document when the requester is the consumer or producer", async () => {
@@ -1801,7 +1801,7 @@ describe("Agreement service", () => {
     it("should throw an agreementNotFound error when the agreement does not exist", async () => {
       const agreementId = generateId<AgreementId>();
       const authData = getRandomAuthData(agreement1.consumerId);
-      await addOneAgreement(buildAgreement(), postgresDB, agreements);
+      await addOneAgreement(getMockAgreement(), postgresDB, agreements);
       await expect(
         agreementService.getAgreementConsumerDocument(
           agreementId,

--- a/packages/agreement-process/test/agreementService.integration.test.ts
+++ b/packages/agreement-process/test/agreementService.integration.test.ts
@@ -1801,7 +1801,7 @@ describe("Agreement service", () => {
     it("should throw an agreementNotFound error when the agreement does not exist", async () => {
       const agreementId = generateId<AgreementId>();
       const authData = getRandomAuthData(agreement1.consumerId);
-
+      await addOneAgreement(buildAgreement(), postgresDB, agreements);
       await expect(
         agreementService.getAgreementConsumerDocument(
           agreementId,

--- a/packages/agreement-process/test/testAgreementConsumerDocuments.ts
+++ b/packages/agreement-process/test/testAgreementConsumerDocuments.ts
@@ -1,0 +1,97 @@
+/* eslint-disable functional/no-let */
+import { generateMock } from "@anatine/zod-mock";
+import {
+  getMockAgreement,
+  getRandomAuthData,
+  randomArrayItem,
+} from "pagopa-interop-commons-test/index.js";
+import {
+  Agreement,
+  AgreementDocument,
+  generateId,
+  AgreementId,
+  TenantId,
+  AgreementDocumentId,
+} from "pagopa-interop-models";
+import { describe, beforeEach, it, expect } from "vitest";
+import {
+  agreementNotFound,
+  operationNotAllowed,
+  agreementDocumentNotFound,
+} from "../src/model/domain/errors.js";
+import {
+  postgresDB,
+  agreements,
+  agreementService,
+} from "./agreementService.integration.test.js";
+import { addOneAgreement } from "./utils.js";
+
+export const testAgreementConsumerDocuments = (): ReturnType<typeof describe> =>
+  describe("get agreement consumer document", () => {
+    let agreement1: Agreement;
+
+    beforeEach(async () => {
+      agreement1 = {
+        ...getMockAgreement(),
+        consumerDocuments: [
+          generateMock(AgreementDocument),
+          generateMock(AgreementDocument),
+        ],
+      };
+
+      await addOneAgreement(agreement1, postgresDB, agreements);
+      await addOneAgreement(getMockAgreement(), postgresDB, agreements);
+    });
+
+    it("should get an agreement consumer document when the requester is the consumer or producer", async () => {
+      const authData = getRandomAuthData(
+        randomArrayItem([agreement1.consumerId, agreement1.producerId])
+      );
+      const result = await agreementService.getAgreementConsumerDocument(
+        agreement1.id,
+        agreement1.consumerDocuments[0].id,
+        authData
+      );
+
+      expect(result).toEqual(agreement1.consumerDocuments[0]);
+    });
+
+    it("should throw an agreementNotFound error when the agreement does not exist", async () => {
+      const agreementId = generateId<AgreementId>();
+      const authData = getRandomAuthData(agreement1.consumerId);
+      await addOneAgreement(getMockAgreement(), postgresDB, agreements);
+      await expect(
+        agreementService.getAgreementConsumerDocument(
+          agreementId,
+          agreement1.consumerDocuments[0].id,
+          authData
+        )
+      ).rejects.toThrowError(agreementNotFound(agreementId));
+    });
+
+    it("should throw an operationNotAllowed error when the requester is not the consumer or producer", async () => {
+      const authData = getRandomAuthData(generateId<TenantId>());
+
+      await expect(
+        agreementService.getAgreementConsumerDocument(
+          agreement1.id,
+          agreement1.consumerDocuments[0].id,
+          authData
+        )
+      ).rejects.toThrowError(operationNotAllowed(authData.organizationId));
+    });
+
+    it("should throw an agreementDocumentNotFound error when the document does not exist", async () => {
+      const authData = getRandomAuthData(agreement1.consumerId);
+      const agreementDocumentId = generateId<AgreementDocumentId>();
+      await expect(
+        agreementService.getAgreementConsumerDocument(
+          agreement1.id,
+          agreementDocumentId,
+          authData
+        )
+      ).rejects.toThrowError(
+        agreementDocumentNotFound(agreementDocumentId, agreement1.id)
+      );
+    });
+  });


### PR DESCRIPTION
[ To be merged after #328 ]

Closes [IMN-225](https://pagopa.atlassian.net/browse/IMN-225)

# Tests

## New automated tests work ✅

<img width="673" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/34dc995b-1cf5-4f03-8427-57d16254e24c">

## Manual tests ✅

### Agreement in read model:

<img width="934" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/ea409c1d-f8bd-4978-ba36-d35fd7e02f3c">

### Retrieving document

<img width="767" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/b9527361-116e-4b25-9829-d2558f5ba35b">

### Document not found

<img width="756" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/0648f409-1640-46d1-8c4b-905b32ddf504">



[IMN-225]: https://pagopa.atlassian.net/browse/IMN-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ