### PR TITLE
IMN-436 Add getPurposes in purpose-process

### DIFF
--- a/packages/purpose-process/src/model/domain/apiConverter.ts
+++ b/packages/purpose-process/src/model/domain/apiConverter.ts
@@ -69,6 +69,18 @@ export const purposeVersionStateToApiPurposeVersionState = (
     .with(purposeVersionState.waitingForApproval, () => "WAITING_FOR_APPROVAL")
     .exhaustive();
 
+export const apiPurposeVersionStateToPurposeVersionState = (
+  state: ApiPurposeVersionState
+): PurposeVersionState =>
+  match<ApiPurposeVersionState, PurposeVersionState>(state)
+    .with("ACTIVE", () => purposeVersionState.active)
+    .with("ARCHIVED", () => purposeVersionState.archived)
+    .with("DRAFT", () => purposeVersionState.draft)
+    .with("REJECTED", () => purposeVersionState.rejected)
+    .with("SUSPENDED", () => purposeVersionState.suspended)
+    .with("WAITING_FOR_APPROVAL", () => purposeVersionState.waitingForApproval)
+    .exhaustive();
+
 export const purposeVersionDocumentToApiPurposeVersionDocument = (
   document: PurposeVersionDocument
 ): ApiPurposeVersionDocument => ({

--- a/packages/purpose-process/src/model/domain/models.ts
+++ b/packages/purpose-process/src/model/domain/models.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  EServiceId,
+  PurposeVersionState,
+  TenantId,
+} from "pagopa-interop-models";
 import * as api from "../generated/api.js";
 
 export type ApiRiskAnalysisForm = z.infer<typeof api.schemas.RiskAnalysisForm>;
@@ -22,3 +27,12 @@ export type RiskAnalysisFormSeed = z.infer<
 export type ReversePurposeUpdateContent = z.infer<
   typeof api.schemas.ReversePurposeUpdateContent
 >;
+
+export type ApiGetPurposesFilters = {
+  name?: string;
+  eservicesIds: EServiceId[];
+  consumersIds: TenantId[];
+  producersIds: TenantId[];
+  states: PurposeVersionState[];
+  excludeDraft: boolean | undefined;
+};

--- a/packages/purpose-process/src/routers/PurposeRouter.ts
+++ b/packages/purpose-process/src/routers/PurposeRouter.ts
@@ -92,8 +92,7 @@ const purposeRouter = (
               states: states.map(apiPurposeVersionStateToPurposeVersionState),
               excludeDraft,
             },
-            offset,
-            limit
+            { offset, limit }
           );
           return res
             .status(200)

--- a/packages/purpose-process/src/routers/PurposeRouter.ts
+++ b/packages/purpose-process/src/routers/PurposeRouter.ts
@@ -70,7 +70,7 @@ const purposeRouter = (
         INTERNAL_ROLE,
         SUPPORT_ROLE,
       ]),
-      (_req, res) => res.status(501).send()
+      (_req, res) => res.status(501).send() // TO DO
     )
     .post("/purposes", authorizationMiddleware([ADMIN_ROLE]), (_req, res) =>
       res.status(501).send()

--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -25,6 +25,7 @@ import {
   PurposeEvent,
   EServiceMode,
   Ownership,
+  ListResult,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import {
@@ -49,6 +50,7 @@ import {
   toCreateEventWaitingForApprovalPurposeVersionDeleted,
 } from "../model/domain/toEvent.js";
 import {
+  ApiGetPurposesFilters,
   PurposeUpdateContent,
   ReversePurposeUpdateContent,
 } from "../model/domain/models.js";
@@ -474,6 +476,36 @@ export function purposeServiceBuilder(
 
       await repository.createEvent(event);
       return suspendedPurposeVersion;
+    },
+    async getPurposes(
+      filters: ApiGetPurposesFilters,
+      offset: number,
+      limit: number
+    ): Promise<ListResult<Purpose>> {
+      logger.info("To DO");
+
+      const purposesList = await readModelService.getPurposes(
+        filters,
+        offset,
+        limit
+      );
+
+      const purposesToReturn: Purpose[] = purposesList.results.map(
+        (purpose) => ({
+          ...purpose,
+          versions: filters.excludeDraft
+            ? purpose.versions.filter(
+                (version) => version.state !== purposeVersionState.draft
+              )
+            : purpose.versions,
+          riskAnalysisForm: undefined,
+        })
+      );
+
+      return {
+        results: purposesToReturn,
+        totalCount: purposesList.totalCount,
+      };
     },
   };
 }

--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -479,8 +479,7 @@ export function purposeServiceBuilder(
     },
     async getPurposes(
       filters: ApiGetPurposesFilters,
-      offset: number,
-      limit: number
+      { offset, limit }: { offset: number; limit: number }
     ): Promise<ListResult<Purpose>> {
       logger.info("To DO");
 

--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -495,7 +495,9 @@ export function purposeServiceBuilder(
       filters: ApiGetPurposesFilters,
       { offset, limit }: { offset: number; limit: number }
     ): Promise<ListResult<Purpose>> {
-      logger.info("To DO");
+      logger.info(
+        `Getting Purposes with name = ${filters.name}, eservicesIds = ${filters.eservicesIds}, consumers = ${filters.consumersIds}, producers = ${filters.producersIds}, states = ${filters.states}, excludeDraft = ${filters.excludeDraft}, limit = ${limit}, offset = ${offset}`
+      );
 
       const purposesList = await readModelService.getPurposes(
         filters,

--- a/packages/purpose-process/src/services/readModelService.ts
+++ b/packages/purpose-process/src/services/readModelService.ts
@@ -181,24 +181,24 @@ export function readModelServiceBuilder(
             ...draftFilter,
           } satisfies ReadModelFilter<Purpose>,
         },
-        producersIds.length > 0
-          ? [
-              {
-                $lookup: {
-                  from: "eservices",
-                  localField: "data.eserviceId",
-                  foreignField: "data.id",
-                  as: "eservices",
-                },
-              },
-              { $unwind: "$eservices" },
-              {
-                $match: {
-                  "data.producerId": { $in: producersIds },
-                },
-              },
-            ]
-          : [],
+        // producersIds.length > 0
+        //   ? [
+        //       {
+        //         $lookup: {
+        //           from: "eservices",
+        //           localField: "data.eserviceId",
+        //           foreignField: "data.id",
+        //           as: "eservices",
+        //         },
+        //       },
+        //       { $unwind: "$eservices" },
+        //       {
+        //         $match: {
+        //           "data.producerId": { $in: producersIds },
+        //         },
+        //       },
+        //     ]
+        //   : [],
         {
           $project: {
             data: 1,

--- a/packages/purpose-process/src/services/readModelService.ts
+++ b/packages/purpose-process/src/services/readModelService.ts
@@ -161,7 +161,7 @@ export function readModelServiceBuilder(
                 $and: [
                   { "data.versions": { $size: 1 } },
                   {
-                    "data.descriptors.state": {
+                    "data.versions.state": {
                       $eq: purposeVersionState.draft,
                     },
                   },

--- a/packages/purpose-process/src/services/readModelService.ts
+++ b/packages/purpose-process/src/services/readModelService.ts
@@ -181,24 +181,24 @@ export function readModelServiceBuilder(
             ...draftFilter,
           } satisfies ReadModelFilter<Purpose>,
         },
-        // producersIds.length > 0
-        //   ? [
-        //       {
-        //         $lookup: {
-        //           from: "eservices",
-        //           localField: "data.eserviceId",
-        //           foreignField: "data.id",
-        //           as: "eservices",
-        //         },
-        //       },
-        //       { $unwind: "$eservices" },
-        //       {
-        //         $match: {
-        //           "data.producerId": { $in: producersIds },
-        //         },
-        //       },
-        //     ]
-        //   : [],
+        ...(producersIds.length > 0
+          ? [
+              {
+                $lookup: {
+                  from: "eservices",
+                  localField: "data.eserviceId",
+                  foreignField: "data.id",
+                  as: "eservices",
+                },
+              },
+              { $unwind: "$eservices" },
+              {
+                $match: {
+                  "eservices.data.producerId": { $in: producersIds },
+                },
+              },
+            ]
+          : []),
         {
           $project: {
             data: 1,

--- a/packages/purpose-process/test/purposeService.integration.test.ts
+++ b/packages/purpose-process/test/purposeService.integration.test.ts
@@ -129,6 +129,7 @@ describe("database test", async () => {
 
   afterEach(async () => {
     await purposes.deleteMany({});
+    await eservices.deleteMany({});
 
     await postgresDB.none("TRUNCATE TABLE purpose.events RESTART IDENTITY");
   });
@@ -1308,6 +1309,19 @@ describe("database test", async () => {
         await addOnePurpose(mockPurpose5, postgresDB, purposes);
         await addOnePurpose(mockPurpose6, postgresDB, purposes);
         await addOnePurpose(mockPurpose7, postgresDB, purposes);
+
+        await writeInReadmodel(
+          toReadModelEService(mockEService1ByTenant1),
+          eservices
+        );
+        await writeInReadmodel(
+          toReadModelEService(mockEService2ByTenant1),
+          eservices
+        );
+        await writeInReadmodel(
+          toReadModelEService(mockEService3ByTenant2),
+          eservices
+        );
       });
 
       it("should get the purposes if they exist (parameters: name)", async () => {
@@ -1354,7 +1368,7 @@ describe("database test", async () => {
         expect(result.totalCount).toBe(2);
         expect(result.results).toEqual([mockPurpose5, mockPurpose6]);
       });
-      it.skip("should get the purposes if they exist (parameters: producersIds)", async () => {
+      it("should get the purposes if they exist (parameters: producersIds)", async () => {
         const result = await purposeService.getPurposes(
           {
             eservicesIds: [],

--- a/packages/purpose-process/test/purposeService.integration.test.ts
+++ b/packages/purpose-process/test/purposeService.integration.test.ts
@@ -7,6 +7,7 @@ import {
   afterAll,
   afterEach,
   beforeAll,
+  beforeEach,
   describe,
   expect,
   it,
@@ -1203,33 +1204,261 @@ describe("database test", async () => {
       });
     });
 
-    describe("getPurposes", () => {
-      it("should get the purposes if they exist (parameters: name)", () => {
-        expect(1).toBe(1);
+    describe("getPurposes", async () => {
+      const producerId1: TenantId = generateId();
+      const producerId2: TenantId = generateId();
+      const consumerId1: TenantId = generateId();
+
+      const mockEService1ByTenant1: EService = {
+        ...getMockEService(),
+        producerId: producerId1,
+      };
+
+      const mockEService2ByTenant1: EService = {
+        ...getMockEService(),
+        producerId: producerId1,
+      };
+
+      const mockEService3ByTenant2: EService = {
+        ...getMockEService(),
+        producerId: producerId2,
+      };
+
+      const mockPurposeVersion1: PurposeVersion = {
+        ...getMockPurposeVersion(),
+        state: purposeVersionState.draft,
+      };
+      const mockPurpose1: Purpose = {
+        ...getMockPurpose(),
+        title: "purpose 1 - test",
+        eserviceId: mockEService1ByTenant1.id,
+        versions: [mockPurposeVersion1],
+      };
+
+      const mockPurposeVersion2: PurposeVersion = {
+        ...getMockPurposeVersion(),
+        state: purposeVersionState.draft,
+      };
+      const mockPurpose2: Purpose = {
+        ...getMockPurpose(),
+        title: "purpose 2",
+        eserviceId: mockEService1ByTenant1.id,
+        versions: [mockPurposeVersion2],
+      };
+
+      const mockPurposeVersion3: PurposeVersion = {
+        ...getMockPurposeVersion(),
+        state: purposeVersionState.active,
+      };
+      const mockPurpose3: Purpose = {
+        ...getMockPurpose(),
+        title: "purpose 3",
+        eserviceId: mockEService2ByTenant1.id,
+        versions: [mockPurposeVersion3],
+      };
+
+      const mockPurposeVersion4: PurposeVersion = {
+        ...getMockPurposeVersion(),
+        state: purposeVersionState.rejected,
+      };
+      const mockPurpose4: Purpose = {
+        ...getMockPurpose(),
+        title: "purpose 4",
+        eserviceId: mockEService3ByTenant2.id,
+        versions: [mockPurposeVersion4],
+      };
+
+      const mockPurposeVersion5: PurposeVersion = {
+        ...getMockPurposeVersion(),
+        state: purposeVersionState.rejected,
+      };
+      const mockPurpose5: Purpose = {
+        ...getMockPurpose(),
+        title: "purpose 5",
+        consumerId: consumerId1,
+        versions: [mockPurposeVersion5],
+      };
+
+      const mockPurposeVersion6_1: PurposeVersion = {
+        ...getMockPurposeVersion(),
+        state: purposeVersionState.archived,
+      };
+      const mockPurposeVersion6_2: PurposeVersion = {
+        ...getMockPurposeVersion(),
+        state: purposeVersionState.draft,
+      };
+      const mockPurpose6: Purpose = {
+        ...getMockPurpose(),
+        title: "purpose 6",
+        consumerId: consumerId1,
+        versions: [mockPurposeVersion6_1, mockPurposeVersion6_2],
+      };
+
+      const mockPurpose7: Purpose = {
+        ...getMockPurpose(),
+        title: "purpose 7",
+        versions: [],
+      };
+
+      beforeEach(async () => {
+        await addOnePurpose(mockPurpose1, postgresDB, purposes);
+        await addOnePurpose(mockPurpose2, postgresDB, purposes);
+        await addOnePurpose(mockPurpose3, postgresDB, purposes);
+        await addOnePurpose(mockPurpose4, postgresDB, purposes);
+        await addOnePurpose(mockPurpose5, postgresDB, purposes);
+        await addOnePurpose(mockPurpose6, postgresDB, purposes);
+        await addOnePurpose(mockPurpose7, postgresDB, purposes);
       });
-      it("should get the purposes if they exist (parameters: eservicesIds)", () => {
-        expect(1).toBe(1);
+
+      it("should get the purposes if they exist (parameters: name)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            name: "test",
+            eservicesIds: [],
+            consumersIds: [],
+            producersIds: [],
+            states: [],
+            excludeDraft: undefined,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(1);
+        expect(result.results).toEqual([mockPurpose1]);
       });
-      it("should get the purposes if they exist (parameters: consumersIds)", () => {
-        expect(1).toBe(1);
+      it("should get the purposes if they exist (parameters: eservicesIds)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            eservicesIds: [mockEService1ByTenant1.id],
+            consumersIds: [],
+            producersIds: [],
+            states: [],
+            excludeDraft: undefined,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(2);
+        expect(result.results).toEqual([mockPurpose1, mockPurpose2]);
       });
-      it("should get the purposes if they exist (parameters: producersIds)", () => {
-        expect(1).toBe(1);
+
+      it("should get the purposes if they exist (parameters: consumersIds)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            eservicesIds: [],
+            consumersIds: [consumerId1],
+            producersIds: [],
+            states: [],
+            excludeDraft: undefined,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(2);
+        expect(result.results).toEqual([mockPurpose5, mockPurpose6]);
       });
-      it("should get the purposes if they exist (parameters: states)", () => {
-        expect(1).toBe(1);
+      it.skip("should get the purposes if they exist (parameters: producersIds)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            eservicesIds: [],
+            consumersIds: [],
+            producersIds: [producerId2],
+            states: [],
+            excludeDraft: undefined,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(1);
+        expect(result.results).toEqual([mockPurpose4]);
       });
-      it("should not include purposes whose only version is draft (excludeDraft = true)", () => {
-        expect(1).toBe(1);
+      it("should get the purposes if they exist (parameters: states)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            eservicesIds: [],
+            consumersIds: [],
+            producersIds: [],
+            states: [
+              purposeVersionState.rejected,
+              purposeVersionState.archived,
+            ],
+            excludeDraft: undefined,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(3);
+        expect(result.results).toEqual([
+          mockPurpose4,
+          mockPurpose5,
+          mockPurpose6,
+        ]);
       });
-      it("should include purposes whose only version is draft (excludeDraft = false)", () => {
-        expect(1).toBe(1);
+      it("should not include draft versions and purposes without versions (excludeDraft = true)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            eservicesIds: [],
+            consumersIds: [],
+            producersIds: [],
+            states: [],
+            excludeDraft: true,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(4);
+        expect(result.results).toEqual([
+          mockPurpose3,
+          mockPurpose4,
+          mockPurpose5,
+          { ...mockPurpose6, versions: [mockPurposeVersion6_1] },
+        ]);
       });
-      it("should not filter out draft versions if the purpose has both draft and non-draft ones (excludeDraft = false)", () => {
-        expect(1).toBe(1);
+      it("should include draft versions and purposes without versions (excludeDraft = false)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            eservicesIds: [],
+            consumersIds: [],
+            producersIds: [],
+            states: [],
+            excludeDraft: false,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(7);
+        expect(result.results).toEqual([
+          mockPurpose1,
+          mockPurpose2,
+          mockPurpose3,
+          mockPurpose4,
+          mockPurpose5,
+          mockPurpose6,
+          mockPurpose7,
+        ]);
       });
-      it("should filter out draft versions if the purpose has both draft and non-draft ones (excludeDraft = true)", () => {
-        expect(1).toBe(1);
+      it("should get the purposes if they exist (pagination: offset)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            eservicesIds: [],
+            consumersIds: [],
+            producersIds: [],
+            states: [],
+            excludeDraft: undefined,
+          },
+          { offset: 5, limit: 50 }
+        );
+        expect(result.results).toEqual([mockPurpose6, mockPurpose7]);
+      });
+      it("should get the purposes if they exist (pagination: limit)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            eservicesIds: [],
+            consumersIds: [],
+            producersIds: [],
+            states: [],
+            excludeDraft: undefined,
+          },
+          { offset: 0, limit: 3 }
+        );
+        expect(result.results).toEqual([
+          mockPurpose1,
+          mockPurpose2,
+          mockPurpose3,
+        ]);
       });
     });
   });

--- a/packages/purpose-process/test/purposeService.integration.test.ts
+++ b/packages/purpose-process/test/purposeService.integration.test.ts
@@ -1203,6 +1203,34 @@ describe("database test", async () => {
       });
     });
 
+    describe("getPurposes", () => {
+      it("should get the purposes if they exist (parameters: name)", () => {
+        expect(1).toBe(1);
+      });
+      it("should get the purposes if they exist (parameters: eservicesIds)", () => {
+        expect(1).toBe(1);
+      });
+      it("should get the purposes if they exist (parameters: consumersIds)", () => {
+        expect(1).toBe(1);
+      });
+      it("should get the purposes if they exist (parameters: producersIds)", () => {
+        expect(1).toBe(1);
+      });
+      it("should get the purposes if they exist (parameters: states)", () => {
+        expect(1).toBe(1);
+      });
+      it("should not include purposes whose only version is draft (excludeDraft = true)", () => {
+        expect(1).toBe(1);
+      });
+      it("should include purposes whose only version is draft (excludeDraft = false)", () => {
+        expect(1).toBe(1);
+      });
+      it("should not filter out draft versions if the purpose has both draft and non-draft ones (excludeDraft = false)", () => {
+        expect(1).toBe(1);
+      });
+      it("should filter out draft versions if the purpose has both draft and non-draft ones (excludeDraft = true)", () => {
+        expect(1).toBe(1);
+      });
     });
   });
 });

--- a/packages/purpose-process/test/purposeService.integration.test.ts
+++ b/packages/purpose-process/test/purposeService.integration.test.ts
@@ -64,6 +64,7 @@ import {
   toPurposeV2,
   toReadModelEService,
   unsafeBrandId,
+  PurposeVersionState,
 } from "pagopa-interop-models";
 import { config } from "../src/utilities/config.js";
 import {
@@ -2033,6 +2034,7 @@ describe("Integration tests", async () => {
       const mockPurpose1: Purpose = {
         ...getMockPurpose(),
         title: "purpose 1 - test",
+        consumerId: consumerId1,
         eserviceId: mockEService1ByTenant1.id,
         versions: [mockPurposeVersion1],
       };
@@ -2091,14 +2093,15 @@ describe("Integration tests", async () => {
       };
       const mockPurpose6: Purpose = {
         ...getMockPurpose(),
-        title: "purpose 6",
+        title: "purpose 6 - test",
         consumerId: consumerId1,
+        eserviceId: mockEService3ByTenant2.id,
         versions: [mockPurposeVersion6_1, mockPurposeVersion6_2],
       };
 
       const mockPurpose7: Purpose = {
         ...getMockPurpose(),
-        title: "purpose 7",
+        title: "purpose 7 - test",
         versions: [],
       };
 
@@ -2137,8 +2140,12 @@ describe("Integration tests", async () => {
           },
           { offset: 0, limit: 50 }
         );
-        expect(result.totalCount).toBe(1);
-        expect(result.results).toEqual([mockPurpose1]);
+        expect(result.totalCount).toBe(3);
+        expect(result.results).toEqual([
+          mockPurpose1,
+          mockPurpose6,
+          mockPurpose7,
+        ]);
       });
       it("should get the purposes if they exist (parameters: eservicesIds)", async () => {
         const result = await purposeService.getPurposes(
@@ -2154,7 +2161,6 @@ describe("Integration tests", async () => {
         expect(result.totalCount).toBe(2);
         expect(result.results).toEqual([mockPurpose1, mockPurpose2]);
       });
-
       it("should get the purposes if they exist (parameters: consumersIds)", async () => {
         const result = await purposeService.getPurposes(
           {
@@ -2166,8 +2172,12 @@ describe("Integration tests", async () => {
           },
           { offset: 0, limit: 50 }
         );
-        expect(result.totalCount).toBe(2);
-        expect(result.results).toEqual([mockPurpose5, mockPurpose6]);
+        expect(result.totalCount).toBe(3);
+        expect(result.results).toEqual([
+          mockPurpose1,
+          mockPurpose5,
+          mockPurpose6,
+        ]);
       });
       it("should get the purposes if they exist (parameters: producersIds)", async () => {
         const result = await purposeService.getPurposes(
@@ -2180,8 +2190,8 @@ describe("Integration tests", async () => {
           },
           { offset: 0, limit: 50 }
         );
-        expect(result.totalCount).toBe(1);
-        expect(result.results).toEqual([mockPurpose4]);
+        expect(result.totalCount).toBe(2);
+        expect(result.results).toEqual([mockPurpose4, mockPurpose6]);
       });
       it("should get the purposes if they exist (parameters: states)", async () => {
         const result = await purposeService.getPurposes(
@@ -2274,6 +2284,52 @@ describe("Integration tests", async () => {
           mockPurpose2,
           mockPurpose3,
         ]);
+      });
+      it("should not get the purposes if they don't exist", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            eservicesIds: [generateId()],
+            consumersIds: [],
+            producersIds: [generateId()],
+            states: [],
+            excludeDraft: undefined,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(0);
+        expect(result.results).toEqual([]);
+      });
+      it("should get the purposes if they exist (parameters: name, eservicesIds, consumersIds, producersIds, states; exlcudeDraft = true)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            name: "test",
+            eservicesIds: [mockEService3ByTenant2.id],
+            consumersIds: [consumerId1],
+            producersIds: [producerId2],
+            states: [purposeVersionState.archived],
+            excludeDraft: true,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(1);
+        expect(result.results).toEqual([
+          { ...mockPurpose6, versions: [mockPurposeVersion6_1] },
+        ]);
+      });
+      it("should get the purposes if they exist (parameters: name, eservicesIds, consumersIds, producersIds, states; exlcudeDraft = false)", async () => {
+        const result = await purposeService.getPurposes(
+          {
+            name: "test",
+            eservicesIds: [mockEService1ByTenant1.id],
+            consumersIds: [consumerId1],
+            producersIds: [producerId1],
+            states: [purposeVersionState.draft],
+            excludeDraft: false,
+          },
+          { offset: 0, limit: 50 }
+        );
+        expect(result.totalCount).toBe(1);
+        expect(result.results).toEqual([mockPurpose1]);
       });
     });
   });


### PR DESCRIPTION
[To be merged after #419]

This pull request is for implementing the `getPurposes` endpoint in `purpose-process`.