### PR TITLE
Fixing mongo express local dev credentials

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,8 +60,10 @@ services:
     ports:
       - 8081:8081
     environment:
-      ME_CONFIG_MONGODB_ADMINUSERNAME: root
-      ME_CONFIG_MONGODB_ADMINPASSWORD: example
+      ME_CONFIG_MONGODB_AUTH_USERNAME: root
+      ME_CONFIG_MONGODB_AUTH_PASSWORD: example
+      ME_CONFIG_BASICAUTH_USERNAME: root
+      ME_CONFIG_BASICAUTH_PASSWORD: example
       ME_CONFIG_MONGODB_URL: mongodb://root:example@readmodel:27017/
     depends_on:
       - readmodel


### PR DESCRIPTION
See docs: https://github.com/mongo-express/mongo-express

* log in now works with `root` `example` on the local Mongo express 
* smoke tested some API calls to process + readmodel writes, still working correctly