### PR TITLE
PIN-5154 Fix documents deletion in deleteEservice in catalog-process

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -588,6 +588,12 @@ export function catalogServiceBuilder(
         );
         await repository.createEvent(eserviceDeletionEvent);
       } else {
+        await deleteDescriptorInterfaceAndDocs(
+          eservice.data.descriptors[0],
+          fileManager,
+          logger
+        );
+
         const eserviceWithoutDescriptors: EService = {
           ...eservice.data,
           descriptors: [],
@@ -986,20 +992,7 @@ export function catalogServiceBuilder(
         throw notValidDescriptor(descriptorId, descriptor.state);
       }
 
-      const descriptorInterface = descriptor.interface;
-      if (descriptorInterface !== undefined) {
-        await fileManager.delete(
-          config.s3Bucket,
-          descriptorInterface.path,
-          logger
-        );
-      }
-
-      const deleteDescriptorDocs = descriptor.docs.map((doc: Document) =>
-        fileManager.delete(config.s3Bucket, doc.path, logger)
-      );
-
-      await Promise.all(deleteDescriptorDocs);
+      await deleteDescriptorInterfaceAndDocs(descriptor, fileManager, logger);
 
       const eserviceAfterDescriptorDeletion: EService = {
         ...eservice.data,
@@ -1717,6 +1710,23 @@ const applyVisibilityToEService = (
       (d) => d.state !== descriptorState.draft
     ),
   };
+};
+
+const deleteDescriptorInterfaceAndDocs = async (
+  descriptor: Descriptor,
+  fileManager: FileManager,
+  logger: Logger
+): Promise<void> => {
+  const descriptorInterface = descriptor.interface;
+  if (descriptorInterface !== undefined) {
+    await fileManager.delete(config.s3Bucket, descriptorInterface.path, logger);
+  }
+
+  const deleteDescriptorDocs = descriptor.docs.map((doc: Document) =>
+    fileManager.delete(config.s3Bucket, doc.path, logger)
+  );
+
+  await Promise.all(deleteDescriptorDocs);
 };
 
 export type CatalogService = ReturnType<typeof catalogServiceBuilder>;

--- a/packages/catalog-process/test/deleteEservice.test.ts
+++ b/packages/catalog-process/test/deleteEservice.test.ts
@@ -13,11 +13,12 @@ import {
   EServiceDraftDescriptorDeletedV2,
   toEServiceV2,
 } from "pagopa-interop-models";
-import { expect, describe, it } from "vitest";
+import { expect, describe, it, vi } from "vitest";
 import {
   eServiceNotFound,
   eserviceNotInDraftState,
 } from "../src/model/domain/errors.js";
+import { config } from "../src/config/config.js";
 import {
   addOneEService,
   catalogService,
@@ -27,6 +28,7 @@ import {
   getMockDocument,
   getMockEService,
   postgresDB,
+  fileManager,
 } from "./utils.js";
 
 describe("delete eservice", () => {
@@ -59,11 +61,52 @@ describe("delete eservice", () => {
     expect(writtenPayload.eserviceId).toBe(eservice.id);
   });
 
-  it("should write on event-store for the deletion of an eservice (eservice with a draft descriptor only)", async () => {
+  it.only("should write on event-store for the deletion of an eservice (eservice with a draft descriptor only) and delete the interface and documents of the draft descriptor", async () => {
+    vi.spyOn(fileManager, "delete");
+
+    const mockDocument = getMockDocument();
+    const mockInterface = getMockDocument();
+    const document = {
+      ...mockDocument,
+      name: `${mockDocument.name}`,
+      path: `${config.eserviceDocumentsPath}/${mockDocument.id}/${mockDocument.name}`,
+    };
+    const interfaceDocument = {
+      ...mockInterface,
+      name: `${mockDocument.name}_interface`,
+      path: `${config.eserviceDocumentsPath}/${mockInterface.id}/${mockInterface.name}_interface`,
+    };
+
+    await fileManager.storeBytes(
+      config.s3Bucket,
+      config.eserviceDocumentsPath,
+      interfaceDocument.id,
+      interfaceDocument.name,
+      Buffer.from("testtest"),
+      genericLogger
+    );
+
+    await fileManager.storeBytes(
+      config.s3Bucket,
+      config.eserviceDocumentsPath,
+      document.id,
+      document.name,
+      Buffer.from("testtest"),
+      genericLogger
+    );
+
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).toContain(interfaceDocument.path);
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).toContain(document.path);
+
     const descriptor: Descriptor = {
       ...mockDescriptor,
-      interface: mockDocument,
+      interface: interfaceDocument,
       state: descriptorState.draft,
+      docs: [document],
     };
     const eservice: EService = {
       ...mockEService,
@@ -116,6 +159,24 @@ describe("delete eservice", () => {
       eservice: toEServiceV2(expectedEserviceWithoutDescriptors),
       descriptorId: eservice.descriptors[0].id,
     });
+
+    expect(fileManager.delete).toHaveBeenCalledWith(
+      config.s3Bucket,
+      interfaceDocument.path,
+      genericLogger
+    );
+    expect(fileManager.delete).toHaveBeenCalledWith(
+      config.s3Bucket,
+      document.path,
+      genericLogger
+    );
+
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).not.toContain(interfaceDocument.path);
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).not.toContain(document.path);
   });
 
   it("should throw eServiceNotFound if the eservice doesn't exist", () => {


### PR DESCRIPTION
This pull request is for deleting the interface and documents of a draft descriptor when that descriptor gets deleted during the `deleteEService`.