### PR TITLE
Adding automergeDigest to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     ":automergeLinters",
     ":automergeTesters",
     ":automergeTypes",
+    ":automergeDigest",
     ":combinePatchMinorReleases",
     ":ignoreUnstable",
     ":rebaseStalePrs",


### PR DESCRIPTION
# Issue

We did not have auto-merge enabled for PRs that merely update the digest of a Docker image.
This caused PRs like the following to wait for manual merge thus blocking Renovate automatic updates for days if not manually merged:
- https://github.com/pagopa/interop-be-monorepo/pull/680
- https://github.com/pagopa/interop-be-monorepo/pull/683

# Solution

This PR adds a config to enable auto-merge of digest updates.
See: https://docs.renovatebot.com/docker/#automerge-digest-updates