### PR TITLE
fix: KAFKA_BROKERS value

### DIFF
--- a/packages/commons/src/config/kafkaConfig.ts
+++ b/packages/commons/src/config/kafkaConfig.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 export const KafkaConfig = z
   .object({
-    KAFKA_BROKERS: z.string(),
+    KAFKA_BROKERS: z.string().transform((value) => value.split(",")),
     KAFKA_CLIENT_ID: z.string(),
     KAFKA_GROUP_ID: z.string(),
     KAFKA_DISABLE_AWS_IAM_AUTH: z.literal("true").optional(),

--- a/packages/commons/src/config/producerServiceConfig.ts
+++ b/packages/commons/src/config/producerServiceConfig.ts
@@ -5,7 +5,7 @@ import { AWSConfig } from "./awsConfig.js";
 export const KafkaProducerConfig = AWSConfig.and(
   z.object({
     PURPOSE_OUTBOUND_TOPIC: z.string(),
-    PRODUCER_KAFKA_BROKERS: z.string(),
+    PRODUCER_KAFKA_BROKERS: z.string().transform((value) => value.split(",")),
     PRODUCER_KAFKA_CLIENT_ID: z.string(),
     PRODUCER_KAFKA_DISABLE_AWS_IAM_AUTH: z.literal("true").optional(),
     PRODUCER_KAFKA_LOG_LEVEL: z

--- a/packages/kafka-iam-auth/src/index.ts
+++ b/packages/kafka-iam-auth/src/index.ts
@@ -123,13 +123,13 @@ const initConsumer = async (
   const kafkaConfig: KafkaConfig = config.kafkaDisableAwsIamAuth
     ? {
         clientId: config.kafkaClientId,
-        brokers: [config.kafkaBrokers],
+        brokers: config.kafkaBrokers,
         logLevel: config.kafkaLogLevel,
         ssl: false,
       }
     : {
         clientId: config.kafkaClientId,
-        brokers: [config.kafkaBrokers],
+        brokers: config.kafkaBrokers,
         logLevel: config.kafkaLogLevel,
         reauthenticationThreshold: config.kafkaReauthenticationThreshold,
         ssl: true,


### PR DESCRIPTION
Currently MSK Serverless provides a single bootstrap host, but typical Kafka clusters provide multiple hosts.
This PR will fix KAFKA_BROKERS configuration to correctly parse comma-separated hosts.