### PR TITLE
IMN-487 - always log correlation id

### DIFF
--- a/packages/agreement-process/src/app.ts
+++ b/packages/agreement-process/src/app.ts
@@ -1,6 +1,6 @@
 import {
   authenticationMiddleware,
-  contextMiddleware,
+  loggerContextMiddleware,
   loggerMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
@@ -13,7 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware("agreement-process"));
+app.use(loggerContextMiddleware("agreement-process"));
 app.use(loggerMiddleware());
 
 // Unauthenticated routes

--- a/packages/agreement-process/src/app.ts
+++ b/packages/agreement-process/src/app.ts
@@ -13,12 +13,13 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware);
-app.use(loggerMiddleware("agreement-process")());
+app.use(contextMiddleware("agreement-process"));
+app.use(loggerMiddleware());
 
-// NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes
-// we want to be unauthenticated.
+// Unauthenticated routes
 app.use(healthRouter);
+
+// Authenticated routes
 app.use(authenticationMiddleware());
 app.use(agreementRouter(zodiosCtx));
 

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -97,6 +97,7 @@ const agreementRouter = (
         const id = await agreementService.submitAgreement(
           unsafeBrandId(req.params.agreementId),
           req.body,
+          req.ctx.authData,
           req.ctx.correlationId
         );
         return res.status(200).json({ id }).end();

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -198,6 +198,7 @@ export function agreementServiceBuilder(
     async submitAgreement(
       agreementId: AgreementId,
       payload: ApiAgreementSubmissionPayload,
+      authData: AuthData,
       correlationId: string
     ): Promise<string> {
       logger.info(`Submitting agreement ${agreementId}`);
@@ -208,6 +209,7 @@ export function agreementServiceBuilder(
         eserviceQuery,
         agreementQuery,
         tenantQuery,
+        authData,
         correlationId
       );
 

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-params */
-import { CreateEvent, getContext, logger } from "pagopa-interop-commons";
+import { AuthData, CreateEvent, logger } from "pagopa-interop-commons";
 import {
   Agreement,
   AgreementDocument,
@@ -65,10 +65,10 @@ export async function submitAgreementLogic(
   eserviceQuery: EserviceQuery,
   agreementQuery: AgreementQuery,
   tenantQuery: TenantQuery,
+  authData: AuthData,
   correlationId: string
 ): Promise<Array<CreateEvent<AgreementEvent>>> {
   logger.info(`Submitting agreement ${agreementId}`);
-  const { authData } = getContext();
 
   const agreement = await agreementQuery.getAgreementById(agreementId);
 
@@ -107,6 +107,7 @@ export async function submitAgreementLogic(
     agreementQuery,
     tenantQuery,
     constractBuilder,
+    authData,
     correlationId
   );
 }
@@ -120,10 +121,10 @@ const submitAgreement = async (
   agreementQuery: AgreementQuery,
   tenantQuery: TenantQuery,
   constractBuilder: ContractBuilder,
+  authData: AuthData,
   correlationId: string
 ): Promise<Array<CreateEvent<AgreementEvent>>> => {
   const agreement = agreementData.data;
-  const { authData } = getContext();
   const nextStateByAttributes = nextState(agreement, descriptor, consumer);
   const suspendedByPlatform = suspendedByPlatformFlag(nextStateByAttributes);
 

--- a/packages/agreement-readmodel-writer/src/index.ts
+++ b/packages/agreement-readmodel-writer/src/index.ts
@@ -6,7 +6,7 @@ import {
   agreementTopicConfig,
   decodeKafkaMessage,
   logger,
-  runWithContext,
+  runWithLoggerContext,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
 import { AgreementEvent } from "pagopa-interop-models";
@@ -24,7 +24,7 @@ async function processMessage({
 }: EachMessagePayload): Promise<void> {
   const msg = decodeKafkaMessage(message, AgreementEvent);
 
-  await runWithContext(
+  await runWithLoggerContext(
     {
       serviceName: "agreement-readmodel-writer",
       messageData: {

--- a/packages/agreement-readmodel-writer/src/index.ts
+++ b/packages/agreement-readmodel-writer/src/index.ts
@@ -26,6 +26,7 @@ async function processMessage({
 
   await runWithContext(
     {
+      serviceName: "agreement-readmodel-writer",
       messageData: {
         eventType: msg.type,
         eventVersion: msg.event_version,

--- a/packages/attribute-registry-process/src/app.ts
+++ b/packages/attribute-registry-process/src/app.ts
@@ -13,11 +13,13 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware);
-app.use(loggerMiddleware("attribute-registry-process")());
-// NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes
-// we want to be unauthenticated.
+app.use(contextMiddleware("attribute-registry-process"));
+app.use(loggerMiddleware());
+
+// Unauthenticated routes
 app.use(healthRouter);
+
+// Authenticated routes
 app.use(authenticationMiddleware());
 app.use(attributeRouter(zodiosCtx));
 

--- a/packages/attribute-registry-process/src/app.ts
+++ b/packages/attribute-registry-process/src/app.ts
@@ -1,5 +1,5 @@
 import {
-  contextMiddleware,
+  loggerContextMiddleware,
   loggerMiddleware,
   authenticationMiddleware,
   zodiosCtx,
@@ -13,7 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware("attribute-registry-process"));
+app.use(loggerContextMiddleware("attribute-registry-process"));
 app.use(loggerMiddleware());
 
 // Unauthenticated routes

--- a/packages/attribute-registry-readmodel-writer/src/index.ts
+++ b/packages/attribute-registry-readmodel-writer/src/index.ts
@@ -6,7 +6,7 @@ import {
   decodeKafkaMessage,
   logger,
   readModelWriterConfig,
-  runWithContext,
+  runWithLoggerContext,
 } from "pagopa-interop-commons";
 import { createMechanism } from "@jm18457/kafkajs-msk-iam-authentication-mechanism";
 import { AttributeEvent } from "pagopa-interop-models";
@@ -55,7 +55,7 @@ async function processMessage({
 }: EachMessagePayload): Promise<void> {
   const msg = decodeKafkaMessage(message, AttributeEvent);
 
-  await runWithContext(
+  await runWithLoggerContext(
     {
       serviceName: "attribute-registry-readmodel-writer",
       messageData: {

--- a/packages/attribute-registry-readmodel-writer/src/index.ts
+++ b/packages/attribute-registry-readmodel-writer/src/index.ts
@@ -57,6 +57,7 @@ async function processMessage({
 
   await runWithContext(
     {
+      serviceName: "attribute-registry-readmodel-writer",
       messageData: {
         eventType: msg.type,
         eventVersion: msg.event_version,

--- a/packages/authorization-updater/src/index.ts
+++ b/packages/authorization-updater/src/index.ts
@@ -8,7 +8,7 @@ import {
   logger,
   CatalogTopicConfig,
   catalogTopicConfig,
-  runWithContext,
+  runWithLoggerContext,
 } from "pagopa-interop-commons";
 import {
   Descriptor,
@@ -80,7 +80,7 @@ function processMessage(
       );
       const decodedMsg = messageDecoder(messagePayload.message);
 
-      await runWithContext(
+      await runWithLoggerContext(
         {
           serviceName: "authorization-updater",
           messageData: {

--- a/packages/authorization-updater/src/index.ts
+++ b/packages/authorization-updater/src/index.ts
@@ -142,7 +142,8 @@ function processMessage(
                 updateSeed.descriptorId,
                 updateSeed.eserviceId,
                 updateSeed.audience,
-                updateSeed.voucherLifespan
+                updateSeed.voucherLifespan,
+                decodedMsg.correlation_id
               )
             );
           }

--- a/packages/authorization-updater/src/index.ts
+++ b/packages/authorization-updater/src/index.ts
@@ -82,6 +82,7 @@ function processMessage(
 
       await runWithContext(
         {
+          serviceName: "authorization-updater",
           messageData: {
             eventType: decodedMsg.type,
             eventVersion: decodedMsg.event_version,

--- a/packages/catalog-process/src/app.ts
+++ b/packages/catalog-process/src/app.ts
@@ -1,5 +1,5 @@
 import {
-  contextMiddleware,
+  loggerContextMiddleware,
   loggerMiddleware,
   authenticationMiddleware,
   zodiosCtx,
@@ -13,7 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware("catalog-process"));
+app.use(loggerContextMiddleware("catalog-process"));
 app.use(loggerMiddleware());
 
 // Unauthenticated routes

--- a/packages/catalog-process/src/app.ts
+++ b/packages/catalog-process/src/app.ts
@@ -13,11 +13,13 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware);
-app.use(loggerMiddleware("catalog-process")());
-// NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes
-// we want to be unauthenticated.
+app.use(contextMiddleware("catalog-process"));
+app.use(loggerMiddleware());
+
+// Unauthenticated routes
 app.use(healthRouter);
+
+// Authenticated routes
 app.use(authenticationMiddleware());
 app.use(eservicesRouter(zodiosCtx));
 

--- a/packages/catalog-readmodel-writer/src/index.ts
+++ b/packages/catalog-readmodel-writer/src/index.ts
@@ -6,7 +6,7 @@ import {
   readModelWriterConfig,
   catalogTopicConfig,
   decodeKafkaMessage,
-  runWithContext,
+  runWithLoggerContext,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
 import { EServiceEvent } from "pagopa-interop-models";
@@ -24,7 +24,7 @@ async function processMessage({
 }: EachMessagePayload): Promise<void> {
   const decodedMessage = decodeKafkaMessage(message, EServiceEvent);
 
-  await runWithContext(
+  await runWithLoggerContext(
     {
       serviceName: "catalog-readmodel-writer",
       messageData: {

--- a/packages/catalog-readmodel-writer/src/index.ts
+++ b/packages/catalog-readmodel-writer/src/index.ts
@@ -26,6 +26,7 @@ async function processMessage({
 
   await runWithContext(
     {
+      serviceName: "catalog-readmodel-writer",
       messageData: {
         eventType: decodedMessage.type,
         eventVersion: decodedMessage.event_version,

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -1,14 +1,15 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { ZodiosRouterContextRequestHandler } from "@zodios/express";
 import {
+  genericError,
   makeApiProblemBuilder,
   missingBearer,
   missingHeader,
   unauthorizedError,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
-import { ExpressContext, getMutableContext } from "../index.js";
-import { logger } from "../logging/index.js";
+import { ExpressContext } from "../index.js";
+import { getMutableLoggerContext, logger } from "../logging/index.js";
 import { AuthData } from "./authData.js";
 import { Headers } from "./headers.js";
 import { readAuthDataFromJwtToken, verifyJwtToken } from "./jwt.js";
@@ -42,13 +43,16 @@ export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<E
         }
 
         const authData: AuthData = readAuthDataFromJwtToken(jwtToken);
-        const context = getMutableContext();
+        const context = getMutableLoggerContext();
         if (context) {
           // eslint-disable-next-line functional/immutable-data
           context.authData = authData;
         } else {
-          logger.warn("Cannot set authData in context - context not found.");
+          throw genericError(
+            "Cannot set authData in context - context not found."
+          );
         }
+
         // eslint-disable-next-line functional/immutable-data
         req.ctx = {
           authData: { ...authData },

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -43,10 +43,10 @@ export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<E
         }
 
         const authData: AuthData = readAuthDataFromJwtToken(jwtToken);
-        const context = getMutableLoggerContext();
-        if (context) {
+        const loggerContext = getMutableLoggerContext();
+        if (loggerContext) {
           // eslint-disable-next-line functional/immutable-data
-          context.authData = authData;
+          loggerContext.authData = authData;
         } else {
           throw genericError(
             "Cannot set authData in logger context - logger context not found."

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -49,7 +49,7 @@ export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<E
           context.authData = authData;
         } else {
           throw genericError(
-            "Cannot set authData in context - context not found."
+            "Cannot set authData in logger context - logger context not found."
           );
         }
 

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -7,7 +7,7 @@ import {
   unauthorizedError,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
-import { ExpressContext } from "../index.js";
+import { ExpressContext, getMutableContext } from "../index.js";
 import { logger } from "../logging/index.js";
 import { AuthData } from "./authData.js";
 import { Headers } from "./headers.js";
@@ -42,6 +42,13 @@ export const authenticationMiddleware: () => ZodiosRouterContextRequestHandler<E
         }
 
         const authData: AuthData = readAuthDataFromJwtToken(jwtToken);
+        const context = getMutableContext();
+        if (context) {
+          // eslint-disable-next-line functional/immutable-data
+          context.authData = authData;
+        } else {
+          logger.warn("Cannot set authData in context - context not found.");
+        }
         // eslint-disable-next-line functional/immutable-data
         req.ctx = {
           authData: { ...authData },

--- a/packages/commons/src/auth/headers.ts
+++ b/packages/commons/src/auth/headers.ts
@@ -18,6 +18,14 @@ export const ParsedHeaders = z
   .and(AuthData);
 export type ParsedHeaders = z.infer<typeof ParsedHeaders>;
 
+export const readCorrelationIdHeader = (req: Request): string | undefined =>
+  match(req.headers)
+    .with(
+      { "x-correlation-id": P.string },
+      (headers) => headers["x-correlation-id"]
+    )
+    .otherwise(() => undefined);
+
 export const readHeaders = (req: Request): ParsedHeaders | undefined => {
   try {
     const headers = Headers.parse(req.headers);

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -8,6 +8,7 @@ import { AuthData } from "../auth/authData.js";
 import { readCorrelationIdHeader } from "../auth/headers.js";
 
 export type AppContext = {
+  serviceName: string;
   authData?: AuthData;
   messageData?: {
     eventType: string;
@@ -31,17 +32,16 @@ const globalStore = new AsyncLocalStorage<AppContext>();
 export const getMutableContext = (): AppContext | undefined =>
   globalStore.getStore();
 
-export const contextMiddleware = (
-  req: Request,
-  _res: Response,
-  next: NextFunction
-): void =>
-  globalStore.run(
-    {
-      correlationId: readCorrelationIdHeader(req) ?? uuidv4(),
-    },
-    () => next()
-  );
+export const contextMiddleware =
+  (serviceName: string) =>
+  (req: Request, _res: Response, next: NextFunction): void =>
+    globalStore.run(
+      {
+        serviceName,
+        correlationId: readCorrelationIdHeader(req) ?? uuidv4(),
+      },
+      () => next()
+    );
 
 export async function runWithContext(
   context: AppContext,

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -1,24 +1,7 @@
 /* eslint-disable functional/immutable-data */
-import { AsyncLocalStorage } from "async_hooks";
-import { NextFunction, Request, Response } from "express";
 import { zodiosContext } from "@zodios/express";
 import { z } from "zod";
-import { v4 as uuidv4 } from "uuid";
 import { AuthData } from "../auth/authData.js";
-import { readCorrelationIdHeader } from "../auth/headers.js";
-
-export type AppContext = {
-  serviceName: string;
-  authData?: AuthData;
-  messageData?: {
-    eventType: string;
-    eventVersion: number;
-    streamId: string;
-  };
-  correlationId?: string | null | undefined;
-};
-export type ZodiosContext = NonNullable<typeof zodiosCtx>;
-export type ExpressContext = NonNullable<typeof zodiosCtx.context>;
 
 export const ctx = z.object({
   authData: AuthData,
@@ -26,26 +9,5 @@ export const ctx = z.object({
 });
 
 export const zodiosCtx = zodiosContext(z.object({ ctx }));
-
-const globalStore = new AsyncLocalStorage<AppContext>();
-
-export const getMutableContext = (): AppContext | undefined =>
-  globalStore.getStore();
-
-export const contextMiddleware =
-  (serviceName: string) =>
-  (req: Request, _res: Response, next: NextFunction): void =>
-    globalStore.run(
-      {
-        serviceName,
-        correlationId: readCorrelationIdHeader(req) ?? uuidv4(),
-      },
-      () => next()
-    );
-
-export async function runWithContext(
-  context: AppContext,
-  fn: () => Promise<void>
-): Promise<void> {
-  await globalStore.run(context, fn);
-}
+export type ZodiosContext = NonNullable<typeof zodiosCtx>;
+export type ExpressContext = NonNullable<typeof zodiosCtx.context>;

--- a/packages/commons/src/logging/index.ts
+++ b/packages/commons/src/logging/index.ts
@@ -1,1 +1,2 @@
 export * from "./loggerMiddleware.js";
+export * from "./loggerContext.js";

--- a/packages/commons/src/logging/loggerContext.ts
+++ b/packages/commons/src/logging/loggerContext.ts
@@ -1,0 +1,40 @@
+/* eslint-disable functional/immutable-data */
+import { AsyncLocalStorage } from "async_hooks";
+import { NextFunction, Request, Response } from "express";
+import { v4 as uuidv4 } from "uuid";
+import { AuthData } from "../auth/authData.js";
+import { readCorrelationIdHeader } from "../auth/headers.js";
+
+export type LoggerContext = {
+  serviceName: string;
+  authData?: AuthData;
+  messageData?: {
+    eventType: string;
+    eventVersion: number;
+    streamId: string;
+  };
+  correlationId?: string | null | undefined;
+};
+
+const loggerContextStore = new AsyncLocalStorage<LoggerContext>();
+
+export const getMutableLoggerContext = (): LoggerContext | undefined =>
+  loggerContextStore.getStore();
+
+export const loggerContextMiddleware =
+  (serviceName: string) =>
+  (req: Request, _res: Response, next: NextFunction): void =>
+    loggerContextStore.run(
+      {
+        serviceName,
+        correlationId: readCorrelationIdHeader(req) ?? uuidv4(),
+      },
+      () => next()
+    );
+
+export async function runWithLoggerContext(
+  loggerContext: LoggerContext,
+  fn: () => Promise<void>
+): Promise<void> {
+  await loggerContextStore.run(loggerContext, fn);
+}

--- a/packages/commons/src/logging/loggerMiddleware.ts
+++ b/packages/commons/src/logging/loggerMiddleware.ts
@@ -2,9 +2,8 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import * as expressWinston from "express-winston";
 import * as winston from "winston";
-import { v4 } from "uuid";
 import { LoggerConfig } from "../config/commonConfig.js";
-import { getContext } from "../index.js";
+import { getMutableContext } from "../index.js";
 import { bigIntReplacer } from "./utils.js";
 
 export type SessionMetaData = {
@@ -24,12 +23,12 @@ const config: LoggerConfig = parsedLoggerConfig.success
     };
 
 const getLoggerMetadata = (): SessionMetaData => {
-  const appContext = getContext();
+  const appContext = getMutableContext();
   return !appContext
     ? {
         userId: undefined,
         organizationId: undefined,
-        correlationId: v4(),
+        correlationId: undefined,
         eventType: undefined,
         eventVersion: undefined,
         streamId: undefined,

--- a/packages/commons/src/logging/loggerMiddleware.ts
+++ b/packages/commons/src/logging/loggerMiddleware.ts
@@ -3,7 +3,7 @@
 import * as expressWinston from "express-winston";
 import * as winston from "winston";
 import { LoggerConfig } from "../config/commonConfig.js";
-import { getMutableContext } from "../index.js";
+import { getMutableLoggerContext } from "./loggerContext.js";
 import { bigIntReplacer } from "./utils.js";
 
 export type SessionMetaData = {
@@ -24,8 +24,8 @@ const config: LoggerConfig = parsedLoggerConfig.success
     };
 
 const getLoggerMetadata = (): SessionMetaData => {
-  const appContext = getMutableContext();
-  return !appContext
+  const loggerContext = getMutableLoggerContext();
+  return !loggerContext
     ? {
         serviceName: undefined,
         userId: undefined,
@@ -36,13 +36,13 @@ const getLoggerMetadata = (): SessionMetaData => {
         streamId: undefined,
       }
     : {
-        serviceName: appContext.serviceName,
-        userId: appContext.authData?.userId,
-        organizationId: appContext.authData?.organizationId,
-        correlationId: appContext.correlationId,
-        eventType: appContext.messageData?.eventType,
-        eventVersion: appContext.messageData?.eventVersion,
-        streamId: appContext.messageData?.streamId,
+        serviceName: loggerContext.serviceName,
+        userId: loggerContext.authData?.userId,
+        organizationId: loggerContext.authData?.organizationId,
+        correlationId: loggerContext.correlationId,
+        eventType: loggerContext.messageData?.eventType,
+        eventVersion: loggerContext.messageData?.eventVersion,
+        streamId: loggerContext.messageData?.streamId,
       };
 };
 

--- a/packages/notifier-seeder/src/index.ts
+++ b/packages/notifier-seeder/src/index.ts
@@ -36,6 +36,7 @@ export function processMessage(topicConfig: CatalogTopicConfig) {
 
     await runWithContext(
       {
+        serviceName: "notifier-seeder",
         messageData: {
           eventType: decodedMessage.type,
           eventVersion: decodedMessage.event_version,

--- a/packages/notifier-seeder/src/index.ts
+++ b/packages/notifier-seeder/src/index.ts
@@ -8,7 +8,7 @@ import {
   logger,
   loggerConfig,
   messageDecoderSupplier,
-  runWithContext,
+  runWithLoggerContext,
 } from "pagopa-interop-commons";
 import { toCatalogItemEventNotification } from "./models/catalogItemEventNotificationConverter.js";
 import { buildCatalogMessage } from "./models/catalogItemEventNotificationMessage.js";
@@ -34,7 +34,7 @@ export function processMessage(topicConfig: CatalogTopicConfig) {
 
     const decodedMessage = messageDecoder(kafkaMessage.message);
 
-    await runWithContext(
+    await runWithLoggerContext(
       {
         serviceName: "notifier-seeder",
         messageData: {

--- a/packages/purpose-process/src/app.ts
+++ b/packages/purpose-process/src/app.ts
@@ -13,9 +13,13 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware);
-app.use(loggerMiddleware("purpose-process")());
+app.use(contextMiddleware("purpose-process"));
+app.use(loggerMiddleware());
+
+// Unauthenticated routes
 app.use(healthRouter);
+
+// Authenticated routes
 app.use(authenticationMiddleware());
 app.use(purposeRouter(zodiosCtx));
 

--- a/packages/purpose-process/src/app.ts
+++ b/packages/purpose-process/src/app.ts
@@ -1,5 +1,5 @@
 import {
-  contextMiddleware,
+  loggerContextMiddleware,
   loggerMiddleware,
   authenticationMiddleware,
   zodiosCtx,
@@ -13,7 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware("purpose-process"));
+app.use(loggerContextMiddleware("purpose-process"));
 app.use(loggerMiddleware());
 
 // Unauthenticated routes

--- a/packages/purpose-readmodel-writer/src/index.ts
+++ b/packages/purpose-readmodel-writer/src/index.ts
@@ -26,6 +26,7 @@ async function processMessage({
 
   await runWithContext(
     {
+      serviceName: "purpose-readmodel-writer",
       messageData: {
         eventType: decodedMessage.type,
         eventVersion: decodedMessage.event_version,

--- a/packages/purpose-readmodel-writer/src/index.ts
+++ b/packages/purpose-readmodel-writer/src/index.ts
@@ -6,7 +6,7 @@ import {
   readModelWriterConfig,
   decodeKafkaMessage,
   purposeTopicConfig,
-  runWithContext,
+  runWithLoggerContext,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
 import { PurposeEvent } from "pagopa-interop-models";
@@ -24,7 +24,7 @@ async function processMessage({
 }: EachMessagePayload): Promise<void> {
   const decodedMessage = decodeKafkaMessage(message, PurposeEvent);
 
-  await runWithContext(
+  await runWithLoggerContext(
     {
       serviceName: "purpose-readmodel-writer",
       messageData: {

--- a/packages/tenant-process/src/app.ts
+++ b/packages/tenant-process/src/app.ts
@@ -13,12 +13,13 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware);
-app.use(loggerMiddleware("tenant-process")());
+app.use(contextMiddleware("tenant-process"));
+app.use(loggerMiddleware());
 
-// NOTE(gabro): the order is relevant, authMiddleware must come *after* the routes
-// we want to be unauthenticated.
+// Unauthenticated routes
 app.use(healthRouter);
+
+// Authenticated routes
 app.use(authenticationMiddleware());
 app.use(tenantRouter(zodiosCtx));
 

--- a/packages/tenant-process/src/app.ts
+++ b/packages/tenant-process/src/app.ts
@@ -1,6 +1,6 @@
 import {
   authenticationMiddleware,
-  contextMiddleware,
+  loggerContextMiddleware,
   loggerMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
@@ -13,7 +13,7 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware("tenant-process"));
+app.use(loggerContextMiddleware("tenant-process"));
 app.use(loggerMiddleware());
 
 // Unauthenticated routes

--- a/packages/tenant-readmodel-writer/src/index.ts
+++ b/packages/tenant-readmodel-writer/src/index.ts
@@ -5,7 +5,7 @@ import {
   readModelWriterConfig,
   tenantTopicConfig,
   decodeKafkaMessage,
-  runWithContext,
+  runWithLoggerContext,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
 import { TenantEvent } from "pagopa-interop-models";
@@ -17,7 +17,7 @@ async function processMessage({
 }: EachMessagePayload): Promise<void> {
   const decodedMessage = decodeKafkaMessage(message, TenantEvent);
 
-  await runWithContext(
+  await runWithLoggerContext(
     {
       serviceName: "tenant-readmodel-writer",
       messageData: {

--- a/packages/tenant-readmodel-writer/src/index.ts
+++ b/packages/tenant-readmodel-writer/src/index.ts
@@ -19,6 +19,7 @@ async function processMessage({
 
   await runWithContext(
     {
+      serviceName: "tenant-readmodel-writer",
       messageData: {
         eventType: decodedMessage.type,
         eventVersion: decodedMessage.event_version,


### PR DESCRIPTION
Closes [IMN-487](https://pagopa.atlassian.net/browse/IMN-487)

**Note:**
* This PR also adds the service name to every log; at the moment, it was being logged only in express-winston logs performed by the logger middleware, but not in other logs

# Tests

## 401 due to JWT signature verification error
<img width="758" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/38f92507-ea23-4f11-874d-176a5697bdd5">

## 401 due to JWT audience verification error
<img width="753" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/aef49f06-ef93-4818-bb62-e0453e60bbf6">

## 401 due to JWT claims parsing error
<img width="752" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/1372f40f-cf4a-4561-a18c-65d8d263af70">

# Smoke tests for other API calls

## GET `/eservices` 

### Success
<img width="755" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/d192c519-97ce-402b-8cbe-54a9609bb0ac">

### Error
<img width="756" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/6a71f46c-c9f0-4100-b4d3-fc4b34179821">

## POST `/eservices` 

### Success
<img width="756" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/aaff1e39-142d-4b26-bd5b-d3e0e3d61a3e">

### Error
<img width="758" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/97f4bf07-70b2-4364-b564-4fc0e9a8deaf">

## Catalog readmodel writer

<img width="755" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/b568d2df-a222-4488-91ad-acafbad76e0e">


[IMN-487]: https://pagopa.atlassian.net/browse/IMN-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ