### PR TITLE
FIX `compute-agreement-consumer` crash on startup

### DIFF
--- a/packages/compute-agreements-consumer/src/converters.ts
+++ b/packages/compute-agreements-consumer/src/converters.ts
@@ -9,13 +9,13 @@ import {
   VerifiedTenantAttribute,
 } from "pagopa-interop-models";
 
-function toApiCompactTenantCertifiedVerifiedAttribute(
+function toApiCompactTenantCertifiedDeclaredAttribute(
   attr: CertifiedTenantAttribute
 ): agreementApi.CertifiedTenantAttribute;
-function toApiCompactTenantCertifiedVerifiedAttribute(
+function toApiCompactTenantCertifiedDeclaredAttribute(
   attr: DeclaredTenantAttribute
 ): agreementApi.DeclaredTenantAttribute;
-function toApiCompactTenantCertifiedVerifiedAttribute(
+function toApiCompactTenantCertifiedDeclaredAttribute(
   attr: CertifiedTenantAttribute | DeclaredTenantAttribute
 ):
   | agreementApi.CertifiedTenantAttribute
@@ -56,11 +56,11 @@ function toCompactTenantAttribute(
     .returnType<agreementApi.TenantAttribute>()
     .with(
       { type: tenantAttributeType.CERTIFIED },
-      toApiCompactTenantCertifiedVerifiedAttribute
+      toApiCompactTenantCertifiedDeclaredAttribute
     )
     .with(
       { type: tenantAttributeType.DECLARED },
-      toApiCompactTenantCertifiedVerifiedAttribute
+      toApiCompactTenantCertifiedDeclaredAttribute
     )
     .with(
       { type: tenantAttributeType.VERIFIED },

--- a/packages/compute-agreements-consumer/src/converters.ts
+++ b/packages/compute-agreements-consumer/src/converters.ts
@@ -1,0 +1,76 @@
+import { match } from "ts-pattern";
+import { agreementApi } from "pagopa-interop-api-clients";
+import {
+  CertifiedTenantAttribute,
+  DeclaredTenantAttribute,
+  Tenant,
+  TenantAttribute,
+  tenantAttributeType,
+  VerifiedTenantAttribute,
+} from "pagopa-interop-models";
+
+function toApiCompactTenantCertifiedVerifiedAttribute(
+  attr: CertifiedTenantAttribute
+): agreementApi.CertifiedTenantAttribute;
+function toApiCompactTenantCertifiedVerifiedAttribute(
+  attr: DeclaredTenantAttribute
+): agreementApi.DeclaredTenantAttribute;
+function toApiCompactTenantCertifiedVerifiedAttribute(
+  attr: CertifiedTenantAttribute | DeclaredTenantAttribute
+):
+  | agreementApi.CertifiedTenantAttribute
+  | agreementApi.DeclaredTenantAttribute {
+  return {
+    id: attr.id,
+    assignmentTimestamp: attr.assignmentTimestamp.toISOString(),
+    revocationTimestamp: attr.revocationTimestamp?.toISOString(),
+  };
+}
+
+function toApiCompactTenantVerifiedAttribute(
+  attr: VerifiedTenantAttribute
+): agreementApi.VerifiedTenantAttribute {
+  return {
+    id: attr.id,
+    assignmentTimestamp: attr.assignmentTimestamp.toISOString(),
+    verifiedBy: attr.verifiedBy.map((v) => ({
+      id: v.id,
+      extensionDate: v.extensionDate?.toISOString(),
+      verificationDate: v.verificationDate?.toISOString(),
+      expirationDate: v.expirationDate?.toISOString(),
+    })),
+    revokedBy: attr.revokedBy.map((v) => ({
+      id: v.id,
+      extensionDate: v.extensionDate?.toISOString(),
+      verificationDate: v.verificationDate.toISOString(),
+      revocationDate: v.verificationDate.toISOString(),
+      expirationDate: v.expirationDate?.toISOString(),
+    })),
+  };
+}
+
+function toCompactTenantAttribute(
+  attribute: TenantAttribute
+): agreementApi.TenantAttribute {
+  return match(attribute)
+    .returnType<agreementApi.TenantAttribute>()
+    .with(
+      { type: tenantAttributeType.CERTIFIED },
+      toApiCompactTenantCertifiedVerifiedAttribute
+    )
+    .with(
+      { type: tenantAttributeType.DECLARED },
+      toApiCompactTenantCertifiedVerifiedAttribute
+    )
+    .with(
+      { type: tenantAttributeType.VERIFIED },
+      toApiCompactTenantVerifiedAttribute
+    );
+}
+
+export function toApiCompactTenant(tenant: Tenant): agreementApi.CompactTenant {
+  return {
+    id: tenant.id,
+    attributes: tenant.attributes.map(toCompactTenantAttribute),
+  };
+}

--- a/packages/compute-agreements-consumer/src/index.ts
+++ b/packages/compute-agreements-consumer/src/index.ts
@@ -16,6 +16,7 @@ import { match, P } from "ts-pattern";
 import { v4 as uuidv4 } from "uuid";
 import { agreementApi } from "pagopa-interop-api-clients";
 import { config } from "./config/config.js";
+import { toApiCompactTenant } from "./converters.js";
 
 const agreementProcessClient = agreementApi.createAgreementApiClient(
   config.agreementProcessUrl
@@ -64,7 +65,7 @@ async function processMessage({
           await agreementProcessClient.computeAgreementsByAttribute(
             {
               attributeId: unsafeBrandId(attributeId),
-              consumer: fromTenantV2(tenant),
+              consumer: toApiCompactTenant(fromTenantV2(tenant)),
             },
             {
               headers: {


### PR DESCRIPTION
This PR fixes a crash due to an incorrect data conversion coming from the event.
A converter that converts the tenant event data structure to a tenant data structure compatible to the `computeAgreementsByAttribute` request body. 