### PR TITLE
Add default config turbo ui as stream

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "ui": "stream",
   "globalDependencies": [
     "tsconfig.json"
   ],


### PR DESCRIPTION
# Description
This PR introduces the turbo configuration UI into the project configuration, simplifying the use with old UI without needing additional environment variables or parameters when launching tasks.Very effectful when there isn't enough space to display the shell, the old configuration works well. In my opinion, the old UI is more readable and intuitive.

### The new UI with navigation 
<img width="924" alt="Screenshot 2024-06-13 at 15 09 20" src="https://github.com/pagopa/interop-be-monorepo/assets/5895397/7f33439b-d572-4eeb-9708-a0a35dd3dc78">

### The OLD UI  
<img width="920" alt="Screenshot 2024-06-13 at 15 09 03" src="https://github.com/pagopa/interop-be-monorepo/assets/5895397/1604065a-ffbd-4377-a97b-5a1991c51730">
