### PR TITLE
Add types to Catalog Item Notifications

### DIFF
--- a/packages/notifier-seeder/src/models/catalogItemEventNotification.ts
+++ b/packages/notifier-seeder/src/models/catalogItemEventNotification.ts
@@ -82,12 +82,12 @@ export type CatalogItemV1Notification = Omit<
 
 // CatalogItemV1AddedV1 | ClonedCatalogItemV1AddedV1 | CatalogItemV1UpdatedV1 | MovedAttributesFromEserviceToDescriptorsV1
 export type CatalogItemNotification = {
-  catalogItem?: CatalogItemV1Notification;
+  catalogItem: CatalogItemV1Notification;
 };
 
 // CatalogItemWithDescriptorsDeletedV1
 export type CatalogItemDescriptorDeletedNotification = {
-  catalogItem?: CatalogItemV1Notification;
+  catalogItem: CatalogItemV1Notification;
   descriptorId: string;
 };
 
@@ -95,7 +95,7 @@ export type CatalogItemDocumentUpdateNotification = {
   eServiceId: string;
   descriptorId: string;
   documentId: string;
-  updatedDocument?: CatalogDocumentV1Notification;
+  updatedDocument: CatalogDocumentV1Notification;
   serverUrls: string[];
 };
 
@@ -103,7 +103,7 @@ export type CatalogItemDocumentUpdateNotification = {
 export type CatalogItemDocumentAddedNotification = {
   eServiceId: string;
   descriptorId: string;
-  document?: CatalogDocumentV1Notification;
+  document: CatalogDocumentV1Notification;
   isInterface: boolean;
   serverUrls: string[];
 };
@@ -111,12 +111,12 @@ export type CatalogItemDocumentAddedNotification = {
 // CatalogItemDescriptorAddedV1 | CatalogItemDescriptorUpdatedV1
 export type CatalogDescriptorNotification = {
   eServiceId: string;
-  catalogDescriptor?: CatalogDescriptorV1Notification;
+  catalogDescriptor: CatalogDescriptorV1Notification;
 };
 
 // CatalogItemRiskAnalysisAddedV1 | CatalogItemRiskAnalysisUpdatedV1 | CatalogItemRiskAnalysisDeletedV1;
 export type CatalogItemRiskAnalysisNotification = {
-  catalogItem?: CatalogItemV1Notification;
+  catalogItem: CatalogItemV1Notification;
   catalogRiskAnalysisId: string;
 };
 

--- a/packages/notifier-seeder/src/models/catalogItemEventNotification.ts
+++ b/packages/notifier-seeder/src/models/catalogItemEventNotification.ts
@@ -2,8 +2,6 @@ import {
   CatalogAttributeValueV1,
   CatalogDescriptorV1,
   CatalogDocumentV1,
-  CatalogItemDeletedV1,
-  CatalogItemDocumentDeletedV1,
   CatalogItemRiskAnalysisV1,
   CatalogItemV1,
 } from "../gen/v1/events.js";
@@ -19,45 +17,6 @@ applies some conversion on a specific fields before sending to queue:
 NOTE: this implementation is temporary and will be removed when all old services 
 will be updated to digest a message with new format of V2 events.
 */
-export type CatalogItemEventNotification =
-  // CatalogItemV1AddedV1 | ClonedCatalogItemV1AddedV1 | CatalogItemV1UpdatedV1 | MovedAttributesFromEserviceToDescriptorsV1
-  | {
-      catalogItem?: CatalogItemV1Notification;
-    }
-  // CatalogItemWithDescriptorsDeletedV1
-  | {
-      catalogItem?: CatalogItemV1Notification;
-      descriptorId: string;
-    }
-  // CatalogItemDocumentUpdatedV1
-  | CatalogItemDeletedV1
-  | {
-      eServiceId: string;
-      descriptorId: string;
-      documentId: string;
-      updatedDocument?: CatalogDocumentV1Notification;
-      serverUrls: string[];
-    }
-  | CatalogItemDocumentDeletedV1
-  // CatalogItemDocumentAddedV1
-  | {
-      eServiceId: string;
-      descriptorId: string;
-      document?: CatalogDocumentV1Notification;
-      isInterface: boolean;
-      serverUrls: string[];
-    }
-  // | CatalogItemDescriptorAddedV1 | CatalogItemDescriptorUpdatedV1
-  | {
-      eServiceId: string;
-      catalogDescriptor?: CatalogDescriptorV1Notification;
-    }
-
-  // | CatalogItemRiskAnalysisAddedV1 | CatalogItemRiskAnalysisUpdatedV1 | CatalogItemRiskAnalysisDeletedV1;
-  | {
-      catalogItem?: CatalogItemV1Notification;
-      catalogRiskAnalysisId: string;
-    };
 
 export type CatalogDocumentV1Notification = Omit<
   CatalogDocumentV1,
@@ -120,3 +79,65 @@ export type CatalogItemV1Notification = Omit<
   mode: string;
   attributes?: CatalogAttributesV1Notification;
 };
+
+// CatalogItemV1AddedV1 | ClonedCatalogItemV1AddedV1 | CatalogItemV1UpdatedV1 | MovedAttributesFromEserviceToDescriptorsV1
+export type CatalogItemNotification = {
+  catalogItem?: CatalogItemV1Notification;
+};
+
+// CatalogItemWithDescriptorsDeletedV1
+export type CatalogItemDescriptorDeletedNotification = {
+  catalogItem?: CatalogItemV1Notification;
+  descriptorId: string;
+};
+
+export type CatalogItemDocumentUpdateNotification = {
+  eServiceId: string;
+  descriptorId: string;
+  documentId: string;
+  updatedDocument?: CatalogDocumentV1Notification;
+  serverUrls: string[];
+};
+
+// CatalogItemDocumentAddedV1
+export type CatalogItemDocumentAddedNotification = {
+  eServiceId: string;
+  descriptorId: string;
+  document?: CatalogDocumentV1Notification;
+  isInterface: boolean;
+  serverUrls: string[];
+};
+
+// CatalogItemDescriptorAddedV1 | CatalogItemDescriptorUpdatedV1
+export type CatalogDescriptorNotification = {
+  eServiceId: string;
+  catalogDescriptor?: CatalogDescriptorV1Notification;
+};
+
+// CatalogItemRiskAnalysisAddedV1 | CatalogItemRiskAnalysisUpdatedV1 | CatalogItemRiskAnalysisDeletedV1;
+export type CatalogItemRiskAnalysisNotification = {
+  catalogItem?: CatalogItemV1Notification;
+  catalogRiskAnalysisId: string;
+};
+
+// CatalogItemDeletedV1 | CatalogItemDocumentUpdatedV1
+export type CatalogItemIdNotification = {
+  catalogItemId: string;
+};
+
+// CatalogItemDocumentDeletedV1
+export type CatalogItemDocumentDeletedNotification = {
+  eServiceId: string;
+  descriptorId: string;
+  documentId: string;
+};
+
+export type CatalogItemEventNotification =
+  | CatalogItemNotification
+  | CatalogItemIdNotification
+  | CatalogItemDocumentDeletedNotification
+  | CatalogItemDocumentUpdateNotification
+  | CatalogItemDocumentAddedNotification
+  | CatalogDescriptorNotification
+  | CatalogItemDescriptorDeletedNotification
+  | CatalogItemRiskAnalysisNotification;

--- a/packages/notifier-seeder/src/models/catalogItemEventNotificationConverter.ts
+++ b/packages/notifier-seeder/src/models/catalogItemEventNotificationConverter.ts
@@ -6,9 +6,17 @@ import {
 import { match } from "ts-pattern";
 import { eventV1ConversionError } from "../notifierErrors.js";
 import {
+  CatalogDescriptorNotification,
   CatalogDescriptorV1Notification,
   CatalogDocumentV1Notification,
+  CatalogItemDescriptorDeletedNotification,
+  CatalogItemDocumentAddedNotification,
+  CatalogItemDocumentDeletedNotification,
+  CatalogItemDocumentUpdateNotification,
   CatalogItemEventNotification,
+  CatalogItemIdNotification,
+  CatalogItemNotification,
+  CatalogItemRiskAnalysisNotification,
   CatalogItemV1Notification,
 } from "./catalogItemEventNotification.js";
 import { toCatalogItemV1 } from "./catalogItemEventNotificationMappers.js";
@@ -82,13 +90,13 @@ export const toCatalogItemEventNotification = (
       { type: "EServiceAdded" }, // CatalogItemV1AddedV1
       { type: "EServiceCloned" }, // ClonedCatalogItemV1AddedV1
       { type: "DraftEServiceUpdated" }, // CatalogItemV1UpdatedV1
-      (e) => ({
+      (e): CatalogItemNotification => ({
         catalogItem: getCatalogItem(e),
       })
     )
     .with(
       { type: "EServiceDeleted" }, // CatalogItemDeletedV1
-      (e) => ({
+      (e): CatalogItemIdNotification => ({
         catalogItemId: e.data.eserviceId,
       })
     )
@@ -100,7 +108,7 @@ export const toCatalogItemEventNotification = (
       { type: "EServiceDescriptorPublished" }, // CatalogItemDescriptorUpdatedV1
       { type: "EServiceDescriptorSuspended" }, // CatalogItemDescriptorUpdatedV1
       { type: "EServiceDescriptorQuotasUpdated" },
-      (e) => {
+      (e): CatalogDescriptorNotification => {
         const catalogItem = getCatalogItem(e);
         const catalogItemDescriptor = getCatalogItemDescriptor(
           catalogItem,
@@ -115,14 +123,14 @@ export const toCatalogItemEventNotification = (
     )
     .with(
       { type: "EServiceDraftDescriptorDeleted" }, // CatalogItemWithDescriptorsDeletedV1
-      (e) => ({
+      (e): CatalogItemDescriptorDeletedNotification => ({
         catalogItem: getCatalogItem(e),
         descriptorId: e.data.descriptorId,
       })
     )
     .with(
       { type: "EServiceDescriptorDocumentAdded" }, // CatalogItemDocumentAddedV1
-      (e) => {
+      (e): CatalogItemDocumentAddedNotification => {
         const catalogItem = getCatalogItem(e);
         const catalogItemDescriptor = getCatalogItemDescriptor(
           catalogItem,
@@ -144,7 +152,7 @@ export const toCatalogItemEventNotification = (
     )
     .with(
       { type: "EServiceDescriptorInterfaceAdded" }, // CatalogItemDocumentAddedV1
-      (e) => {
+      (e): CatalogItemDocumentAddedNotification => {
         const catalogItem = getCatalogItem(e);
         const catalogItemDescriptor = getCatalogItemDescriptor(
           catalogItem,
@@ -167,7 +175,7 @@ export const toCatalogItemEventNotification = (
     .with(
       { type: "EServiceDescriptorDocumentDeleted" }, // CatalogItemDocumentDeletedV1
       { type: "EServiceDescriptorInterfaceDeleted" }, // CatalogItemDocumentDeletedV1
-      (e) => {
+      (e): CatalogItemDocumentDeletedNotification => {
         if (!e.data.eservice) {
           throw missingKafkaMessageDataError("eservice", e.type);
         }
@@ -181,7 +189,7 @@ export const toCatalogItemEventNotification = (
     )
     .with(
       { type: "EServiceDescriptorInterfaceUpdated" }, // CatalogItemDocumentUpdatedV1
-      (e) => {
+      (e): CatalogItemDocumentUpdateNotification => {
         const eserviceV1 = getCatalogItem(e);
         const descriptorV1 = getCatalogItemDescriptor(
           eserviceV1,
@@ -203,7 +211,7 @@ export const toCatalogItemEventNotification = (
     )
     .with(
       { type: "EServiceDescriptorDocumentUpdated" }, // CatalogItemDocumentUpdatedV1
-      (e) => {
+      (e): CatalogItemDocumentUpdateNotification => {
         const eserviceV1 = getCatalogItem(e);
         const descriptorV1 = getCatalogItemDescriptor(
           eserviceV1,
@@ -227,7 +235,7 @@ export const toCatalogItemEventNotification = (
       { type: "EServiceRiskAnalysisAdded" }, // CatalogItemRiskAnalysisAddedV1
       { type: "EServiceRiskAnalysisDeleted" }, // CatalogItemRiskAnalysisDeletedV1
       { type: "EServiceRiskAnalysisUpdated" }, // CatalogItemRiskAnalysisUpdatedV1
-      (e) => ({
+      (e): CatalogItemRiskAnalysisNotification => ({
         catalogItem: getCatalogItem(e),
         catalogRiskAnalysisId: e.data.riskAnalysisId,
       })


### PR DESCRIPTION
Close [IMN-485](https://pagopa.atlassian.net/browse/IMN-485)

# DESCRIPTION
This PR introduce catalog notification types used by Notification-seeder service when handle catalog item event and publish to the SQS queue.  
The types are used during the notification's creation in `toCatalogItemEventNotification` methods


## TEST
✅ Integration test "Update Descriptor Event Message" successed

[IMN-485]: https://pagopa.atlassian.net/browse/IMN-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ