### PR TITLE
IMN-614: Error logging and passthrough in BFF

### DIFF
--- a/packages/bff/src/routers/catalogRouter.ts
+++ b/packages/bff/src/routers/catalogRouter.ts
@@ -44,7 +44,8 @@ const catalogRouter = (
         const errorRes = makeApiProblem(
           error,
           bffGetCatalogErrorMapper,
-          ctx.logger
+          ctx.logger,
+          "Error retrieving Catalog EServices"
         );
         return res.status(errorRes.status).json(errorRes).end();
       }

--- a/packages/bff/src/routers/purposeRouter.ts
+++ b/packages/bff/src/routers/purposeRouter.ts
@@ -40,7 +40,8 @@ const purposeRouter = (
         const errorRes = makeApiProblem(
           error,
           reversePurposeUpdateErrorMapper,
-          ctx.logger
+          ctx.logger,
+          `Error updating reverse purpose ${req.params.purposeId}`
         );
         return res.status(errorRes.status).json(errorRes).end();
       }

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -128,7 +128,9 @@ export function makeApiProblemBuilder<T extends string>(errors: {
             },
           },
           (e) => {
+            const receivedProblem: Problem = e.response.data;
             logger.warn(logMessage ?? "");
+            logger.warn(makeProblemLogString(receivedProblem, error));
             return e.response.data;
           }
         )


### PR DESCRIPTION
With the changes introduces in this PR we allow the following:

1. Optional `logMessage` inside the `makeApiProblem` in order to let the BFF introduce an additional log other than the one received from a process;
2. Correctly manage the bubble up of the Problem received from a process.

### Before
![immagine](https://github.com/user-attachments/assets/7ea311ee-1dfd-4cbf-89ae-3ef220089225)

### After
![immagine](https://github.com/user-attachments/assets/e2c55da6-1111-47c9-8197-a20192835f39)
