### PR TITLE
IMN-475 - Adding custom error handler for zodios validation errors

### DIFF
--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -8,6 +8,7 @@ import {
   initDB,
   ReadModelRepository,
   initFileManager,
+  zodiosValidationErrorToApiProblem,
 } from "pagopa-interop-commons";
 import {
   Agreement,
@@ -84,7 +85,9 @@ const {
 const agreementRouter = (
   ctx: ZodiosContext
 ): ZodiosRouter<ZodiosEndpointDefinitions, ExpressContext> => {
-  const agreementRouter = ctx.router(api.api);
+  const agreementRouter = ctx.router(api.api, {
+    validationErrorHandler: zodiosValidationErrorToApiProblem,
+  });
 
   agreementRouter.post(
     "/agreements/:agreementId/submit",

--- a/packages/attribute-registry-process/src/routers/AttributeRouter.ts
+++ b/packages/attribute-registry-process/src/routers/AttributeRouter.ts
@@ -7,6 +7,7 @@ import {
   authorizationMiddleware,
   ReadModelRepository,
   initDB,
+  zodiosValidationErrorToApiProblem,
 } from "pagopa-interop-commons";
 import { unsafeBrandId } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
@@ -46,7 +47,9 @@ const attributeRegistryService = attributeRegistryServiceBuilder(
 const attributeRouter = (
   ctx: ZodiosContext
 ): ZodiosRouter<ZodiosEndpointDefinitions, ExpressContext> => {
-  const attributeRouter = ctx.router(api.api);
+  const attributeRouter = ctx.router(api.api, {
+    validationErrorHandler: zodiosValidationErrorToApiProblem,
+  });
   const {
     ADMIN_ROLE,
     SECURITY_ROLE,

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -8,6 +8,7 @@ import {
   ReadModelRepository,
   initDB,
   initFileManager,
+  zodiosValidationErrorToApiProblem,
 } from "pagopa-interop-commons";
 import {
   unsafeBrandId,
@@ -73,7 +74,9 @@ const catalogService = catalogServiceBuilder(
 const eservicesRouter = (
   ctx: ZodiosContext
 ): ZodiosRouter<ZodiosEndpointDefinitions, ExpressContext> => {
-  const eservicesRouter = ctx.router(api.api);
+  const eservicesRouter = ctx.router(api.api, {
+    validationErrorHandler: zodiosValidationErrorToApiProblem,
+  });
   const {
     ADMIN_ROLE,
     SECURITY_ROLE,

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -35,7 +35,8 @@
     "ts-pattern": "5.0.6",
     "uuid": "9.0.1",
     "winston": "3.9.0",
-    "zod": "3.21.4"
+    "zod": "3.21.4",
+    "zod-validation-error": "^3.1.0"
   },
   "devDependencies": {
     "@types/express": "4.17.17",

--- a/packages/commons/src/auth/authorizationMiddleware.ts
+++ b/packages/commons/src/auth/authorizationMiddleware.ts
@@ -96,7 +96,9 @@ export const authorizationMiddleware =
         .with(P.instanceOf(ApiError), (error) =>
           makeApiProblem(
             new ApiError({
-              ...error,
+              code: error.code,
+              detail: error.detail,
+              title: error.title,
               correlationId: headers?.correlationId,
             }),
             (error) => (error.code === "unauthorizedError" ? 403 : 500)

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -11,3 +11,4 @@ export * from "./repositories/db.js";
 export * from "./types/index.js";
 export * from "./auth/token/index.js";
 export * from "./risk-analysis/index.js";
+export * from "./router/zodiosValidationErrorHandler.js";

--- a/packages/commons/src/router/zodiosValidationErrorHandler.ts
+++ b/packages/commons/src/router/zodiosValidationErrorHandler.ts
@@ -16,15 +16,15 @@ export function zodiosValidationErrorToApiProblem(
   res: Response,
   _next: NextFunction
 ): void {
-  const details = `${zodError.context} = ${zodError.error
-    .map((e) => fromZodIssue(e))
-    .join(", ")}`;
+  const detail = `Incorrect value for ${zodError.context}`;
+
+  const errors = zodError.error.map((e) => fromZodIssue(e));
 
   res
     .status(constants.HTTP_STATUS_BAD_REQUEST)
     .json(
       makeApiProblem(
-        badRequestError(details),
+        badRequestError(detail, errors),
         () => constants.HTTP_STATUS_BAD_REQUEST
       )
     )

--- a/packages/commons/src/router/zodiosValidationErrorHandler.ts
+++ b/packages/commons/src/router/zodiosValidationErrorHandler.ts
@@ -21,7 +21,7 @@ export function zodiosValidationErrorToApiProblem(
     .join(", ")}`;
 
   res
-    .status(400)
+    .status(constants.HTTP_STATUS_BAD_REQUEST)
     .json(
       makeApiProblem(
         badRequestError(details),

--- a/packages/commons/src/router/zodiosValidationErrorHandler.ts
+++ b/packages/commons/src/router/zodiosValidationErrorHandler.ts
@@ -17,7 +17,6 @@ export function zodiosValidationErrorToApiProblem(
   _next: NextFunction
 ): void {
   const detail = `Incorrect value for ${zodError.context}`;
-
   const errors = zodError.error.map((e) => fromZodIssue(e));
 
   res

--- a/packages/commons/src/router/zodiosValidationErrorHandler.ts
+++ b/packages/commons/src/router/zodiosValidationErrorHandler.ts
@@ -1,0 +1,32 @@
+import { constants } from "http2";
+import { Request, Response, NextFunction } from "express";
+import { badRequestError, makeApiProblemBuilder } from "pagopa-interop-models";
+import { z } from "zod";
+import { fromZodIssue } from "zod-validation-error";
+import { logger } from "../logging/index.js";
+
+const makeApiProblem = makeApiProblemBuilder(logger, {});
+
+export function zodiosValidationErrorToApiProblem(
+  zodError: {
+    context: string;
+    error: z.ZodIssue[];
+  },
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  const details = `${zodError.context} = ${zodError.error
+    .map((e) => fromZodIssue(e))
+    .join(", ")}`;
+
+  res
+    .status(400)
+    .json(
+      makeApiProblem(
+        badRequestError(details),
+        () => constants.HTTP_STATUS_BAD_REQUEST
+      )
+    )
+    .send();
+}

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -65,9 +65,12 @@ export type Problem = {
   toString: () => string;
 };
 
-const makeProblemLogString = (problem: Problem): string => {
+const makeProblemLogString = (
+  problem: Problem,
+  originalError: unknown
+): string => {
   const errorsString = problem.errors.map((e) => e.detail).join(" - ");
-  return `- title: ${problem.title} - detail: ${problem.detail} - errors: ${errorsString} - orignal error: ${error}`;
+  return `- title: ${problem.title} - detail: ${problem.detail} - errors: ${errorsString} - orignal error: ${originalError}`;
 };
 
 export function makeApiProblemBuilder<T extends string>(
@@ -99,12 +102,12 @@ export function makeApiProblemBuilder<T extends string>(
     return match<unknown, Problem>(error)
       .with(P.instanceOf(ApiError<T | CommonErrorCodes>), (error) => {
         const problem = makeProblem(httpMapper(error), error);
-        logger.warn(makeProblemLogString(problem));
+        logger.warn(makeProblemLogString(problem, error));
         return problem;
       })
-      .otherwise(() => {
+      .otherwise((error: unknown) => {
         const problem = makeProblem(500, genericError("Unexpected error"));
-        logger.error(makeProblemLogString(problem));
+        logger.error(makeProblemLogString(problem, error));
         return problem;
       });
   };

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -110,6 +110,7 @@ const errorCodes = {
   missingRSAKey: "9996",
   missingKafkaMessageData: "9997",
   kafkaMessageProcessError: "9998",
+  badRequestError: "9999",
 } as const;
 
 export type CommonErrorCodes = keyof typeof errorCodes;
@@ -205,6 +206,14 @@ export function unauthorizedError(details: string): ApiError<CommonErrorCodes> {
     detail: details,
     code: "unauthorizedError",
     title: "Unauthorized",
+  });
+}
+
+export function badRequestError(details: string): ApiError<CommonErrorCodes> {
+  return new ApiError({
+    detail: details,
+    code: "badRequestError",
+    title: "Bad request",
   });
 }
 

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -65,6 +65,11 @@ export type Problem = {
   toString: () => string;
 };
 
+const makeProblemLogString = (problem: Problem): string => {
+  const errorsString = problem.errors.map((e) => e.detail).join(" - ");
+  return `- title: ${problem.title} - detail: ${problem.detail} - errors: ${errorsString} - orignal error: ${error}`;
+};
+
 export function makeApiProblemBuilder<T extends string>(
   logger: { error: (message: string) => void; warn: (message: string) => void },
   errors: {
@@ -90,11 +95,6 @@ export function makeApiProblemBuilder<T extends string>(
         detail,
       })),
     });
-
-    const makeProblemLogString = (problem: Problem): string => {
-      const errorsString = problem.errors.map((e) => e.detail).join(" - ");
-      return `- title: ${problem.title} - detail: ${problem.detail} - errors: ${errorsString} - orignal error: ${error}`;
-    };
 
     return match<unknown, Problem>(error)
       .with(P.instanceOf(ApiError<T | CommonErrorCodes>), (error) => {

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -2,9 +2,9 @@
 import { P, match } from "ts-pattern";
 
 export class ApiError<T> extends Error {
-  /* TODO consider refactoring of the code property is used:
-    From the API point of view, it is an information relating to the single error
-    in the errors array - not to the main Problem response.
+  /* TODO consider refactoring how the code property is used:
+    From the API point of view, it is an info present only in the single error
+    in the errors array - not in the main Problem response.
     However, at the moment we need it because it is used around the codebase to
     map ApiError to a specific HTTP status code.
     */

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -91,19 +91,23 @@ export function makeApiProblemBuilder<T extends string>(
       })),
     });
 
+    const makeProblemLogString = (problem: Problem): string => {
+      const errorsString =
+        problem.errors.length > 0
+          ? problem.errors.map((e) => e.detail).join(" - ") + " - "
+          : "";
+      return `- ${problem.title} - ${problem.detail} - ${errorsString}orignal error: ${error}`;
+    };
+
     return match<unknown, Problem>(error)
       .with(P.instanceOf(ApiError<T | CommonErrorCodes>), (error) => {
         const problem = makeProblem(httpMapper(error), error);
-        logger.warn(
-          `- ${problem.title} - ${problem.detail} - orignal error: ${error}`
-        );
+        logger.warn(makeProblemLogString(problem));
         return problem;
       })
       .otherwise(() => {
         const problem = makeProblem(500, genericError("Unexpected error"));
-        logger.error(
-          `- ${problem.title} - ${problem.detail} - orignal error: ${error}`
-        );
+        logger.error(makeProblemLogString(problem));
         return problem;
       });
   };

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -92,11 +92,8 @@ export function makeApiProblemBuilder<T extends string>(
     });
 
     const makeProblemLogString = (problem: Problem): string => {
-      const errorsString =
-        problem.errors.length > 0
-          ? problem.errors.map((e) => e.detail).join(" - ") + " - "
-          : "";
-      return `- ${problem.title} - ${problem.detail} - ${errorsString}orignal error: ${error}`;
+      const errorsString = problem.errors.map((e) => e.detail).join(" - ");
+      return `- title: ${problem.title} - detail: ${problem.detail} - errors: ${errorsString} - orignal error: ${error}`;
     };
 
     return match<unknown, Problem>(error)

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -2,9 +2,16 @@
 import { P, match } from "ts-pattern";
 
 export class ApiError<T> extends Error {
+  /* TODO consider refactoring of the code property is used:
+    From the API point of view, it is an information relating to the single error
+    in the errors array - not to the main Problem response.
+    However, at the moment we need it because it is used around the codebase to
+    map ApiError to a specific HTTP status code.
+    */
   public code: T;
   public title: string;
   public detail: string;
+  public errors: Array<{ code: T; detail: string }>;
   public correlationId?: string;
 
   constructor({
@@ -12,17 +19,23 @@ export class ApiError<T> extends Error {
     title,
     detail,
     correlationId,
+    errors,
   }: {
     code: T;
     title: string;
     detail: string;
     correlationId?: string;
+    errors?: Error[];
   }) {
     super(detail);
     this.code = code;
     this.title = title;
     this.detail = detail;
     this.correlationId = correlationId;
+    this.errors =
+      errors && errors.length > 0
+        ? errors.map((e) => ({ code, detail: e.message }))
+        : [{ code, detail }];
   }
 }
 
@@ -65,19 +78,17 @@ export function makeApiProblemBuilder<T extends string>(
   return (error, httpMapper) => {
     const makeProblem = (
       httpStatus: number,
-      { code, title, detail, correlationId }: ApiError<T | CommonErrorCodes>
+      { title, detail, correlationId, errors }: ApiError<T | CommonErrorCodes>
     ): Problem => ({
       type: "about:blank",
       title,
       status: httpStatus,
       detail,
       correlationId,
-      errors: [
-        {
-          code: allErrors[code],
-          detail,
-        },
-      ],
+      errors: errors.map(({ code, detail }) => ({
+        code: allErrors[code],
+        detail,
+      })),
     });
 
     return match<unknown, Problem>(error)
@@ -209,11 +220,15 @@ export function unauthorizedError(details: string): ApiError<CommonErrorCodes> {
   });
 }
 
-export function badRequestError(details: string): ApiError<CommonErrorCodes> {
+export function badRequestError(
+  detail: string,
+  errors: Error[]
+): ApiError<CommonErrorCodes> {
   return new ApiError({
-    detail: details,
+    detail,
     code: "badRequestError",
     title: "Bad request",
+    errors,
   });
 }
 

--- a/packages/purpose-process/src/routers/PurposeRouter.ts
+++ b/packages/purpose-process/src/routers/PurposeRouter.ts
@@ -5,13 +5,16 @@ import {
   userRoles,
   ZodiosContext,
   authorizationMiddleware,
+  zodiosValidationErrorToApiProblem,
 } from "pagopa-interop-commons";
 import { api } from "../model/generated/api.js";
 
 const purposeRouter = (
   ctx: ZodiosContext
 ): ZodiosRouter<ZodiosEndpointDefinitions, ExpressContext> => {
-  const purposeRouter = ctx.router(api.api);
+  const purposeRouter = ctx.router(api.api, {
+    validationErrorHandler: zodiosValidationErrorToApiProblem,
+  });
   const {
     ADMIN_ROLE,
     API_ROLE,

--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -6,6 +6,7 @@ import {
   ZodiosContext,
   authorizationMiddleware,
   initDB,
+  zodiosValidationErrorToApiProblem,
 } from "pagopa-interop-commons";
 import { unsafeBrandId } from "pagopa-interop-models";
 import { api } from "../model/generated/api.js";
@@ -47,7 +48,9 @@ const tenantService = tenantServiceBuilder(
 const tenantsRouter = (
   ctx: ZodiosContext
 ): ZodiosRouter<ZodiosEndpointDefinitions, ExpressContext> => {
-  const tenantsRouter = ctx.router(api.api);
+  const tenantsRouter = ctx.router(api.api, {
+    validationErrorHandler: zodiosValidationErrorToApiProblem,
+  });
   const {
     ADMIN_ROLE,
     SECURITY_ROLE,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,6 +585,9 @@ importers:
       zod:
         specifier: 3.21.4
         version: 3.21.4
+      zod-validation-error:
+        specifier: ^3.1.0
+        version: 3.1.0(zod@3.21.4)
     devDependencies:
       '@types/express':
         specifier: 4.17.17
@@ -8863,6 +8866,15 @@ packages:
       compress-commons: 4.1.2
       readable-stream: 3.6.2
     dev: true
+
+  /zod-validation-error@3.1.0(zod@3.21.4):
+    resolution: {integrity: sha512-zujS6HqJjMZCsvjfbnRs7WI3PXN39ovTcY1n8a+KTm4kOH0ZXYsNiJkH1odZf4xZKMkBDL7M2rmQ913FCS1p9w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.18.0
+    dependencies:
+      zod: 3.21.4
+    dev: false
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}


### PR DESCRIPTION
Closes [IMN-475](https://pagopa.atlassian.net/browse/IMN-475)

This PR adds a custom `zodios` error handler that converts zod validation errors into API problems with code `400 bad request`. In this way, in case of missing or bad query parameters/body in requests, the error response follows the API problems standard used by other error responses.

Run some smoke tests on different requests.

#  GET `/eservices` bad requests (query params validation)
<img width="1025" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/3cdc5305-eaa1-45a6-aec6-8e660eed8bb2">

## Logs

<img width="769" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/3db94d1c-e5c5-4e44-aeca-d0de431ea7ce">


--- 

<img width="1000" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/bf26197c-b146-479c-bc24-30e6b78b52a2">

### Logs

<img width="769" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/7c015202-8ffe-4b4d-94a4-5eff10222f9b">



# POST `/eservices` bad request - (body validation)

<img width="1028" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/6ee0758e-2ffd-450b-945c-864b00cc0ffa">

### Logs
<img width="770" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/45e4d05e-55e1-4d39-a68f-b04275d9de5b">

# GET `/agreements` bad request

<img width="1023" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/a6bf9041-2bcd-467c-9893-87ab7ae0b738">

## Logs

<img width="765" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/edc2c549-4980-4998-83b3-3d73dd7b05e2">

# GET `/eservices` success case

![image](https://github.com/pagopa/interop-be-monorepo/assets/6418684/656acc11-0a70-4d29-8b91-21c563785b6e)


# POST `/eservices` success case

![image](https://github.com/pagopa/interop-be-monorepo/assets/6418684/1e4273f0-628a-4af8-9824-ee2064688ca8)


# GET `/agreements` success case

![image](https://github.com/pagopa/interop-be-monorepo/assets/6418684/c7ea44e8-04c6-4a4e-90b1-8f1c9c19298e)

# Testing a GET with a different error

To test that errors different from this new bad request error are still working as expected.

<img width="1023" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/5a8a4930-2206-4da2-94b4-09b3484c8c50">

<img width="768" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/01962f1f-08e5-4009-9dbc-31c4082b86ae">

[IMN-475]: https://pagopa.atlassian.net/browse/IMN-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ