### PR TITLE
Reusing vitest global setup in EServices Descriptor Archiver

### DIFF
--- a/packages/agreement-process/src/utilities/config.ts
+++ b/packages/agreement-process/src/utilities/config.ts
@@ -4,20 +4,20 @@ import {
   CommonHTTPServiceConfig,
   ReadModelDbConfig,
   EventStoreConfig,
+  S3Config,
 } from "pagopa-interop-commons";
 
 const AgreementProcessConfig = CommonHTTPServiceConfig.and(EventStoreConfig)
   .and(ReadModelDbConfig)
   .and(FileManagerConfig)
+  .and(S3Config)
   .and(
     z
       .object({
-        S3_BUCKET: z.string(),
         CONSUMER_DOCUMENTS_PATH: z.string(),
         AGREEMENT_CONTRACTS_PATH: z.string(),
       })
       .transform((c) => ({
-        s3Bucket: c.S3_BUCKET,
         consumerDocumentsPath: c.CONSUMER_DOCUMENTS_PATH,
         agreementContractsPath: c.AGREEMENT_CONTRACTS_PATH,
       }))

--- a/packages/agreement-process/test/utils.ts
+++ b/packages/agreement-process/test/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   StoredEvent,
   readLastEventByStreamId,
@@ -33,15 +34,14 @@ import { config } from "../src/utilities/config.js";
 export const { cleanup, ...testSetupServices } = setupTestContainersVitest(
   inject("readModelConfig"),
   inject("eventStoreConfig"),
-  inject("fileManagerConfig"),
-  inject("loggerConfig")
+  inject("fileManagerConfig")
 );
 
 afterEach(cleanup);
 
 const readModelRepository = testSetupServices.readModelRepository!;
 const postgresDB = testSetupServices.postgresDB!;
-const fileManager = testSetupServices.fileManager!;
+export const fileManager = testSetupServices.fileManager!;
 
 export const agreements = readModelRepository.agreements;
 export const eservices = readModelRepository.eservices;

--- a/packages/agreement-process/test/utils.ts
+++ b/packages/agreement-process/test/utils.ts
@@ -30,10 +30,18 @@ import { readModelServiceBuilder } from "../src/services/readmodel/readModelServ
 import { tenantQueryBuilder } from "../src/services/readmodel/tenantQuery.js";
 import { config } from "../src/utilities/config.js";
 
-export const { readModelRepository, postgresDB, fileManager, cleanup } =
-  setupTestContainersVitest(inject("config"));
+export const { cleanup, ...testSetupServices } = setupTestContainersVitest(
+  inject("readModelConfig"),
+  inject("eventStoreConfig"),
+  inject("fileManagerConfig"),
+  inject("loggerConfig")
+);
 
 afterEach(cleanup);
+
+const readModelRepository = testSetupServices.readModelRepository!;
+const postgresDB = testSetupServices.postgresDB!;
+const fileManager = testSetupServices.fileManager!;
 
 export const agreements = readModelRepository.agreements;
 export const eservices = readModelRepository.eservices;

--- a/packages/agreement-process/test/utils.ts
+++ b/packages/agreement-process/test/utils.ts
@@ -31,17 +31,14 @@ import { readModelServiceBuilder } from "../src/services/readmodel/readModelServ
 import { tenantQueryBuilder } from "../src/services/readmodel/tenantQuery.js";
 import { config } from "../src/utilities/config.js";
 
-export const { cleanup, ...testSetupServices } = setupTestContainersVitest(
-  inject("readModelConfig"),
-  inject("eventStoreConfig"),
-  inject("fileManagerConfig")
-);
+export const { cleanup, readModelRepository, postgresDB, fileManager } =
+  setupTestContainersVitest(
+    inject("readModelConfig"),
+    inject("eventStoreConfig"),
+    inject("fileManagerConfig")
+  );
 
 afterEach(cleanup);
-
-const readModelRepository = testSetupServices.readModelRepository!;
-const postgresDB = testSetupServices.postgresDB!;
-export const fileManager = testSetupServices.fileManager!;
 
 export const agreements = readModelRepository.agreements;
 export const eservices = readModelRepository.eservices;

--- a/packages/attribute-registry-process/test/utils.ts
+++ b/packages/attribute-registry-process/test/utils.ts
@@ -22,15 +22,13 @@ import { AuthData } from "pagopa-interop-commons";
 import { readModelServiceBuilder } from "../src/services/readModelService.js";
 import { attributeRegistryServiceBuilder } from "../src/services/attributeRegistryService.js";
 
-export const { cleanup, ...testSetupServices } = setupTestContainersVitest(
-  inject("readModelConfig"),
-  inject("eventStoreConfig")
-);
+export const { cleanup, readModelRepository, postgresDB } =
+  setupTestContainersVitest(
+    inject("readModelConfig"),
+    inject("eventStoreConfig")
+  );
 
 afterEach(cleanup);
-
-const readModelRepository = testSetupServices.readModelRepository!;
-const postgresDB = testSetupServices.postgresDB!;
 
 export const agreements = readModelRepository.agreements;
 export const eservices = readModelRepository.eservices;

--- a/packages/attribute-registry-process/test/utils.ts
+++ b/packages/attribute-registry-process/test/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { setupTestContainersVitest } from "pagopa-interop-commons-test/index.js";
 import { afterEach, inject } from "vitest";
 import {
@@ -21,10 +22,15 @@ import { AuthData } from "pagopa-interop-commons";
 import { readModelServiceBuilder } from "../src/services/readModelService.js";
 import { attributeRegistryServiceBuilder } from "../src/services/attributeRegistryService.js";
 
-export const { readModelRepository, postgresDB, fileManager, cleanup } =
-  setupTestContainersVitest(inject("config"));
+export const { cleanup, ...testSetupServices } = setupTestContainersVitest(
+  inject("readModelConfig"),
+  inject("eventStoreConfig")
+);
 
 afterEach(cleanup);
+
+const readModelRepository = testSetupServices.readModelRepository!;
+const postgresDB = testSetupServices.postgresDB!;
 
 export const agreements = readModelRepository.agreements;
 export const eservices = readModelRepository.eservices;

--- a/packages/catalog-process/src/utilities/config.ts
+++ b/packages/catalog-process/src/utilities/config.ts
@@ -12,12 +12,10 @@ const CataloProcessConfig = CommonHTTPServiceConfig.and(ReadModelDbConfig)
   .and(
     z
       .object({
-        S3_BUCKET: z.string(),
         ESERVICE_DOCUMENTS_PATH: z.string(),
         PRODUCER_ALLOWED_ORIGINS: z.string(),
       })
       .transform((c) => ({
-        s3Bucket: c.S3_BUCKET,
         eserviceDocumentsPath: c.ESERVICE_DOCUMENTS_PATH,
         producerAllowedOrigins: c.PRODUCER_ALLOWED_ORIGINS.split(",")
           .map((origin) => origin.trim())

--- a/packages/catalog-process/src/utilities/config.ts
+++ b/packages/catalog-process/src/utilities/config.ts
@@ -3,11 +3,13 @@ import {
   ReadModelDbConfig,
   FileManagerConfig,
   EventStoreConfig,
+  S3Config,
 } from "pagopa-interop-commons";
 import { z } from "zod";
 
 const CataloProcessConfig = CommonHTTPServiceConfig.and(ReadModelDbConfig)
   .and(FileManagerConfig)
+  .and(S3Config)
   .and(EventStoreConfig)
   .and(
     z

--- a/packages/commons-test/src/containerTestUtils.ts
+++ b/packages/commons-test/src/containerTestUtils.ts
@@ -77,13 +77,13 @@ export const minioContainer = (config: {
     ])
     .withExposedPorts(TEST_MINIO_PORT);
 
+export const S3Config = z
+  .object({ S3_BUCKET: z.string().optional() })
+  .transform((c) => ({ s3Bucket: c.S3_BUCKET }));
+
 export const TestContainersConfig = LoggerConfig.and(ReadModelDbConfig)
   .and(EventStoreConfig)
   .and(FileManagerConfig)
-  .and(
-    z
-      .object({ S3_BUCKET: z.string().optional() })
-      .transform((c) => ({ s3Bucket: c.S3_BUCKET }))
-  );
+  .and(S3Config);
 
 export type TestContainersConfig = z.infer<typeof TestContainersConfig>;

--- a/packages/commons-test/src/containerTestUtils.ts
+++ b/packages/commons-test/src/containerTestUtils.ts
@@ -1,11 +1,9 @@
 import {
   EventStoreConfig,
-  FileManagerConfig,
-  LoggerConfig,
   ReadModelDbConfig,
+  FileManagerConfig,
 } from "pagopa-interop-commons";
 import { GenericContainer } from "testcontainers";
-import { z } from "zod";
 
 export const TEST_MONGO_DB_PORT = 27017;
 export const TEST_MONGO_DB_IMAGE = "mongo:4";
@@ -62,9 +60,7 @@ export const postgreSQLContainer = (
  * @returns A promise that resolves to the started test container.
  */
 
-export const minioContainer = (config: {
-  s3Bucket: string;
-}): GenericContainer =>
+export const minioContainer = (config: FileManagerConfig): GenericContainer =>
   new GenericContainer(TEST_MINIO_IMAGE)
     .withEnvironment({
       MINIO_ROOT_USER: "test-aws-key",
@@ -76,14 +72,3 @@ export const minioContainer = (config: {
       `mkdir -p /data/${config.s3Bucket} && /usr/bin/minio server /data`,
     ])
     .withExposedPorts(TEST_MINIO_PORT);
-
-export const S3Config = z
-  .object({ S3_BUCKET: z.string().optional() })
-  .transform((c) => ({ s3Bucket: c.S3_BUCKET }));
-
-export const TestContainersConfig = LoggerConfig.and(ReadModelDbConfig)
-  .and(EventStoreConfig)
-  .and(FileManagerConfig)
-  .and(S3Config);
-
-export type TestContainersConfig = z.infer<typeof TestContainersConfig>;

--- a/packages/commons-test/src/containerTestUtils.ts
+++ b/packages/commons-test/src/containerTestUtils.ts
@@ -1,7 +1,7 @@
 import {
   EventStoreConfig,
   ReadModelDbConfig,
-  FileManagerConfig,
+  S3Config,
 } from "pagopa-interop-commons";
 import { GenericContainer } from "testcontainers";
 
@@ -60,7 +60,7 @@ export const postgreSQLContainer = (
  * @returns A promise that resolves to the started test container.
  */
 
-export const minioContainer = (config: FileManagerConfig): GenericContainer =>
+export const minioContainer = (config: S3Config): GenericContainer =>
   new GenericContainer(TEST_MINIO_IMAGE)
     .withEnvironment({
       MINIO_ROOT_USER: "test-aws-key",

--- a/packages/commons-test/src/setupTestContainersVitest.ts
+++ b/packages/commons-test/src/setupTestContainersVitest.ts
@@ -11,6 +11,7 @@ import {
   LoggerConfig,
   ReadModelDbConfig,
   ReadModelRepository,
+  S3Config,
   genericLogger,
   initDB,
   initFileManager,
@@ -38,8 +39,7 @@ import {
 export function setupTestContainersVitest(
   readModelDbConfig?: ReadModelDbConfig,
   eventStoreConfig?: EventStoreConfig,
-  fileManagerConfig?: FileManagerConfig,
-  loggerConfig?: LoggerConfig
+  fileManagerConfig?: FileManagerConfig & S3Config & LoggerConfig
 ) {
   const s3OriginalBucket = fileManagerConfig?.s3Bucket;
 
@@ -63,11 +63,8 @@ export function setupTestContainersVitest(
     });
   }
 
-  if (fileManagerConfig && loggerConfig) {
-    fileManager = initFileManager({
-      ...fileManagerConfig,
-      ...loggerConfig,
-    });
+  if (fileManagerConfig) {
+    fileManager = initFileManager(fileManagerConfig);
   }
 
   return {

--- a/packages/commons-test/src/setupTestContainersVitest.ts
+++ b/packages/commons-test/src/setupTestContainersVitest.ts
@@ -1,8 +1,11 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable functional/no-let */
 /* eslint-disable functional/immutable-data */
 
 import {
+  DB,
+  FileManager,
   ReadModelRepository,
   genericLogger,
   initDB,
@@ -32,47 +35,62 @@ import { TestContainersConfig } from "./containerTestUtils.js";
 export function setupTestContainersVitest(config: TestContainersConfig) {
   const s3OriginalBucket = config.s3Bucket;
 
-  const readModelRepository = ReadModelRepository.init(config);
+  let readModelRepository: ReadModelRepository | undefined;
+  if (config.readModelDbHost) {
+    readModelRepository = ReadModelRepository.init(config);
+  }
 
-  const postgresDB = initDB({
-    username: config.eventStoreDbUsername,
-    password: config.eventStoreDbPassword,
-    host: config.eventStoreDbHost,
-    port: config.eventStoreDbPort,
-    database: config.eventStoreDbName,
-    schema: config.eventStoreDbSchema,
-    useSSL: config.eventStoreDbUseSSL,
-  });
+  let postgresDB: DB | undefined;
+  if (config.eventStoreDbHost) {
+    postgresDB = initDB({
+      username: config.eventStoreDbUsername,
+      password: config.eventStoreDbPassword,
+      host: config.eventStoreDbHost,
+      port: config.eventStoreDbPort,
+      database: config.eventStoreDbName,
+      schema: config.eventStoreDbSchema,
+      useSSL: config.eventStoreDbUseSSL,
+    });
+  }
 
-  const fileManager = initFileManager(config);
+  let fileManager: FileManager | undefined;
+  if (config.s3ServerHost) {
+    fileManager = initFileManager(config);
+  }
 
   return {
     readModelRepository,
     postgresDB,
     fileManager,
     cleanup: async (): Promise<void> => {
-      await readModelRepository.agreements.deleteMany({});
-      await readModelRepository.eservices.deleteMany({});
-      await readModelRepository.tenants.deleteMany({});
-      await readModelRepository.purposes.deleteMany({});
-      await readModelRepository.attributes.deleteMany({});
+      await readModelRepository?.agreements.deleteMany({});
+      await readModelRepository?.eservices.deleteMany({});
+      await readModelRepository?.tenants.deleteMany({});
+      await readModelRepository?.purposes.deleteMany({});
+      await readModelRepository?.attributes.deleteMany({});
 
-      await postgresDB.none("TRUNCATE TABLE agreement.events RESTART IDENTITY");
-      await postgresDB.none("TRUNCATE TABLE attribute.events RESTART IDENTITY");
-      await postgresDB.none("TRUNCATE TABLE catalog.events RESTART IDENTITY");
-      await postgresDB.none("TRUNCATE TABLE tenant.events RESTART IDENTITY");
-      await postgresDB.none("TRUNCATE TABLE purpose.events RESTART IDENTITY");
+      await postgresDB?.none(
+        "TRUNCATE TABLE agreement.events RESTART IDENTITY"
+      );
+      await postgresDB?.none(
+        "TRUNCATE TABLE attribute.events RESTART IDENTITY"
+      );
+      await postgresDB?.none("TRUNCATE TABLE catalog.events RESTART IDENTITY");
+      await postgresDB?.none("TRUNCATE TABLE tenant.events RESTART IDENTITY");
+      await postgresDB?.none("TRUNCATE TABLE purpose.events RESTART IDENTITY");
 
       if (s3OriginalBucket) {
-        const files = await fileManager.listFiles(
+        const files = await fileManager?.listFiles(
           s3OriginalBucket,
           genericLogger
         );
-        await Promise.all(
-          files.map((file) =>
-            fileManager.delete(s3OriginalBucket, file, genericLogger)
-          )
-        );
+        if (files) {
+          await Promise.all(
+            files.map((file) =>
+              fileManager!.delete(s3OriginalBucket, file, genericLogger)
+            )
+          );
+        }
         // Some tests change the bucket name, so we need to reset it
         config.s3Bucket = s3OriginalBucket;
       }

--- a/packages/commons-test/src/setupTestContainersVitest.ts
+++ b/packages/commons-test/src/setupTestContainersVitest.ts
@@ -37,10 +37,39 @@ import {
  * ```
  */
 export function setupTestContainersVitest(
+  readModelDbConfig?: ReadModelDbConfig
+): {
+  readModelRepository: ReadModelRepository;
+  cleanup: () => Promise<void>;
+};
+export function setupTestContainersVitest(
+  readModelDbConfig?: ReadModelDbConfig,
+  eventStoreConfig?: EventStoreConfig
+): {
+  readModelRepository: ReadModelRepository;
+  postgresDB: DB;
+  cleanup: () => Promise<void>;
+};
+export function setupTestContainersVitest(
   readModelDbConfig?: ReadModelDbConfig,
   eventStoreConfig?: EventStoreConfig,
   fileManagerConfig?: FileManagerConfig & S3Config & LoggerConfig
-) {
+): {
+  readModelRepository: ReadModelRepository;
+  postgresDB: DB;
+  fileManager: FileManager;
+  cleanup: () => Promise<void>;
+};
+export function setupTestContainersVitest(
+  readModelDbConfig?: ReadModelDbConfig,
+  eventStoreConfig?: EventStoreConfig,
+  fileManagerConfig?: FileManagerConfig & S3Config & LoggerConfig
+): {
+  readModelRepository?: ReadModelRepository;
+  postgresDB?: DB;
+  fileManager?: FileManager;
+  cleanup: () => Promise<void>;
+} {
   const s3OriginalBucket = fileManagerConfig?.s3Bucket;
 
   let readModelRepository: ReadModelRepository | undefined;

--- a/packages/commons-test/src/setupTestContainersVitestGlobal.ts
+++ b/packages/commons-test/src/setupTestContainersVitestGlobal.ts
@@ -12,6 +12,7 @@ import {
   FileManagerConfig,
   LoggerConfig,
   ReadModelDbConfig,
+  S3Config,
 } from "pagopa-interop-commons";
 import {
   TEST_MINIO_PORT,
@@ -26,8 +27,7 @@ declare module "vitest" {
   export interface ProvidedContext {
     readModelConfig?: ReadModelDbConfig;
     eventStoreConfig?: EventStoreConfig;
-    fileManagerConfig?: FileManagerConfig;
-    loggerConfig?: LoggerConfig;
+    fileManagerConfig?: FileManagerConfig & LoggerConfig & S3Config;
   }
 }
 
@@ -43,8 +43,9 @@ export function setupTestContainersVitestGlobal() {
   dotenv();
   const eventStoreConfig = EventStoreConfig.safeParse(process.env);
   const readModelConfig = ReadModelDbConfig.safeParse(process.env);
-  const fileManagerConfig = FileManagerConfig.safeParse(process.env);
-  const loggerConfig = LoggerConfig.safeParse(process.env);
+  const fileManagerConfig = FileManagerConfig.and(S3Config)
+    .and(LoggerConfig)
+    .safeParse(process.env);
 
   return async function ({
     provide,
@@ -103,10 +104,6 @@ export function setupTestContainersVitestGlobal() {
         startedMinioContainer?.getMappedPort(TEST_MINIO_PORT);
 
       provide("fileManagerConfig", fileManagerConfig.data);
-    }
-
-    if (loggerConfig.success) {
-      provide("loggerConfig", loggerConfig.data);
     }
 
     return async (): Promise<void> => {

--- a/packages/commons/src/config/fileManagerConfig.ts
+++ b/packages/commons/src/config/fileManagerConfig.ts
@@ -36,5 +36,5 @@ export const S3Config = z
   .transform((c) => ({ s3Bucket: c.S3_BUCKET }));
 export type S3Config = z.infer<typeof S3Config>;
 
-export const FileManagerConfig = S3Config.and(S3CustomServerConfig);
+export const FileManagerConfig = S3CustomServerConfig;
 export type FileManagerConfig = z.infer<typeof FileManagerConfig>;

--- a/packages/commons/src/config/fileManagerConfig.ts
+++ b/packages/commons/src/config/fileManagerConfig.ts
@@ -31,5 +31,10 @@ const S3CustomServerConfig = z.preprocess(
     )
 );
 
-export const FileManagerConfig = S3CustomServerConfig;
+export const S3Config = z
+  .object({ S3_BUCKET: z.string() })
+  .transform((c) => ({ s3Bucket: c.S3_BUCKET }));
+export type S3Config = z.infer<typeof S3Config>;
+
+export const FileManagerConfig = S3Config.and(S3CustomServerConfig);
 export type FileManagerConfig = z.infer<typeof FileManagerConfig>;

--- a/packages/eservice-descriptors-archiver/test/eserviceDescriptorsArchiver.integration.test.ts
+++ b/packages/eservice-descriptors-archiver/test/eserviceDescriptorsArchiver.integration.test.ts
@@ -1,11 +1,9 @@
 /* eslint-disable functional/immutable-data */
 /* eslint-disable functional/no-let */
 import {
-  TEST_MONGO_DB_PORT,
   getMockAgreement,
   getMockDescriptorPublished,
   getMockEService,
-  mongoDBContainer,
 } from "pagopa-interop-commons-test";
 import {
   beforeAll,
@@ -16,14 +14,7 @@ import {
   afterEach,
   beforeEach,
 } from "vitest";
-import { StartedTestContainer } from "testcontainers";
-import {
-  AgreementCollection,
-  EServiceCollection,
-  ReadModelRepository,
-  RefreshableInteropToken,
-  genericLogger,
-} from "pagopa-interop-commons";
+import { RefreshableInteropToken, genericLogger } from "pagopa-interop-commons";
 import {
   EServiceId,
   TenantId,
@@ -32,17 +23,12 @@ import {
   generateId,
   genericInternalError,
 } from "pagopa-interop-models";
-import { config } from "../src/utilities/config.js";
-import {
-  ReadModelService,
-  readModelServiceBuilder,
-} from "../src/services/readModelService.js";
 import {
   CatalogProcessClient,
   catalogProcessClientBuilder,
 } from "../src/services/catalogProcessClient.js";
 import { archiveDescriptorForArchivedAgreement } from "../src/services/archiveDescriptorProcessor.js";
-import { addOneAgreement, addOneEService } from "./utils.js";
+import { addOneAgreement, addOneEService, readModelService } from "./utils.js";
 
 describe("EService Descripors Archiver", async () => {
   describe("archiveDescriptorsForArchivedAgreement", async () => {
@@ -53,24 +39,10 @@ describe("EService Descripors Archiver", async () => {
       Authorization: `Bearer ${testToken}`,
     };
 
-    let startedMongodbContainer: StartedTestContainer;
-    let readModelService: ReadModelService;
-    let eservices: EServiceCollection;
-    let agreements: AgreementCollection;
     let catalogProcessClient: CatalogProcessClient;
     let mockRefreshableToken: RefreshableInteropToken;
 
     beforeAll(async () => {
-      startedMongodbContainer = await mongoDBContainer(config).start();
-
-      config.readModelDbPort =
-        startedMongodbContainer.getMappedPort(TEST_MONGO_DB_PORT);
-
-      const readModelRepository = ReadModelRepository.init(config);
-      eservices = readModelRepository.eservices;
-      agreements = readModelRepository.agreements;
-      readModelService = readModelServiceBuilder(readModelRepository);
-
       mockRefreshableToken = {
         get: () => Promise.resolve({ serialized: testToken }),
       } as RefreshableInteropToken;
@@ -129,10 +101,10 @@ describe("EService Descripors Archiver", async () => {
         producerId,
       };
 
-      await addOneEService(eservice, eservices);
-      await addOneAgreement(archivedAgreement, agreements);
-      await addOneAgreement(otherAgreement1, agreements);
-      await addOneAgreement(otherAgreement2, agreements);
+      await addOneEService(eservice);
+      await addOneAgreement(archivedAgreement);
+      await addOneAgreement(otherAgreement1);
+      await addOneAgreement(otherAgreement2);
 
       await archiveDescriptorForArchivedAgreement(
         archivedAgreement,
@@ -204,10 +176,10 @@ describe("EService Descripors Archiver", async () => {
         producerId,
       };
 
-      await addOneEService(eservice, eservices);
-      await addOneAgreement(archivedAgreement, agreements);
-      await addOneAgreement(otherAgreement1, agreements);
-      await addOneAgreement(otherAgreement2, agreements);
+      await addOneEService(eservice);
+      await addOneAgreement(archivedAgreement);
+      await addOneAgreement(otherAgreement1);
+      await addOneAgreement(otherAgreement2);
 
       await archiveDescriptorForArchivedAgreement(
         archivedAgreement,
@@ -270,10 +242,10 @@ describe("EService Descripors Archiver", async () => {
         producerId,
       };
 
-      await addOneEService(eservice, eservices);
-      await addOneAgreement(archivedAgreement, agreements);
-      await addOneAgreement(otherAgreement1, agreements);
-      await addOneAgreement(otherAgreement2, agreements);
+      await addOneEService(eservice);
+      await addOneAgreement(archivedAgreement);
+      await addOneAgreement(otherAgreement1);
+      await addOneAgreement(otherAgreement2);
 
       await archiveDescriptorForArchivedAgreement(
         archivedAgreement,
@@ -330,10 +302,10 @@ describe("EService Descripors Archiver", async () => {
         producerId,
       };
 
-      await addOneEService(eservice, eservices);
-      await addOneAgreement(archivedAgreement, agreements);
-      await addOneAgreement(otherAgreement1, agreements);
-      await addOneAgreement(otherAgreement2, agreements);
+      await addOneEService(eservice);
+      await addOneAgreement(archivedAgreement);
+      await addOneAgreement(otherAgreement1);
+      await addOneAgreement(otherAgreement2);
 
       await archiveDescriptorForArchivedAgreement(
         archivedAgreement,
@@ -391,10 +363,10 @@ describe("EService Descripors Archiver", async () => {
         producerId,
       };
 
-      await addOneEService(eservice, eservices);
-      await addOneAgreement(archivedAgreement, agreements);
-      await addOneAgreement(otherAgreement1, agreements);
-      await addOneAgreement(otherAgreement2, agreements);
+      await addOneEService(eservice);
+      await addOneAgreement(archivedAgreement);
+      await addOneAgreement(otherAgreement1);
+      await addOneAgreement(otherAgreement2);
 
       await archiveDescriptorForArchivedAgreement(
         archivedAgreement,
@@ -446,7 +418,7 @@ describe("EService Descripors Archiver", async () => {
         producerId,
       };
 
-      await addOneEService(eservice, eservices);
+      await addOneEService(eservice);
 
       await expect(
         archiveDescriptorForArchivedAgreement(

--- a/packages/eservice-descriptors-archiver/test/utils.ts
+++ b/packages/eservice-descriptors-archiver/test/utils.ts
@@ -1,25 +1,32 @@
 import {
-  AgreementCollection,
-  EServiceCollection,
-} from "pagopa-interop-commons";
-import { writeInReadmodel } from "pagopa-interop-commons-test/index.js";
+  setupTestContainersVitest,
+  writeInReadmodel,
+} from "pagopa-interop-commons-test";
+import { inject, afterEach } from "vitest";
 import {
   Agreement,
   EService,
   toReadModelAgreement,
   toReadModelEService,
 } from "pagopa-interop-models";
+import { readModelServiceBuilder } from "../src/services/readModelService.js";
 
-export const addOneAgreement = async (
-  agreement: Agreement,
-  agreements: AgreementCollection
-): Promise<void> => {
+export const { readModelRepository, cleanup } = setupTestContainersVitest(
+  inject("config")
+);
+
+afterEach(cleanup);
+
+export const agreements = readModelRepository.agreements;
+export const eservices = readModelRepository.eservices;
+export const tenants = readModelRepository.tenants;
+
+export const readModelService = readModelServiceBuilder(readModelRepository);
+
+export const addOneAgreement = async (agreement: Agreement): Promise<void> => {
   await writeInReadmodel(toReadModelAgreement(agreement), agreements);
 };
 
-export const addOneEService = async (
-  eservice: EService,
-  eservices: EServiceCollection
-): Promise<void> => {
+export const addOneEService = async (eservice: EService): Promise<void> => {
   await writeInReadmodel(toReadModelEService(eservice), eservices);
 };

--- a/packages/eservice-descriptors-archiver/test/utils.ts
+++ b/packages/eservice-descriptors-archiver/test/utils.ts
@@ -11,14 +11,11 @@ import {
 } from "pagopa-interop-models";
 import { readModelServiceBuilder } from "../src/services/readModelService.js";
 
-export const { cleanup, ...testSetupServices } = setupTestContainersVitest(
+export const { cleanup, readModelRepository } = setupTestContainersVitest(
   inject("readModelConfig")
 );
 
 afterEach(cleanup);
-
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const readModelRepository = testSetupServices.readModelRepository!;
 
 export const agreements = readModelRepository.agreements;
 export const eservices = readModelRepository.eservices;

--- a/packages/eservice-descriptors-archiver/test/utils.ts
+++ b/packages/eservice-descriptors-archiver/test/utils.ts
@@ -11,11 +11,14 @@ import {
 } from "pagopa-interop-models";
 import { readModelServiceBuilder } from "../src/services/readModelService.js";
 
-export const { readModelRepository, cleanup } = setupTestContainersVitest(
-  inject("config")
+export const { cleanup, ...testSetupServices } = setupTestContainersVitest(
+  inject("readModelConfig")
 );
 
 afterEach(cleanup);
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const readModelRepository = testSetupServices.readModelRepository!;
 
 export const agreements = readModelRepository.agreements;
 export const eservices = readModelRepository.eservices;

--- a/packages/eservice-descriptors-archiver/test/vitestGlobalSetup.ts
+++ b/packages/eservice-descriptors-archiver/test/vitestGlobalSetup.ts
@@ -1,0 +1,3 @@
+import { setupTestContainersVitestGlobal } from "pagopa-interop-commons-test";
+
+export default setupTestContainersVitestGlobal();

--- a/packages/eservice-descriptors-archiver/vitest.config.ts
+++ b/packages/eservice-descriptors-archiver/vitest.config.ts
@@ -2,8 +2,10 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    globalSetup: ["./test/vitestGlobalSetup.ts"],
     testTimeout: 60000,
     hookTimeout: 60000,
-    setupFiles: ["dotenv-flow/config"],
+    fileParallelism: false,
+    pool: "forks",
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8493,6 +8493,9 @@ packages:
   /ts-pattern@5.1.1:
     resolution: {integrity: sha512-i+owkHr5RYdQxj8olUgRrqpiWH9x27PuWVfXwDmJ/n/CoF/SAa7WW1i2oUpPDMQpJ4U+bGRUcZkVq7i1m3zFCg==}
 
+  /ts-pattern@5.1.1:
+    resolution: {integrity: sha512-i+owkHr5RYdQxj8olUgRrqpiWH9x27PuWVfXwDmJ/n/CoF/SAa7WW1i2oUpPDMQpJ4U+bGRUcZkVq7i1m3zFCg==}
+
   /ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8493,9 +8493,6 @@ packages:
   /ts-pattern@5.1.1:
     resolution: {integrity: sha512-i+owkHr5RYdQxj8olUgRrqpiWH9x27PuWVfXwDmJ/n/CoF/SAa7WW1i2oUpPDMQpJ4U+bGRUcZkVq7i1m3zFCg==}
 
-  /ts-pattern@5.1.1:
-    resolution: {integrity: sha512-i+owkHr5RYdQxj8olUgRrqpiWH9x27PuWVfXwDmJ/n/CoF/SAa7WW1i2oUpPDMQpJ4U+bGRUcZkVq7i1m3zFCg==}
-
   /ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
 


### PR DESCRIPTION
This PR closes [IMN-536](https://pagopa.atlassian.net/browse/IMN-536) only for the `eservices-descritptors-archiver` service, if the approach makes sense I will port it also to all other services.

[IMN-536]: https://pagopa.atlassian.net/browse/IMN-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ