### PR TITLE
Fix delete keys from producer keychain and client logic

### DIFF
--- a/packages/authorization-process/src/model/domain/errors.ts
+++ b/packages/authorization-process/src/model/domain/errors.ts
@@ -37,6 +37,7 @@ export const errorCodes = {
   producerKeyNotFound: "0024",
   organizationNotAllowedOnEService: "0025",
   eserviceAlreadyLinkedToProducerKeychain: "0026",
+  userNotAllowedToDeleteProducerKeychainKey: "0027",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -257,6 +258,18 @@ export function userNotAllowedOnProducerKeychain(
     detail: `User ${userId} is not allowed on producer keychain ${producerKeychain}`,
     code: "userNotAllowedOnProducerKeychain",
     title: "User not allowed on producer keychain",
+  });
+}
+
+export function userNotAllowedToDeleteProducerKeychainKey(
+  userId: UserId,
+  producerKeychain: ProducerKeychainId,
+  kid: string
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `User ${userId} is not allowed to delete producer keychain (${producerKeychain}) key ${kid}`,
+    code: "userNotAllowedToDeleteProducerKeychainKey",
+    title: "User not allowed to delete producer keychain key",
   });
 }
 

--- a/packages/authorization-process/src/model/domain/errors.ts
+++ b/packages/authorization-process/src/model/domain/errors.ts
@@ -37,7 +37,8 @@ export const errorCodes = {
   producerKeyNotFound: "0024",
   organizationNotAllowedOnEService: "0025",
   eserviceAlreadyLinkedToProducerKeychain: "0026",
-  userNotAllowedToDeleteProducerKeychainKey: "0027",
+  userNotAllowedToDeleteClientKey: "0027",
+  userNotAllowedToDeleteProducerKeychainKey: "0028",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -258,6 +259,18 @@ export function userNotAllowedOnProducerKeychain(
     detail: `User ${userId} is not allowed on producer keychain ${producerKeychain}`,
     code: "userNotAllowedOnProducerKeychain",
     title: "User not allowed on producer keychain",
+  });
+}
+
+export function userNotAllowedToDeleteClientKey(
+  userId: UserId,
+  client: ClientId,
+  kid: string
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `User ${userId} is not allowed to delete client (${client}) key ${kid}`,
+    code: "userNotAllowedToDeleteClientKey",
+    title: "User not allowed to delete producer keychain key",
   });
 }
 


### PR DESCRIPTION
It is possibile to delete a client/producer keychain key, only when:
- The user requesting it is inside the client/producer keychain;
- Then, If the requester is a security operator, he can delete only the keys he himself uploaded;