### PR TITLE
IMN-55 Fix addClientPurpose error mapper in authorization-process

### DIFF
--- a/packages/authorization-process/src/routers/AuthorizationRouter.ts
+++ b/packages/authorization-process/src/routers/AuthorizationRouter.ts
@@ -39,6 +39,7 @@ import {
   createKeysErrorMapper,
   getClientKeyWithClientErrorMapper,
   getClientsWithKeysErrorMapper,
+  addClientPurposeErrorMapper,
 } from "../utilities/errorMappers.js";
 
 const readModelService = readModelServiceBuilder(
@@ -490,7 +491,7 @@ const authorizationRouter = (
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
-            addUserErrorMapper,
+            addClientPurposeErrorMapper,
             ctx.logger
           );
           return res.status(errorRes.status).json(errorRes).end();


### PR DESCRIPTION
This pull request is for fixing the error mapper used in `addClientPurpose`.