### PR TITLE
IMN-480 - Validating aud in JWT

### DIFF
--- a/packages/agreement-process/.env
+++ b/packages/agreement-process/.env
@@ -17,6 +17,7 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"
 
 AWS_CONFIG_FILE=aws.config.local
 S3_BUCKET=interop-local-bucket

--- a/packages/agreement-process/.env
+++ b/packages/agreement-process/.env
@@ -17,7 +17,7 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui"
 
 AWS_CONFIG_FILE=aws.config.local
 S3_BUCKET=interop-local-bucket

--- a/packages/agreement-process/src/utilities/config.ts
+++ b/packages/agreement-process/src/utilities/config.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 import {
   FileManagerConfig,
-  CommonConfig,
+  CommonHTTPServiceConfig,
   ReadModelDbConfig,
   EventStoreConfig,
 } from "pagopa-interop-commons";
 
-const AgreementProcessConfig = CommonConfig.and(EventStoreConfig)
+const AgreementProcessConfig = CommonHTTPServiceConfig.and(EventStoreConfig)
   .and(ReadModelDbConfig)
   .and(FileManagerConfig)
   .and(

--- a/packages/agreement-readmodel-writer/.env
+++ b/packages/agreement-readmodel-writer/.env
@@ -15,3 +15,4 @@ READMODEL_DB_PORT=27017
 AWS_REGION="eu-central-1"
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"

--- a/packages/agreement-readmodel-writer/.env
+++ b/packages/agreement-readmodel-writer/.env
@@ -1,5 +1,3 @@
-HOST=0.0.0.0
-PORT=3000
 LOG_LEVEL=info
 
 KAFKA_CLIENT_ID="agreement"
@@ -13,6 +11,3 @@ READMODEL_DB_USERNAME="root"
 READMODEL_DB_PASSWORD="example"
 READMODEL_DB_PORT=27017
 AWS_REGION="eu-central-1"
-
-WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"

--- a/packages/attribute-registry-process/.env
+++ b/packages/attribute-registry-process/.env
@@ -17,4 +17,6 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"
+
 PRODUCER_ALLOWED_ORIGINS="IPA"

--- a/packages/attribute-registry-process/.env
+++ b/packages/attribute-registry-process/.env
@@ -17,6 +17,6 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui"
 
 PRODUCER_ALLOWED_ORIGINS="IPA"

--- a/packages/attribute-registry-process/src/utilities/config.ts
+++ b/packages/attribute-registry-process/src/utilities/config.ts
@@ -1,11 +1,11 @@
 import {
-  CommonConfig,
+  CommonHTTPServiceConfig,
   ReadModelDbConfig,
   EventStoreConfig,
 } from "pagopa-interop-commons";
 import { z } from "zod";
 
-const AttributeRegistryConfig = CommonConfig.and(ReadModelDbConfig)
+const AttributeRegistryConfig = CommonHTTPServiceConfig.and(ReadModelDbConfig)
   .and(EventStoreConfig)
   .and(
     z.object({ PRODUCER_ALLOWED_ORIGINS: z.string() }).transform((c) => ({

--- a/packages/attribute-registry-readmodel-writer/.env
+++ b/packages/attribute-registry-readmodel-writer/.env
@@ -15,3 +15,4 @@ READMODEL_DB_PORT=27017
 AWS_REGION="eu-central-1"
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"

--- a/packages/attribute-registry-readmodel-writer/.env
+++ b/packages/attribute-registry-readmodel-writer/.env
@@ -1,5 +1,3 @@
-HOST=0.0.0.0
-PORT=3000
 LOG_LEVEL=info
 
 KAFKA_CLIENT_ID="attribute-registry"
@@ -13,6 +11,3 @@ READMODEL_DB_USERNAME="root"
 READMODEL_DB_PASSWORD="example"
 READMODEL_DB_PORT=27017
 AWS_REGION="eu-central-1"
-
-WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"

--- a/packages/authorization-updater/.env
+++ b/packages/authorization-updater/.env
@@ -1,5 +1,3 @@
-HOST=0.0.0.0
-PORT=3000
 LOG_LEVEL=info
 
 KAFKA_CLIENT_ID="authorization-updater-client"

--- a/packages/catalog-process/.env
+++ b/packages/catalog-process/.env
@@ -17,6 +17,7 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"
 
 AWS_CONFIG_FILE=aws.config.local
 S3_BUCKET=interop-local-bucket

--- a/packages/catalog-process/.env
+++ b/packages/catalog-process/.env
@@ -17,7 +17,7 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui"
 
 AWS_CONFIG_FILE=aws.config.local
 S3_BUCKET=interop-local-bucket

--- a/packages/catalog-process/src/utilities/config.ts
+++ b/packages/catalog-process/src/utilities/config.ts
@@ -1,12 +1,12 @@
 import {
-  CommonConfig,
+  CommonHTTPServiceConfig,
   ReadModelDbConfig,
   FileManagerConfig,
   EventStoreConfig,
 } from "pagopa-interop-commons";
 import { z } from "zod";
 
-const CataloProcessConfig = CommonConfig.and(ReadModelDbConfig)
+const CataloProcessConfig = CommonHTTPServiceConfig.and(ReadModelDbConfig)
   .and(FileManagerConfig)
   .and(EventStoreConfig)
   .and(

--- a/packages/catalog-readmodel-writer/.env
+++ b/packages/catalog-readmodel-writer/.env
@@ -15,3 +15,4 @@ READMODEL_DB_PORT=27017
 AWS_REGION="eu-central-1"
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"

--- a/packages/catalog-readmodel-writer/.env
+++ b/packages/catalog-readmodel-writer/.env
@@ -1,5 +1,3 @@
-HOST=0.0.0.0
-PORT=3000
 LOG_LEVEL=info
 
 KAFKA_CLIENT_ID="catalog"
@@ -13,6 +11,3 @@ READMODEL_DB_USERNAME="root"
 READMODEL_DB_PASSWORD="example"
 READMODEL_DB_PORT=27017
 AWS_REGION="eu-central-1"
-
-WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"

--- a/packages/commons/src/auth/jwt.ts
+++ b/packages/commons/src/auth/jwt.ts
@@ -50,13 +50,20 @@ export const verifyJwtToken = (jwtToken: string): Promise<boolean> => {
     })
   );
   return new Promise((resolve, _reject) => {
-    jwt.verify(jwtToken, getKey(clients), undefined, function (err, _decoded) {
-      if (err) {
-        logger.warn(`Error verifying token: ${err}`);
-        return resolve(false);
+    jwt.verify(
+      jwtToken,
+      getKey(clients),
+      {
+        audience: config.acceptedAudiences,
+      },
+      function (err, _decoded) {
+        if (err) {
+          logger.warn(`Error verifying token: ${err}`);
+          return resolve(false);
+        }
+        return resolve(true);
       }
-      return resolve(true);
-    });
+    );
   });
 };
 

--- a/packages/commons/src/config/commonConfig.ts
+++ b/packages/commons/src/config/commonConfig.ts
@@ -7,9 +7,15 @@ export const JWTConfig = z
       .string()
       .transform((s) => s.split(","))
       .pipe(z.array(APIEndpoint)),
+
+    ACCEPTED_AUDIENCES: z
+      .string()
+      .transform((s) => s.split(","))
+      .pipe(z.array(z.string())),
   })
   .transform((c) => ({
     wellKnownUrls: c.WELL_KNOWN_URLS,
+    acceptedAudiences: c.ACCEPTED_AUDIENCES,
   }));
 export type JWTConfig = z.infer<typeof JWTConfig>;
 

--- a/packages/commons/src/config/commonConfig.ts
+++ b/packages/commons/src/config/commonConfig.ts
@@ -40,5 +40,6 @@ export const HTTPServerConfig = z
   }));
 export type HTTPServerConfig = z.infer<typeof HTTPServerConfig>;
 
-export const CommonConfig = HTTPServerConfig.and(LoggerConfig).and(JWTConfig);
-export type CommonConfig = z.infer<typeof CommonConfig>;
+export const CommonHTTPServiceConfig =
+  HTTPServerConfig.and(LoggerConfig).and(JWTConfig);
+export type CommonHTTPServiceConfig = z.infer<typeof CommonHTTPServiceConfig>;

--- a/packages/purpose-process/.env
+++ b/packages/purpose-process/.env
@@ -17,4 +17,4 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"

--- a/packages/purpose-process/.env
+++ b/packages/purpose-process/.env
@@ -17,4 +17,4 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui"

--- a/packages/purpose-process/src/utilities/config.ts
+++ b/packages/purpose-process/src/utilities/config.ts
@@ -1,12 +1,12 @@
 import {
-  CommonConfig,
+  CommonHTTPServiceConfig,
   ReadModelDbConfig,
   EventStoreConfig,
 } from "pagopa-interop-commons";
 import { z } from "zod";
 
 const PurposeProcessConfig =
-  CommonConfig.and(ReadModelDbConfig).and(EventStoreConfig);
+  CommonHTTPServiceConfig.and(ReadModelDbConfig).and(EventStoreConfig);
 
 export type PurposeProcessConfig = z.infer<typeof PurposeProcessConfig>;
 

--- a/packages/tenant-process/.env
+++ b/packages/tenant-process/.env
@@ -17,4 +17,4 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui"

--- a/packages/tenant-process/.env
+++ b/packages/tenant-process/.env
@@ -17,3 +17,4 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"

--- a/packages/tenant-process/src/utilities/config.ts
+++ b/packages/tenant-process/src/utilities/config.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 import {
-  CommonConfig,
+  CommonHTTPServiceConfig,
   ReadModelDbConfig,
   EventStoreConfig,
 } from "pagopa-interop-commons";
 
 const TenantProcessConfig =
-  CommonConfig.and(EventStoreConfig).and(ReadModelDbConfig);
+  CommonHTTPServiceConfig.and(EventStoreConfig).and(ReadModelDbConfig);
 export type TenantProcessConfig = z.infer<typeof TenantProcessConfig>;
 
 export const config: TenantProcessConfig = {

--- a/packages/tenant-readmodel-writer/.env
+++ b/packages/tenant-readmodel-writer/.env
@@ -15,3 +15,4 @@ READMODEL_DB_PORT=27017
 AWS_REGION="eu-central-1"
 
 WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"

--- a/packages/tenant-readmodel-writer/.env
+++ b/packages/tenant-readmodel-writer/.env
@@ -1,5 +1,3 @@
-HOST=0.0.0.0
-PORT=3000
 LOG_LEVEL=info
 
 KAFKA_CLIENT_ID="tenant"
@@ -13,6 +11,3 @@ READMODEL_DB_USERNAME="root"
 READMODEL_DB_PASSWORD="example"
 READMODEL_DB_PORT=27017
 AWS_REGION="eu-central-1"
-
-WELL_KNOWN_URLS="https://dev.interop.pagopa.it/.well-known/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui, refactor.dev.interop.pagopa.it/ui"


### PR DESCRIPTION
Closes [IMN-480](https://pagopa.atlassian.net/browse/IMN-480)

This PR:
* adds audience validation to JWT token verify
* removes unneeded HTTP/JWT config vars from services that don't need them

# Tests

## Successful request (valid `aud`)
<img width="1019" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/18b0feff-d604-4203-a5c2-3b759aac28a5">


## Unauthorized (invalid `aud`)

Changing valid audiences in `.env`:
<img width="609" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/1e28f768-bf81-46bf-81a9-34856d2e5a94">

Getting `401 Unauthorized`:
<img width="969" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/69415a3b-bc8d-4a10-bfb8-5ed97ab85a9a">


[IMN-480]: https://pagopa.atlassian.net/browse/IMN-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ