### PR TITLE
IMN-780: improve error logging in selfcare client

### DIFF
--- a/packages/api-clients/package.json
+++ b/packages/api-clients/package.json
@@ -27,7 +27,6 @@
     "@pagopa/eslint-config": "3.0.0",
     "@types/node": "20.14.6",
     "@types/qs": "6.9.15",
-    "axios-logger": "2.8.1",
     "handlebars": "4.7.7",
     "openapi-zod-client": "1.18.1",
     "openapi3-ts": "3.1.0",
@@ -38,6 +37,7 @@
   "dependencies": {
     "@zodios/core": "10.9.6",
     "axios": "1.7.2",
+    "axios-logger": "2.8.1",
     "pagopa-interop-commons": "workspace:*",
     "qs": "6.12.3",
     "ts-pattern": "5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       axios:
         specifier: 1.7.2
         version: 1.7.2
+      axios-logger:
+        specifier: 2.8.1
+        version: 2.8.1
       pagopa-interop-commons:
         specifier: workspace:*
         version: link:../commons
@@ -286,9 +289,6 @@ importers:
       '@types/qs':
         specifier: 6.9.15
         version: 6.9.15
-      axios-logger:
-        specifier: 2.8.1
-        version: 2.8.1
       handlebars:
         specifier: 4.7.7
         version: 4.7.7
@@ -4939,7 +4939,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       dateformat: 3.0.3
-    dev: true
+    dev: false
 
   /axios@1.7.2:
     resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
@@ -5150,7 +5150,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
@@ -5424,7 +5423,7 @@ packages:
 
   /dateformat@3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
-    dev: true
+    dev: false
 
   /debounce@2.1.0:
     resolution: {integrity: sha512-OkL3+0pPWCqoBc/nhO9u6TIQNTK44fnBnzuVtJAbp13Naxw9R6u21x+8tVTka87AhDZ3htqZ2pSSsZl9fqL2Wg==}
@@ -6649,7 +6648,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -8663,7 +8661,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}


### PR DESCRIPTION
With this PR a new more detailed log is added whenever selfcare returns an error.

This change is needed since the logging that we introduced [here](https://github.com/pagopa/interop-be-monorepo/pull/745) in some cases wasn't enough and we were still seeing logs like the following:
`2024-07-29T06:13:59.370Z ERROR [agreement-process] - [CID=d2ea5d65-c37e-4a47-b615-d07d146fe2ea] - title: Unexpected error - detail: Unexpected error - errors: Unexpected error - original error: AxiosError: Request failed with status code 404`

### Before:
<img width="803" alt="Screenshot 2024-07-30 alle 09 34 51" src="https://github.com/user-attachments/assets/f68a3f15-49e8-4556-9877-932ab930a850">


### After:
<img width="760" alt="Screenshot 2024-07-30 alle 09 21 49" src="https://github.com/user-attachments/assets/c7274b8d-205b-4c8b-a113-6022cfdc7397">
