### PR TITLE
Fix missing resources files during email sender

### DIFF
--- a/packages/agreement-email-sender/package.json
+++ b/packages/agreement-email-sender/package.json
@@ -16,7 +16,7 @@
     "format:check": "prettier --check src",
     "format:write": "prettier --write src",
     "start": "node --loader ts-node/esm -r 'dotenv-flow/config' --watch  ./src/index.ts",
-    "build": "tsc",
+    "build": "tsc && pnpm cpx './src/resources/**/*' './dist/resources'",
     "check": "tsc --project tsconfig.check.json"
   },
   "keywords": [],
@@ -26,6 +26,7 @@
     "@pagopa/eslint-config": "3.0.0",
     "@types/node": "20.14.6",
     "@types/uuid": "9.0.8",
+    "cpx2": "7.0.1",
     "axios": "1.7.2",
     "pagopa-interop-commons-test": "workspace:*",
     "prettier": "2.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       axios:
         specifier: 1.7.2
         version: 1.7.2
+      cpx2:
+        specifier: 7.0.1
+        version: 7.0.1
       pagopa-interop-commons-test:
         specifier: workspace:*
         version: link:../commons-test
@@ -5521,7 +5524,7 @@ packages:
     hasBin: true
     dependencies:
       debounce: 2.1.0
-      debug: 4.3.4
+      debug: 4.3.5
       duplexer: 0.1.2
       fs-extra: 11.2.0
       glob: 10.4.1


### PR DESCRIPTION
This FIX allows copying of HTML resource files during build task for email sender service.