### PR TITLE
IMN-863 - Fixing Add Consumer Document path in BFF

### DIFF
--- a/packages/backend-for-frontend/src/services/agreementService.ts
+++ b/packages/backend-for-frontend/src/services/agreementService.ts
@@ -153,7 +153,7 @@ export function agreementServiceBuilder(
       const documentContent = Buffer.from(await doc.doc.arrayBuffer());
       const documentId = randomUUID();
 
-      const path = await fileManager.storeBytes(
+      const storagePath = await fileManager.storeBytes(
         {
           bucket: config.consumerDocumentsContainer,
           path: documentPath,
@@ -169,7 +169,7 @@ export function agreementServiceBuilder(
         prettyName: doc.prettyName,
         name: doc.doc.name,
         contentType: doc.doc.type,
-        path,
+        path: storagePath,
       };
 
       await agreementProcessClient.addAgreementConsumerDocument(seed, {

--- a/packages/backend-for-frontend/src/services/agreementService.ts
+++ b/packages/backend-for-frontend/src/services/agreementService.ts
@@ -153,7 +153,7 @@ export function agreementServiceBuilder(
       const documentContent = Buffer.from(await doc.doc.arrayBuffer());
       const documentId = randomUUID();
 
-      await fileManager.storeBytes(
+      const path = await fileManager.storeBytes(
         {
           bucket: config.consumerDocumentsContainer,
           path: documentPath,
@@ -169,7 +169,7 @@ export function agreementServiceBuilder(
         prettyName: doc.prettyName,
         name: doc.doc.name,
         contentType: doc.doc.type,
-        path: documentPath,
+        path,
       };
 
       await agreementProcessClient.addAgreementConsumerDocument(seed, {

--- a/packages/commons/src/file-manager/fileManager.ts
+++ b/packages/commons/src/file-manager/fileManager.ts
@@ -20,11 +20,6 @@ import {
 } from "./fileManagerErrors.js";
 
 export type FileManager = {
-  buildS3Key: (
-    path: string,
-    resourceId: string | undefined,
-    fileName: string
-  ) => string;
   delete: (bucket: string, path: string, logger: Logger) => Promise<void>;
   copy: (
     bucket: string,
@@ -105,11 +100,6 @@ export function initFileManager(
   };
 
   return {
-    buildS3Key: (
-      path: string,
-      resourceId: string | undefined,
-      fileName: string
-    ): string => buildS3Key(path, resourceId, fileName),
     delete: async (
       bucket: string,
       path: string,


### PR DESCRIPTION
Closes [IMN-863](https://pagopa.atlassian.net/browse/IMN-863)

## Before

1. Add a consumer document to an agreement
2. Try to retrieve it
3. Error (logs say the file cannot be found in the bucket at the specified path)

## After

The same flow works - **the document must be re-added because the error was on the add, not on the retrieve.**


[IMN-863]: https://pagopa.atlassian.net/browse/IMN-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ