### PR TITLE
IMN 473 - Fix global storage usage

### DIFF
--- a/packages/agreement-process/src/app.ts
+++ b/packages/agreement-process/src/app.ts
@@ -1,7 +1,6 @@
 import {
   authenticationMiddleware,
-  contextDataMiddleware,
-  globalContextMiddleware,
+  contextMiddleware,
   loggerMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
@@ -14,8 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(globalContextMiddleware);
-app.use(contextDataMiddleware);
+app.use(contextMiddleware);
 app.use(loggerMiddleware("agreement-process")());
 
 // NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes

--- a/packages/agreement-readmodel-writer/src/index.ts
+++ b/packages/agreement-readmodel-writer/src/index.ts
@@ -6,7 +6,7 @@ import {
   agreementTopicConfig,
   decodeKafkaMessage,
   logger,
-  getContext,
+  runWithContext,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
 import { AgreementEvent } from "pagopa-interop-models";
@@ -24,21 +24,25 @@ async function processMessage({
 }: EachMessagePayload): Promise<void> {
   const msg = decodeKafkaMessage(message, AgreementEvent);
 
-  const ctx = getContext();
-  ctx.messageData = {
-    eventType: msg.type,
-    eventVersion: msg.event_version,
-    streamId: msg.stream_id,
-  };
-  ctx.correlationId = msg.correlation_id;
+  runWithContext(
+    {
+      messageData: {
+        eventType: msg.type,
+        eventVersion: msg.event_version,
+        streamId: msg.stream_id,
+      },
+      correlationId: msg.correlation_id,
+    },
+    async () => {
+      await match(msg)
+        .with({ event_version: 1 }, (msg) => handleMessageV1(msg, agreements))
+        .with({ event_version: 2 }, (msg) => handleMessageV2(msg, agreements))
+        .exhaustive();
 
-  await match(msg)
-    .with({ event_version: 1 }, (msg) => handleMessageV1(msg, agreements))
-    .with({ event_version: 2 }, (msg) => handleMessageV2(msg, agreements))
-    .exhaustive();
-
-  logger.info(
-    `Read model was updated. Partition number: ${partition}. Offset: ${message.offset}`
+      logger.info(
+        `Read model was updated. Partition number: ${partition}. Offset: ${message.offset}`
+      );
+    }
   );
 }
 

--- a/packages/attribute-registry-process/src/app.ts
+++ b/packages/attribute-registry-process/src/app.ts
@@ -1,6 +1,5 @@
 import {
-  contextDataMiddleware,
-  globalContextMiddleware,
+  contextMiddleware,
   loggerMiddleware,
   authenticationMiddleware,
   zodiosCtx,
@@ -14,8 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(globalContextMiddleware);
-app.use(contextDataMiddleware);
+app.use(contextMiddleware);
 app.use(loggerMiddleware("attribute-registry-process")());
 // NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes
 // we want to be unauthenticated.

--- a/packages/attribute-registry-readmodel-writer/src/index.ts
+++ b/packages/attribute-registry-readmodel-writer/src/index.ts
@@ -4,9 +4,9 @@ import {
   ReadModelRepository,
   attributeTopicConfig,
   decodeKafkaMessage,
-  getContext,
   logger,
   readModelWriterConfig,
+  runWithContext,
 } from "pagopa-interop-commons";
 import { createMechanism } from "@jm18457/kafkajs-msk-iam-authentication-mechanism";
 import { AttributeEvent } from "pagopa-interop-models";
@@ -53,19 +53,23 @@ async function processMessage({
   message,
   partition,
 }: EachMessagePayload): Promise<void> {
-  await handleMessage(decodeKafkaMessage(message, AttributeEvent), attributes);
   const msg = decodeKafkaMessage(message, AttributeEvent);
-  const ctx = getContext();
-  ctx.messageData = {
-    eventType: msg.type,
-    eventVersion: msg.event_version,
-    streamId: msg.stream_id,
-  };
-  ctx.correlationId = msg.correlation_id;
 
-  await handleMessage(msg, attributes);
-  logger.info(
-    `Read model was updated. Partition number: ${partition}. Offset: ${message.offset}`
+  runWithContext(
+    {
+      messageData: {
+        eventType: msg.type,
+        eventVersion: msg.event_version,
+        streamId: msg.stream_id,
+      },
+      correlationId: msg.correlation_id,
+    },
+    async () => {
+      await handleMessage(msg, attributes);
+      logger.info(
+        `Read model was updated. Partition number: ${partition}. Offset: ${message.offset}`
+      );
+    }
   );
 }
 await runConsumer(config, [attributeTopic], processMessage);

--- a/packages/authorization-updater/src/index.ts
+++ b/packages/authorization-updater/src/index.ts
@@ -6,9 +6,9 @@ import {
   messageDecoderSupplier,
   kafkaConsumerConfig,
   logger,
-  getContext,
   CatalogTopicConfig,
   catalogTopicConfig,
+  runWithContext,
 } from "pagopa-interop-commons";
 import {
   Descriptor,
@@ -80,70 +80,74 @@ function processMessage(
       );
       const decodedMsg = messageDecoder(messagePayload.message);
 
-      const ctx = getContext();
-      ctx.messageData = {
-        eventType: decodedMsg.type,
-        eventVersion: decodedMsg.event_version,
-        streamId: decodedMsg.stream_id,
-      };
-      ctx.correlationId = decodedMsg.correlation_id;
+      runWithContext(
+        {
+          messageData: {
+            eventType: decodedMsg.type,
+            eventVersion: decodedMsg.event_version,
+            streamId: decodedMsg.stream_id,
+          },
+          correlationId: decodedMsg.correlation_id,
+        },
+        async () => {
+          const updateSeed = match(decodedMsg)
+            .with(
+              {
+                event_version: 2,
+                type: "EServiceDescriptorPublished",
+              },
+              {
+                event_version: 2,
+                type: "EServiceDescriptorActivated",
+              },
+              (msg) => {
+                const data = getDescriptorFromEvent(msg, decodedMsg.type);
+                return {
+                  state: "ACTIVE",
+                  descriptorId: data.descriptor.id,
+                  eserviceId: data.eserviceId,
+                  audience: data.descriptor.audience,
+                  voucherLifespan: data.descriptor.voucherLifespan,
+                  eventType: decodedMsg.type,
+                };
+              }
+            )
+            .with(
+              {
+                event_version: 2,
+                type: "EServiceDescriptorSuspended",
+              },
+              {
+                event_version: 2,
+                type: "EServiceDescriptorArchived",
+              },
+              (msg) => {
+                const data = getDescriptorFromEvent(msg, decodedMsg.type);
+                return {
+                  state: "INACTIVE",
+                  descriptorId: data.descriptor.id,
+                  eserviceId: data.eserviceId,
+                  audience: data.descriptor.audience,
+                  voucherLifespan: data.descriptor.voucherLifespan,
+                  eventType: decodedMsg.type,
+                };
+              }
+            )
+            .otherwise(() => undefined);
 
-      const updateSeed = match(decodedMsg)
-        .with(
-          {
-            event_version: 2,
-            type: "EServiceDescriptorPublished",
-          },
-          {
-            event_version: 2,
-            type: "EServiceDescriptorActivated",
-          },
-          (msg) => {
-            const data = getDescriptorFromEvent(msg, decodedMsg.type);
-            return {
-              state: "ACTIVE",
-              descriptorId: data.descriptor.id,
-              eserviceId: data.eserviceId,
-              audience: data.descriptor.audience,
-              voucherLifespan: data.descriptor.voucherLifespan,
-              eventType: decodedMsg.type,
-            };
+          if (updateSeed) {
+            await executeUpdate(updateSeed.eventType, messagePayload, () =>
+              authService.updateEServiceState(
+                ApiClientComponent.parse(updateSeed.state),
+                updateSeed.descriptorId,
+                updateSeed.eserviceId,
+                updateSeed.audience,
+                updateSeed.voucherLifespan
+              )
+            );
           }
-        )
-        .with(
-          {
-            event_version: 2,
-            type: "EServiceDescriptorSuspended",
-          },
-          {
-            event_version: 2,
-            type: "EServiceDescriptorArchived",
-          },
-          (msg) => {
-            const data = getDescriptorFromEvent(msg, decodedMsg.type);
-            return {
-              state: "INACTIVE",
-              descriptorId: data.descriptor.id,
-              eserviceId: data.eserviceId,
-              audience: data.descriptor.audience,
-              voucherLifespan: data.descriptor.voucherLifespan,
-              eventType: decodedMsg.type,
-            };
-          }
-        )
-        .otherwise(() => undefined);
-
-      if (updateSeed) {
-        await executeUpdate(updateSeed.eventType, messagePayload, () =>
-          authService.updateEServiceState(
-            ApiClientComponent.parse(updateSeed.state),
-            updateSeed.descriptorId,
-            updateSeed.eserviceId,
-            updateSeed.audience,
-            updateSeed.voucherLifespan
-          )
-        );
-      }
+        }
+      );
     } catch (e) {
       throw kafkaMessageProcessError(
         messagePayload.topic,

--- a/packages/catalog-process/src/app.ts
+++ b/packages/catalog-process/src/app.ts
@@ -1,6 +1,5 @@
 import {
-  contextDataMiddleware,
-  globalContextMiddleware,
+  contextMiddleware,
   loggerMiddleware,
   authenticationMiddleware,
   zodiosCtx,
@@ -14,8 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(globalContextMiddleware);
-app.use(contextDataMiddleware);
+app.use(contextMiddleware);
 app.use(loggerMiddleware("catalog-process")());
 // NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes
 // we want to be unauthenticated.

--- a/packages/catalog-readmodel-writer/src/index.ts
+++ b/packages/catalog-readmodel-writer/src/index.ts
@@ -6,9 +6,8 @@ import {
   readModelWriterConfig,
   catalogTopicConfig,
   decodeKafkaMessage,
-  getContext,
+  runWithContext,
 } from "pagopa-interop-commons";
-import { v4 } from "uuid";
 import { runConsumer } from "kafka-iam-auth";
 import { EServiceEvent } from "pagopa-interop-models";
 import { match } from "ts-pattern";
@@ -24,21 +23,26 @@ async function processMessage({
   partition,
 }: EachMessagePayload): Promise<void> {
   const decodedMessage = decodeKafkaMessage(message, EServiceEvent);
-  const ctx = getContext();
-  ctx.messageData = {
-    eventType: decodedMessage.type,
-    eventVersion: decodedMessage.event_version,
-    streamId: decodedMessage.stream_id,
-  };
-  ctx.correlationId = decodedMessage.correlation_id || v4();
 
-  await match(decodedMessage)
-    .with({ event_version: 1 }, (msg) => handleMessageV1(msg, eservices))
-    .with({ event_version: 2 }, (msg) => handleMessageV2(msg, eservices))
-    .exhaustive();
+  runWithContext(
+    {
+      messageData: {
+        eventType: decodedMessage.type,
+        eventVersion: decodedMessage.event_version,
+        streamId: decodedMessage.stream_id,
+      },
+      correlationId: decodedMessage.correlation_id,
+    },
+    async () => {
+      await match(decodedMessage)
+        .with({ event_version: 1 }, (msg) => handleMessageV1(msg, eservices))
+        .with({ event_version: 2 }, (msg) => handleMessageV2(msg, eservices))
+        .exhaustive();
 
-  logger.info(
-    `Read model was updated. Partition number: ${partition}. Offset: ${message.offset}`
+      logger.info(
+        `Read model was updated. Partition number: ${partition}. Offset: ${message.offset}`
+      );
+    }
   );
 }
 

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -57,3 +57,10 @@ export const contextMiddleware = (
 
   globalStore.run(context, () => next());
 };
+
+export function runWithContext(
+  context: Partial<AppContext>,
+  fn: () => void
+): void {
+  globalStore.run({ ...defaultAppContext, ...context }, fn);
+}

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from "async_hooks";
 import { NextFunction, Request, Response } from "express";
 import { zodiosContext } from "@zodios/express";
 import { z } from "zod";
+import { P, match } from "ts-pattern";
 import { AuthData, defaultAuthData } from "../auth/authData.js";
 import { readHeaders } from "../auth/headers.js";
 
@@ -35,31 +36,24 @@ export const getContext = (): AppContext => {
   return !context ? defaultAppContext : context;
 };
 
-export const globalContextMiddleware = (
-  _req: Request,
-  _res: Response,
-  next: NextFunction
-): void => {
-  globalStore.run(defaultAppContext, () => defaultAppContext);
-  next();
-};
-
-export const contextDataMiddleware = (
+export const contextMiddleware = (
   req: Request,
   _res: Response,
   next: NextFunction
 ): void => {
   const headers = readHeaders(req);
-  if (headers) {
-    const context = getContext();
-    context.authData = {
-      userId: headers.userId,
-      organizationId: headers.organizationId,
-      userRoles: headers.userRoles,
-      externalId: headers.externalId,
-    };
+  const context = match(headers)
+    .with(P.not(P.nullish), (headers) => ({
+      authData: {
+        userId: headers.userId,
+        organizationId: headers.organizationId,
+        userRoles: headers.userRoles,
+        externalId: headers.externalId,
+      },
+      correlationId: headers.correlationId,
+    }))
+    .with(P.nullish, () => defaultAppContext)
+    .exhaustive();
 
-    context.correlationId = headers?.correlationId;
-  }
-  next();
+  globalStore.run(context, () => next());
 };

--- a/packages/purpose-process/src/app.ts
+++ b/packages/purpose-process/src/app.ts
@@ -1,6 +1,5 @@
 import {
-  contextDataMiddleware,
-  globalContextMiddleware,
+  contextMiddleware,
   loggerMiddleware,
   authenticationMiddleware,
   zodiosCtx,
@@ -14,8 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(globalContextMiddleware);
-app.use(contextDataMiddleware);
+app.use(contextMiddleware);
 app.use(loggerMiddleware("purpose-process")());
 app.use(healthRouter);
 app.use(authenticationMiddleware());

--- a/packages/tenant-process/src/app.ts
+++ b/packages/tenant-process/src/app.ts
@@ -1,7 +1,6 @@
 import {
   authenticationMiddleware,
-  contextDataMiddleware,
-  globalContextMiddleware,
+  contextMiddleware,
   loggerMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
@@ -14,8 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(globalContextMiddleware);
-app.use(contextDataMiddleware);
+app.use(contextMiddleware);
 app.use(loggerMiddleware("tenant-process")());
 
 // NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes

--- a/packages/tenant-readmodel-writer/src/index.ts
+++ b/packages/tenant-readmodel-writer/src/index.ts
@@ -5,7 +5,7 @@ import {
   readModelWriterConfig,
   tenantTopicConfig,
   decodeKafkaMessage,
-  getContext,
+  runWithContext,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
 import { TenantEvent } from "pagopa-interop-models";
@@ -17,17 +17,21 @@ async function processMessage({
 }: EachMessagePayload): Promise<void> {
   const decodedMessage = decodeKafkaMessage(message, TenantEvent);
 
-  const ctx = getContext();
-  ctx.messageData = {
-    eventType: decodedMessage.type,
-    eventVersion: decodedMessage.event_version,
-    streamId: decodedMessage.stream_id,
-  };
-  ctx.correlationId = decodedMessage.correlation_id;
-
-  await handleMessage(decodedMessage);
-  logger.info(
-    `Read model was updated. Partition number: ${partition}. Offset: ${message.offset}`
+  runWithContext(
+    {
+      messageData: {
+        eventType: decodedMessage.type,
+        eventVersion: decodedMessage.event_version,
+        streamId: decodedMessage.stream_id,
+      },
+      correlationId: decodedMessage.correlation_id,
+    },
+    async () => {
+      await handleMessage(decodedMessage);
+      logger.info(
+        `Read model was updated. Partition number: ${partition}. Offset: ${message.offset}`
+      );
+    }
   );
 }
 


### PR DESCRIPTION
Closes [IMN-473](https://pagopa.atlassian.net/browse/IMN-473)

## Test
Manually tested locally. The asyc local storage works as before and the correlation id is correctly stored in the database and used by the readmodel-writer. 
More tests should by done on a "real" environment to better check if the concurrency problem is resolved.

![image](https://github.com/pagopa/interop-be-monorepo/assets/32327779/64af4bb8-5be5-461d-b2b4-a84cfe803d26)

![image](https://github.com/pagopa/interop-be-monorepo/assets/32327779/4736c4ce-7219-48d6-852b-5699bf93939c)


[IMN-473]: https://pagopa.atlassian.net/browse/IMN-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ