### PR TITLE
fixed error in clientConverter in authProcess

### DIFF
--- a/packages/authorization-process/package.json
+++ b/packages/authorization-process/package.json
@@ -42,7 +42,6 @@
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",
     "pagopa-interop-selfcare-v2-client": "workspace:*",
-    "pagopa-interop-api-clients": "workspace:*",
     "pg-promise": "11.8.0",
     "ts-pattern": "5.2.0",
     "zod": "3.23.8"

--- a/packages/authorization-process/src/model/domain/apiConverter.ts
+++ b/packages/authorization-process/src/model/domain/apiConverter.ts
@@ -23,18 +23,29 @@ export const keyUseToApiKeyUse = (kid: KeyUse): authorizationApi.KeyUse =>
     .with(keyUse.sig, () => "SIG")
     .exhaustive();
 
+export function clientToApiClientWithKeys(
+  client: Client,
+  { showUsers }: { showUsers: boolean }
+): authorizationApi.ClientWithKeys {
+  return {
+    client: {
+      id: client.id,
+      name: client.name,
+      consumerId: client.consumerId,
+      users: showUsers ? client.users : [],
+      createdAt: client.createdAt.toJSON(),
+      purposes: client.purposes,
+      kind: clientKindToApiClientKind(client.kind),
+      description: client.description,
+    },
+    keys: client.keys.map(keyToApiKey),
+  };
+}
+
 export function clientToApiClient(
   client: Client,
-  { includeKeys, showUsers }: { includeKeys: true; showUsers: boolean }
-): authorizationApi.ClientWithKeys;
-export function clientToApiClient(
-  client: Client,
-  { includeKeys, showUsers }: { includeKeys: false; showUsers: boolean }
-): authorizationApi.Client;
-export function clientToApiClient(
-  client: Client,
-  { includeKeys, showUsers }: { includeKeys: boolean; showUsers: boolean }
-): authorizationApi.ClientWithKeys | authorizationApi.Client {
+  { showUsers }: { showUsers: boolean }
+): authorizationApi.Client {
   return {
     id: client.id,
     name: client.name,
@@ -44,7 +55,6 @@ export function clientToApiClient(
     purposes: client.purposes,
     kind: clientKindToApiClientKind(client.kind),
     description: client.description,
-    ...(includeKeys ? { keys: client.keys } : {}),
   };
 }
 

--- a/packages/authorization-process/src/routers/AuthorizationRouter.ts
+++ b/packages/authorization-process/src/routers/AuthorizationRouter.ts
@@ -18,6 +18,7 @@ import { readModelServiceBuilder } from "../services/readModelService.js";
 import { authorizationServiceBuilder } from "../services/authorizationService.js";
 import {
   clientToApiClient,
+  clientToApiClientWithKeys,
   keyToApiKey,
 } from "../model/domain/apiConverter.js";
 import { makeApiProblem } from "../model/domain/errors.js";
@@ -81,7 +82,7 @@ const authorizationRouter = (
             });
           return res
             .status(200)
-            .json(clientToApiClient(client, { includeKeys: false, showUsers }))
+            .json(clientToApiClient(client, { showUsers }))
             .end();
         } catch (error) {
           const errorRes = makeApiProblem(
@@ -108,7 +109,7 @@ const authorizationRouter = (
             });
           return res
             .status(200)
-            .json(clientToApiClient(client, { includeKeys: false, showUsers }))
+            .json(clientToApiClient(client, { showUsers }))
             .end();
         } catch (error) {
           const errorRes = makeApiProblem(
@@ -159,8 +160,7 @@ const authorizationRouter = (
             .status(200)
             .json({
               results: clients.results.map((client) =>
-                clientToApiClient(client, {
-                  includeKeys: true,
+                clientToApiClientWithKeys(client, {
                   showUsers: ctx.authData.organizationId === client.consumerId,
                 })
               ),
@@ -210,7 +210,6 @@ const authorizationRouter = (
             .json({
               results: clients.results.map((client) =>
                 clientToApiClient(client, {
-                  includeKeys: false,
                   showUsers: ctx.authData.organizationId === client.consumerId,
                 })
               ),
@@ -246,7 +245,7 @@ const authorizationRouter = (
             });
           return res
             .status(200)
-            .json(clientToApiClient(client, { includeKeys: false, showUsers }))
+            .json(clientToApiClient(client, { showUsers }))
             .end();
         } catch (error) {
           const errorRes = makeApiProblem(
@@ -349,7 +348,7 @@ const authorizationRouter = (
           );
           return res
             .status(200)
-            .json(clientToApiClient(client, { includeKeys: false, showUsers }))
+            .json(clientToApiClient(client, { showUsers }))
             .end();
         } catch (error) {
           const errorRes = makeApiProblem(
@@ -578,7 +577,6 @@ const authorizationRouter = (
           .json({
             key: JWKKey,
             client: clientToApiClient(client, {
-              includeKeys: false,
               showUsers: false,
             }),
           })


### PR DESCRIPTION
This PR is for fixing the following wrong response on `getClientWithKeys`:

`2024-07-18 13:51:09.228 WARN [it.pagopa.interop.backendforfrontend.service.impl.AuthorizationProcessServiceImpl] - [UID=f07ddb8f-17f9-47d4-b31e-35d1ac10e521] [OID=e79a24cd-8edc-441e-ae8d-e87c3aea0059] [CID=f1f1d1b5-ce89-4c54-b0fe-e22e8cdb0758] Retrieving clients with keys FAILED. code > 200 - message > Unable to unmarshall content to [it.pagopa.interop.authorizationprocess.client.model.ClientsWithKeys] - response > Some({"results":[{"id":"66f3193f-5d2a-41b6-a4c9-6dea7e76d36a","name":"client-0-6172431924968498-1068392203566964","consumerId":"e79a24cd-8edc-441e-ae8d-e87c3aea0059","users":[],"createdAt":"2024-07-18T13:51:08.220Z","purposes":[],"kind":"CONSUMER","description":"Descrizione client","keys":[]},{"id":"4d8b7580-58d7-4dc8-b8b7-4648fcbd172c","name":"client-1-6172431924968498-6011607587784988","consumerId":"e79a24cd-8edc-441e-ae8d-e87c3aea0059","users":[],"createdAt":"2024-07-18T13:51:08.225Z","purposes":[],"kind":"CONSUMER","description":"Descrizione client","keys":[]},{"id":"b66bf94f-c554-4320-8dc2-bf974730f046","name":"client-3-6172431924968498-1799934060276757","consumerId":"e79a24cd-8edc-441e-ae8d-e87c3aea0059","users":[],"createdAt":"2024-07-18T13:51:08.223Z","purposes":[],"kind":"CONSUMER","description":"Descrizione client","keys":[]}],"totalCount":5})`