### PR TITLE
IMN-590 - Fixing suspendedByPlatform flag inconsistencies

### DIFF
--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -188,7 +188,7 @@ export async function createActivationEvent(
       ])
       .otherwise(() => {
         throw genericError(
-          `Unexpected organizationId - nextState pair in activateAgreement - organizationId: ${authData.organizationId} - nextState: ${updatedAgreement.state}`
+          `Unexpected organizationId - nextState pair in activateAgreement. OrganizationId: ${authData.organizationId} - nextState: ${updatedAgreement.state}`
         );
       });
   }

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -72,7 +72,6 @@ export function createActivationUpdateAgreementSeed({
         ),
         suspendedByConsumer,
         suspendedByProducer,
-        suspendedByPlatform: false,
         stamps: {
           ...agreement.stamps,
           activation: stamp,

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -175,7 +175,7 @@ export const archiveRelatedToAgreements = async (
   );
 };
 
-export function createSuspensionByPlatformEvent(
+export function maybeCreateSuspensionByPlatformEvent(
   agreement: WithMetadata<Agreement>,
   updatedAgreement: Agreement,
   correlationId: string

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -190,7 +190,7 @@ export function maybeCreateSuspensionByPlatformEvent(
     ) {
       toCreateEventAgreementSuspendedByPlatform(
         updatedAgreement,
-        agreement.metadata.version,
+        agreement.metadata.version + 1,
         correlationId
       );
     }
@@ -202,7 +202,7 @@ export function maybeCreateSuspensionByPlatformEvent(
     ) {
       return toCreateEventAgreementUnsuspendedByPlatform(
         updatedAgreement,
-        agreement.metadata.version,
+        agreement.metadata.version + 1,
         correlationId
       );
     }

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -45,6 +45,7 @@ export function createActivationUpdateAgreementSeed({
   agreement,
   suspendedByConsumer,
   suspendedByProducer,
+  suspendedByPlatform,
 }: {
   firstActivation: boolean;
   newState: AgreementState;
@@ -55,6 +56,7 @@ export function createActivationUpdateAgreementSeed({
   agreement: Agreement;
   suspendedByConsumer: boolean | undefined;
   suspendedByProducer: boolean | undefined;
+  suspendedByPlatform: boolean;
 }): UpdateAgreementSeed {
   const stamp = createStamp(authData.userId);
 
@@ -70,6 +72,7 @@ export function createActivationUpdateAgreementSeed({
         ),
         suspendedByConsumer,
         suspendedByProducer,
+        suspendedByPlatform,
         stamps: {
           ...agreement.stamps,
           activation: stamp,
@@ -79,6 +82,7 @@ export function createActivationUpdateAgreementSeed({
         state: newState,
         suspendedByConsumer,
         suspendedByProducer,
+        suspendedByPlatform,
         stamps: {
           ...agreement.stamps,
           suspensionByConsumer: suspendedByConsumerStamp(

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -226,25 +226,21 @@ export function maybeCreateSuspensionByPlatformEvents(
       agreement.data.suspendedByPlatform &&
     updatedAgreement.state === agreementState.suspended
   ) {
-    if (updatedAgreement.suspendedByPlatform) {
-      return [
-        toCreateEventAgreementSuspendedByPlatform(
-          updatedAgreement,
-          agreement.metadata.version + 1,
-          correlationId
-        ),
-      ];
-    }
-
-    if (updatedAgreement.suspendedByPlatform === false) {
-      return [
-        toCreateEventAgreementUnsuspendedByPlatform(
-          updatedAgreement,
-          agreement.metadata.version + 1,
-          correlationId
-        ),
-      ];
-    }
+    return updatedAgreement.suspendedByPlatform
+      ? [
+          toCreateEventAgreementSuspendedByPlatform(
+            updatedAgreement,
+            agreement.metadata.version + 1,
+            correlationId
+          ),
+        ]
+      : [
+          toCreateEventAgreementUnsuspendedByPlatform(
+            updatedAgreement,
+            agreement.metadata.version + 1,
+            correlationId
+          ),
+        ];
   }
   return [];
 }

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -21,6 +21,7 @@ import {
 } from "../model/domain/validators.js";
 import {
   toCreateEventAgreementActivated,
+  toCreateEventAgreementSuspendedByPlatform,
   toCreateEventAgreementUnsuspendedByConsumer,
   toCreateEventAgreementUnsuspendedByProducer,
 } from "../model/domain/toEvent.js";
@@ -45,7 +46,6 @@ export function createActivationUpdateAgreementSeed({
   agreement,
   suspendedByConsumer,
   suspendedByProducer,
-  suspendedByPlatform,
 }: {
   firstActivation: boolean;
   newState: AgreementState;
@@ -56,7 +56,6 @@ export function createActivationUpdateAgreementSeed({
   agreement: Agreement;
   suspendedByConsumer: boolean | undefined;
   suspendedByProducer: boolean | undefined;
-  suspendedByPlatform: boolean;
 }): UpdateAgreementSeed {
   const stamp = createStamp(authData.userId);
 
@@ -72,7 +71,6 @@ export function createActivationUpdateAgreementSeed({
         ),
         suspendedByConsumer,
         suspendedByProducer,
-        suspendedByPlatform,
         stamps: {
           ...agreement.stamps,
           activation: stamp,
@@ -82,7 +80,6 @@ export function createActivationUpdateAgreementSeed({
         state: newState,
         suspendedByConsumer,
         suspendedByProducer,
-        suspendedByPlatform,
         stamps: {
           ...agreement.stamps,
           suspensionByConsumer: suspendedByConsumerStamp(
@@ -177,3 +174,19 @@ export const archiveRelatedToAgreements = async (
     createAgreementArchivedByUpgradeEvent(agreementData, userId, correlationId)
   );
 };
+
+export function createSuspensionByPlatformEvent(
+  agreement: WithMetadata<Agreement>,
+  updatedAgreement: Agreement,
+  correlationId: string
+): CreateEvent<AgreementEvent> | undefined {
+  return updatedAgreement.state === agreementState.suspended &&
+    updatedAgreement.suspendedByPlatform &&
+    updatedAgreement.suspendedByPlatform !== agreement.data.suspendedByPlatform
+    ? toCreateEventAgreementSuspendedByPlatform(
+        updatedAgreement,
+        agreement.metadata.version,
+        correlationId
+      )
+    : undefined;
+}

--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -244,7 +244,7 @@ export function maybeCreateSuspensionByPlatformEvents(
       return [
         toCreateEventAgreementSuspendedByPlatform(
           updatedAgreement,
-          agreement.metadata.version,
+          agreement.metadata.version + 1,
           correlationId
         ),
       ];
@@ -254,7 +254,7 @@ export function maybeCreateSuspensionByPlatformEvents(
       return [
         toCreateEventAgreementUnsuspendedByPlatform(
           updatedAgreement,
-          agreement.metadata.version,
+          agreement.metadata.version + 1,
           correlationId
         ),
       ];

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -33,6 +33,7 @@ import {
 import { z } from "zod";
 import { apiAgreementDocumentToAgreementDocument } from "../model/domain/apiConverter.js";
 import {
+  agreementActivationFailed,
   agreementAlreadyExists,
   agreementDocumentAlreadyExists,
   agreementDocumentNotFound,
@@ -59,6 +60,7 @@ import {
   toCreateEventAgreementConsumerDocumentRemoved,
   toCreateEventAgreementDeleted,
   toCreateEventAgreementRejected,
+  toCreateEventAgreementSetMissingCertifiedAttributesByPlatform,
   toCreateEventAgreementSubmitted,
   toCreateEventDraftAgreementUpdated,
 } from "../model/domain/toEvent.js";
@@ -913,6 +915,33 @@ export function agreementServiceBuilder(
         consumer
       );
 
+      const suspendedByPlatform = suspendedByPlatformFlag(
+        nextStateByAttributes
+      );
+
+      if (
+        agreement.data.state === agreementState.pending &&
+        nextStateByAttributes === agreementState.missingCertifiedAttributes &&
+        suspendedByPlatform
+      ) {
+        /* In this case, it means that one of the certified attributes is not
+          valid anymore. We put the agreement in the missingCertifiedAttributes state
+          and fail the activation */
+        const missingCertifiedAttributesByPlatformAgreement = {
+          ...agreement.data,
+          state: agreementState.missingCertifiedAttributes,
+          suspendedByPlatform,
+        };
+        await repository.createEvent(
+          toCreateEventAgreementSetMissingCertifiedAttributesByPlatform(
+            missingCertifiedAttributesByPlatformAgreement,
+            agreement.metadata.version,
+            correlationId
+          )
+        );
+        throw agreementActivationFailed(agreement.data.id);
+      }
+
       const suspendedByConsumer = suspendedByConsumerFlag(
         agreement.data,
         authData.organizationId,
@@ -922,9 +951,6 @@ export function agreementServiceBuilder(
         agreement.data,
         authData.organizationId,
         targetDestinationState
-      );
-      const suspendedByPlatform = suspendedByPlatformFlag(
-        nextStateByAttributes
       );
 
       const newState = agreementStateByFlags(

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -1155,10 +1155,10 @@ function maybeCreateSetToMissingCertifiedAttributesByPlatformEvent(
     /* In this case, it means that one of the certified attributes is not
       valid anymore. We put the agreement in the missingCertifiedAttributes state
       and fail the submission */
-    const missingCertifiedAttributesByPlatformAgreement = {
+    const missingCertifiedAttributesByPlatformAgreement: Agreement = {
       ...agreement.data,
       state: agreementState.missingCertifiedAttributes,
-      newSuspendedByPlatform,
+      suspendedByPlatform: true,
     };
 
     return toCreateEventAgreementSetMissingCertifiedAttributesByPlatform(

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -108,7 +108,6 @@ import {
   archiveRelatedToAgreements,
   createActivationEvent,
   createActivationUpdateAgreementSeed,
-  maybeCreateSuspensionByPlatformEvent,
 } from "./agreementActivationProcessor.js";
 import { contractBuilder } from "./agreementContractBuilder.js";
 import { createStamp } from "./agreementStampUtils.js";
@@ -992,17 +991,18 @@ export function agreementServiceBuilder(
           agreement: agreement.data,
           suspendedByConsumer,
           suspendedByProducer,
+          suspendedByPlatform,
         });
 
-      const updatedAgreementWithoutSuspendedByPlatform: Agreement = {
+      const updatedAgreement: Agreement = {
         ...agreement.data,
         ...updatedAgreementSeed,
       };
 
-      const activationEvent = await createActivationEvent(
+      const activationEvents = await createActivationEvent(
         firstActivation,
         agreement,
-        updatedAgreementWithoutSuspendedByPlatform,
+        updatedAgreement,
         updatedAgreementSeed,
         eservice,
         consumer,
@@ -1012,20 +1012,6 @@ export function agreementServiceBuilder(
         contractBuilderInstance
       );
 
-      /* We update the suspendedByPlatform flag after creating the activation event,
-      so that, if changed, the suspendedByPlatform flag is updated only in the
-      dedicated event */
-      const updatedAgreement = {
-        ...updatedAgreementWithoutSuspendedByPlatform,
-        suspendedByPlatform,
-      };
-
-      const suspensionByPlatformEvent = maybeCreateSuspensionByPlatformEvent(
-        agreement,
-        updatedAgreement,
-        correlationId
-      );
-
       const archiveEvents = await archiveRelatedToAgreements(
         agreement.data,
         authData.userId,
@@ -1033,11 +1019,7 @@ export function agreementServiceBuilder(
         correlationId
       );
 
-      await repository.createEvents([
-        activationEvent,
-        ...(suspensionByPlatformEvent ? [suspensionByPlatformEvent] : []),
-        ...archiveEvents,
-      ]);
+      await repository.createEvents([...activationEvents, ...archiveEvents]);
 
       return updatedAgreement;
     },

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -396,6 +396,7 @@ export function agreementServiceBuilder(
         descriptor,
         consumer
       );
+
       const suspendedByPlatform = suspendedByPlatformFlag(nextState);
 
       const newState = agreementStateByFlags(
@@ -915,7 +916,6 @@ export function agreementServiceBuilder(
         authData.organizationId,
         agreementState.active
       );
-
       const suspendedByPlatform = suspendedByPlatformFlag(nextState);
 
       const newState = agreementStateByFlags(

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -396,12 +396,13 @@ export function agreementServiceBuilder(
         descriptor,
         consumer
       );
+      const suspendedByPlatform = suspendedByPlatformFlag(nextState);
 
       const newState = agreementStateByFlags(
         nextState,
         undefined,
         undefined,
-        undefined
+        suspendedByPlatform
       );
 
       validateActiveOrPendingAgreement(agreement.data.id, newState);
@@ -413,6 +414,7 @@ export function agreementServiceBuilder(
         agreement.data,
         payload,
         newState,
+        suspendedByPlatform,
         authData.userId
       );
 

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -106,6 +106,7 @@ import {
   archiveRelatedToAgreements,
   createActivationEvent,
   createActivationUpdateAgreementSeed,
+  createSuspensionByPlatformEvent,
 } from "./agreementActivationProcessor.js";
 import { contractBuilder } from "./agreementContractBuilder.js";
 import { createStamp } from "./agreementStampUtils.js";
@@ -922,7 +923,8 @@ export function agreementServiceBuilder(
       if (
         agreement.data.state === agreementState.pending &&
         nextStateByAttributes === agreementState.missingCertifiedAttributes &&
-        suspendedByPlatform
+        suspendedByPlatform &&
+        suspendedByPlatform !== agreement.data.suspendedByPlatform
       ) {
         /* In this case, it means that one of the certified attributes is not
           valid anymore. We put the agreement in the missingCertifiedAttributes state
@@ -977,10 +979,9 @@ export function agreementServiceBuilder(
           agreement: agreement.data,
           suspendedByConsumer,
           suspendedByProducer,
-          suspendedByPlatform,
         });
 
-      const updatedAgreement: Agreement = {
+      const updatedAgreementWithoutSuspendedByPlatform: Agreement = {
         ...agreement.data,
         ...updatedAgreementSeed,
       };
@@ -988,7 +989,7 @@ export function agreementServiceBuilder(
       const activationEvent = await createActivationEvent(
         firstActivation,
         agreement,
-        updatedAgreement,
+        updatedAgreementWithoutSuspendedByPlatform,
         updatedAgreementSeed,
         eservice,
         consumer,
@@ -998,6 +999,17 @@ export function agreementServiceBuilder(
         contractBuilderInstance
       );
 
+      const updatedAgreement = {
+        ...updatedAgreementWithoutSuspendedByPlatform,
+        suspendedByPlatform,
+      };
+
+      const suspensionByPlatformEvent = createSuspensionByPlatformEvent(
+        agreement,
+        updatedAgreement,
+        correlationId
+      );
+
       const archiveEvents = await archiveRelatedToAgreements(
         agreement.data,
         authData.userId,
@@ -1005,7 +1017,11 @@ export function agreementServiceBuilder(
         correlationId
       );
 
-      await repository.createEvents([activationEvent, ...archiveEvents]);
+      await repository.createEvents([
+        activationEvent,
+        ...(suspensionByPlatformEvent ? [suspensionByPlatformEvent] : []),
+        ...archiveEvents,
+      ]);
 
       return updatedAgreement;
     },

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -110,7 +110,7 @@ import { createStamp } from "./agreementStampUtils.js";
 import {
   agreementStateByFlags,
   computeAgreementsStateByAttribute,
-  nextStateByAttributes,
+  nextStateByAttributesFSM,
   suspendedByConsumerFlag,
   suspendedByPlatformFlag,
   suspendedByProducerFlag,
@@ -391,16 +391,18 @@ export function agreementServiceBuilder(
         readModelService
       );
 
-      const nextState = nextStateByAttributes(
+      const nextStateByAttributes = nextStateByAttributesFSM(
         agreement.data,
         descriptor,
         consumer
       );
 
-      const suspendedByPlatform = suspendedByPlatformFlag(nextState);
+      const suspendedByPlatform = suspendedByPlatformFlag(
+        nextStateByAttributes
+      );
 
       const newState = agreementStateByFlags(
-        nextState,
+        nextStateByAttributes,
         undefined,
         undefined,
         suspendedByPlatform
@@ -900,7 +902,12 @@ export function agreementServiceBuilder(
         readModelService
       );
 
-      const nextState = nextStateByAttributes(
+      /* nextAttributesState VS targetDestinationState
+      -- targetDestinationState is the state where the caller wants to go (active, in this case)
+      -- nextStateByAttributes is the next state of the Agreement based the attributes of the consumer
+      */
+      const targetDestinationState = agreementState.active;
+      const nextStateByAttributes = nextStateByAttributesFSM(
         agreement.data,
         descriptor,
         consumer
@@ -909,17 +916,19 @@ export function agreementServiceBuilder(
       const suspendedByConsumer = suspendedByConsumerFlag(
         agreement.data,
         authData.organizationId,
-        agreementState.active
+        targetDestinationState
       );
       const suspendedByProducer = suspendedByProducerFlag(
         agreement.data,
         authData.organizationId,
-        agreementState.active
+        targetDestinationState
       );
-      const suspendedByPlatform = suspendedByPlatformFlag(nextState);
+      const suspendedByPlatform = suspendedByPlatformFlag(
+        nextStateByAttributes
+      );
 
       const newState = agreementStateByFlags(
-        nextState,
+        nextStateByAttributes,
         suspendedByProducer,
         suspendedByConsumer,
         suspendedByPlatform

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -440,7 +440,8 @@ export function agreementServiceBuilder(
         agreement.data,
         payload,
         newState,
-        authData.userId
+        authData.userId,
+        suspendedByPlatform
       );
 
       const agreements = (

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -106,7 +106,7 @@ import {
   archiveRelatedToAgreements,
   createActivationEvent,
   createActivationUpdateAgreementSeed,
-  createSuspensionByPlatformEvent,
+  maybeCreateSuspensionByPlatformEvent,
 } from "./agreementActivationProcessor.js";
 import { contractBuilder } from "./agreementContractBuilder.js";
 import { createStamp } from "./agreementStampUtils.js";
@@ -999,12 +999,15 @@ export function agreementServiceBuilder(
         contractBuilderInstance
       );
 
+      /* We update the suspendedByPlatform flag after creating the activation event,
+      so that, if changed, the suspendedByPlatform flag is updated only in the
+      dedicated event */
       const updatedAgreement = {
         ...updatedAgreementWithoutSuspendedByPlatform,
         suspendedByPlatform,
       };
 
-      const suspensionByPlatformEvent = createSuspensionByPlatformEvent(
+      const suspensionByPlatformEvent = maybeCreateSuspensionByPlatformEvent(
         agreement,
         updatedAgreement,
         correlationId

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -1000,14 +1000,19 @@ export function agreementServiceBuilder(
         ...updatedAgreementSeed,
       };
 
+      const suspendedByPlatformChanged =
+        agreement.data.suspendedByPlatform !==
+        updatedAgreement.suspendedByPlatform;
       const activationEvents = await createActivationEvent(
         firstActivation,
-        agreement,
         updatedAgreement,
         updatedAgreementSeed,
         eservice,
         consumer,
         producer,
+        agreement.data.suspendedByPlatform,
+        suspendedByPlatformChanged,
+        agreement.metadata.version,
         authData,
         correlationId,
         contractBuilderInstance

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -444,7 +444,6 @@ export function agreementServiceBuilder(
         agreement.data,
         payload,
         newState,
-        suspendedByPlatform,
         authData.userId
       );
 

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -1144,13 +1144,13 @@ export function createAgreementArchivedByUpgradeEvent(
 function maybeCreateSetToMissingCertifiedAttributesByPlatformEvent(
   agreement: WithMetadata<Agreement>,
   nextStateByAttributes: AgreementState,
-  newSuspendedByPlatform: boolean,
+  recalculatedSuspendedByPlatform: boolean,
   correlationId: string
 ): CreateEvent<AgreementEvent> | undefined {
   if (
     nextStateByAttributes === agreementState.missingCertifiedAttributes &&
-    newSuspendedByPlatform &&
-    newSuspendedByPlatform !== agreement.data.suspendedByPlatform
+    recalculatedSuspendedByPlatform &&
+    recalculatedSuspendedByPlatform !== agreement.data.suspendedByPlatform
   ) {
     /* In this case, it means that one of the certified attributes is not
       valid anymore. We put the agreement in the missingCertifiedAttributes state

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -112,6 +112,7 @@ import {
   computeAgreementsStateByAttribute,
   nextStateByAttributes,
   suspendedByConsumerFlag,
+  suspendedByPlatformFlag,
   suspendedByProducerFlag,
 } from "./agreementStateProcessor.js";
 import {
@@ -913,11 +914,13 @@ export function agreementServiceBuilder(
         agreementState.active
       );
 
+      const suspendedByPlatform = suspendedByPlatformFlag(nextState);
+
       const newState = agreementStateByFlags(
         nextState,
         suspendedByProducer,
         suspendedByConsumer,
-        undefined
+        suspendedByPlatform
       );
 
       failOnActivationFailure(newState, agreement.data);
@@ -937,6 +940,7 @@ export function agreementServiceBuilder(
           agreement: agreement.data,
           suspendedByConsumer,
           suspendedByProducer,
+          suspendedByPlatform,
         });
 
       const updatedAgreement: Agreement = {

--- a/packages/agreement-process/src/services/agreementStateProcessor.ts
+++ b/packages/agreement-process/src/services/agreementStateProcessor.ts
@@ -106,7 +106,7 @@ const nextStateFromMissingCertifiedAttributes = (
   return missingCertifiedAttributes;
 };
 
-export const nextStateByAttributes = (
+export const nextStateByAttributesFSM = (
   agreement: Agreement,
   descriptor: Descriptor,
   tenant: Tenant | CompactTenant
@@ -129,13 +129,13 @@ export const nextStateByAttributes = (
     .exhaustive();
 
 export const agreementStateByFlags = (
-  stateByAttribute: AgreementState,
+  nextStateByAttributes: AgreementState,
   suspendedByProducer: boolean | undefined,
   suspendedByConsumer: boolean | undefined,
   suspendedByPlatform: boolean | undefined
 ): AgreementState =>
   match([
-    stateByAttribute,
+    nextStateByAttributes,
     suspendedByProducer,
     suspendedByConsumer,
     suspendedByPlatform,
@@ -146,28 +146,30 @@ export const agreementStateByFlags = (
       [agreementState.active, P.any, P.any, true],
       () => agreementState.suspended
     )
-    .otherwise(() => stateByAttribute);
+    .otherwise(() => nextStateByAttributes);
 
-export const suspendedByPlatformFlag = (fsmState: AgreementState): boolean =>
-  fsmState === agreementState.suspended ||
-  fsmState === agreementState.missingCertifiedAttributes;
+export const suspendedByPlatformFlag = (
+  nextStateByAttributes: AgreementState
+): boolean =>
+  nextStateByAttributes === agreementState.suspended ||
+  nextStateByAttributes === agreementState.missingCertifiedAttributes;
 
 export const suspendedByConsumerFlag = (
   agreement: Agreement,
   requesterOrgId: Tenant["id"],
-  destinationState: AgreementState
+  targetDestinationState: AgreementState
 ): boolean | undefined =>
   requesterOrgId === agreement.consumerId
-    ? destinationState === agreementState.suspended
+    ? targetDestinationState === agreementState.suspended
     : agreement.suspendedByConsumer;
 
 export const suspendedByProducerFlag = (
   agreement: Agreement,
   requesterOrgId: Tenant["id"],
-  destinationState: AgreementState
+  targetDestinationState: AgreementState
 ): boolean | undefined =>
   requesterOrgId === agreement.producerId
-    ? destinationState === agreementState.suspended
+    ? targetDestinationState === agreementState.suspended
     : agreement.suspendedByProducer;
 
 const allowedStateTransitions = (state: AgreementState): AgreementState[] =>
@@ -210,12 +212,16 @@ function updateAgreementState(
     return;
   }
 
-  const nextState = nextStateByAttributes(agreement.data, descriptor, consumer);
+  const nextStateByAttributes = nextStateByAttributesFSM(
+    agreement.data,
+    descriptor,
+    consumer
+  );
 
-  const newSuspendedByPlatform = suspendedByPlatformFlag(nextState);
+  const newSuspendedByPlatform = suspendedByPlatformFlag(nextStateByAttributes);
 
   const finalState = agreementStateByFlags(
-    nextState,
+    nextStateByAttributes,
     agreement.data.suspendedByProducer,
     agreement.data.suspendedByConsumer,
     newSuspendedByPlatform

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -59,6 +59,7 @@ export const createSubmissionUpdateAgreementSeed = (
   agreement: Agreement,
   payload: ApiAgreementSubmissionPayload,
   newState: AgreementState,
+  suspendedByPlatform: boolean,
   userId: UserId
 ): UpdateAgreementSeed => {
   const stamps = calculateStamps(agreement, newState, createStamp(userId));
@@ -76,6 +77,7 @@ export const createSubmissionUpdateAgreementSeed = (
         ),
         suspendedByConsumer: agreement.suspendedByConsumer,
         suspendedByProducer: agreement.suspendedByProducer,
+        suspendedByPlatform,
         consumerNotes: payload.consumerNotes,
         stamps,
       }
@@ -86,6 +88,7 @@ export const createSubmissionUpdateAgreementSeed = (
         verifiedAttributes: [],
         suspendedByConsumer: undefined,
         suspendedByProducer: undefined,
+        suspendedByPlatform,
         consumerNotes: payload.consumerNotes,
         stamps,
       };

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -59,7 +59,6 @@ export const createSubmissionUpdateAgreementSeed = (
   agreement: Agreement,
   payload: ApiAgreementSubmissionPayload,
   newState: AgreementState,
-  suspendedByPlatform: boolean,
   userId: UserId
 ): UpdateAgreementSeed => {
   const stamps = calculateStamps(agreement, newState, createStamp(userId));
@@ -77,7 +76,6 @@ export const createSubmissionUpdateAgreementSeed = (
         ),
         suspendedByConsumer: agreement.suspendedByConsumer,
         suspendedByProducer: agreement.suspendedByProducer,
-        suspendedByPlatform,
         consumerNotes: payload.consumerNotes,
         stamps,
       }
@@ -88,7 +86,6 @@ export const createSubmissionUpdateAgreementSeed = (
         verifiedAttributes: [],
         suspendedByConsumer: undefined,
         suspendedByProducer: undefined,
-        suspendedByPlatform,
         consumerNotes: payload.consumerNotes,
         stamps,
       };

--- a/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSubmissionProcessor.ts
@@ -59,7 +59,8 @@ export const createSubmissionUpdateAgreementSeed = (
   agreement: Agreement,
   payload: ApiAgreementSubmissionPayload,
   newState: AgreementState,
-  userId: UserId
+  userId: UserId,
+  suspendedByPlatform: boolean | undefined
 ): UpdateAgreementSeed => {
   const stamps = calculateStamps(agreement, newState, createStamp(userId));
   const isActivation = newState === agreementState.active;
@@ -76,6 +77,7 @@ export const createSubmissionUpdateAgreementSeed = (
         ),
         suspendedByConsumer: agreement.suspendedByConsumer,
         suspendedByProducer: agreement.suspendedByProducer,
+        suspendedByPlatform,
         consumerNotes: payload.consumerNotes,
         stamps,
       }
@@ -86,6 +88,7 @@ export const createSubmissionUpdateAgreementSeed = (
         verifiedAttributes: [],
         suspendedByConsumer: undefined,
         suspendedByProducer: undefined,
+        suspendedByPlatform,
         consumerNotes: payload.consumerNotes,
         stamps,
       };

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -16,7 +16,7 @@ import {
 } from "../model/domain/toEvent.js";
 import {
   agreementStateByFlags,
-  nextStateByAttributes,
+  nextStateByAttributesFSM,
   suspendedByConsumerFlag,
   suspendedByProducerFlag,
 } from "./agreementStateProcessor.js";
@@ -37,21 +37,30 @@ export function createSuspensionUpdatedAgreement({
   descriptor: Descriptor;
   consumer: Tenant;
 }): Agreement {
-  const nextState = nextStateByAttributes(agreement, descriptor, consumer);
+  /* nextAttributesState VS targetDestinationState
+  -- targetDestinationState is the state where the caller wants to go (suspended, in this case)
+  -- nextStateByAttributes is the next state of the Agreement based the attributes of the consumer
+  */
+  const targetDestinationState = agreementState.suspended;
+  const nextStateByAttributes = nextStateByAttributesFSM(
+    agreement,
+    descriptor,
+    consumer
+  );
 
   const suspendedByConsumer = suspendedByConsumerFlag(
     agreement,
     authData.organizationId,
-    agreementState.suspended
+    targetDestinationState
   );
   const suspendedByProducer = suspendedByProducerFlag(
     agreement,
     authData.organizationId,
-    agreementState.suspended
+    targetDestinationState
   );
 
   const newState = agreementStateByFlags(
-    nextState,
+    nextStateByAttributes,
     suspendedByProducer,
     suspendedByConsumer,
     agreement.suspendedByPlatform

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -18,6 +18,7 @@ import {
   agreementStateByFlags,
   nextStateByAttributes,
   suspendedByConsumerFlag,
+  suspendedByPlatformFlag,
   suspendedByProducerFlag,
 } from "./agreementStateProcessor.js";
 import {
@@ -50,11 +51,13 @@ export function createSuspensionUpdatedAgreement({
     agreementState.suspended
   );
 
+  const suspendedByPlatform = suspendedByPlatformFlag(nextState);
+
   const newState = agreementStateByFlags(
     nextState,
     suspendedByProducer,
     suspendedByConsumer,
-    undefined
+    suspendedByPlatform
   );
 
   const stamp = createStamp(authData.userId);

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -18,7 +18,6 @@ import {
   agreementStateByFlags,
   nextStateByAttributes,
   suspendedByConsumerFlag,
-  suspendedByPlatformFlag,
   suspendedByProducerFlag,
 } from "./agreementStateProcessor.js";
 import {
@@ -51,13 +50,11 @@ export function createSuspensionUpdatedAgreement({
     agreementState.suspended
   );
 
-  const suspendedByPlatform = suspendedByPlatformFlag(nextState);
-
   const newState = agreementStateByFlags(
     nextState,
     suspendedByProducer,
     suspendedByConsumer,
-    suspendedByPlatform
+    agreement.suspendedByPlatform
   );
 
   const stamp = createStamp(authData.userId);

--- a/packages/agreement-process/test/suspendAgreement.test.ts
+++ b/packages/agreement-process/test/suspendAgreement.test.ts
@@ -24,12 +24,11 @@ import {
   AgreementId,
   AgreementSuspendedByConsumerV2,
   AgreementSuspendedByProducerV2,
-  CertifiedTenantAttribute,
-  DeclaredTenantAttribute,
   Descriptor,
   EService,
+  EServiceId,
+  Tenant,
   TenantId,
-  VerifiedTenantAttribute,
   agreementState,
   generateId,
   toAgreementV2,
@@ -63,44 +62,26 @@ describe("suspend agreement", () => {
     vi.useRealTimers();
   });
 
-  it("should succeed when requester is Consumer or Producer, Consumer has all attributes satisfied, and the Agreement is in an suspendable state", async () => {
+  it("should succeed when requester is Consumer or Producer and the Agreement is in an suspendable state", async () => {
     const producerId = generateId<TenantId>();
 
-    const tenantCertifiedAttribute: CertifiedTenantAttribute = {
-      ...getMockCertifiedTenantAttribute(),
-      revocationTimestamp: undefined,
-    };
-
-    const tenantDeclaredAttribute: DeclaredTenantAttribute = {
-      ...getMockDeclaredTenantAttribute(),
-      revocationTimestamp: undefined,
-    };
-
-    const tenantVerifiedAttribute: VerifiedTenantAttribute = {
-      ...getMockVerifiedTenantAttribute(),
-      verifiedBy: [
-        {
-          id: producerId,
-          verificationDate: new Date(),
-          extensionDate: new Date(new Date().getTime() + 3600 * 1000),
-        },
-      ],
-    };
-
-    const consumer = {
+    // Adding some attributes to consumer, descriptor and eService to verify
+    // that the suspension ignores them and does not update them
+    const consumer: Tenant = {
       ...getMockTenant(),
       attributes: [
-        tenantCertifiedAttribute,
-        tenantDeclaredAttribute,
-        tenantVerifiedAttribute,
+        getMockCertifiedTenantAttribute(),
+        getMockDeclaredTenantAttribute(),
+        getMockVerifiedTenantAttribute(),
       ],
     };
-    const descriptor: Descriptor = {
+
+    const descriptor = {
       ...getMockDescriptorPublished(),
       attributes: {
-        certified: [[getMockEServiceAttribute(tenantCertifiedAttribute.id)]],
-        declared: [[getMockEServiceAttribute(tenantDeclaredAttribute.id)]],
-        verified: [[getMockEServiceAttribute(tenantVerifiedAttribute.id)]],
+        certified: [[getMockEServiceAttribute(consumer.attributes[0].id)]],
+        declared: [[getMockEServiceAttribute(consumer.attributes[1].id)]],
+        verified: [[getMockEServiceAttribute(consumer.attributes[2].id)]],
       },
     };
     const eservice: EService = {
@@ -115,7 +96,6 @@ describe("suspend agreement", () => {
       eserviceId: eservice.id,
       descriptorId: descriptor.id,
       producerId: eservice.producerId,
-      suspendedByPlatform: false,
       state: randomArrayItem(agreementSuspendableStates),
       certifiedAttributes: [
         getMockAgreementAttribute(consumer.attributes[0].id),
@@ -164,10 +144,8 @@ describe("suspend agreement", () => {
       payload: agreementEvent.data,
     }).agreement;
 
-    /* If the consumer has all the attributes satisfied,
-      the agreement will be suspended with suspendedByPlatform flag set to false
-      and suspendedByConsumer or suspendedByProducer flag set
-      to true depending on the requester (consumer or producer) */
+    /* The agreement will be suspended with suspendedByConsumer or suspendedByProducer flag set
+    to true depending on the requester (consumer or producer) */
     const expectedStamps = {
       suspensionByConsumer: isConsumer
         ? {
@@ -189,145 +167,6 @@ describe("suspend agreement", () => {
       suspendedByProducer: !isConsumer
         ? true
         : agreement.suspendedByProducer ?? false,
-      suspendedByPlatform: false,
-    };
-    const expectedAgreementSuspended: Agreement = {
-      ...agreement,
-      ...expectedSuspensionFlags,
-      state: agreementState.suspended,
-      suspendedAt: agreement.suspendedAt ?? new Date(),
-      stamps: {
-        ...agreement.stamps,
-        ...expectedStamps,
-      },
-    };
-    expect(actualAgreementSuspended).toMatchObject(
-      toAgreementV2(expectedAgreementSuspended)
-    );
-  });
-
-  it("should succeed when requester is Consumer or Producer, Consumer attributes are not satisfied, and the Agreement is in an suspendable state", async () => {
-    const producerId = generateId<TenantId>();
-
-    const tenantCertifiedAttribute: CertifiedTenantAttribute = {
-      ...getMockCertifiedTenantAttribute(),
-      revocationTimestamp: undefined,
-    };
-
-    const tenantDeclaredAttribute: DeclaredTenantAttribute = {
-      ...getMockDeclaredTenantAttribute(),
-      revocationTimestamp: undefined,
-    };
-
-    const tenantVerifiedAttribute: VerifiedTenantAttribute = {
-      ...getMockVerifiedTenantAttribute(),
-      verifiedBy: [
-        {
-          id: producerId,
-          verificationDate: new Date(),
-          extensionDate: new Date(new Date().getTime() + 3600 * 1000),
-        },
-      ],
-    };
-
-    const consumer = {
-      ...getMockTenant(),
-      attributes: [
-        tenantVerifiedAttribute,
-        // Missing certified and declared attributes from the descriptor
-      ],
-    };
-    const descriptor: Descriptor = {
-      ...getMockDescriptorPublished(),
-      attributes: {
-        certified: [[getMockEServiceAttribute(tenantCertifiedAttribute.id)]],
-        declared: [[getMockEServiceAttribute(tenantDeclaredAttribute.id)]],
-        verified: [[getMockEServiceAttribute(tenantVerifiedAttribute.id)]],
-      },
-    };
-    const eservice: EService = {
-      ...getMockEService(),
-      producerId,
-      descriptors: [descriptor],
-    };
-
-    const agreement: Agreement = {
-      ...getMockAgreement(),
-      consumerId: consumer.id,
-      eserviceId: eservice.id,
-      descriptorId: descriptor.id,
-      producerId: eservice.producerId,
-      suspendedByPlatform: false,
-      state: randomArrayItem(agreementSuspendableStates),
-      certifiedAttributes: [
-        getMockAgreementAttribute(consumer.attributes[0].id),
-      ],
-      declaredAttributes: [getMockAgreementAttribute()],
-      verifiedAttributes: [getMockAgreementAttribute()],
-    };
-
-    await addOneTenant(consumer);
-    await addOneEService(eservice);
-    await addOneAgreement(agreement);
-
-    const requesterId = randomArrayItem([
-      agreement.consumerId,
-      agreement.producerId,
-    ]);
-    const authData = getRandomAuthData(requesterId);
-
-    await agreementService.suspendAgreement(agreement.id, {
-      authData,
-      serviceName: "",
-      correlationId: "",
-      logger: genericLogger,
-    });
-
-    const agreementEvent = await readLastAgreementEvent(agreement.id);
-
-    const isConsumer = requesterId === agreement.consumerId;
-    expect(agreementEvent).toMatchObject({
-      type: isConsumer
-        ? "AgreementSuspendedByConsumer"
-        : "AgreementSuspendedByProducer",
-      event_version: 2,
-      version: "1",
-      stream_id: agreement.id,
-    });
-
-    const actualAgreementSuspended = decodeProtobufPayload({
-      messageType: isConsumer
-        ? AgreementSuspendedByConsumerV2
-        : AgreementSuspendedByProducerV2,
-      payload: agreementEvent.data,
-    }).agreement;
-
-    /* If the consumer DOES NOT have all the attributes satisfied,
-      the agreement will be suspended with suspendedByPlatform flag set to true
-      and suspendedByConsumer or suspendedByProducer flag set
-      to true depending on the requester (consumer or producer) */
-    const expectedStamps = {
-      suspensionByConsumer: isConsumer
-        ? {
-            who: authData.userId,
-            when: new Date(),
-          }
-        : agreement.stamps.suspensionByConsumer,
-      suspensionByProducer: !isConsumer
-        ? {
-            who: authData.userId,
-            when: new Date(),
-          }
-        : agreement.stamps.suspensionByProducer,
-    };
-    const expectedSuspensionFlags = {
-      suspendedByConsumer: isConsumer
-        ? true
-        : agreement.suspendedByConsumer ?? false,
-      suspendedByProducer: !isConsumer
-        ? true
-        : agreement.suspendedByProducer ?? false,
-      suspendedByPlatform: false,
     };
     const expectedAgreementSuspended: Agreement = {
       ...agreement,
@@ -347,8 +186,24 @@ describe("suspend agreement", () => {
   it("should succeed when requester is Consumer or Producer, Agreement producer and consumer are the same, and the Agreement is in an suspendable state", async () => {
     const producerAndConsumerId = generateId<TenantId>();
 
-    const consumer = getMockTenant(producerAndConsumerId);
-    const descriptor: Descriptor = getMockDescriptorPublished();
+    // Adding some attributes to consumer, descriptor and eService to verify
+    // that the suspension ignores them and does not update them
+    const consumer: Tenant = {
+      ...getMockTenant(producerAndConsumerId),
+      attributes: [
+        getMockCertifiedTenantAttribute(),
+        getMockDeclaredTenantAttribute(),
+        getMockVerifiedTenantAttribute(),
+      ],
+    };
+    const descriptor: Descriptor = {
+      ...getMockDescriptorPublished(),
+      attributes: {
+        certified: [[getMockEServiceAttribute(consumer.attributes[0].id)]],
+        declared: [[getMockEServiceAttribute(consumer.attributes[1].id)]],
+        verified: [[getMockEServiceAttribute(consumer.attributes[2].id)]],
+      },
+    };
 
     const eservice: EService = {
       ...getMockEService(),
@@ -362,11 +217,16 @@ describe("suspend agreement", () => {
       eserviceId: eservice.id,
       descriptorId: descriptor.id,
       producerId: eservice.producerId,
-      suspendedByPlatform: false,
       state: randomArrayItem(agreementSuspendableStates),
-      certifiedAttributes: [getMockAgreementAttribute()],
-      declaredAttributes: [getMockAgreementAttribute()],
-      verifiedAttributes: [getMockAgreementAttribute()],
+      certifiedAttributes: [
+        getMockAgreementAttribute(consumer.attributes[0].id),
+      ],
+      declaredAttributes: [
+        getMockAgreementAttribute(consumer.attributes[1].id),
+      ],
+      verifiedAttributes: [
+        getMockAgreementAttribute(consumer.attributes[2].id),
+      ],
     };
 
     await addOneTenant(consumer);
@@ -396,14 +256,12 @@ describe("suspend agreement", () => {
       payload: agreementEvent.data,
     }).agreement;
 
-    /* If the consumer and producer of the agreement are the same, there is no need to check the attributes.
-      the agreement will be suspended with suspendedByPlatform flag set to false
-      and suspendedByConsumer and suspendedByProducer flags both set to true */
+    /* If the consumer and producer of the agreement are the same the agreement will be
+    suspended with suspendedByConsumer and suspendedByProducer flags both set to true */
     const expectedAgreementSuspended: Agreement = {
       ...agreement,
       suspendedByConsumer: true,
       suspendedByProducer: true,
-      suspendedByPlatform: false,
       state: agreementState.suspended,
       suspendedAt: agreement.suspendedAt ?? new Date(),
       stamps: {
@@ -426,43 +284,8 @@ describe("suspend agreement", () => {
   it("should preserve the suspension flags and the stamps that it does not update", async () => {
     const producerId = generateId<TenantId>();
 
-    const tenantCertifiedAttribute: CertifiedTenantAttribute = {
-      ...getMockCertifiedTenantAttribute(),
-      revocationTimestamp: undefined,
-    };
-
-    const tenantDeclaredAttribute: DeclaredTenantAttribute = {
-      ...getMockDeclaredTenantAttribute(),
-      revocationTimestamp: undefined,
-    };
-
-    const tenantVerifiedAttribute: VerifiedTenantAttribute = {
-      ...getMockVerifiedTenantAttribute(),
-      verifiedBy: [
-        {
-          id: producerId,
-          verificationDate: new Date(),
-          extensionDate: new Date(new Date().getTime() + 3600 * 1000),
-        },
-      ],
-    };
-
-    const consumer = {
-      ...getMockTenant(),
-      attributes: [
-        tenantCertifiedAttribute,
-        tenantDeclaredAttribute,
-        tenantVerifiedAttribute,
-      ],
-    };
-    const descriptor: Descriptor = {
-      ...getMockDescriptorPublished(),
-      attributes: {
-        certified: [[getMockEServiceAttribute(tenantCertifiedAttribute.id)]],
-        declared: [[getMockEServiceAttribute(tenantDeclaredAttribute.id)]],
-        verified: [[getMockEServiceAttribute(tenantVerifiedAttribute.id)]],
-      },
-    };
+    const consumer = getMockTenant();
+    const descriptor: Descriptor = getMockDescriptorPublished();
     const eservice: EService = {
       ...getMockEService(),
       producerId,
@@ -481,7 +304,7 @@ describe("suspend agreement", () => {
       state: agreementState.suspended,
       suspendedByConsumer: randomBoolean(),
       suspendedByProducer: randomBoolean(),
-      suspendedByPlatform: false,
+      suspendedByPlatform: randomBoolean(),
       stamps: {
         activation: createStamp(authData.userId),
         archiving: createStamp(authData.userId),
@@ -491,15 +314,6 @@ describe("suspend agreement", () => {
         suspensionByConsumer: createStamp(authData.userId),
         suspensionByProducer: createStamp(authData.userId),
       },
-      certifiedAttributes: [
-        getMockAgreementAttribute(consumer.attributes[0].id),
-      ],
-      declaredAttributes: [
-        getMockAgreementAttribute(consumer.attributes[1].id),
-      ],
-      verifiedAttributes: [
-        getMockAgreementAttribute(consumer.attributes[2].id),
-      ],
     };
 
     await addOneTenant(consumer);
@@ -553,7 +367,6 @@ describe("suspend agreement", () => {
       suspendedByProducer: !isConsumer
         ? true
         : agreement.suspendedByProducer ?? false,
-      suspendedByPlatform: false,
     };
     const expectedAgreementSuspended: Agreement = {
       ...agreement,
@@ -642,7 +455,11 @@ describe("suspend agreement", () => {
   it("should throw a tenantNotFound error when the consumer does not exist", async () => {
     await addOneTenant(getMockTenant());
     const descriptor = getMockDescriptorPublished();
-    const eservice = { ...getMockEService(), descriptors: [descriptor] };
+    const eservice = getMockEService(
+      generateId<EServiceId>(),
+      generateId<TenantId>(),
+      [descriptor]
+    );
     const consumer = getMockTenant();
     const agreement = {
       ...getMockAgreement(),

--- a/packages/agreement-process/test/suspendAgreement.test.ts
+++ b/packages/agreement-process/test/suspendAgreement.test.ts
@@ -24,11 +24,12 @@ import {
   AgreementId,
   AgreementSuspendedByConsumerV2,
   AgreementSuspendedByProducerV2,
+  CertifiedTenantAttribute,
+  DeclaredTenantAttribute,
   Descriptor,
   EService,
-  EServiceId,
-  Tenant,
   TenantId,
+  VerifiedTenantAttribute,
   agreementState,
   generateId,
   toAgreementV2,
@@ -62,26 +63,44 @@ describe("suspend agreement", () => {
     vi.useRealTimers();
   });
 
-  it("should succeed when requester is Consumer or Producer and the Agreement is in an suspendable state", async () => {
+  it("should succeed when requester is Consumer or Producer, Consumer has all attributes satisfied, and the Agreement is in an suspendable state", async () => {
     const producerId = generateId<TenantId>();
 
-    // Adding some attributes to consumer, descriptor and eService to verify
-    // that the suspension ignores them and does not update them
-    const consumer: Tenant = {
-      ...getMockTenant(),
-      attributes: [
-        getMockCertifiedTenantAttribute(),
-        getMockDeclaredTenantAttribute(),
-        getMockVerifiedTenantAttribute(),
+    const tenantCertifiedAttribute: CertifiedTenantAttribute = {
+      ...getMockCertifiedTenantAttribute(),
+      revocationTimestamp: undefined,
+    };
+
+    const tenantDeclaredAttribute: DeclaredTenantAttribute = {
+      ...getMockDeclaredTenantAttribute(),
+      revocationTimestamp: undefined,
+    };
+
+    const tenantVerifiedAttribute: VerifiedTenantAttribute = {
+      ...getMockVerifiedTenantAttribute(),
+      verifiedBy: [
+        {
+          id: producerId,
+          verificationDate: new Date(),
+          extensionDate: new Date(new Date().getTime() + 3600 * 1000),
+        },
       ],
     };
 
-    const descriptor = {
+    const consumer = {
+      ...getMockTenant(),
+      attributes: [
+        tenantCertifiedAttribute,
+        tenantDeclaredAttribute,
+        tenantVerifiedAttribute,
+      ],
+    };
+    const descriptor: Descriptor = {
       ...getMockDescriptorPublished(),
       attributes: {
-        certified: [[getMockEServiceAttribute(consumer.attributes[0].id)]],
-        declared: [[getMockEServiceAttribute(consumer.attributes[1].id)]],
-        verified: [[getMockEServiceAttribute(consumer.attributes[2].id)]],
+        certified: [[getMockEServiceAttribute(tenantCertifiedAttribute.id)]],
+        declared: [[getMockEServiceAttribute(tenantDeclaredAttribute.id)]],
+        verified: [[getMockEServiceAttribute(tenantVerifiedAttribute.id)]],
       },
     };
     const eservice: EService = {
@@ -96,6 +115,7 @@ describe("suspend agreement", () => {
       eserviceId: eservice.id,
       descriptorId: descriptor.id,
       producerId: eservice.producerId,
+      suspendedByPlatform: false,
       state: randomArrayItem(agreementSuspendableStates),
       certifiedAttributes: [
         getMockAgreementAttribute(consumer.attributes[0].id),
@@ -144,8 +164,10 @@ describe("suspend agreement", () => {
       payload: agreementEvent.data,
     }).agreement;
 
-    /* The agreement will be suspended with suspendedByConsumer or suspendedByProducer flag set
-    to true depending on the requester (consumer or producer) */
+    /* If the consumer has all the attributes satisfied,
+      the agreement will be suspended with suspendedByPlatform flag set to false
+      and suspendedByConsumer or suspendedByProducer flag set
+      to true depending on the requester (consumer or producer) */
     const expectedStamps = {
       suspensionByConsumer: isConsumer
         ? {
@@ -167,6 +189,145 @@ describe("suspend agreement", () => {
       suspendedByProducer: !isConsumer
         ? true
         : agreement.suspendedByProducer ?? false,
+      suspendedByPlatform: false,
+    };
+    const expectedAgreementSuspended: Agreement = {
+      ...agreement,
+      ...expectedSuspensionFlags,
+      state: agreementState.suspended,
+      suspendedAt: agreement.suspendedAt ?? new Date(),
+      stamps: {
+        ...agreement.stamps,
+        ...expectedStamps,
+      },
+    };
+    expect(actualAgreementSuspended).toMatchObject(
+      toAgreementV2(expectedAgreementSuspended)
+    );
+  });
+
+  it("should succeed when requester is Consumer or Producer, Consumer attributes are not satisfied, and the Agreement is in an suspendable state", async () => {
+    const producerId = generateId<TenantId>();
+
+    const tenantCertifiedAttribute: CertifiedTenantAttribute = {
+      ...getMockCertifiedTenantAttribute(),
+      revocationTimestamp: undefined,
+    };
+
+    const tenantDeclaredAttribute: DeclaredTenantAttribute = {
+      ...getMockDeclaredTenantAttribute(),
+      revocationTimestamp: undefined,
+    };
+
+    const tenantVerifiedAttribute: VerifiedTenantAttribute = {
+      ...getMockVerifiedTenantAttribute(),
+      verifiedBy: [
+        {
+          id: producerId,
+          verificationDate: new Date(),
+          extensionDate: new Date(new Date().getTime() + 3600 * 1000),
+        },
+      ],
+    };
+
+    const consumer = {
+      ...getMockTenant(),
+      attributes: [
+        tenantVerifiedAttribute,
+        // Missing certified and declared attributes from the descriptor
+      ],
+    };
+    const descriptor: Descriptor = {
+      ...getMockDescriptorPublished(),
+      attributes: {
+        certified: [[getMockEServiceAttribute(tenantCertifiedAttribute.id)]],
+        declared: [[getMockEServiceAttribute(tenantDeclaredAttribute.id)]],
+        verified: [[getMockEServiceAttribute(tenantVerifiedAttribute.id)]],
+      },
+    };
+    const eservice: EService = {
+      ...getMockEService(),
+      producerId,
+      descriptors: [descriptor],
+    };
+
+    const agreement: Agreement = {
+      ...getMockAgreement(),
+      consumerId: consumer.id,
+      eserviceId: eservice.id,
+      descriptorId: descriptor.id,
+      producerId: eservice.producerId,
+      suspendedByPlatform: false,
+      state: randomArrayItem(agreementSuspendableStates),
+      certifiedAttributes: [
+        getMockAgreementAttribute(consumer.attributes[0].id),
+      ],
+      declaredAttributes: [getMockAgreementAttribute()],
+      verifiedAttributes: [getMockAgreementAttribute()],
+    };
+
+    await addOneTenant(consumer);
+    await addOneEService(eservice);
+    await addOneAgreement(agreement);
+
+    const requesterId = randomArrayItem([
+      agreement.consumerId,
+      agreement.producerId,
+    ]);
+    const authData = getRandomAuthData(requesterId);
+
+    await agreementService.suspendAgreement(agreement.id, {
+      authData,
+      serviceName: "",
+      correlationId: "",
+      logger: genericLogger,
+    });
+
+    const agreementEvent = await readLastAgreementEvent(agreement.id);
+
+    const isConsumer = requesterId === agreement.consumerId;
+    expect(agreementEvent).toMatchObject({
+      type: isConsumer
+        ? "AgreementSuspendedByConsumer"
+        : "AgreementSuspendedByProducer",
+      event_version: 2,
+      version: "1",
+      stream_id: agreement.id,
+    });
+
+    const actualAgreementSuspended = decodeProtobufPayload({
+      messageType: isConsumer
+        ? AgreementSuspendedByConsumerV2
+        : AgreementSuspendedByProducerV2,
+      payload: agreementEvent.data,
+    }).agreement;
+
+    /* If the consumer DOES NOT have all the attributes satisfied,
+      the agreement will be suspended with suspendedByPlatform flag set to true
+      and suspendedByConsumer or suspendedByProducer flag set
+      to true depending on the requester (consumer or producer) */
+    const expectedStamps = {
+      suspensionByConsumer: isConsumer
+        ? {
+            who: authData.userId,
+            when: new Date(),
+          }
+        : agreement.stamps.suspensionByConsumer,
+      suspensionByProducer: !isConsumer
+        ? {
+            who: authData.userId,
+            when: new Date(),
+          }
+        : agreement.stamps.suspensionByProducer,
+    };
+    const expectedSuspensionFlags = {
+      suspendedByConsumer: isConsumer
+        ? true
+        : agreement.suspendedByConsumer ?? false,
+      suspendedByProducer: !isConsumer
+        ? true
+        : agreement.suspendedByProducer ?? false,
+      suspendedByPlatform: false,
     };
     const expectedAgreementSuspended: Agreement = {
       ...agreement,
@@ -186,24 +347,8 @@ describe("suspend agreement", () => {
   it("should succeed when requester is Consumer or Producer, Agreement producer and consumer are the same, and the Agreement is in an suspendable state", async () => {
     const producerAndConsumerId = generateId<TenantId>();
 
-    // Adding some attributes to consumer, descriptor and eService to verify
-    // that the suspension ignores them and does not update them
-    const consumer: Tenant = {
-      ...getMockTenant(producerAndConsumerId),
-      attributes: [
-        getMockCertifiedTenantAttribute(),
-        getMockDeclaredTenantAttribute(),
-        getMockVerifiedTenantAttribute(),
-      ],
-    };
-    const descriptor: Descriptor = {
-      ...getMockDescriptorPublished(),
-      attributes: {
-        certified: [[getMockEServiceAttribute(consumer.attributes[0].id)]],
-        declared: [[getMockEServiceAttribute(consumer.attributes[1].id)]],
-        verified: [[getMockEServiceAttribute(consumer.attributes[2].id)]],
-      },
-    };
+    const consumer = getMockTenant(producerAndConsumerId);
+    const descriptor: Descriptor = getMockDescriptorPublished();
 
     const eservice: EService = {
       ...getMockEService(),
@@ -217,16 +362,11 @@ describe("suspend agreement", () => {
       eserviceId: eservice.id,
       descriptorId: descriptor.id,
       producerId: eservice.producerId,
+      suspendedByPlatform: false,
       state: randomArrayItem(agreementSuspendableStates),
-      certifiedAttributes: [
-        getMockAgreementAttribute(consumer.attributes[0].id),
-      ],
-      declaredAttributes: [
-        getMockAgreementAttribute(consumer.attributes[1].id),
-      ],
-      verifiedAttributes: [
-        getMockAgreementAttribute(consumer.attributes[2].id),
-      ],
+      certifiedAttributes: [getMockAgreementAttribute()],
+      declaredAttributes: [getMockAgreementAttribute()],
+      verifiedAttributes: [getMockAgreementAttribute()],
     };
 
     await addOneTenant(consumer);
@@ -256,12 +396,14 @@ describe("suspend agreement", () => {
       payload: agreementEvent.data,
     }).agreement;
 
-    /* If the consumer and producer of the agreement are the same the agreement will be
-    suspended with suspendedByConsumer and suspendedByProducer flags both set to true */
+    /* If the consumer and producer of the agreement are the same, there is no need to check the attributes.
+      the agreement will be suspended with suspendedByPlatform flag set to false
+      and suspendedByConsumer and suspendedByProducer flags both set to true */
     const expectedAgreementSuspended: Agreement = {
       ...agreement,
       suspendedByConsumer: true,
       suspendedByProducer: true,
+      suspendedByPlatform: false,
       state: agreementState.suspended,
       suspendedAt: agreement.suspendedAt ?? new Date(),
       stamps: {
@@ -284,8 +426,43 @@ describe("suspend agreement", () => {
   it("should preserve the suspension flags and the stamps that it does not update", async () => {
     const producerId = generateId<TenantId>();
 
-    const consumer = getMockTenant();
-    const descriptor: Descriptor = getMockDescriptorPublished();
+    const tenantCertifiedAttribute: CertifiedTenantAttribute = {
+      ...getMockCertifiedTenantAttribute(),
+      revocationTimestamp: undefined,
+    };
+
+    const tenantDeclaredAttribute: DeclaredTenantAttribute = {
+      ...getMockDeclaredTenantAttribute(),
+      revocationTimestamp: undefined,
+    };
+
+    const tenantVerifiedAttribute: VerifiedTenantAttribute = {
+      ...getMockVerifiedTenantAttribute(),
+      verifiedBy: [
+        {
+          id: producerId,
+          verificationDate: new Date(),
+          extensionDate: new Date(new Date().getTime() + 3600 * 1000),
+        },
+      ],
+    };
+
+    const consumer = {
+      ...getMockTenant(),
+      attributes: [
+        tenantCertifiedAttribute,
+        tenantDeclaredAttribute,
+        tenantVerifiedAttribute,
+      ],
+    };
+    const descriptor: Descriptor = {
+      ...getMockDescriptorPublished(),
+      attributes: {
+        certified: [[getMockEServiceAttribute(tenantCertifiedAttribute.id)]],
+        declared: [[getMockEServiceAttribute(tenantDeclaredAttribute.id)]],
+        verified: [[getMockEServiceAttribute(tenantVerifiedAttribute.id)]],
+      },
+    };
     const eservice: EService = {
       ...getMockEService(),
       producerId,
@@ -304,7 +481,7 @@ describe("suspend agreement", () => {
       state: agreementState.suspended,
       suspendedByConsumer: randomBoolean(),
       suspendedByProducer: randomBoolean(),
-      suspendedByPlatform: randomBoolean(),
+      suspendedByPlatform: false,
       stamps: {
         activation: createStamp(authData.userId),
         archiving: createStamp(authData.userId),
@@ -314,6 +491,15 @@ describe("suspend agreement", () => {
         suspensionByConsumer: createStamp(authData.userId),
         suspensionByProducer: createStamp(authData.userId),
       },
+      certifiedAttributes: [
+        getMockAgreementAttribute(consumer.attributes[0].id),
+      ],
+      declaredAttributes: [
+        getMockAgreementAttribute(consumer.attributes[1].id),
+      ],
+      verifiedAttributes: [
+        getMockAgreementAttribute(consumer.attributes[2].id),
+      ],
     };
 
     await addOneTenant(consumer);
@@ -367,6 +553,7 @@ describe("suspend agreement", () => {
       suspendedByProducer: !isConsumer
         ? true
         : agreement.suspendedByProducer ?? false,
+      suspendedByPlatform: false,
     };
     const expectedAgreementSuspended: Agreement = {
       ...agreement,
@@ -455,11 +642,7 @@ describe("suspend agreement", () => {
   it("should throw a tenantNotFound error when the consumer does not exist", async () => {
     await addOneTenant(getMockTenant());
     const descriptor = getMockDescriptorPublished();
-    const eservice = getMockEService(
-      generateId<EServiceId>(),
-      generateId<TenantId>(),
-      [descriptor]
-    );
+    const eservice = { ...getMockEService(), descriptors: [descriptor] };
     const consumer = getMockTenant();
     const agreement = {
       ...getMockAgreement(),


### PR DESCRIPTION
Closes [IMN-590](https://pagopa.atlassian.net/browse/IMN-590)

In this PR I re-added the update of the `suspendedByPlatform` in activation and submission, and its usage in calculating the next state (also for suspension) - all things removed in #296. Not updating the flag could potentially lead to inconsistent Agreement states. For example: in the activation, the result could be an `Active` agreement with the `suspendedByPlatform` flag set to true but without writing a corresponding SuspendByPlatform event

Since we now update the flag in activate and submit, I also added the corresponding events.


[IMN-590]: https://pagopa.atlassian.net/browse/IMN-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Tests

See corresponding automated tests being implemented in #567 