### PR TITLE
Reenabling event store schema enum for tests

### DIFF
--- a/packages/commons-test/src/eventStoreTestUtils.ts
+++ b/packages/commons-test/src/eventStoreTestUtils.ts
@@ -18,6 +18,13 @@ import {
 import { Event } from "pagopa-interop-commons";
 import { match } from "ts-pattern";
 
+type EventStoreSchema =
+  | "agreement"
+  | "attribute"
+  | "catalog"
+  | "tenant"
+  | "purpose";
+
 export type StoredEvent<T extends Event> = {
   stream_id: string;
   version: number;
@@ -32,13 +39,19 @@ export type ReadEvent<T extends Event> = {
   data: Uint8Array;
 };
 
-export async function writeInEventstore(
-  event:
-    | StoredEvent<AgreementEvent>
-    | StoredEvent<AttributeEvent>
-    | StoredEvent<EServiceEvent>
-    | StoredEvent<TenantEvent>,
-  schema: string,
+export async function writeInEventstore<T extends EventStoreSchema>(
+  event: T extends "agreement"
+    ? StoredEvent<AgreementEvent>
+    : T extends "attribute"
+    ? StoredEvent<AttributeEvent>
+    : T extends "catalog"
+    ? StoredEvent<EServiceEvent>
+    : T extends "tenant"
+    ? StoredEvent<TenantEvent>
+    : T extends "purpose"
+    ? never // Purpose events not implemented yet
+    : never,
+  schema: T,
   postgresDB: IDatabase<unknown>
 ): Promise<void> {
   await postgresDB.none(
@@ -48,7 +61,7 @@ export async function writeInEventstore(
       event.version,
       event.event.type,
       event.event.event_version,
-      match(schema)
+      match<EventStoreSchema>(schema)
         .with("agreement", () =>
           agreementEventToBinaryData(event.event as AgreementEvent)
         )
@@ -71,13 +84,35 @@ export async function writeInEventstore(
   );
 }
 
-export async function readLastEventByStreamId<
-  T extends AgreementId | AttributeId | EServiceId | TenantId
->(
-  streamId: T,
-  schema: string,
+export async function readLastEventByStreamId<T extends EventStoreSchema>(
+  streamId: T extends "agreement"
+    ? AgreementId
+    : T extends "attribute"
+    ? AttributeId
+    : T extends "catalog"
+    ? EServiceId
+    : T extends "tenant"
+    ? TenantId
+    : T extends "purpose"
+    ? never // Purpose events not implemented yet
+    : never,
+  schema: T,
   postgresDB: IDatabase<unknown>
-): Promise<ReadEvent<Event>> {
+): Promise<
+  ReadEvent<
+    T extends "agreement"
+      ? AgreementEvent
+      : T extends "attribute"
+      ? AttributeEvent
+      : T extends "catalog"
+      ? EServiceEvent
+      : T extends "tenant"
+      ? TenantEvent
+      : T extends "purpose"
+      ? never // Purpose events not implemented yet
+      : never
+  >
+> {
   return postgresDB.one(
     `SELECT * FROM ${schema}.events WHERE stream_id = $1 ORDER BY sequence_num DESC LIMIT 1`,
     [streamId]

--- a/packages/commons-test/src/eventStoreTestUtils.ts
+++ b/packages/commons-test/src/eventStoreTestUtils.ts
@@ -77,9 +77,7 @@ export async function writeInEventstore<T extends EventStoreSchema>(
         .with("purpose", () => {
           throw new Error("Purpose events not implemented yet");
         })
-        .otherwise((v) => {
-          throw new Error(`${v} events not implemented`);
-        }),
+        .exhaustive(),
     ]
   );
 }


### PR DESCRIPTION
Re-introducing event store schema checks after #444, only as a test utility for event store test functions, to avoid issues such as https://github.com/pagopa/interop-be-monorepo/pull/377#discussion_r1567590890