### PR TITLE
IMN-740 get import presigned url

### DIFF
--- a/packages/bff/.env
+++ b/packages/bff/.env
@@ -61,3 +61,9 @@ RATE_LIMITER_TIMEOUT="300"
 EXPORT_ESERVICE_CONTAINER="interop-application-import-export-local"
 EXPORT_ESERVICE_PATH="local/eservices-export"
 PRESIGNED_URL_GET_DURATION_MINUTES=5000
+
+IMPORT_ESERVICE_CONTAINER= "interop-application-import-export-local"
+IMPORT_ESERVICE_PATH= "local/eservices-import"
+PRESIGNED_URL_PUT_DURATION_MINUTES= 5000
+
+RISK_ANALYSIS_DOCUMENTS_PATH="risk-analysis/docs"

--- a/packages/bff/src/config/config.ts
+++ b/packages/bff/src/config/config.ts
@@ -120,7 +120,20 @@ export const ExportFileConfig = z
   }));
 export type ExportFileConfig = z.infer<typeof ExportFileConfig>;
 
-export const S3RiskAnalysisConfig = z
+export const ImportFileConfig = z
+  .object({
+    IMPORT_ESERVICE_CONTAINER: z.string(),
+    IMPORT_ESERVICE_PATH: z.string(),
+    PRESIGNED_URL_PUT_DURATION_MINUTES: z.coerce.number(),
+  })
+  .transform((c) => ({
+    importEserviceContainer: c.IMPORT_ESERVICE_CONTAINER,
+    importEservicePath: c.IMPORT_ESERVICE_PATH,
+    presignedUrlPutDurationMinutes: c.PRESIGNED_URL_PUT_DURATION_MINUTES,
+  }));
+export type ImportFileConfig = z.infer<typeof ImportFileConfig>;
+
+export const RiskAnalysisDocumentConfig = z
   .object({
     RISK_ANALYSIS_DOCUMENTS_PATH: z.string(),
   })
@@ -139,10 +152,11 @@ const BffProcessConfig = CommonHTTPServiceConfig.and(TenantProcessServerConfig)
   .and(TokenGenerationConfig)
   .and(SessionTokenGenerationConfig)
   .and(FileManagerConfig)
-  .and(S3RiskAnalysisConfig)
   .and(AllowedListConfig)
   .and(S3Config)
-  .and(ExportFileConfig);
+  .and(RiskAnalysisDocumentConfig)
+  .and(ExportFileConfig)
+  .and(ImportFileConfig);
 
 export type BffProcessConfig = z.infer<typeof BffProcessConfig>;
 export const config: BffProcessConfig = BffProcessConfig.parse(process.env);

--- a/packages/bff/src/routers/catalogRouter.ts
+++ b/packages/bff/src/routers/catalogRouter.ts
@@ -580,9 +580,25 @@ const catalogRouter = (
         }
       }
     )
-    .get("/import/eservices/presignedUrl", async (_req, res) =>
-      res.status(501).send()
-    )
+    .get("/import/eservices/presignedUrl", async (req, res) => {
+      const ctx = fromBffAppContext(req.ctx, req.headers);
+      try {
+        const response = await catalogService.generatePutPresignedUrl(
+          req.query.fileName,
+          ctx
+        );
+
+        return res.status(200).json(response).send();
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          bffGetCatalogErrorMapper,
+          ctx.logger,
+          "Error getting eservice import presigned url"
+        );
+        return res.status(errorRes.status).json(errorRes).end();
+      }
+    })
     .post("/import/eservices", async (_req, res) => res.status(501).send());
 
   return catalogRouter;

--- a/packages/bff/src/services/catalogService.ts
+++ b/packages/bff/src/services/catalogService.ts
@@ -927,5 +927,22 @@ export function catalogServiceBuilder(
         url,
       };
     },
+    generatePutPresignedUrl: async (
+      filename: string,
+      { authData }: WithLogger<BffAppContext>
+    ): Promise<bffApi.FileResource> => {
+      const path = `${bffConfig.importEservicePath}/${authData.organizationId}`;
+      const url = await fileManager.generatePutPresignedUrl(
+        bffConfig.importEserviceContainer,
+        path,
+        filename,
+        bffConfig.presignedUrlPutDurationMinutes
+      );
+
+      return {
+        filename,
+        url,
+      };
+    },
   };
 }

--- a/packages/commons/src/file-manager/fileManager.ts
+++ b/packages/commons/src/file-manager/fileManager.ts
@@ -52,6 +52,12 @@ export type FileManager = {
     fileName: string,
     durationInMinutes: number
   ) => Promise<string>;
+  generatePutPresignedUrl: (
+    bucketName: string,
+    path: string,
+    fileName: string,
+    durationInMinutes: number
+  ) => Promise<string>;
 };
 
 export function initFileManager(
@@ -193,6 +199,16 @@ export function initFileManager(
     ): Promise<string> => {
       const key: string = buildS3Key(path, undefined, fileName);
       const command = new GetObjectCommand({ Bucket: bucketName, Key: key });
+      return getSignedUrl(client, command, { expiresIn: durationInMinutes });
+    },
+    generatePutPresignedUrl: async (
+      bucketName: string,
+      path: string,
+      fileName: string,
+      durationInMinutes: number
+    ): Promise<string> => {
+      const key: string = buildS3Key(path, undefined, fileName);
+      const command = new PutObjectCommand({ Bucket: bucketName, Key: key });
       return getSignedUrl(client, command, { expiresIn: durationInMinutes });
     },
   };


### PR DESCRIPTION
Part of [BFF Catalog Routes](https://pagopa.atlassian.net/browse/IMN-604)
Closes [IMN-740](https://pagopa.atlassian.net/browse/IMN-740)

Merge after [PR-882](https://github.com/pagopa/interop-be-monorepo/pull/882)

# Description
Implements `/import/eservices/presignedUrl` 

# Test
✅  Local test return response 200 with putSignedUrl and fileName

<img width="1297" alt="Screenshot 2024-08-13 at 10 45 23" src="https://github.com/user-attachments/assets/332e79c3-4e96-4377-86b0-5b4811295339">

[IMN-740]: https://pagopa.atlassian.net/browse/IMN-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ