### PR TITLE
Fix purpose version's `expectedApprovalDate` being saved as number in the readmodel in purpose process

### DIFF
--- a/packages/models/src/purpose/protobufConverterFromV1.ts
+++ b/packages/models/src/purpose/protobufConverterFromV1.ts
@@ -57,6 +57,7 @@ export const fromPurposeVersionV1 = (
     : undefined,
   createdAt: bigIntToDate(input.createdAt),
   updatedAt: bigIntToDate(input.updatedAt),
+  expectedApprovalDate: bigIntToDate(input.expectedApprovalDate),
   firstActivationAt: bigIntToDate(input.firstActivationAt),
   suspendedAt: bigIntToDate(input.suspendedAt),
 });

--- a/packages/models/src/purpose/purpose.ts
+++ b/packages/models/src/purpose/purpose.ts
@@ -39,6 +39,7 @@ export const PurposeVersion = z.object({
   rejectionReason: z.string().optional(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date().optional(),
+  expectedApprovalDate: z.coerce.date().optional(),
   firstActivationAt: z.coerce.date().optional(),
   suspendedAt: z.coerce.date().optional(),
 });

--- a/packages/models/src/purpose/purposeReadModelAdapter.ts
+++ b/packages/models/src/purpose/purposeReadModelAdapter.ts
@@ -20,6 +20,7 @@ export const toReadModelPurposeVersion = (
   updatedAt: purposeVersion.updatedAt?.toISOString(),
   firstActivationAt: purposeVersion.firstActivationAt?.toISOString(),
   suspendedAt: purposeVersion.suspendedAt?.toISOString(),
+  expectedApprovalDate: purposeVersion.expectedApprovalDate?.toISOString(),
   riskAnalysis: purposeVersion.riskAnalysis
     ? toReadModelPurposeVersionDocument(purposeVersion.riskAnalysis)
     : undefined,

--- a/packages/models/src/read-models/purposeReadModel.ts
+++ b/packages/models/src/read-models/purposeReadModel.ts
@@ -24,6 +24,7 @@ export const PurposeVersionReadModel = PurposeVersion.extend({
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime().optional(),
   firstActivationAt: z.string().datetime().optional(),
+  expectedApprovalDate: z.string().datetime().optional(),
   suspendedAt: z.string().datetime().optional(),
   riskAnalysis: PurposeVersionDocumentReadModel.optional(),
 });

--- a/packages/notifier-seeder/src/models/purpose/purposeEventNotification.ts
+++ b/packages/notifier-seeder/src/models/purpose/purposeEventNotification.ts
@@ -18,6 +18,7 @@ export type PurposeVersionV1Notification = Omit<
   | "updatedAt"
   | "firstActivationAt"
   | "suspendedAt"
+  | "expectedApprovalDate"
 > & {
   state: string;
   riskAnalysis?: PurposeVersionDocumentV1Notification;

--- a/packages/purpose-readmodel-writer/test/protobufConverterToV1.ts
+++ b/packages/purpose-readmodel-writer/test/protobufConverterToV1.ts
@@ -43,6 +43,7 @@ export const toPurposeVersionV1 = (
   updatedAt: dateToBigInt(input.updatedAt),
   firstActivationAt: dateToBigInt(input.firstActivationAt),
   suspendedAt: dateToBigInt(input.suspendedAt),
+  expectedApprovalDate: dateToBigInt(input.expectedApprovalDate),
   riskAnalysis: input.riskAnalysis
     ? toPurposeVersionDocumentV1(input.riskAnalysis)
     : undefined,


### PR DESCRIPTION
The conversion from bigint to number of `expectedApprovalDate` was not happening since this value was not being mapped in the `PurposeVersion` model. 

This caused the expectedApprovalDate` being written as a bigint in the readmodel.

This PR fixes this problem.