### PR TITLE
Fix wrong `req` value serialization in error log

### DIFF
--- a/packages/backend-for-frontend/src/routers/producerKeychainRouter.ts
+++ b/packages/backend-for-frontend/src/routers/producerKeychainRouter.ts
@@ -82,7 +82,9 @@ const producerKeychainRouter = (
           error,
           emptyErrorMapper,
           ctx.logger,
-          `Error creating producer keychain with seed: ${JSON.stringify(req)}`
+          `Error creating producer keychain with seed: ${JSON.stringify(
+            req.body
+          )}`
         );
         return res.status(errorRes.status).send(errorRes);
       }


### PR DESCRIPTION
`JSON.stringify` could not serialize the `req` object and that led to the entire crash of the pod