### PR TITLE
Fix auth notifier seeder

### DIFF
--- a/packages/notifier-seeder/src/models/authorization/authorizationEventNotification.ts
+++ b/packages/notifier-seeder/src/models/authorization/authorizationEventNotification.ts
@@ -5,8 +5,7 @@ export type KeyV1Notification = Omit<KeyV1, "use"> & {
 };
 
 export type KeyPayloadNotification = {
-  kid: string;
-  key: KeyV1Notification;
+  [kid: string]: KeyV1Notification;
 };
 
 export type KeysAddedNotification = {

--- a/packages/notifier-seeder/src/models/authorization/authorizationEventNotification.ts
+++ b/packages/notifier-seeder/src/models/authorization/authorizationEventNotification.ts
@@ -4,9 +4,14 @@ export type KeyV1Notification = Omit<KeyV1, "use"> & {
   use: string;
 };
 
+export type KeyPayloadNotification = {
+  kid: string;
+  key: KeyV1Notification;
+};
+
 export type KeysAddedNotification = {
   clientId: string;
-  keys: KeyV1Notification[];
+  keys: KeyPayloadNotification;
 };
 
 export type KeyDeletedNotification = {

--- a/packages/notifier-seeder/src/models/authorization/authorizationEventNotificationConverter.ts
+++ b/packages/notifier-seeder/src/models/authorization/authorizationEventNotificationConverter.ts
@@ -29,7 +29,10 @@ export const toAuthorizationEventNotification = (
       const keyV2 = fromKeyV2(key);
       return {
         clientId: event.data.client.id,
-        keys: [toKeyV1Notification(keyV2)],
+        keys: {
+          kid: keyV2.kid,
+          key: toKeyV1Notification(keyV2),
+        },
       };
     })
     .with({ type: "ClientKeyDeleted" }, (event): KeyDeletedNotification => {

--- a/packages/notifier-seeder/src/models/authorization/authorizationEventNotificationConverter.ts
+++ b/packages/notifier-seeder/src/models/authorization/authorizationEventNotificationConverter.ts
@@ -30,8 +30,7 @@ export const toAuthorizationEventNotification = (
       return {
         clientId: event.data.client.id,
         keys: {
-          kid: keyV2.kid,
-          key: toKeyV1Notification(keyV2),
+          [keyV2.kid]: toKeyV1Notification(keyV2),
         },
       };
     })

--- a/packages/notifier-seeder/test/notificationMessage.integration.test.ts
+++ b/packages/notifier-seeder/test/notificationMessage.integration.test.ts
@@ -267,12 +267,12 @@ describe("Notification tests", async () => {
       });
       expect(receivedAuthorizationMessage.payload).toEqual({
         clientId: mockClient.id,
-        keys: [
-          {
+        keys: {
+          [mockClient.keys[0].kid]: {
             ...mockClient.keys[0],
             createdAt: new Date().toISOString(),
           },
-        ],
+        },
       });
 
       vi.useRealTimers();


### PR DESCRIPTION
This pull request is for fixing the handling of the `KeysAdded` event in `notification-seeder`