### PR TITLE
Quick fix for local dev - fixing local well known JWKS

### DIFF
--- a/docker/local-kms-seed/jwks.json
+++ b/docker/local-kms-seed/jwks.json
@@ -2,13 +2,6 @@
   "keys": [
     {
       "kty": "RSA",
-      "n": "0HTSeVF1Xg6s5HNHsJFfViAhS7iV7h85xzpjgdupeBPOzPHgJmAcgdCuQye366yE2BC7C10eXMymOBUnZcu-MG8I9t9n1bnjo6KeId2-6ZRGUexOOlg-2xgqvc_peHzdzMYzBgNTBnlXUG6W6cJIEcWqCTnygHr22QWJ3wNczzBYRVheUOF6e1vT2VyFlMCrjLBxwzAtfMwME8JkyLFcTjJbJLApiQ8oDir1K8ys_q11m6yeGjW-cxueQhBK4E677CFUxTAxZx-_3mF4cog2A6hhlRIqEgjs8DIO2wpJKF2wrGN0FMJz6SarokE_0S9W53atLPJDVsIdvGv_1KGTeQ",
-      "e": "AQAB",
-      "alg": "RS256",
-      "kid": "17c1177f-d7dc-4181-9f54-6fd416bf229b"
-    },
-    {
-      "kty": "RSA",
       "n": "k5JxTIGte3mNfH5l7PuJCzZ3q2Ri7XuMop8SKQqFE7-xbrjmdM5pFK9gznrbsHWr2FB-w9C_oSGBDn4vyKGmnPWR2lTzBD9lmsEpEUKOs3ZlMSbpkWJOHCELocgq4kRAGxifTodqfj4uakGWHBFzIQ-79QVYzZ0B_3dsaUU9AOOa7TgiV9bbyhkWVWGzT8uGhi-F84M1VwVnsG8I3NI9YhwOs_JRufuh-ZvFnRcPuWTVAgcDYoZW94mpXvl0Kw8l2YoyTrl9xqvDOObA_axu1EWptJOD-65BQDDG-YLMvfxV9fnIlX59o6kbc2I6qFtrtvZCGLDPs_jE-k8_6hfAJw",
       "e": "AQAB",
       "alg": "RS256",
@@ -16,10 +9,10 @@
     },
     {
       "kty": "RSA",
-      "n": "rETceL76VNTt7_Vgsi3lDwpwQg6TpXZGKWRXeUYuZbJ8igKd7Jc8fQKJg0CYDZNxzdfPHrAiZ6MOo9VNWIAWdsj_F1XOAM0FowlIN_XpWIhp6d7Bj50DxVaSSO6iyNP4BzLe5EYPaBqH5jvI3dy-0tjXhtwCKcf0gaMuD0KX0YtnjuR5fkmfJy3Da7b4ALUleIIqMYLgnvAL_xUyJZoSdBpJW1-GYKSzQg3mjvc2wZYHCFEZz8CJNoZ2wjxjGNxalHFshBbPyw8KZ9-ZqG7jvSJBYkC1l-grZb_ZEpkLlfCGF_4l4zyGKPwn29mOed3C5sR09JUWTxvaGyZcou-KOQ",
+      "n": "rgYWtcWT6u1HnPDugjSyV2OnqndlPJ6HTzK0sCaMtx9i0zkYWzjD0328-WrECJ7yvglrDxsnOOD9-WF7jU4mI-CQch0922MsSeEKECFS2Ssl4jqrGMgoe1kNWlNBTqTPjBUwpNjoHF4xozh7JZOqxhsweidufn36VQH91PXH-N-YfEX0T1jjQZfV0wzmJteuqtdf1eqTQ7A6mXUDs-Hsgg-LrB7VJhB6Q6o_x-1O_WlOSTu_eajRoFVLiznHwFiUZFgpKv_KSfhAaIsfw3xgm_wDW9b-IqZYZQ2ZE7N_bi5slxPK93KjzUJNwHsFsVqQj3R7J1iJgtGk2g3Iwimpuw",
       "e": "AQAB",
       "alg": "RS256",
-      "kid": "3281b445-1700-4a46-a6ee-e7e02c9079ae"
+      "kid": "fcd1bab9-ae4d-49ce-9252-262db866e327"
     }
   ]
 }


### PR DESCRIPTION
We have a local, well-known JWKS file to avoid fetching the real one and to be able to locally accept tokens generated by the local KMS. However, the local JWKS shall also include the key for tokens generated for the dev environment so that they can work on local dev.

The dev JWKS changed after migration to the new region: https://dev.interop.pagopa.it/.well-known/jwks.json

In this PR I update the local one to include the same key from the dev one plus the entry for the local KMS key.