### PR TITLE
Fix for restarting authUpdater

### DIFF
--- a/packages/api-clients/open-api/authorizationManagementApi.yaml
+++ b/packages/api-clients/open-api/authorizationManagementApi.yaml
@@ -883,6 +883,9 @@ components:
       description: Models the seed for a client to be persisted
       type: object
       properties:
+        clientId:
+          type: string
+          format: uuid
         consumerId:
           type: string
           format: uuid

--- a/packages/authorization-updater/src/authorizationService.ts
+++ b/packages/authorization-updater/src/authorizationService.ts
@@ -255,7 +255,7 @@ export const authorizationServiceBuilder = (
       const headers = getHeaders(correlationId, token);
       await authMgmtClients.clientApiClient.createClient(
         {
-          id: client.id,
+          clientId: client.id,
           name: client.name,
           description: client.description,
           consumerId: client.consumerId,

--- a/packages/authorization-updater/test/authorizationUpdater.test.ts
+++ b/packages/authorization-updater/test/authorizationUpdater.test.ts
@@ -757,7 +757,7 @@ describe("Authorization Updater processMessage", () => {
       authorizationManagementClients.clientApiClient.createClient
     ).toHaveBeenCalledWith(
       {
-        id: client.id,
+        clientId: client.id,
         name: client.name,
         description: client.description,
         consumerId: client.consumerId,


### PR DESCRIPTION
This PR should solve the problem of `authUpdater` that keeps restarting since there was an incorrect parameter being passed to the `createClient` of the `auth-Management`; its open api wasn't correct too and has been updated to reflect the one in Scala.

Thanks to @rGregnanin for pointing out the problem on the `createClient`