### PR TITLE
Pin protoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "@tsconfig/node-lts": "18.12.5",
     "turbo": "1.10.7"
   },
+  "config":  { 
+   "protocVersion": "26.1"
+  },
   "packageManager": "pnpm@8.6.3"
 }


### PR DESCRIPTION
The lib `@protobuf-ts/protoc` always uses the latest version of the `protoc`, in order to avoid breaking change we pin the version in the `package.json`