### PR TITLE
Fixing commons tests JWT flaky test

### DIFF
--- a/packages/commons-test/test/jwt.unit.test.ts
+++ b/packages/commons-test/test/jwt.unit.test.ts
@@ -172,12 +172,12 @@ describe("JWT tests", () => {
       ]);
       const token = getMockSignedToken({
         ...mockToken,
-        sub: undefined,
+        aud: undefined,
         jti: undefined,
       });
 
       expect(() => readAuthDataFromJwtToken(token)).toThrowError(
-        invalidClaim(`Validation error: Required at "jti"; Required at "sub"`)
+        invalidClaim(`Validation error: Required at "aud"; Required at "jti"`)
       );
     });
 


### PR DESCRIPTION
The test was checking `sub` as a required claim, but actually `sub` is the only standard claim not present in all cases: it is not present in interop UI tokens.