### PR TITLE
IMN-504 - pnpm stricter peer dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+auto-install-peers = false
+strict-peer-dependencies = true

--- a/packages/agreement-process/package.json
+++ b/packages/agreement-process/package.json
@@ -22,6 +22,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@anatine/zod-mock": "3.13.4",
+    "@faker-js/faker": "8.4.1",
     "@pagopa/eslint-config": "3.0.0",
     "@types/express": "4.17.21",
     "@types/node": "20.14.2",

--- a/packages/agreement-readmodel-writer/package.json
+++ b/packages/agreement-readmodel-writer/package.json
@@ -20,6 +20,8 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@anatine/zod-mock": "3.13.4",
+    "@faker-js/faker": "8.4.1",
     "@pagopa/eslint-config": "3.0.0",
     "@types/node": "20.14.2",
     "@types/uuid": "9.0.8",
@@ -29,8 +31,7 @@
     "ts-node": "10.9.2",
     "typescript": "5.4.5",
     "uuid": "9.0.1",
-    "vitest": "1.6.0",
-    "@anatine/zod-mock": "3.13.4"
+    "vitest": "1.6.0"
   },
   "dependencies": {
     "@protobuf-ts/runtime": "2.9.4",

--- a/packages/commons-test/package.json
+++ b/packages/commons-test/package.json
@@ -19,6 +19,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@anatine/zod-mock": "3.13.4",
+    "@faker-js/faker": "8.4.1",
     "@pagopa/eslint-config": "3.0.0",
     "@protobuf-ts/runtime": "2.9.4",
     "@testcontainers/postgresql": "10.9.0",

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -25,6 +25,7 @@
     "@zodios/core": "10.9.6",
     "@zodios/express": "10.6.1",
     "axios": "1.7.2",
+    "express": "4.19.2",
     "connection-string": "4.4.0",
     "date-fns": "3.6.0",
     "date-fns-tz": "3.1.3",

--- a/packages/eservice-descriptors-archiver/package.json
+++ b/packages/eservice-descriptors-archiver/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@zodios/core": "10.9.6",
     "dotenv-flow": "4.1.0",
+    "axios": "1.7.2",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "2.2.4",
     "pagopa-interop-commons": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:
@@ -57,6 +57,9 @@ importers:
       '@anatine/zod-mock':
         specifier: 3.13.4
         version: 3.13.4(@faker-js/faker@8.4.1)(zod@3.23.8)
+      '@faker-js/faker':
+        specifier: 8.4.1
+        version: 8.4.1
       '@pagopa/eslint-config':
         specifier: 3.0.0
         version: 3.0.0(typescript@5.4.5)
@@ -130,6 +133,9 @@ importers:
       '@anatine/zod-mock':
         specifier: 3.13.4
         version: 3.13.4(@faker-js/faker@8.4.1)(zod@3.23.8)
+      '@faker-js/faker':
+        specifier: 8.4.1
+        version: 8.4.1
       '@pagopa/eslint-config':
         specifier: 3.0.0
         version: 3.0.0(typescript@5.4.5)
@@ -546,6 +552,9 @@ importers:
       date-fns-tz:
         specifier: 3.1.3
         version: 3.1.3(date-fns@3.6.0)
+      express:
+        specifier: 4.19.2
+        version: 4.19.2
       handlebars:
         specifier: 4.7.8
         version: 4.7.8
@@ -616,6 +625,9 @@ importers:
       '@anatine/zod-mock':
         specifier: 3.13.4
         version: 3.13.4(@faker-js/faker@8.4.1)(zod@3.23.8)
+      '@faker-js/faker':
+        specifier: 8.4.1
+        version: 8.4.1
       '@pagopa/eslint-config':
         specifier: 3.0.0
         version: 3.0.0(typescript@5.4.5)
@@ -676,6 +688,9 @@ importers:
       '@zodios/core':
         specifier: 10.9.6
         version: 10.9.6(axios@1.7.2)(zod@3.23.8)
+      axios:
+        specifier: 1.7.2
+        version: 1.7.2
       dotenv-flow:
         specifier: 4.1.0
         version: 4.1.0
@@ -7794,6 +7809,7 @@ packages:
   /mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
+    hasBin: true
     dev: false
 
   /mimic-fn@4.0.0:


### PR DESCRIPTION
Closes [IMN-504](https://pagopa.atlassian.net/browse/IMN-504)

[IMN-504]: https://pagopa.atlassian.net/browse/IMN-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

We still have warnings on the TS version because `@pagopa/eslint-config` uses an old version of `eslint-plugin-functional` that has `typescript` as a peer dependency. Updating it should fix the issue.

<img width="488" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/b4472056-3ce0-44fd-bdcf-7c18413e21b4">
