### PR TITLE
IMN-819 parse responses

### DIFF
--- a/packages/agreement-process/src/services/readModelService.ts
+++ b/packages/agreement-process/src/services/readModelService.ts
@@ -205,7 +205,7 @@ const getAllAgreements = async (
   filters: AgreementQueryFilters
 ): Promise<Array<WithMetadata<Agreement>>> => {
   const data = await agreements
-    .aggregate([getAgreementsFilters(filters)])
+    .aggregate([getAgreementsFilters(filters)], { allowDiskUse: true })
     .toArray();
 
   const result = z
@@ -263,7 +263,9 @@ async function searchTenantsByName(
   );
 
   const data = await agreements
-    .aggregate([...aggregationPipeline, { $skip: offset }, { $limit: limit }])
+    .aggregate([...aggregationPipeline, { $skip: offset }, { $limit: limit }], {
+      allowDiskUse: true,
+    })
     .toArray();
 
   const result = z
@@ -282,7 +284,7 @@ async function searchTenantsByName(
     totalCount: await ReadModelRepository.getTotalCount(
       agreements,
       aggregationPipeline,
-      false
+      true
     ),
   };
 }
@@ -381,11 +383,10 @@ export function readModelServiceBuilder(
       ];
 
       const data = await agreements
-        .aggregate([
-          ...aggregationPipeline,
-          { $skip: offset },
-          { $limit: limit },
-        ])
+        .aggregate(
+          [...aggregationPipeline, { $skip: offset }, { $limit: limit }],
+          { allowDiskUse: true }
+        )
         .toArray();
 
       const result = z.array(Agreement).safeParse(data.map((d) => d.data));
@@ -402,7 +403,7 @@ export function readModelServiceBuilder(
         totalCount: await ReadModelRepository.getTotalCount(
           agreements,
           aggregationPipeline,
-          false
+          true
         ),
       };
     },
@@ -538,11 +539,10 @@ export function readModelServiceBuilder(
       ];
 
       const data = await eservices
-        .aggregate([
-          ...aggregationPipeline,
-          { $skip: offset },
-          { $limit: limit },
-        ])
+        .aggregate(
+          [...aggregationPipeline, { $skip: offset }, { $limit: limit }],
+          { allowDiskUse: true }
+        )
         .toArray();
 
       const result = z
@@ -561,7 +561,7 @@ export function readModelServiceBuilder(
         totalCount: await ReadModelRepository.getTotalCount(
           eservices,
           aggregationPipeline,
-          false
+          true
         ),
       };
     },

--- a/packages/bff/src/routers/agreementRouter.ts
+++ b/packages/bff/src/routers/agreementRouter.ts
@@ -58,7 +58,7 @@ const agreementRouter = (
           },
           ctx
         );
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Agreements.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -75,7 +75,7 @@ const agreementRouter = (
 
       try {
         const result = await agreementService.createAgreement(req.body, ctx);
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Agreement.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -104,7 +104,10 @@ const agreementRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.CompactEServicesLight.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -132,7 +135,10 @@ const agreementRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.CatalogEServices.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -157,7 +163,10 @@ const agreementRouter = (
           },
           ctx
         );
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.CompactOrganizations.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -182,7 +191,10 @@ const agreementRouter = (
           },
           ctx
         );
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.CompactOrganizations.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -202,7 +214,7 @@ const agreementRouter = (
           req.params.agreementId,
           ctx
         );
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Agreement.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -261,7 +273,7 @@ const agreementRouter = (
           req.params.agreementId,
           ctx
         );
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Agreement.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -281,7 +293,10 @@ const agreementRouter = (
           req.params.agreementId,
           ctx
         );
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.CompactAgreement.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -373,7 +388,7 @@ const agreementRouter = (
           req.body,
           ctx
         );
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Agreement.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -393,7 +408,7 @@ const agreementRouter = (
           req.params.agreementId,
           ctx
         );
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Agreement.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -414,7 +429,7 @@ const agreementRouter = (
           req.body,
           ctx
         );
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Agreement.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -452,7 +467,7 @@ const agreementRouter = (
           req.body,
           ctx
         );
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Agreement.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -472,7 +487,7 @@ const agreementRouter = (
           req.params.agreementId,
           ctx
         );
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Agreement.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/bff/src/routers/agreementRouter.ts
+++ b/packages/bff/src/routers/agreementRouter.ts
@@ -137,7 +137,7 @@ const agreementRouter = (
 
         return res
           .status(200)
-          .json(bffApi.CatalogEServices.parse(result))
+          .json(bffApi.CompactEServicesLight.parse(result))
           .end();
       } catch (error) {
         const errorRes = makeApiProblem(
@@ -293,10 +293,7 @@ const agreementRouter = (
           req.params.agreementId,
           ctx
         );
-        return res
-          .status(200)
-          .json(bffApi.CompactAgreement.parse(result))
-          .end();
+        return res.status(200).json(bffApi.CreatedResource.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/bff/src/routers/attributeRouter.ts
+++ b/packages/bff/src/routers/attributeRouter.ts
@@ -109,14 +109,7 @@ const attributeRouter = (
           ctx
         );
 
-        return res
-          .json(
-            bffApi.Attributes.parse({
-              results: attributes.results,
-              pagination: { offset, limit, totalCount: attributes.totalCount },
-            })
-          )
-          .end();
+        return res.json(bffApi.Attributes.parse(attributes)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/bff/src/routers/attributeRouter.ts
+++ b/packages/bff/src/routers/attributeRouter.ts
@@ -32,7 +32,7 @@ const attributeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Attribute.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -55,7 +55,7 @@ const attributeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Attribute.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -78,7 +78,7 @@ const attributeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Attribute.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -110,10 +110,12 @@ const attributeRouter = (
         );
 
         return res
-          .json({
-            results: attributes.results,
-            pagination: { offset, limit, totalCount: attributes.totalCount },
-          })
+          .json(
+            bffApi.Attributes.parse({
+              results: attributes.results,
+              pagination: { offset, limit, totalCount: attributes.totalCount },
+            })
+          )
           .end();
       } catch (error) {
         const errorRes = makeApiProblem(
@@ -135,7 +137,7 @@ const attributeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Attribute.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -157,7 +159,7 @@ const attributeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Attribute.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/bff/src/routers/authorizationRouter.ts
+++ b/packages/bff/src/routers/authorizationRouter.ts
@@ -53,7 +53,11 @@ const authorizationRouter = (
           throw tooManyRequestsError(result.rateLimitedTenantId);
         }
 
-        return res.status(200).send({ session_token: result.sessionToken });
+        return res
+          .status(200)
+          .send(
+            bffApi.SessionToken.parse({ session_token: result.sessionToken })
+          );
       } catch (error) {
         const err = makeApiProblem(
           error,

--- a/packages/bff/src/routers/authorizationRouter.ts
+++ b/packages/bff/src/routers/authorizationRouter.ts
@@ -55,9 +55,7 @@ const authorizationRouter = (
 
         return res
           .status(200)
-          .send(
-            bffApi.SessionToken.parse({ session_token: result.sessionToken })
-          );
+          .send(bffApi.SessionToken.parse(result.sessionToken));
       } catch (error) {
         const err = makeApiProblem(
           error,

--- a/packages/bff/src/routers/catalogRouter.ts
+++ b/packages/bff/src/routers/catalogRouter.ts
@@ -56,7 +56,10 @@ const catalogRouter = (
       try {
         const response = await catalogService.getCatalog(ctx, queryParams);
 
-        return res.status(200).json(response).send();
+        return res
+          .status(200)
+          .json(bffApi.CatalogEServices.parse(response))
+          .send();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -78,7 +81,10 @@ const catalogRouter = (
           ctx
         );
 
-        return res.status(200).json(response).send();
+        return res
+          .status(200)
+          .json(bffApi.ProducerEServices.parse(response))
+          .send();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -96,7 +102,10 @@ const catalogRouter = (
           unsafeBrandId(req.params.eserviceId),
           ctx
         );
-        return res.status(200).json(response).send();
+        return res
+          .status(200)
+          .json(bffApi.ProducerEServiceDetails.parse(response))
+          .send();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -118,7 +127,10 @@ const catalogRouter = (
             unsafeBrandId(req.params.descriptorId),
             ctx
           );
-          return res.status(200).json(response).send();
+          return res
+            .status(200)
+            .json(bffApi.ProducerEServiceDescriptor.parse(response))
+            .send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -141,7 +153,10 @@ const catalogRouter = (
             ctx
           );
 
-          return res.status(200).json(response).send();
+          return res
+            .status(200)
+            .json(bffApi.CatalogEServiceDescriptor.parse(response))
+            .send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -211,7 +226,10 @@ const catalogRouter = (
             req.body,
             ctx
           );
-          return res.status(200).json(createdResource).send();
+          return res
+            .status(200)
+            .json(bffApi.CreatedResource.parse(createdResource))
+            .send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -234,7 +252,10 @@ const catalogRouter = (
           unsafeBrandId(req.params.eServiceId),
           ctx
         );
-        return res.status(200).json(createdResource).send();
+        return res
+          .status(200)
+          .json(bffApi.CreatedResource.parse(createdResource))
+          .send();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -278,7 +299,10 @@ const catalogRouter = (
             req.body,
             ctx
           );
-          return res.status(200).json().send({ id });
+          return res
+            .status(200)
+            .json()
+            .send(bffApi.CreatedResource.parse({ id }));
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -347,7 +371,10 @@ const catalogRouter = (
             req.body,
             ctx
           );
-          return res.status(200).json(resp).send();
+          return res
+            .status(200)
+            .json(bffApi.CreatedResource.parse(resp))
+            .send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -420,7 +447,12 @@ const catalogRouter = (
               unsafeBrandId(req.params.descriptorId),
               ctx
             );
-          return res.status(200).json(createdEServiceDescriptor).send();
+          return res
+            .status(200)
+            .json(
+              bffApi.CreatedEServiceDescriptor.parse(createdEServiceDescriptor)
+            )
+            .send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -454,7 +486,7 @@ const catalogRouter = (
             ctx
           );
 
-          return res.status(200).json(doc).send();
+          return res.status(200).json(bffApi.EServiceDoc.parse(doc)).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -473,7 +505,9 @@ const catalogRouter = (
           req.body,
           ctx
         );
-        return res.status(200).send(createdResource);
+        return res
+          .status(200)
+          .send(bffApi.CreatedEServiceDescriptor.parse(createdResource));
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -510,7 +544,9 @@ const catalogRouter = (
           req.body,
           ctx
         );
-        return res.status(200).send(createdResource);
+        return res
+          .status(200)
+          .send(bffApi.CreatedResource.parse(createdResource));
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -549,7 +585,7 @@ const catalogRouter = (
           unsafeBrandId(req.params.eServiceId),
           req.body
         );
-        return res.status(200).json(id).send();
+        return res.status(200).json(bffApi.CreatedResource.parse(id)).send();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -571,7 +607,10 @@ const catalogRouter = (
             ctx
           );
 
-          return res.status(200).json(riskAnalysis).send();
+          return res
+            .status(200)
+            .json(bffApi.EServiceRiskAnalysis.parse(riskAnalysis))
+            .send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -639,7 +678,7 @@ const catalogRouter = (
             ctx
           );
 
-          return res.json(response).send();
+          return res.json(bffApi.FileResource.parse(response)).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -659,7 +698,7 @@ const catalogRouter = (
           ctx
         );
 
-        return res.status(200).json(response).send();
+        return res.status(200).json(bffApi.FileResource.parse(response)).send();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -677,7 +716,12 @@ const catalogRouter = (
           req.body,
           ctx
         );
-        return res.status(200).json(createdEServiceDescriptor).send();
+        return res
+          .status(200)
+          .json(
+            bffApi.CreatedEServiceDescriptor.parse(createdEServiceDescriptor)
+          )
+          .send();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/bff/src/routers/catalogRouter.ts
+++ b/packages/bff/src/routers/catalogRouter.ts
@@ -698,7 +698,7 @@ const catalogRouter = (
           ctx
         );
 
-        return res.status(200).json(bffApi.FileResource.parse(response)).send();
+        return res.status(200).json(bffApi.PresignedUrl.parse(response)).send();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/bff/src/routers/clientRouter.ts
+++ b/packages/bff/src/routers/clientRouter.ts
@@ -16,7 +16,6 @@ import {
   emptyErrorMapper,
   getClientUsersErrorMapper,
 } from "../utilities/errorMappers.js";
-import { toBffApiCompactClient } from "../api/authorizationApiConverter.js";
 
 const clientRouter = (
   ctx: ZodiosContext,

--- a/packages/bff/src/routers/clientRouter.ts
+++ b/packages/bff/src/routers/clientRouter.ts
@@ -49,19 +49,7 @@ const clientRouter = (
           ctx
         );
 
-        return res
-          .status(200)
-          .json(
-            bffApi.CompactClients.parse({
-              results: clients.results.map(toBffApiCompactClient),
-              pagination: {
-                limit,
-                offset,
-                totalCount: clients.totalCount,
-              },
-            })
-          )
-          .end();
+        return res.status(200).json(bffApi.CompactClients.parse(clients)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/bff/src/routers/clientRouter.ts
+++ b/packages/bff/src/routers/clientRouter.ts
@@ -51,14 +51,16 @@ const clientRouter = (
 
         return res
           .status(200)
-          .json({
-            results: clients.results.map(toBffApiCompactClient),
-            pagination: {
-              limit,
-              offset,
-              totalCount: clients.totalCount,
-            },
-          })
+          .json(
+            bffApi.CompactClients.parse({
+              results: clients.results.map(toBffApiCompactClient),
+              pagination: {
+                limit,
+                offset,
+                totalCount: clients.totalCount,
+              },
+            })
+          )
           .end();
       } catch (error) {
         const errorRes = makeApiProblem(
@@ -79,7 +81,7 @@ const clientRouter = (
           ctx
         );
 
-        return res.status(200).json(client).end();
+        return res.status(200).json(bffApi.Client.parse(client)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -139,7 +141,7 @@ const clientRouter = (
           ctx
         );
 
-        return res.status(200).json(key).end();
+        return res.status(200).json(bffApi.PublicKey.parse(key)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -182,7 +184,7 @@ const clientRouter = (
           ctx
         );
 
-        return res.status(200).json(createdUser);
+        return res.status(200).json(bffApi.CreatedResource.parse(createdUser));
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -248,7 +250,7 @@ const clientRouter = (
           ctx
         );
 
-        return res.status(200).json(users).end();
+        return res.status(200).json(bffApi.CompactUsers.parse(users)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -286,7 +288,7 @@ const clientRouter = (
           ctx
         );
 
-        return res.status(200).json({ keys }).end();
+        return res.status(200).json(bffApi.PublicKeys.parse({ keys })).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -307,7 +309,7 @@ const clientRouter = (
           ctx
         );
 
-        return res.status(200).json(key).end();
+        return res.status(200).json(bffApi.EncodedClientKey.parse(key)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -325,7 +327,7 @@ const clientRouter = (
       try {
         const result = await clientService.createConsumerClient(req.body, ctx);
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.CreatedResource.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -343,7 +345,7 @@ const clientRouter = (
       try {
         const result = await clientService.createApiClient(req.body, ctx);
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.CreatedResource.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/bff/src/routers/privacyNoticeRouter.ts
+++ b/packages/bff/src/routers/privacyNoticeRouter.ts
@@ -51,7 +51,7 @@ const privacyNoticeRouter = (
           userId,
           ctx.logger
         );
-        return res.status(200).json(notice).end();
+        return res.status(200).json(bffApi.PrivacyNotice.parse(notice)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/bff/src/routers/producerKeychainRouter.ts
+++ b/packages/bff/src/routers/producerKeychainRouter.ts
@@ -53,16 +53,18 @@ const producerKeychainRouter = (
 
         return res
           .status(200)
-          .json({
-            results: producerKeychains.results.map(
-              toBffApiCompactProducerKeychain
-            ),
-            pagination: {
-              limit,
-              offset,
-              totalCount: producerKeychains.totalCount,
-            },
-          })
+          .json(
+            bffApi.CompactProducerKeychains.parse({
+              results: producerKeychains.results.map(
+                toBffApiCompactProducerKeychain
+              ),
+              pagination: {
+                limit,
+                offset,
+                totalCount: producerKeychains.totalCount,
+              },
+            })
+          )
           .end();
       } catch (error) {
         const errorRes = makeApiProblem(
@@ -87,7 +89,7 @@ const producerKeychainRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.CreatedResource.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -107,7 +109,10 @@ const producerKeychainRouter = (
             ctx
           );
 
-        return res.status(200).json(producerKeychain).end();
+        return res
+          .status(200)
+          .json(bffApi.ProducerKeychain.parse(producerKeychain))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -215,7 +220,7 @@ const producerKeychainRouter = (
           ctx
         );
 
-        return res.status(200).json({ keys }).end();
+        return res.status(200).json(bffApi.PublicKeys.parse(keys)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -239,7 +244,7 @@ const producerKeychainRouter = (
             ctx
           );
 
-          return res.status(200).json(key).end();
+          return res.status(200).json(bffApi.PublicKey.parse(key)).end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -284,7 +289,7 @@ const producerKeychainRouter = (
           ctx
         );
 
-        return res.status(200).json(users).end();
+        return res.status(200).json(bffApi.CompactUsers.parse(users)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -308,7 +313,9 @@ const producerKeychainRouter = (
               ctx
             );
 
-          return res.status(200).json(createdUser);
+          return res
+            .status(200)
+            .json(bffApi.CreatedResource.parse(createdUser));
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -356,7 +363,7 @@ const producerKeychainRouter = (
               ctx
             );
 
-          return res.status(200).json(key).end();
+          return res.status(200).json(bffApi.EncodedClientKey.parse(key)).end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/bff/src/routers/producerKeychainRouter.ts
+++ b/packages/bff/src/routers/producerKeychainRouter.ts
@@ -18,7 +18,6 @@ import {
 } from "../utilities/errorMappers.js";
 import { producerKeychainServiceBuilder } from "../services/producerKeychainService.js";
 import { config } from "../config/config.js";
-import { toBffApiCompactProducerKeychain } from "../api/authorizationApiConverter.js";
 
 const producerKeychainRouter = (
   ctx: ZodiosContext,
@@ -53,18 +52,7 @@ const producerKeychainRouter = (
 
         return res
           .status(200)
-          .json(
-            bffApi.CompactProducerKeychains.parse({
-              results: producerKeychains.results.map(
-                toBffApiCompactProducerKeychain
-              ),
-              pagination: {
-                limit,
-                offset,
-                totalCount: producerKeychains.totalCount,
-              },
-            })
-          )
+          .json(bffApi.CompactProducerKeychains.parse(producerKeychains))
           .end();
       } catch (error) {
         const errorRes = makeApiProblem(

--- a/packages/bff/src/routers/purposeRouter.ts
+++ b/packages/bff/src/routers/purposeRouter.ts
@@ -48,7 +48,7 @@ const purposeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.CreatedResource.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -69,7 +69,10 @@ const purposeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.PurposeVersionResource.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -86,7 +89,7 @@ const purposeRouter = (
       try {
         const result = await purposeService.createPurpose(req.body, ctx);
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.CreatedResource.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -114,7 +117,7 @@ const purposeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Purposes.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -142,7 +145,7 @@ const purposeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Purposes.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -163,7 +166,10 @@ const purposeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.PurposeVersionResource.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -184,7 +190,10 @@ const purposeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.PurposeVersionResource.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -257,7 +266,10 @@ const purposeRouter = (
             ctx
           );
 
-          return res.status(200).json(result).end();
+          return res
+            .status(200)
+            .json(bffApi.PurposeVersionResource.parse(result))
+            .end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -281,7 +293,10 @@ const purposeRouter = (
             ctx
           );
 
-          return res.status(200).json(result).end();
+          return res
+            .status(200)
+            .json(bffApi.PurposeVersionResource.parse(result))
+            .end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -305,7 +320,10 @@ const purposeRouter = (
             ctx
           );
 
-          return res.status(200).json(result).end();
+          return res
+            .status(200)
+            .json(bffApi.PurposeVersionResource.parse(result))
+            .end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -347,7 +365,10 @@ const purposeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.PurposeVersionResource.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -388,7 +409,7 @@ const purposeRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Purpose.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -406,7 +427,10 @@ const purposeRouter = (
         const result =
           await purposeService.retrieveLatestRiskAnalysisConfiguration(ctx);
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.RiskAnalysisFormConfig.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -430,7 +454,10 @@ const purposeRouter = (
               ctx
             );
 
-          return res.status(200).json(result).end();
+          return res
+            .status(200)
+            .json(bffApi.RiskAnalysisFormConfig.parse(result))
+            .end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/bff/src/routers/selfcareRouter.ts
+++ b/packages/bff/src/routers/selfcareRouter.ts
@@ -61,8 +61,6 @@ const selfcareRouter = (
 
       try {
         const products = await selfcareService.getSelfcareInstitutionsProducts(
-          ctx.authData.userId,
-          ctx.authData.selfcareId,
           ctx
         );
 
@@ -85,10 +83,7 @@ const selfcareRouter = (
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
       try {
-        const institutions = await selfcareService.getSelfcareInstitutions(
-          ctx.authData.userId,
-          ctx
-        );
+        const institutions = await selfcareService.getSelfcareInstitutions(ctx);
 
         return res
           .status(200)

--- a/packages/bff/src/routers/supportRouter.ts
+++ b/packages/bff/src/routers/supportRouter.ts
@@ -39,12 +39,12 @@ const supportRouter = (
 
     try {
       const samlDecoded = Buffer.from(saml2, "base64").toString();
-      const jwt = await authorizationService.getSaml2Token(
+      const sessionToken = await authorizationService.getSaml2Token(
         samlDecoded,
         tenantId,
         ctx
       );
-      return res.status(200).send({ session_token: jwt });
+      return res.status(200).send(bffApi.SessionToken.parse(sessionToken));
     } catch (error) {
       makeApiProblem(
         error,

--- a/packages/bff/src/routers/tenantRouter.ts
+++ b/packages/bff/src/routers/tenantRouter.ts
@@ -39,7 +39,10 @@ const tenantRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.CompactOrganizations.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -61,7 +64,10 @@ const tenantRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.CompactOrganizations.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -82,7 +88,10 @@ const tenantRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.RequesterCertifiedAttributes.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -103,7 +112,10 @@ const tenantRouter = (
           ctx
         );
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.CertifiedAttributesResponse.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -174,7 +186,10 @@ const tenantRouter = (
         const tenantId = unsafeBrandId<TenantId>(req.params.tenantId);
         const result = await tenantService.getDeclaredAttributes(tenantId, ctx);
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.DeclaredAttributesResponse.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -192,7 +207,10 @@ const tenantRouter = (
         const tenantId = unsafeBrandId<TenantId>(req.params.tenantId);
         const result = await tenantService.getVerifiedAttributes(tenantId, ctx);
 
-        return res.status(200).json(result).end();
+        return res
+          .status(200)
+          .json(bffApi.VerifiedAttributesResponse.parse(result))
+          .end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -312,7 +330,7 @@ const tenantRouter = (
       try {
         const tenantId = unsafeBrandId<TenantId>(req.params.tenantId);
         const result = await tenantService.getTenant(tenantId, ctx);
-        return res.status(200).json(result).end();
+        return res.status(200).json(bffApi.Tenant.parse(result)).end();
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -369,7 +387,7 @@ const tenantRouter = (
             req.query.limit,
             ctx
           );
-          return res.status(200).json(result).end();
+          return res.status(200).json(bffApi.Tenants.parse(result)).end();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/bff/src/services/attributeService.ts
+++ b/packages/bff/src/services/attributeService.ts
@@ -112,12 +112,17 @@ export function attributeServiceBuilder(
         origin?: string;
       },
       { logger, headers }: WithLogger<BffAppContext>
-    ): Promise<attributeRegistryApi.Attributes> {
+    ): Promise<bffApi.Attributes> {
       logger.info("Retrieving attributes");
-      return attributeClient.getAttributes({
+
+      const attributes = await attributeClient.getAttributes({
         queries: { offset, limit, kinds, name, origin },
         headers,
       });
+      return {
+        results: attributes.results,
+        pagination: { offset, limit, totalCount: attributes.totalCount },
+      };
     },
   };
 }

--- a/packages/bff/src/services/authorizationService.ts
+++ b/packages/bff/src/services/authorizationService.ts
@@ -1,4 +1,4 @@
-import { tenantApi } from "pagopa-interop-api-clients";
+import { bffApi, tenantApi } from "pagopa-interop-api-clients";
 import {
   CustomClaims,
   InteropTokenGenerator,
@@ -257,7 +257,7 @@ export function authorizationServiceBuilder(
       samlResponse: string,
       tenantId: string,
       { headers, logger }: WithLogger<BffAppContext>
-    ): Promise<string> => {
+    ): Promise<bffApi.SessionToken> => {
       logger.info("Calling get SAML2 token");
 
       validateSamlResponse(samlResponse);
@@ -267,13 +267,13 @@ export function authorizationServiceBuilder(
         headers,
       });
 
-      const { serialized: sessionToken } =
+      const { serialized: session_token } =
         await interopTokenGenerator.generateSessionToken(
           retrieveSupportClaims(tenant),
           config.supportJwtDuration
         );
 
-      return sessionToken;
+      return { session_token };
     },
   };
 }

--- a/packages/bff/src/services/authorizationService.ts
+++ b/packages/bff/src/services/authorizationService.ts
@@ -42,7 +42,7 @@ type GetSessionTokenReturnType =
     }
   | {
       limitReached: false;
-      sessionToken: string;
+      sessionToken: bffApi.SessionToken;
       rateLimiterStatus: Omit<RateLimiterStatus, "limitReached">;
     };
 
@@ -222,7 +222,7 @@ export function authorizationServiceBuilder(
 
       return {
         limitReached: false,
-        sessionToken,
+        sessionToken: { session_token: sessionToken },
         rateLimiterStatus,
       };
     },

--- a/packages/bff/src/services/catalogService.ts
+++ b/packages/bff/src/services/catalogService.ts
@@ -1001,7 +1001,7 @@ export function catalogServiceBuilder(
     generatePutPresignedUrl: async (
       filename: string,
       { authData, logger }: WithLogger<BffAppContext>
-    ): Promise<bffApi.FileResource> => {
+    ): Promise<bffApi.PresignedUrl> => {
       logger.info(
         `Generating presigned url for file ${filename} for organization ${authData.organizationId}`
       );
@@ -1014,7 +1014,6 @@ export function catalogServiceBuilder(
       );
 
       return {
-        filename,
         url,
       };
     },

--- a/packages/bff/src/services/clientService.ts
+++ b/packages/bff/src/services/clientService.ts
@@ -156,7 +156,7 @@ export function clientServiceBuilder(
       clientId: string,
       userIds: string[],
       { logger, headers, authData }: WithLogger<BffAppContext>
-    ): Promise<bffApi.PublicKey[]> {
+    ): Promise<bffApi.PublicKeys> {
       logger.info(`Retrieve keys of client ${clientId}`);
 
       const { keys } = await authorizationClient.client.getClientKeys({
@@ -165,11 +165,13 @@ export function clientServiceBuilder(
         headers,
       });
 
-      return Promise.all(
+      const decoratedKeys = await Promise.all(
         keys.map((k) =>
           decorateKey(selfcareUsersClient, k, authData.selfcareId)
         )
       );
+
+      return { keys: decoratedKeys };
     },
 
     async addClientPurpose(
@@ -189,7 +191,7 @@ export function clientServiceBuilder(
       clientId: string,
       selfcareId: string,
       { logger, headers }: WithLogger<BffAppContext>
-    ): Promise<bffApi.CompactUser[]> {
+    ): Promise<bffApi.CompactUsers> {
       logger.info(`Retrieving users for client ${clientId}`);
 
       const clientUsers = await authorizationClient.client.getClientUsers({

--- a/packages/bff/src/services/clientService.ts
+++ b/packages/bff/src/services/clientService.ts
@@ -12,7 +12,10 @@ import {
   PagoPAInteropBeClients,
 } from "../clients/clientsProvider.js";
 import { BffAppContext } from "../utilities/context.js";
-import { toAuthorizationKeySeed } from "../api/authorizationApiConverter.js";
+import {
+  toAuthorizationKeySeed,
+  toBffApiCompactClient,
+} from "../api/authorizationApiConverter.js";
 import { toBffApiCompactUser } from "../api/selfcareApiConverter.js";
 
 export function clientServiceBuilder(
@@ -39,10 +42,10 @@ export function clientServiceBuilder(
         kind?: bffApi.ClientKind;
       },
       { logger, headers }: WithLogger<BffAppContext>
-    ): Promise<authorizationApi.ClientsWithKeys> {
+    ): Promise<bffApi.CompactClients> {
       logger.info(`Retrieving clients`);
 
-      return authorizationClient.client.getClientsWithKeys({
+      const clients = await authorizationClient.client.getClientsWithKeys({
         queries: {
           offset,
           limit,
@@ -54,6 +57,15 @@ export function clientServiceBuilder(
         },
         headers,
       });
+
+      return {
+        results: clients.results.map(toBffApiCompactClient),
+        pagination: {
+          limit,
+          offset,
+          totalCount: clients.totalCount,
+        },
+      };
     },
 
     async getClientById(

--- a/packages/bff/src/services/producerKeychainService.ts
+++ b/packages/bff/src/services/producerKeychainService.ts
@@ -139,7 +139,7 @@ export function producerKeychainServiceBuilder(
       producerKeychainId: string,
       userIds: string[],
       { logger, headers, authData }: WithLogger<BffAppContext>
-    ): Promise<bffApi.PublicKey[]> {
+    ): Promise<bffApi.PublicKeys> {
       logger.info(`Retrieve keys of producer keychain ${producerKeychainId}`);
 
       const selfcareId = authData.selfcareId;
@@ -151,9 +151,11 @@ export function producerKeychainServiceBuilder(
           headers,
         });
 
-      return Promise.all(
+      const decoratedKeys = await Promise.all(
         keys.map((k) => decorateKey(selfcareUsersClient, k, selfcareId))
       );
+
+      return { keys: decoratedKeys };
     },
     async getProducerKeyById(
       producerKeychainId: string,
@@ -194,7 +196,7 @@ export function producerKeychainServiceBuilder(
     async getProducerKeychainUsers(
       producerKeychainId: string,
       { logger, headers, authData }: WithLogger<BffAppContext>
-    ): Promise<bffApi.CompactUser[]> {
+    ): Promise<bffApi.CompactUsers> {
       logger.info(
         `Retrieving users for producer keychain ${producerKeychainId}`
       );

--- a/packages/bff/src/services/purposeService.ts
+++ b/packages/bff/src/services/purposeService.ts
@@ -266,9 +266,7 @@ export function purposeServiceBuilder(
     async createPurposeForReceiveEservice(
       createSeed: bffApi.PurposeEServiceSeed,
       { logger, headers }: WithLogger<BffAppContext>
-    ): Promise<
-      ReturnType<typeof purposeProcessClient.createPurposeFromEService>
-    > {
+    ): Promise<bffApi.CreatedResource> {
       logger.info(
         `Creating purpose from ESErvice ${createSeed.eserviceId} and Risk Analysis ${createSeed.riskAnalysisId}`
       );
@@ -276,15 +274,20 @@ export function purposeServiceBuilder(
         ...createSeed,
         eServiceId: createSeed.eserviceId,
       };
-      return await purposeProcessClient.createPurposeFromEService(payload, {
-        headers,
-      });
+
+      const { id } = await purposeProcessClient.createPurposeFromEService(
+        payload,
+        {
+          headers,
+        }
+      );
+      return { id };
     },
     async reversePurposeUpdate(
       id: PurposeId,
       updateSeed: bffApi.ReversePurposeUpdateContent,
       { logger, headers }: WithLogger<BffAppContext>
-    ): Promise<{ purposeId: PurposeId; versionId: PurposeVersionId }> {
+    ): Promise<bffApi.PurposeVersionResource> {
       logger.info(`Updating reverse purpose ${id}`);
       const updatedPurpose = await purposeProcessClient.updateReversePurpose(
         updateSeed,


### PR DESCRIPTION
This PR introduces a `Zod.parse` on every response of the BFF router.
This guarantees that we are not returning properties in excess to the client avoiding potential security issues or leaking of information.