### PR TITLE
IMN-607 - BFF Tenant router - Pt4

### DIFF
--- a/packages/bff/src/model/api/tenantApiConverter.ts
+++ b/packages/bff/src/model/api/tenantApiConverter.ts
@@ -160,3 +160,17 @@ export function toBffApiTenant(
     },
   };
 }
+
+export async function toBffApiCompactTenant(
+  tenant: tenantApi.Tenant,
+  getLogoUrl: (
+    selfcareId: tenantApi.Tenant["selfcareId"]
+  ) => Promise<bffApi.CompactTenant["logoUrl"]>
+): Promise<bffApi.CompactTenant> {
+  return {
+    id: tenant.id,
+    name: tenant.name,
+    selfcareId: tenant.selfcareId,
+    logoUrl: await getLogoUrl(tenant.selfcareId),
+  };
+}

--- a/packages/bff/src/model/api/tenantApiConverter.ts
+++ b/packages/bff/src/model/api/tenantApiConverter.ts
@@ -111,3 +111,52 @@ export function toBffApiVerifiedTenantAttributes(
     )
     .filter(isDefined);
 }
+
+function toBffApiTenantMail(
+  tenantMails: tenantApi.Tenant["mails"]
+): bffApi.Mail | undefined {
+  const mail = tenantMails.find(
+    (m) => m.kind === tenantApi.MailKind.Values.CONTACT_EMAIL
+  );
+  return mail
+    ? {
+        address: mail.address,
+        description: mail.description,
+      }
+    : undefined;
+}
+
+export function toBffApiTenant(
+  tenant: tenantApi.Tenant,
+  certifiedAttributes: tenantApi.CertifiedTenantAttribute[],
+  declaredAttributes: tenantApi.DeclaredTenantAttribute[],
+  verifiedAttributes: tenantApi.VerifiedTenantAttribute[],
+  registryAttributesMap: RegistryAttributesMap
+): bffApi.Tenant {
+  return {
+    id: tenant.id,
+    selfcareId: tenant.selfcareId,
+    externalId: tenant.externalId,
+    createdAt: tenant.createdAt,
+    updatedAt: tenant.updatedAt,
+    name: tenant.name,
+    features: tenant.features,
+    onboardedAt: tenant.onboardedAt,
+    subUnitType: tenant.subUnitType,
+    contactMail: toBffApiTenantMail(tenant.mails),
+    attributes: {
+      certified: toBffApiCertifiedTenantAttributes(
+        certifiedAttributes,
+        registryAttributesMap
+      ),
+      declared: toBffApiDeclaredTenantAttributes(
+        declaredAttributes,
+        registryAttributesMap
+      ),
+      verified: toBffApiVerifiedTenantAttributes(
+        verifiedAttributes,
+        registryAttributesMap
+      ),
+    },
+  };
+}

--- a/packages/bff/src/providers/clientProvider.ts
+++ b/packages/bff/src/providers/clientProvider.ts
@@ -5,6 +5,8 @@ import {
   agreementApi,
   purposeApi,
   authorizationApi,
+  selfcareV2ClientApi,
+  selfcareV2InstitutionClientBuilder,
 } from "pagopa-interop-api-clients";
 import { config } from "../config/config.js";
 
@@ -38,6 +40,12 @@ export type AuthorizationProcessClient = {
   user: ReturnType<typeof authorizationApi.createUserApiClient>;
 };
 
+export type SelfcareV2Client = {
+  institution: ReturnType<
+    typeof selfcareV2ClientApi.createInstitutionsApiClient
+  >;
+};
+
 export type PagoPAInteropBeClients = {
   tenantProcessClient: TenantProcessClient;
   attributeProcessClient: AttributeProcessClient;
@@ -45,6 +53,7 @@ export type PagoPAInteropBeClients = {
   agreementProcessClient: AgreementProcessClient;
   purposeProcessClient: PurposeProcessClient;
   authorizationClient: AuthorizationProcessClient;
+  selfcareV2Client: SelfcareV2Client;
 };
 
 export function getInteropBeClients(): PagoPAInteropBeClients {
@@ -72,6 +81,9 @@ export function getInteropBeClients(): PagoPAInteropBeClients {
         config.authorizationUrl
       ),
       user: authorizationApi.createUserApiClient(config.authorizationUrl),
+    },
+    selfcareV2Client: {
+      institution: selfcareV2InstitutionClientBuilder(config),
     },
   };
 }

--- a/packages/bff/src/routers/tenantRouter.ts
+++ b/packages/bff/src/routers/tenantRouter.ts
@@ -23,7 +23,8 @@ const tenantRouter = (
 
   const tenantService = tenantServiceBuilder(
     clients.tenantProcessClient,
-    clients.attributeProcessClient
+    clients.attributeProcessClient,
+    clients.selfcareV2Client
   );
 
   tenantRouter

--- a/packages/bff/src/routers/tenantRouter.ts
+++ b/packages/bff/src/routers/tenantRouter.ts
@@ -305,7 +305,23 @@ const tenantRouter = (
         }
       }
     )
-    .get("/tenants/:tenantId", async (_req, res) => res.status(501).send())
+    .get("/tenants/:tenantId", async (req, res) => {
+      const ctx = fromBffAppContext(req.ctx, req.headers);
+
+      try {
+        const tenantId = unsafeBrandId<TenantId>(req.params.tenantId);
+        const result = await tenantService.getTenant(tenantId, ctx);
+        return res.status(200).json(result).end();
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx.logger,
+          `Error retrieving tenant with tenantId ${req.params.tenantId}`
+        );
+        return res.status(errorRes.status).json(errorRes).end();
+      }
+    })
     .post("/tenants/:tenantId/mails", async (req, res) => {
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
@@ -340,7 +356,30 @@ const tenantRouter = (
         return res.status(errorRes.status).json(errorRes).end();
       }
     })
-    .get("/tenants", async (_req, res) => res.status(501).send());
+    .get(
+      "/tenants",
+
+      async (req, res) => {
+        const ctx = fromBffAppContext(req.ctx, req.headers);
+
+        try {
+          const result = await tenantService.getTenants(
+            req.query.name,
+            req.query.limit,
+            ctx
+          );
+          return res.status(200).json(result).end();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx.logger,
+            `Error retrieving tenants`
+          );
+          return res.status(errorRes.status).json(errorRes).end();
+        }
+      }
+    );
 
   return tenantRouter;
 };

--- a/packages/bff/src/services/tenantService.ts
+++ b/packages/bff/src/services/tenantService.ts
@@ -78,6 +78,13 @@ export function tenantServiceBuilder(
         registryAttributesMap
       );
     },
+    async getTenants(
+      name: string | undefined,
+      limit: number,
+      { headers }: WithLogger<BffAppContext>
+    ): Promise<bffApi.Tenants> {
+      // TODO implement
+    },
     async getConsumers(
       name: string | undefined,
       offset: number,


### PR DESCRIPTION
Based on #934 

Last part of [IMN-607](https://pagopa.atlassian.net/browse/IMN-607)

This PR implements the following BFF tenant methods:

- Get tenant
- Get tenants

# GET Tenant

<img width="674" alt="image" src="https://github.com/user-attachments/assets/0a291916-4a4c-4aed-8aea-99c809477c1c">

# GET Tenants


<img width="611" alt="image" src="https://github.com/user-attachments/assets/b3d0dec4-7b52-4f1b-9356-216f4379fbcf">

### Limit works
<img width="623" alt="image" src="https://github.com/user-attachments/assets/3ca29421-5359-4171-8518-df4c939e5e4a">

### Name query works
<img width="631" alt="image" src="https://github.com/user-attachments/assets/5b8e46c4-7291-40a6-817f-302efb4c8b9e">



[IMN-607]: https://pagopa.atlassian.net/browse/IMN-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ