### PR TITLE
PIN-5153 Adjust deleteEService and deleteDraftDescriptor in catalog-process

### DIFF
--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -385,13 +385,12 @@ export const toCreateEventEServiceDocumentDeleted = (
 });
 
 export const toCreateEventEServiceDraftDescriptorDeleted = (
-  streamId: string,
   version: number,
   eservice: EService,
   descriptorId: DescriptorId,
   correlationId: string
 ): CreateEvent<EServiceEvent> => ({
-  streamId,
+  streamId: eservice.id,
   version,
   event: {
     type: "EServiceDraftDescriptorDeleted",

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -311,18 +311,17 @@ export const toCreateEventEServiceDescriptorSuspended = (
 });
 
 export const toCreateEventEServiceDeleted = (
-  streamId: string,
   version: number,
   eservice: EService,
   correlationId: string
 ): CreateEvent<EServiceEvent> => ({
-  streamId,
+  streamId: eservice.id,
   version,
   event: {
     type: "EServiceDeleted",
     event_version: 2,
     data: {
-      eserviceId: streamId,
+      eserviceId: eservice.id,
       eservice: toEServiceV2(eservice),
     },
   },

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -986,15 +986,29 @@ export function catalogServiceBuilder(
         ),
       };
 
-      const event = toCreateEventEServiceDraftDescriptorDeleted(
-        eservice.data.id,
-        eservice.metadata.version,
-        newEservice,
-        descriptorId,
-        correlationId
-      );
+      const descriptorDeletionEvent =
+        toCreateEventEServiceDraftDescriptorDeleted(
+          eservice.data.id,
+          eservice.metadata.version,
+          newEservice,
+          descriptorId,
+          correlationId
+        );
 
-      await repository.createEvent(event);
+      if (newEservice.descriptors.length === 0) {
+        const eserviceDeletionEvent = toCreateEventEServiceDeleted(
+          eservice.data.id,
+          eservice.metadata.version + 1,
+          newEservice,
+          correlationId
+        );
+        await repository.createEvents([
+          descriptorDeletionEvent,
+          eserviceDeletionEvent,
+        ]);
+      } else {
+        await repository.createEvent(descriptorDeletionEvent);
+      }
     },
 
     async updateDraftDescriptor(

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -580,7 +580,15 @@ export function catalogServiceBuilder(
 
       assertIsDraftEservice(eservice.data);
 
-      if (eservice.data.descriptors.length === 1) {
+      if (eservice.data.descriptors.length === 0) {
+        const eserviceDeletionEvent = toCreateEventEServiceDeleted(
+          eserviceId,
+          eservice.metadata.version,
+          eservice.data,
+          correlationId
+        );
+        await repository.createEvent(eserviceDeletionEvent);
+      } else {
         const eserviceWithoutDescriptors: EService = {
           ...eservice.data,
           descriptors: [],
@@ -602,14 +610,6 @@ export function catalogServiceBuilder(
           descriptorDeletionEvent,
           eserviceDeletionEvent,
         ]);
-      } else {
-        const eserviceDeletionEvent = toCreateEventEServiceDeleted(
-          eserviceId,
-          eservice.metadata.version,
-          eservice.data,
-          correlationId
-        );
-        await repository.createEvent(eserviceDeletionEvent);
       }
     },
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -582,7 +582,6 @@ export function catalogServiceBuilder(
 
       if (eservice.data.descriptors.length === 0) {
         const eserviceDeletionEvent = toCreateEventEServiceDeleted(
-          eserviceId,
           eservice.metadata.version,
           eservice.data,
           correlationId
@@ -601,7 +600,6 @@ export function catalogServiceBuilder(
             correlationId
           );
         const eserviceDeletionEvent = toCreateEventEServiceDeleted(
-          eserviceId,
           eservice.metadata.version + 1,
           eserviceWithoutDescriptors,
           correlationId
@@ -1003,7 +1001,7 @@ export function catalogServiceBuilder(
 
       await Promise.all(deleteDescriptorDocs);
 
-      const newEservice: EService = {
+      const eserviceAfterDescriptorDeletion: EService = {
         ...eservice.data,
         descriptors: eservice.data.descriptors.filter(
           (d: Descriptor) => d.id !== descriptorId
@@ -1013,16 +1011,15 @@ export function catalogServiceBuilder(
       const descriptorDeletionEvent =
         toCreateEventEServiceDraftDescriptorDeleted(
           eservice.metadata.version,
-          newEservice,
+          eserviceAfterDescriptorDeletion,
           descriptorId,
           correlationId
         );
 
-      if (newEservice.descriptors.length === 0) {
+      if (eserviceAfterDescriptorDeletion.descriptors.length === 0) {
         const eserviceDeletionEvent = toCreateEventEServiceDeleted(
-          eservice.data.id,
           eservice.metadata.version + 1,
-          newEservice,
+          eserviceAfterDescriptorDeletion,
           correlationId
         );
         await repository.createEvents([

--- a/packages/catalog-process/test/deleteDraftDescriptor.test.ts
+++ b/packages/catalog-process/test/deleteDraftDescriptor.test.ts
@@ -219,7 +219,7 @@ describe("delete draft descriptor", () => {
     ).not.toContain(document2.path);
   });
 
-  it.only("should write on event-store for the deletion of a draft descriptor and the entire eservice", async () => {
+  it("should write on event-store for the deletion of a draft descriptor and the entire eservice", async () => {
     const draftDescriptor: Descriptor = {
       ...getMockDescriptor(descriptorState.draft),
     };

--- a/packages/catalog-process/test/deleteDraftDescriptor.test.ts
+++ b/packages/catalog-process/test/deleteDraftDescriptor.test.ts
@@ -8,6 +8,8 @@ import {
   EServiceDraftDescriptorDeletedV2,
   toEServiceV2,
   operationForbidden,
+  DescriptorId,
+  generateId,
 } from "pagopa-interop-models";
 import { vi, expect, describe, it } from "vitest";
 import { config } from "../src/config/config.js";
@@ -28,27 +30,35 @@ import {
 } from "./utils.js";
 
 describe("delete draft descriptor", () => {
-  const mockEService = getMockEService();
-  const mockDescriptor = getMockDescriptor();
   const mockDocument = getMockDocument();
   it("should write on event-store for the deletion of a draft descriptor (no interface nor documents to delete)", async () => {
     vi.spyOn(fileManager, "delete");
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
-      state: descriptorState.draft,
+
+    const publishedDescriptor: Descriptor = {
+      ...getMockDescriptor(descriptorState.published),
+      version: "1",
     };
+    const descriptorToDelete: Descriptor = {
+      ...getMockDescriptor(descriptorState.draft),
+      version: "2",
+    };
+
     const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
+      ...getMockEService(),
+      descriptors: [publishedDescriptor, descriptorToDelete],
     };
     await addOneEService(eservice);
 
-    await catalogService.deleteDraftDescriptor(eservice.id, descriptor.id, {
-      authData: getMockAuthData(eservice.producerId),
-      correlationId: "",
-      serviceName: "",
-      logger: genericLogger,
-    });
+    await catalogService.deleteDraftDescriptor(
+      eservice.id,
+      descriptorToDelete.id,
+      {
+        authData: getMockAuthData(eservice.producerId),
+        correlationId: "",
+        serviceName: "",
+        logger: genericLogger,
+      }
+    );
 
     const writtenEvent = await readLastEserviceEvent(eservice.id);
     expect(writtenEvent).toMatchObject({
@@ -65,11 +75,11 @@ describe("delete draft descriptor", () => {
 
     const expectedEservice = toEServiceV2({
       ...eservice,
-      descriptors: [],
+      descriptors: [publishedDescriptor],
     });
 
     expect(writtenPayload.eservice).toEqual(expectedEservice);
-    expect(writtenPayload.descriptorId).toEqual(descriptor.id);
+    expect(writtenPayload.descriptorId).toEqual(descriptorToDelete.id);
     expect(fileManager.delete).not.toHaveBeenCalled();
   });
 
@@ -92,15 +102,20 @@ describe("delete draft descriptor", () => {
       path: `${config.eserviceDocumentsPath}/${mockDocument.id}/${mockDocument.name}_interface`,
     };
 
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
+    const publishedDescriptor: Descriptor = {
+      ...getMockDescriptor(descriptorState.published),
+      version: "1",
+    };
+    const descriptorToDelete: Descriptor = {
+      ...getMockDescriptor(descriptorState.draft),
       docs: [document1, document2],
       interface: interfaceDocument,
-      state: descriptorState.draft,
+      version: "2",
     };
+
     const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
+      ...getMockEService(),
+      descriptors: [publishedDescriptor, descriptorToDelete],
     };
     await addOneEService(eservice);
 
@@ -141,12 +156,16 @@ describe("delete draft descriptor", () => {
       await fileManager.listFiles(config.s3Bucket, genericLogger)
     ).toContain(document2.path);
 
-    await catalogService.deleteDraftDescriptor(eservice.id, descriptor.id, {
-      authData: getMockAuthData(eservice.producerId),
-      correlationId: "",
-      serviceName: "",
-      logger: genericLogger,
-    });
+    await catalogService.deleteDraftDescriptor(
+      eservice.id,
+      descriptorToDelete.id,
+      {
+        authData: getMockAuthData(eservice.producerId),
+        correlationId: "",
+        serviceName: "",
+        logger: genericLogger,
+      }
+    );
 
     const writtenEvent = await readLastEserviceEvent(eservice.id);
     expect(writtenEvent).toMatchObject({
@@ -162,11 +181,11 @@ describe("delete draft descriptor", () => {
 
     const expectedEservice = toEServiceV2({
       ...eservice,
-      descriptors: [],
+      descriptors: [publishedDescriptor],
     });
 
     expect(writtenPayload.eservice).toEqual(expectedEservice);
-    expect(writtenPayload.descriptorId).toEqual(descriptor.id);
+    expect(writtenPayload.descriptorId).toEqual(descriptorToDelete.id);
 
     expect(fileManager.delete).toHaveBeenCalledWith(
       config.s3Bucket,
@@ -198,19 +217,23 @@ describe("delete draft descriptor", () => {
   it("should fail if one of the file deletions fails", async () => {
     config.s3Bucket = "invalid-bucket"; // configure an invalid bucket to force a failure
 
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
+    const publishedDescriptor: Descriptor = {
+      ...getMockDescriptor(descriptorState.published),
+      version: "1",
+    };
+    const descriptorToDelete: Descriptor = {
+      ...getMockDescriptor(descriptorState.draft),
       docs: [mockDocument, mockDocument],
-      state: descriptorState.draft,
+      version: "2",
     };
     const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
+      ...getMockEService(),
+      descriptors: [publishedDescriptor, descriptorToDelete],
     };
     await addOneEService(eservice);
 
     await expect(
-      catalogService.deleteDraftDescriptor(eservice.id, descriptor.id, {
+      catalogService.deleteDraftDescriptor(eservice.id, descriptorToDelete.id, {
         authData: getMockAuthData(eservice.producerId),
         correlationId: "",
         serviceName: "",
@@ -226,8 +249,10 @@ describe("delete draft descriptor", () => {
   });
 
   it("should throw eServiceNotFound if the eservice doesn't exist", () => {
+    const mockEService = getMockEService();
+    const mockDescriptorId: DescriptorId = generateId();
     expect(
-      catalogService.deleteDraftDescriptor(mockEService.id, mockDescriptor.id, {
+      catalogService.deleteDraftDescriptor(mockEService.id, mockDescriptorId, {
         authData: getMockAuthData(mockEService.producerId),
         correlationId: "",
         serviceName: "",
@@ -237,35 +262,40 @@ describe("delete draft descriptor", () => {
   });
 
   it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
+    const descriptorIdToDelete: DescriptorId = generateId();
     const eservice: EService = {
-      ...mockEService,
-      descriptors: [],
+      ...getMockEService(),
+      descriptors: [getMockDescriptor()],
     };
     await addOneEService(eservice);
     expect(
-      catalogService.deleteDraftDescriptor(mockEService.id, mockDescriptor.id, {
-        authData: getMockAuthData(mockEService.producerId),
+      catalogService.deleteDraftDescriptor(eservice.id, descriptorIdToDelete, {
+        authData: getMockAuthData(eservice.producerId),
         correlationId: "",
         serviceName: "",
         logger: genericLogger,
       })
     ).rejects.toThrowError(
-      eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
+      eServiceDescriptorNotFound(eservice.id, descriptorIdToDelete)
     );
   });
 
   it("should throw operationForbidden if the requester is not the producer", async () => {
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
-      state: descriptorState.draft,
+    const publishedDescriptor: Descriptor = {
+      ...getMockDescriptor(descriptorState.published),
+      version: "1",
+    };
+    const descriptorToDelete: Descriptor = {
+      ...getMockDescriptor(descriptorState.draft),
+      version: "2",
     };
     const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
+      ...getMockEService(),
+      descriptors: [publishedDescriptor, descriptorToDelete],
     };
     await addOneEService(eservice);
     expect(
-      catalogService.deleteDraftDescriptor(eservice.id, descriptor.id, {
+      catalogService.deleteDraftDescriptor(eservice.id, descriptorToDelete.id, {
         authData: getMockAuthData(),
         correlationId: "",
         serviceName: "",
@@ -274,102 +304,60 @@ describe("delete draft descriptor", () => {
     ).rejects.toThrowError(operationForbidden);
   });
 
-  it("should throw notValidDescriptor if the eservice is in published state", async () => {
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
-      interface: mockDocument,
-      state: descriptorState.published,
-    };
-    const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
-    };
-    await addOneEService(eservice);
+  it.each([descriptorState.published, descriptorState.suspended])(
+    "should throw notValidDescriptor if the eservice is in %s state",
+    async (state) => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(state),
+        interface: mockDocument,
+      };
+      const eservice: EService = {
+        ...getMockEService(),
+        descriptors: [descriptor],
+      };
+      await addOneEService(eservice);
 
-    expect(
-      catalogService.deleteDraftDescriptor(eservice.id, descriptor.id, {
-        authData: getMockAuthData(eservice.producerId),
-        correlationId: "",
-        serviceName: "",
-        logger: genericLogger,
-      })
-    ).rejects.toThrowError(
-      notValidDescriptor(descriptor.id, descriptorState.published)
-    );
-  });
-  it("should throw notValidDescriptor if the eservice is in deprecated state", async () => {
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
-      interface: mockDocument,
-      state: descriptorState.deprecated,
-      publishedAt: new Date(),
-      deprecatedAt: new Date(),
-    };
-    const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
-    };
-    await addOneEService(eservice);
+      expect(
+        catalogService.deleteDraftDescriptor(eservice.id, descriptor.id, {
+          authData: getMockAuthData(eservice.producerId),
+          correlationId: "",
+          serviceName: "",
+          logger: genericLogger,
+        })
+      ).rejects.toThrowError(notValidDescriptor(descriptor.id, state));
+    }
+  );
 
-    expect(
-      catalogService.deleteDraftDescriptor(eservice.id, descriptor.id, {
-        authData: getMockAuthData(eservice.producerId),
-        correlationId: "",
-        serviceName: "",
-        logger: genericLogger,
-      })
-    ).rejects.toThrowError(
-      notValidDescriptor(descriptor.id, descriptorState.deprecated)
-    );
-  });
-  it("should throw notValidDescriptor if the eservice is in suspended state", async () => {
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
-      interface: mockDocument,
-      state: descriptorState.suspended,
-      publishedAt: new Date(),
-      suspendedAt: new Date(),
-    };
-    const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
-    };
-    await addOneEService(eservice);
+  it.each([descriptorState.deprecated, descriptorState.archived])(
+    "should throw notValidDescriptor if the eservice is in %s state",
+    async (state) => {
+      const descriptorToDelete: Descriptor = {
+        ...getMockDescriptor(state),
+        interface: mockDocument,
+        version: "1",
+      };
+      const publishedDescriptor: Descriptor = {
+        ...getMockDescriptor(descriptorState.published),
+        version: "2",
+      };
+      const eservice: EService = {
+        ...getMockEService(),
+        descriptors: [publishedDescriptor, descriptorToDelete],
+      };
+      await addOneEService(eservice);
 
-    expect(
-      catalogService.deleteDraftDescriptor(eservice.id, descriptor.id, {
-        authData: getMockAuthData(eservice.producerId),
-        correlationId: "",
-        serviceName: "",
-        logger: genericLogger,
-      })
-    ).rejects.toThrowError(
-      notValidDescriptor(descriptor.id, descriptorState.suspended)
-    );
-  });
-  it("should throw notValidDescriptor if the eservice is in archived state", async () => {
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
-      interface: mockDocument,
-      state: descriptorState.archived,
-      publishedAt: new Date(),
-      archivedAt: new Date(),
-    };
-    const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
-    };
-    await addOneEService(eservice);
-
-    expect(
-      catalogService.deleteDraftDescriptor(eservice.id, descriptor.id, {
-        authData: getMockAuthData(eservice.producerId),
-        correlationId: "",
-        serviceName: "",
-        logger: genericLogger,
-      })
-    ).rejects.toThrowError(
-      notValidDescriptor(descriptor.id, descriptorState.archived)
-    );
-  });
+      expect(
+        catalogService.deleteDraftDescriptor(
+          eservice.id,
+          descriptorToDelete.id,
+          {
+            authData: getMockAuthData(eservice.producerId),
+            correlationId: "",
+            serviceName: "",
+            logger: genericLogger,
+          }
+        )
+      ).rejects.toThrowError(notValidDescriptor(descriptorToDelete.id, state));
+    }
+  );
 });


### PR DESCRIPTION
This pull request is for adjusting the `deleteEService` and `deleteDraftDescriptor` endpoints:
- in the former, the deletion of the descriptor has been added as a separate event
- in the latter, the deletion of the last (or only) descriptor should lead to the deletion of the entire eservice.