### PR TITLE
IMN-870 - Fixing parsing error in /reverse/purposes

### DIFF
--- a/packages/backend-for-frontend/src/services/purposeService.ts
+++ b/packages/backend-for-frontend/src/services/purposeService.ts
@@ -276,9 +276,15 @@ export function purposeServiceBuilder(
       logger.info(
         `Creating purpose from ESErvice ${createSeed.eserviceId} and Risk Analysis ${createSeed.riskAnalysisId}`
       );
-      const payload = {
-        ...createSeed,
+      const payload: purposeApi.EServicePurposeSeed = {
         eServiceId: createSeed.eserviceId,
+        consumerId: createSeed.consumerId,
+        riskAnalysisId: createSeed.riskAnalysisId,
+        title: createSeed.title,
+        description: createSeed.description,
+        isFreeOfCharge: createSeed.isFreeOfCharge,
+        freeOfChargeReason: createSeed.freeOfChargeReason,
+        dailyCalls: createSeed.dailyCalls,
       };
 
       const { id } = await purposeProcessClient.createPurposeFromEService(


### PR DESCRIPTION
Closes [IMN-870](https://pagopa.atlassian.net/browse/IMN-870)

## Before

<img width="609" alt="Screenshot 2024-10-02 at 16 30 34" src="https://github.com/user-attachments/assets/96f6b7b6-3f08-446a-818d-006e145679bd">

### A parsing error happened in purpose process call
<img width="748" alt="Screenshot 2024-10-02 at 16 30 56" src="https://github.com/user-attachments/assets/1686deed-b2dc-41fb-b2e2-046461d33d01">


## After: 200 OK ✅ 
<img width="599" alt="Screenshot 2024-10-02 at 16 34 19" src="https://github.com/user-attachments/assets/3c2a65ed-f6ce-4ea1-9284-504714f7c031">

Purpose created in the read model
<img width="677" alt="image" src="https://github.com/user-attachments/assets/6ff7310a-e493-4c49-bf96-a9ab7f45a5dd">



[IMN-870]: https://pagopa.atlassian.net/browse/IMN-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ