### PR TITLE
IMN 573 - Improve consumer error handling

### DIFF
--- a/packages/kafka-iam-auth/src/index.ts
+++ b/packages/kafka-iam-auth/src/index.ts
@@ -7,7 +7,6 @@ export * from "./create-sasl-authentication-request.js";
 export * from "./create-sasl-authentication-response.js";
 import { Consumer, EachMessagePayload, Kafka } from "kafkajs";
 import { KafkaConsumerConfig, genericLogger } from "pagopa-interop-commons";
-import { kafkaMessageProcessError } from "pagopa-interop-models";
 import { createMechanism } from "./create-mechanism.js";
 
 export const DEFAULT_AUTHENTICATION_TIMEOUT = 60 * 60 * 1000;
@@ -157,11 +156,8 @@ const initConsumer = async (
         await consumerHandler(payload);
         await kafkaCommitMessageOffsets(consumer, payload);
       } catch (e) {
-        throw kafkaMessageProcessError(
-          payload.topic,
-          payload.partition,
-          payload.message.offset,
-          e
+        genericLogger.error(
+          `Error during message processing: topic: ${payload.topic}, partition: ${payload.partition}, offset: ${payload.message.offset}, error: ${e}`
         );
       }
     },


### PR DESCRIPTION
Closes [IMN-573](https://pagopa.atlassian.net/browse/IMN-573)

[IMN-573]: https://pagopa.atlassian.net/browse/IMN-573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This PR improves the consumer message error handling. 
Currently, when an error occurs the consumer exits and doesn't consume any other message until the normal restart after 60 minutes to refresh the authentication. 
With these changes, the consumer remains active and processes messages (for other stream IDs).


