### PR TITLE
Fixing main build after  #973

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -87,8 +87,8 @@ jobs:
             dockerfile_path: packages/pn-consumers
           - image_name: one-trust-notices
             dockerfile_path: packages/one-trust-notices
-          - image_name: datalake-data-exporter
-            dockerfile_path: packages/datalake-data-exporter
+          - image_name: datalake-data-export
+            dockerfile_path: packages/datalake-data-export
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The build on main is broken due to a typo in a package folder name after #973 