### PR TITLE
Tenant quick fix - Fixing revocation timestamp missing in tenant

### DIFF
--- a/packages/models/src/tenant/protobufConverterFromV1.ts
+++ b/packages/models/src/tenant/protobufConverterFromV1.ts
@@ -111,8 +111,8 @@ export const fromTenantAttributesV1 = (
         assignmentTimestamp: bigIntToDate(
           certifiedAttribute.assignmentTimestamp
         ),
-        revocationTimestamp: new Date(
-          Number(certifiedAttribute.revocationTimestamp)
+        revocationTimestamp: bigIntToDate(
+          certifiedAttribute.revocationTimestamp
         ),
         type: tenantAttributeType.CERTIFIED,
       };
@@ -134,8 +134,8 @@ export const fromTenantAttributesV1 = (
         assignmentTimestamp: bigIntToDate(
           declaredAttribute.assignmentTimestamp
         ),
-        revocationTimestamp: new Date(
-          Number(declaredAttribute.revocationTimestamp)
+        revocationTimestamp: bigIntToDate(
+          declaredAttribute.revocationTimestamp
         ),
         type: tenantAttributeType.DECLARED,
       };

--- a/packages/models/src/tenant/protobufConverterFromV1.ts
+++ b/packages/models/src/tenant/protobufConverterFromV1.ts
@@ -111,6 +111,9 @@ export const fromTenantAttributesV1 = (
         assignmentTimestamp: bigIntToDate(
           certifiedAttribute.assignmentTimestamp
         ),
+        revocationTimestamp: new Date(
+          Number(certifiedAttribute.revocationTimestamp)
+        ),
         type: tenantAttributeType.CERTIFIED,
       };
     case "verifiedAttribute":
@@ -130,6 +133,9 @@ export const fromTenantAttributesV1 = (
         id: unsafeBrandId(declaredAttribute.id),
         assignmentTimestamp: bigIntToDate(
           declaredAttribute.assignmentTimestamp
+        ),
+        revocationTimestamp: new Date(
+          Number(declaredAttribute.revocationTimestamp)
         ),
         type: tenantAttributeType.DECLARED,
       };

--- a/packages/models/src/tenant/protobufConverterFromV2.ts
+++ b/packages/models/src/tenant/protobufConverterFromV2.ts
@@ -105,6 +105,9 @@ export const fromTenantAttributesV2 = (
         assignmentTimestamp: bigIntToDate(
           certifiedAttribute.assignmentTimestamp
         ),
+        revocationTimestamp: bigIntToDate(
+          certifiedAttribute.revocationTimestamp
+        ),
         type: tenantAttributeType.CERTIFIED,
       };
     case "verifiedAttribute":
@@ -124,6 +127,9 @@ export const fromTenantAttributesV2 = (
         id: unsafeBrandId(declaredAttribute.id),
         assignmentTimestamp: bigIntToDate(
           declaredAttribute.assignmentTimestamp
+        ),
+        revocationTimestamp: bigIntToDate(
+          declaredAttribute.revocationTimestamp
         ),
         type: tenantAttributeType.DECLARED,
       };

--- a/packages/models/src/tenant/protobufConverterToV2.ts
+++ b/packages/models/src/tenant/protobufConverterToV2.ts
@@ -88,6 +88,7 @@ export function toAttributeV2(input: TenantAttribute): TenantAttributeV2 {
         declaredAttribute: {
           id: attribute.id,
           assignmentTimestamp: dateToBigInt(attribute.assignmentTimestamp),
+          revocationTimestamp: dateToBigInt(attribute.revocationTimestamp),
         },
       },
     }))

--- a/packages/tenant-readmodel-writer/test/converterV1.ts
+++ b/packages/tenant-readmodel-writer/test/converterV1.ts
@@ -86,6 +86,7 @@ export function toAttributeV1(input: TenantAttribute): TenantAttributeV1 {
         declaredAttribute: {
           id: attribute.id,
           assignmentTimestamp: dateToBigInt(attribute.assignmentTimestamp),
+          revocationTimestamp: dateToBigInt(attribute.revocationTimestamp),
         },
       },
     }))


### PR DESCRIPTION
Followup after #776 - some tenant model converters were stripping `revocationTimestamp` from tenant attributes. TS was not complaining because undefined is an acceptable value.

Bug found while testing #897 