### PR TITLE
Fix eservice archiver Docker Image

### DIFF
--- a/packages/eservice-descriptors-archiver/Dockerfile
+++ b/packages/eservice-descriptors-archiver/Dockerfile
@@ -21,7 +21,6 @@ COPY ./packages/eservice-descriptors-archiver /app/packages/eservice-descriptors
 COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 COPY ./packages/kafka-iam-auth /app/packages/kafka-iam-auth
-COPY ./packages/catalog-process/open-api/catalog-service-spec.yml /app/packages/catalog-process/open-api/catalog-service-spec.yml
 COPY ./packages/api-clients /app/packages/api-clients
 
 RUN pnpm build && \


### PR DESCRIPTION
In the changes related to #710 I forgot to remove the copy of the catalog service open API specs. 