### PR TITLE
IMN-840 - Purpose service Fix returned type

### DIFF
--- a/packages/backend-for-frontend/src/services/purposeService.ts
+++ b/packages/backend-for-frontend/src/services/purposeService.ts
@@ -255,13 +255,14 @@ export function purposeServiceBuilder(
     async createPurpose(
       createSeed: bffApi.PurposeSeed,
       { logger, headers }: WithLogger<BffAppContext>
-    ): Promise<ReturnType<typeof purposeProcessClient.createPurpose>> {
+    ): Promise<bffApi.CreatedResource> {
       logger.info(
         `Creating purpose with eService ${createSeed.eserviceId} and consumer ${createSeed.consumerId}`
       );
-      return await purposeProcessClient.createPurpose(createSeed, {
+      const result = await purposeProcessClient.createPurpose(createSeed, {
         headers,
       });
+      return { id: result.id };
     },
     async createPurposeForReceiveEservice(
       createSeed: bffApi.PurposeEServiceSeed,


### PR DESCRIPTION
Closes [IMN-840](https://pagopa.atlassian.net/browse/IMN-840?atlOrigin=eyJpIjoiMTliZTBlNTA5MzQ3NDdjNWFjYzBmN2I5ODEyNzBmMjAiLCJwIjoiaiJ9)

# Description 
Fix Purpose service returned type, Bff returns CreatedResource for endpoint `/purposes`

### Local test 
<img width="1087" alt="Screenshot 2024-09-26 at 16 41 13" src="https://github.com/user-attachments/assets/be8e5557-571d-4fc1-9995-e79ed788d73c">



[IMN-840]: https://pagopa.atlassian.net/browse/IMN-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ