### PR TITLE
Fix Zodios API client query param name serialization when value is an…

### DIFF
--- a/packages/api-clients/package.json
+++ b/packages/api-clients/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@pagopa/eslint-config": "3.0.0",
     "@types/node": "20.14.6",
+    "@types/qs": "6.9.15",
     "handlebars": "4.7.7",
     "prettier": "2.8.8",
     "ts-node": "10.9.2",
@@ -35,6 +36,7 @@
   },
   "dependencies": {
     "@zodios/core": "10.9.6",
+    "qs" : "6.12.3",
     "ts-pattern": "5.2.0",
     "zod": "3.23.8",
     "zod-validation-error": "3.3.0"

--- a/packages/api-clients/template-bff.hbs
+++ b/packages/api-clients/template-bff.hbs
@@ -88,8 +88,8 @@ export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: Zo
 			...options,
 			axiosConfig: {
 				...options?.axiosConfig,
-				// This configuration is used to serialize properly query parameter name when value is array  
-				// the default client serialization produce query param name appending the invalid chars "[]"	at the end
+				// This configuration is used to serialize correctly array query parameters.
+				// The default serialization produces a query param name appending "[]" after the equals:
 				// eg: ids[]=1,2,3 instead of ids=1,2,3
 				paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
 			},

--- a/packages/api-clients/template-bff.hbs
+++ b/packages/api-clients/template-bff.hbs
@@ -1,5 +1,6 @@
 import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
 import { z } from "zod";
+import qs from "qs";
 
 {{#each schemas}}
 export const {{@key}} = {{{this}}};

--- a/packages/api-clients/template-bff.hbs
+++ b/packages/api-clients/template-bff.hbs
@@ -36,15 +36,15 @@ export const {{@key}}Endpoints = makeApi([
 				type: "{{type}}",
 				{{/if}}
 				{{#if (and (eq type "Query") (eq schema "z.array(z.string()).optional().default([])"))}}
-						schema: z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string()).optional().default([])),
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string()).optional().default([])), z.array(z.string()).optional().default([])]),
 				{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind)"))}}
-						schema: z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)),
+						schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)), z.array(AttributeKind)])
 				{{else if (and (eq type "Query") (eq schema "z.array(AgreementState).optional().default([])"))}}
-						schema: z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(AgreementState).optional().default([])),
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(AgreementState).optional().default([])),z.array(AgreementState).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(EServiceDescriptorState).optional().default([])"))}}
-						schema: z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(EServiceDescriptorState).optional().default([])),
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(EServiceDescriptorState).optional().default([])), z.array(EServiceDescriptorState).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(PurposeVersionState).optional().default([])"))}}
-						schema: z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeVersionState).optional().default([])),
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeVersionState).optional().default([])), z.array(PurposeVersionState).optional().default([])])
 				{{else}}
 					schema: {{{schema}}},
 				{{/if}}
@@ -83,7 +83,16 @@ export const {{@key}}Endpoints = makeApi([
 export const {{@key}}Api = new Zodios({{#if options.baseUrl}}"{{options.baseUrl}}", {{/if}}{{@key}}Endpoints);
 
 export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: ZodiosOptions) {
-    return new Zodios(baseUrl, {{@key}}Endpoints, options);
+    return new Zodios(baseUrl, {{@key}}Endpoints, {
+			...options,
+			axiosConfig: {
+				...options?.axiosConfig,
+				// This configuration is used to serialize properly query parameter name when value is array  
+				// the default client serialization produce query param name appending the invalid chars "[]"	at the end
+				// eg: ids[]=1,2,3 instead of ids=1,2,3
+				paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
+			},
+		});
 }
 
 {{/each}}

--- a/packages/api-clients/template.hbs
+++ b/packages/api-clients/template.hbs
@@ -1,5 +1,6 @@
 import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
 import { z } from "zod";
+import qs from "qs";
 
 {{#each schemas}}
 export const {{@key}} = {{{this}}};
@@ -36,15 +37,15 @@ export const {{@key}}Endpoints = makeApi([
 				type: "{{type}}",
 				{{/if}}
 				{{#if (and (eq type "Query") (eq schema "z.array(z.string()).optional().default([])"))}}
-						schema: z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string()).optional().default([])),
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string()).optional().default([])), z.array(z.string()).optional().default([])]),
 				{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind)"))}}
-						schema: z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)),
+						schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)), z.array(AttributeKind)])
 				{{else if (and (eq type "Query") (eq schema "z.array(AgreementState).optional().default([])"))}}
-						schema: z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(AgreementState).optional().default([])),
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(AgreementState).optional().default([])),z.array(AgreementState).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(EServiceDescriptorState).optional().default([])"))}}
-						schema: z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(EServiceDescriptorState).optional().default([])),
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(EServiceDescriptorState).optional().default([])), z.array(EServiceDescriptorState).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(PurposeVersionState).optional().default([])"))}}
-						schema: z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeVersionState).optional().default([])),
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeVersionState).optional().default([])), z.array(PurposeVersionState).optional().default([])])
 				{{else}}
 					schema: {{{schema}}},
 				{{/if}}
@@ -77,7 +78,16 @@ export const {{@key}}Endpoints = makeApi([
 export const {{@key}}Api = new Zodios({{#if options.baseUrl}}"{{options.baseUrl}}", {{/if}}{{@key}}Endpoints);
 
 export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: ZodiosOptions) {
-    return new Zodios(baseUrl, {{@key}}Endpoints, options);
+    return new Zodios(baseUrl, {{@key}}Endpoints, {
+			...options,
+			axiosConfig: {
+				...options?.axiosConfig,
+				// This configuration is used to serialize properly query parameter name when value is array  
+				// the default client serialization produce query param name appending the invalid chars "[]"	at the end
+				// eg: ids[]=1,2,3 instead of ids=1,2,3
+				paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
+			},
+		});
 }
 
 {{/each}}

--- a/packages/api-clients/template.hbs
+++ b/packages/api-clients/template.hbs
@@ -82,8 +82,8 @@ export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: Zo
 			...options,
 			axiosConfig: {
 				...options?.axiosConfig,
-				// This configuration is used to serialize properly query parameter name when value is array  
-				// the default client serialization produce query param name appending the invalid chars "[]"	at the end
+				// This configuration is used to serialize correctly array query parameters.
+				// The default serialization produces a query param name appending "[]" after the equals:
 				// eg: ids[]=1,2,3 instead of ids=1,2,3
 				paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
 			},

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -21,6 +21,7 @@
     "@pagopa/eslint-config": "3.0.0",
     "@types/express": "4.17.21",
     "@types/node": "20.14.6",
+    "@types/qs": "6.9.15",
     "@types/uuid": "9.0.8",
     "pagopa-interop-commons-test": "workspace:*",
     "prettier": "2.8.8",
@@ -41,6 +42,7 @@
     "pagopa-interop-models": "workspace:*",
     "pagopa-interop-selfcare-v2-client": "workspace:*",
     "pagopa-interop-agreement-lifecycle": "workspace:*",
+    "qs" : "6.12.3",
     "ts-pattern": "5.2.0",
     "uuid": "10.0.0",
     "zod": "3.23.8"

--- a/packages/bff/src/services/catalogService.ts
+++ b/packages/bff/src/services/catalogService.ts
@@ -94,10 +94,10 @@ export function catalogServiceBuilder(
           headers: context.headers,
           queries: {
             ...queries,
-            eservicesIds: queries.eservicesIds.join(","),
-            producersIds: queries.producersIds.join(","),
+            eservicesIds: queries.eservicesIds,
+            producersIds: queries.producersIds,
             states: queries.states.join(","),
-            attributesIds: queries.attributesIds.join(","),
+            attributesIds: queries.attributesIds,
             agreementStates: queries.agreementStates.join(","),
           },
         });

--- a/packages/bff/src/services/catalogService.ts
+++ b/packages/bff/src/services/catalogService.ts
@@ -96,9 +96,9 @@ export function catalogServiceBuilder(
             ...queries,
             eservicesIds: queries.eservicesIds,
             producersIds: queries.producersIds,
-            states: queries.states.join(","),
+            states: queries.states,
             attributesIds: queries.attributesIds,
-            agreementStates: queries.agreementStates.join(","),
+            agreementStates: queries.agreementStates,
           },
         });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@zodios/core':
         specifier: 10.9.6
         version: 10.9.6(axios@1.7.2)(zod@3.23.8)
+      qs:
+        specifier: 6.12.3
+        version: 6.12.3
       ts-pattern:
         specifier: 5.2.0
         version: 5.2.0
@@ -277,6 +280,9 @@ importers:
       '@types/node':
         specifier: 20.14.6
         version: 20.14.6
+      '@types/qs':
+        specifier: 6.9.15
+        version: 6.9.15
       handlebars:
         specifier: 4.7.7
         version: 4.7.7
@@ -8074,6 +8080,13 @@ packages:
 
   /qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.6
+    dev: false
+
+  /qs@6.12.3:
+    resolution: {integrity: sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==}
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,6 +626,9 @@ importers:
       pagopa-interop-selfcare-v2-client:
         specifier: workspace:*
         version: link:../selfcare-v2-client
+      qs:
+        specifier: 6.12.3
+        version: 6.12.3
       ts-pattern:
         specifier: 5.2.0
         version: 5.2.0
@@ -645,6 +648,9 @@ importers:
       '@types/node':
         specifier: 20.14.6
         version: 20.14.6
+      '@types/qs':
+        specifier: 6.9.15
+        version: 6.9.15
       '@types/uuid':
         specifier: 9.0.8
         version: 9.0.8


### PR DESCRIPTION
# Description
The generated Zodios API clients do not properly produce query parameter names when executing requests if the query parameter refers to a string array, for example when using catalog process service with `producersIds` as a query parameter filter. Actual implementation produces bad request request with a query params name followed by "[]" :

```
/eservices?producersIds[]=69e2865e-65ab-4e48-a638-2037a9ee2ee7,C9F99E60-7C4E-4D5C-97B8-54CF168F02DF&offset=0&limit=1 - Response 400 Bad Request
```

this commit [16a43c3e3ead772716317348337631e3135d7af0](https://github.com/pagopa/interop-be-monorepo/pull/740/commits/16a43c3e3ead772716317348337631e3135d7af0) modifies the templates used for API generation, it introduces a custom `paramsSerializer` as default, that applies string formatting using [Qs library](https://github.com/ljharb/qs) to create a valid query parameter name `producersIds` followed by a comma-separated string of values.
**NOTE** this axsios configuration overrides eventually provided 

```
/eservices?producersIds=69e2865e-65ab-4e48-a638-2037a9ee2ee7,C9F99E60-7C4E-4D5C-97B8-54CF168F02DF&offset=0&limit=1 - Response 200 OK
```

Also allow usages of a plain string or arrays in query parameter requests executed with client. 

