### PR TITLE
IMN-839 Return false if certified attributes is empty

### DIFF
--- a/packages/agreement-lifecycle/src/validator/attributesValidator.ts
+++ b/packages/agreement-lifecycle/src/validator/attributesValidator.ts
@@ -20,13 +20,14 @@ const attributesSatisfied = (
   descriptorAttributes: EServiceAttribute[][],
   consumerAttributeIds: Array<TenantAttribute["id"]>
 ): boolean =>
-  descriptorAttributes.length > 0 &&
-  descriptorAttributes.every((attributeList) => {
-    const attributes = attributeList.map((a) => a.id);
-    return (
-      attributes.filter((a) => consumerAttributeIds.includes(a)).length > 0
-    );
-  });
+  descriptorAttributes
+    .filter((attGroup) => attGroup.length > 0)
+    .every((attributeList) => {
+      const attributes = attributeList.map((a) => a.id);
+      return (
+        attributes.filter((a) => consumerAttributeIds.includes(a)).length > 0
+      );
+    });
 
 export const certifiedAttributesSatisfied = (
   descriptor: DescriptorWithOnlyAttributes,

--- a/packages/agreement-lifecycle/src/validator/attributesValidator.ts
+++ b/packages/agreement-lifecycle/src/validator/attributesValidator.ts
@@ -20,6 +20,7 @@ const attributesSatisfied = (
   descriptorAttributes: EServiceAttribute[][],
   consumerAttributeIds: Array<TenantAttribute["id"]>
 ): boolean =>
+  descriptorAttributes.length > 0 &&
   descriptorAttributes.every((attributeList) => {
     const attributes = attributeList.map((a) => a.id);
     return (


### PR DESCRIPTION
# Description
The function `attributesSatisfied` used to check if all Eservice descriptor attributes are contained into Tenant attributes, 
using [Array.every()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) 
that properly returns true if the array is empty ([example](https://www.typescriptlang.org/play/?#code/MYewdgzgLgBAhgJwQRgFzQQSzAcwNoC6MAvDIQNwBQloksUAptCfEsgHQMBuDCAngAoBAShIA+GFAQBXBsOq0IIADYN2ykDgGNowoA)). 
But it doesn't work properly with an array of empty array, eg:
```
[[],[]].every( predicate )
```

In some case array of empty array were saved into read model and it generate the BUG, `every` function doesn't works as expected with an array of empty array.

# FIX
Filter empty array from provided list

