### PR TITLE
IMN-835 - fix query params Attribute kinds array required in zodios patch

### DIFF
--- a/packages/api-clients/template-bff.hbs
+++ b/packages/api-clients/template-bff.hbs
@@ -40,8 +40,8 @@ export const {{@key}}Endpoints = makeApi([
 				{{/if}}
 				{{#if (and (eq type "Query") (eq schema "z.array(z.string()).optional().default([])"))}}
 						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string()).optional().default([])), z.array(z.string()).optional().default([])]),
-				{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind)"))}}
-						schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)), z.array(AttributeKind)])
+				{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind).default([])"))}}
+						schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind).default([])), z.array(AttributeKind).default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(AgreementState).optional().default([])"))}}
 						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(AgreementState).optional().default([])),z.array(AgreementState).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(EServiceDescriptorState).optional().default([])"))}}

--- a/packages/backend-for-frontend/src/routers/attributeRouter.ts
+++ b/packages/backend-for-frontend/src/routers/attributeRouter.ts
@@ -96,6 +96,7 @@ const attributeRouter = (
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
       try {
+        ctx.logger.info(`Query params provided : ${JSON.stringify(req.query)}`);
         const { q, offset, limit, kinds, origin } = req.query;
 
         const attributes = await attributeService.getAttributes(

--- a/packages/backend-for-frontend/src/routers/attributeRouter.ts
+++ b/packages/backend-for-frontend/src/routers/attributeRouter.ts
@@ -96,7 +96,6 @@ const attributeRouter = (
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
       try {
-        ctx.logger.info(`Query params provided : ${JSON.stringify(req.query)}`);
         const { q, offset, limit, kinds, origin } = req.query;
 
         const attributes = await attributeService.getAttributes(


### PR DESCRIPTION
Close IMN-835

# Description
Fix how query params type array of attribute kind are processed by patch using bff-template.

## Local testing 

### Using more `kind` query param
<img width="1024" alt="Screenshot 2024-09-26 at 11 44 39" src="https://github.com/user-attachments/assets/289aaa75-1af8-40d5-ab04-fc6ae1664282">

### Using single `kind` query param
<img width="1024" alt="Screenshot 2024-09-26 at 11 44 29" src="https://github.com/user-attachments/assets/2d230246-9396-435a-96cf-da44ae1128da">

