### PR TITLE
IMN 607 - BFF Tenant router - Pt2

### DIFF
--- a/packages/bff/src/model/api/tenantApiConverter.ts
+++ b/packages/bff/src/model/api/tenantApiConverter.ts
@@ -1,4 +1,9 @@
-import { tenantApi, bffApi } from "pagopa-interop-api-clients";
+import {
+  tenantApi,
+  bffApi,
+  attributeRegistryApi,
+} from "pagopa-interop-api-clients";
+import { isDefined } from "pagopa-interop-commons";
 
 export const toBffApiCompactOrganization = (
   input: tenantApi.Tenant
@@ -15,3 +20,94 @@ export const toBffApiRequesterCertifiedAttributes = (
   attributeId: input.attributeId,
   attributeName: input.attributeName,
 });
+
+export type RegistryAttributesMap = Map<
+  attributeRegistryApi.Attribute["id"],
+  attributeRegistryApi.Attribute
+>;
+
+const toBffApiCertifiedTenantAttribute = (
+  tenantAttribute: tenantApi.CertifiedTenantAttribute,
+  registryAttributesMap: RegistryAttributesMap
+): bffApi.CertifiedTenantAttribute | undefined => {
+  const registryAttribute = registryAttributesMap.get(tenantAttribute.id);
+
+  return registryAttribute
+    ? {
+        id: tenantAttribute.id,
+        name: registryAttribute.name,
+        description: registryAttribute.description,
+        assignmentTimestamp: tenantAttribute.assignmentTimestamp,
+        revocationTimestamp: tenantAttribute.revocationTimestamp,
+      }
+    : undefined;
+};
+
+const toBffApiDeclaredTenantAttribute = (
+  tenantAttribute: tenantApi.DeclaredTenantAttribute,
+  registryAttributesMap: RegistryAttributesMap
+  // eslint-disable-next-line sonarjs/no-identical-functions
+): bffApi.DeclaredTenantAttribute | undefined => {
+  const registryAttribute = registryAttributesMap.get(tenantAttribute.id);
+
+  return registryAttribute
+    ? {
+        id: tenantAttribute.id,
+        name: registryAttribute.name,
+        description: registryAttribute.description,
+        assignmentTimestamp: tenantAttribute.assignmentTimestamp,
+        revocationTimestamp: tenantAttribute.revocationTimestamp,
+      }
+    : undefined;
+};
+
+const toBffApiVerifiedTenantAttribute = (
+  tenantAttribute: tenantApi.VerifiedTenantAttribute,
+  registryAttributesMap: RegistryAttributesMap
+): bffApi.VerifiedTenantAttribute | undefined => {
+  const registryAttribute = registryAttributesMap.get(tenantAttribute.id);
+
+  return registryAttribute
+    ? {
+        id: tenantAttribute.id,
+        name: registryAttribute.name,
+        description: registryAttribute.description,
+        assignmentTimestamp: tenantAttribute.assignmentTimestamp,
+        verifiedBy: tenantAttribute.verifiedBy,
+        revokedBy: tenantAttribute.revokedBy,
+      }
+    : undefined;
+};
+
+export function toBffApiCertifiedTenantAttributes(
+  certifiedAttributes: tenantApi.CertifiedTenantAttribute[],
+  registryAttributesMap: RegistryAttributesMap
+): bffApi.CertifiedTenantAttribute[] {
+  return certifiedAttributes
+    .map((tenantAttribute) =>
+      toBffApiCertifiedTenantAttribute(tenantAttribute, registryAttributesMap)
+    )
+    .filter(isDefined);
+}
+
+export function toBffApiDeclaredTenantAttributes(
+  declaredAttributes: tenantApi.DeclaredTenantAttribute[],
+  registryAttributesMap: RegistryAttributesMap
+): bffApi.DeclaredTenantAttribute[] {
+  return declaredAttributes
+    .map((tenantAttribute) =>
+      toBffApiDeclaredTenantAttribute(tenantAttribute, registryAttributesMap)
+    )
+    .filter(isDefined);
+}
+
+export function toBffApiVerifiedTenantAttributes(
+  verifiedAttributes: tenantApi.VerifiedTenantAttribute[],
+  registryAttributesMap: RegistryAttributesMap
+): bffApi.VerifiedTenantAttribute[] {
+  return verifiedAttributes
+    .map((tenantAttribute) =>
+      toBffApiVerifiedTenantAttribute(tenantAttribute, registryAttributesMap)
+    )
+    .filter(isDefined);
+}

--- a/packages/bff/src/routers/tenantRouter.ts
+++ b/packages/bff/src/routers/tenantRouter.ts
@@ -21,7 +21,10 @@ const tenantRouter = (
     validationErrorHandler: zodiosValidationErrorToApiProblem,
   });
 
-  const tenantService = tenantServiceBuilder(clients.tenantProcessClient);
+  const tenantService = tenantServiceBuilder(
+    clients.tenantProcessClient,
+    clients.attributeProcessClient
+  );
 
   tenantRouter
     .get("/consumers", async (req, res) => {
@@ -89,9 +92,26 @@ const tenantRouter = (
         return res.status(errorRes.status).json(errorRes).end();
       }
     })
-    .get("/tenants/:tenantId/attributes/certified", async (_req, res) =>
-      res.status(501).send()
-    )
+    .get("/tenants/:tenantId/attributes/certified", async (req, res) => {
+      const ctx = fromBffAppContext(req.ctx, req.headers);
+
+      try {
+        const result = await tenantService.getCertifiedAttributes(
+          req.params.tenantId,
+          ctx
+        );
+
+        return res.status(200).json(result).end();
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx.logger,
+          `Error retrieving certified attributes for tenant ${req.params.tenantId}`
+        );
+        return res.status(errorRes.status).json(errorRes).end();
+      }
+    })
     .post("/tenants/:tenantId/attributes/certified", async (req, res) => {
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
@@ -145,12 +165,46 @@ const tenantRouter = (
         return res.status(errorRes.status).json(errorRes).end();
       }
     })
-    .get("/tenants/:tenantId/attributes/declared", async (_req, res) =>
-      res.status(501).send()
-    )
-    .get("/tenants/:tenantId/attributes/verified", async (_req, res) =>
-      res.status(501).send()
-    )
+    .get("/tenants/:tenantId/attributes/declared", async (req, res) => {
+      const ctx = fromBffAppContext(req.ctx, req.headers);
+
+      try {
+        const result = await tenantService.getDeclaredAttributes(
+          req.params.tenantId,
+          ctx
+        );
+
+        return res.status(200).json(result).end();
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx.logger,
+          `Error retrieving declared attributes for tenant ${req.params.tenantId}`
+        );
+        return res.status(errorRes.status).json(errorRes).end();
+      }
+    })
+    .get("/tenants/:tenantId/attributes/verified", async (req, res) => {
+      const ctx = fromBffAppContext(req.ctx, req.headers);
+
+      try {
+        const result = await tenantService.getVerifiedAttributes(
+          req.params.tenantId,
+          ctx
+        );
+
+        return res.status(200).json(result).end();
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx.logger,
+          `Error retrieving verified attributes for tenant ${req.params.tenantId}`
+        );
+        return res.status(errorRes.status).json(errorRes).end();
+      }
+    })
     .post("/tenants/:tenantId/attributes/verified", async (_req, res) =>
       res.status(501).send()
     )

--- a/packages/bff/src/routers/tenantRouter.ts
+++ b/packages/bff/src/routers/tenantRouter.ts
@@ -96,8 +96,9 @@ const tenantRouter = (
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
       try {
+        const tenantId = unsafeBrandId<TenantId>(req.params.tenantId);
         const result = await tenantService.getCertifiedAttributes(
-          req.params.tenantId,
+          tenantId,
           ctx
         );
 
@@ -169,10 +170,8 @@ const tenantRouter = (
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
       try {
-        const result = await tenantService.getDeclaredAttributes(
-          req.params.tenantId,
-          ctx
-        );
+        const tenantId = unsafeBrandId<TenantId>(req.params.tenantId);
+        const result = await tenantService.getDeclaredAttributes(tenantId, ctx);
 
         return res.status(200).json(result).end();
       } catch (error) {
@@ -189,10 +188,8 @@ const tenantRouter = (
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
       try {
-        const result = await tenantService.getVerifiedAttributes(
-          req.params.tenantId,
-          ctx
-        );
+        const tenantId = unsafeBrandId<TenantId>(req.params.tenantId);
+        const result = await tenantService.getVerifiedAttributes(tenantId, ctx);
 
         return res.status(200).json(result).end();
       } catch (error) {

--- a/packages/bff/src/services/attributeService.ts
+++ b/packages/bff/src/services/attributeService.ts
@@ -1,10 +1,30 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import { WithLogger } from "pagopa-interop-commons";
+import { getAllFromPaginated, WithLogger } from "pagopa-interop-commons";
 import { attributeRegistryApi, bffApi } from "pagopa-interop-api-clients";
-import { PagoPAInteropBeClients } from "../providers/clientProvider.js";
+import {
+  AttributeProcessClient,
+  PagoPAInteropBeClients,
+} from "../providers/clientProvider.js";
 import { toApiAttributeProcessSeed } from "../model/domain/apiConverter.js";
 import { BffAppContext } from "../utilities/context.js";
+
+export async function getAllBulkAttributes(
+  attributeProcessClient: AttributeProcessClient,
+  headers: BffAppContext["headers"],
+  attributeIds: Array<attributeRegistryApi.Attribute["id"]>
+): Promise<attributeRegistryApi.Attribute[]> {
+  return await getAllFromPaginated<attributeRegistryApi.Attribute>(
+    async (offset, limit) =>
+      await attributeProcessClient.getBulkedAttributes(attributeIds, {
+        headers,
+        queries: {
+          offset,
+          limit,
+        },
+      })
+  );
+}
 
 export function attributeServiceBuilder(
   attributeClient: PagoPAInteropBeClients["attributeProcessClient"]

--- a/packages/bff/src/services/tenantService.ts
+++ b/packages/bff/src/services/tenantService.ts
@@ -115,7 +115,7 @@ export function tenantServiceBuilder(
       };
     },
     async getCertifiedAttributes(
-      tenantId: string,
+      tenantId: TenantId,
       { headers }: WithLogger<BffAppContext>
     ): Promise<bffApi.CertifiedAttributesResponse> {
       const tenant = await tenantProcessClient.tenant.getTenant({
@@ -141,7 +141,7 @@ export function tenantServiceBuilder(
       return { attributes };
     },
     async getDeclaredAttributes(
-      tenantId: string,
+      tenantId: TenantId,
       { headers }: WithLogger<BffAppContext>
     ): Promise<bffApi.DeclaredAttributesResponse> {
       const tenant = await tenantProcessClient.tenant.getTenant({
@@ -167,7 +167,7 @@ export function tenantServiceBuilder(
       return { attributes };
     },
     async getVerifiedAttributes(
-      tenantId: string,
+      tenantId: TenantId,
       { headers }: WithLogger<BffAppContext>
     ): Promise<bffApi.VerifiedAttributesResponse> {
       const tenant = await tenantProcessClient.tenant.getTenant({

--- a/packages/commons/src/utils/arrays.ts
+++ b/packages/commons/src/utils/arrays.ts
@@ -1,3 +1,7 @@
+export function isDefined<V>(value: V | null | undefined): value is V {
+  return value !== null && value !== undefined;
+}
+
 export function toSetToArray<V>(a: V[]): V[] {
   return Array.from(new Set(a));
 }


### PR DESCRIPTION
Based on #897 

2nd part of [IMN-607](https://pagopa.atlassian.net/browse/IMN-607)

This PR implements the following BFF Tenant methods:
- GET Certified Attributes
- GET Verified Attributes
- GET Declared Attributes

# GET Certified Attributes

<img width="657" alt="image" src="https://github.com/user-attachments/assets/34162d95-3510-4d7d-bb1a-4b32239d536f">

# GET Declared Attributes

<img width="655" alt="image" src="https://github.com/user-attachments/assets/c4f89bda-ce72-45e5-b6dc-fda621773b0e">

# GET Verified Attributes

<img width="653" alt="image" src="https://github.com/user-attachments/assets/3bb4a349-d810-44c3-bb95-bea70fa3aac3">

[IMN-607]: https://pagopa.atlassian.net/browse/IMN-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ