### PR TITLE
IMN-838 - Fix attributes creation

### DIFF
--- a/packages/backend-for-frontend/src/api/attributeApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/attributeApiConverter.ts
@@ -1,7 +1,7 @@
 import { createHash } from "crypto";
 import { bffApi, attributeRegistryApi } from "pagopa-interop-api-clients";
 
-export const toApiAttributeProcessSeed = (
+export const toApiCertifiedAttributeProcessSeed = (
   seed: bffApi.AttributeSeed
 ): attributeRegistryApi.CertifiedAttributeSeed => ({
   ...seed,

--- a/packages/backend-for-frontend/src/services/attributeService.ts
+++ b/packages/backend-for-frontend/src/services/attributeService.ts
@@ -53,12 +53,9 @@ export function attributeServiceBuilder(
     ): Promise<bffApi.Attribute> {
       logger.info(`Creating verified attribute with name ${seed.name}`);
 
-      return attributeClient.createVerifiedAttribute(
-        toApiAttributeProcessSeed(seed),
-        {
-          headers,
-        }
-      );
+      return attributeClient.createVerifiedAttribute(seed, {
+        headers,
+      });
     },
 
     async createDeclaredAttribute(
@@ -67,12 +64,9 @@ export function attributeServiceBuilder(
     ): Promise<bffApi.Attribute> {
       logger.info(`Creating declared attribute with name ${seed.name}`);
 
-      return attributeClient.createDeclaredAttribute(
-        toApiAttributeProcessSeed(seed),
-        {
-          headers,
-        }
-      );
+      return attributeClient.createDeclaredAttribute(seed, {
+        headers,
+      });
     },
 
     async getAttributeById(

--- a/packages/backend-for-frontend/src/services/attributeService.ts
+++ b/packages/backend-for-frontend/src/services/attributeService.ts
@@ -8,7 +8,7 @@ import {
 } from "../clients/clientsProvider.js";
 import { BffAppContext } from "../utilities/context.js";
 import {
-  toApiAttributeProcessSeed,
+  toApiCertifiedAttributeProcessSeed,
   toCompactAttribute,
 } from "../api/attributeApiConverter.js";
 
@@ -40,7 +40,7 @@ export function attributeServiceBuilder(
       logger.info(`Creating certified attribute with name ${seed.name}`);
 
       return attributeClient.createCertifiedAttribute(
-        toApiAttributeProcessSeed(seed),
+        toApiCertifiedAttributeProcessSeed(seed),
         {
           headers,
         }


### PR DESCRIPTION
The declared and verified attribute creation attribute process call does not need the `toApiAttributeProcessSeed` remapper.

The remapper in question was adding a `code` property which presence is not compatible with body the process calls was expecting.