### PR TITLE
Linter fix - switching to single TSConfig approach for typescript-eslint configuration

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,7 +2,7 @@ module.exports = {
   extends: ["@pagopa/eslint-config/strong"],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ["./packages/*/tsconfig.json", "./packages/*/test/tsconfig.json"],
+    project: "./tsconfig.eslint.json",
   },
   rules: {
     // Any project level custom rule
@@ -26,6 +26,6 @@ module.exports = {
     "**/src/model/generated/*.ts",
     "**/dist",
     "**/patchZodios.ts",
-    "**/paged.polyfill.js"
+    "**/paged.polyfill.js",
   ],
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "turbo test",
     "build": "turbo build",
     "check": "turbo check",
-    "lint": "turbo lint --concurrency=4",
+    "lint": "turbo lint",
     "lint:autofix": "turbo lint:autofix",
     "format:check": "turbo format:check",
     "format:write": "turbo format:write",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // ensure that nobody can accidentally use this config for a build
+    "noEmit": true,
+  },
+  "include": ["packages/**/*"]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,3 +1,6 @@
+// Root tsconfig for typescript-eslint
+// See: https://typescript-eslint.io/getting-started/typed-linting/monorepos#important-note-regarding-large--10-multi-package-monorepos
+// Choosing the root tsconfig approach because of: https://typescript-eslint.io/getting-started/typed-linting/monorepos#important-note-regarding-large--10-multi-package-monorepos
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {


### PR DESCRIPTION
`typescript-eslint` docs suggest two different ways to configure it on a monorepo: https://typescript-eslint.io/getting-started/typed-linting/monorepos

1. One root tsconfig.json
2. One tsconfig.json per package 

We were using approach 2 which can result in out-of-memory errors. Citing [this chapter](https://typescript-eslint.io/getting-started/typed-linting/monorepos#important-note-regarding-large--10-multi-package-monorepos
) of the docs: "We've had reports that for sufficiently large and/or interdependent projects, you may run into OOMs using this approach".

Switching to approach 1 solves our linter issues and speeds up the linter 2x.

See also:
- https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-565286938
- https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-553259601

# Tested that the linter is still working on `src` files

Smoke testing `src` files of some packages, to check that linter still works:

- In VSCode
- Launching `pnpm lint` from the package folder
- Launching `pnpm lint` from the monorepo root (i.e., `turbo lint`)

<img width="676" alt="Screenshot 2024-06-17 at 11 16 41" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/927d3abf-da52-4f5f-b005-41dbd8ea9d21">

<img width="928" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/1b6ccd2e-0019-40b6-8d6b-340db3a7a970">

<img width="935" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/8018d65e-2192-42a7-b314-97ac79a60481">

<img width="893" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/875fb3f0-c384-4f42-8adb-a5ce26a340c6">

# Tested that the linter is still working on `test` files

Same as above for test files:

<img width="943" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/1a45c799-b116-45dc-8ddd-c1d26abdf625">

<img width="811" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/9e4ee3af-5296-481e-8ca5-5a2a293c8bd3">

<img width="910" alt="image" src="https://github.com/pagopa/interop-be-monorepo/assets/6418684/f4ab2481-26c3-42ab-ba8d-161f73cef631">
