### PR TITLE
PIN-5410 -  Added new events and `delegationId`to `EService` models

### DIFF
--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -1453,6 +1453,9 @@ components:
             $ref: "#/components/schemas/EServiceRiskAnalysis"
         mode:
           $ref: "#/components/schemas/EServiceMode"
+        delegationid:
+          type: string
+          format: uuid
     EServiceMode:
       type: string
       description: Risk Analysis Mode

--- a/packages/authorization-updater/src/index.ts
+++ b/packages/authorization-updater/src/index.ts
@@ -122,7 +122,9 @@ export async function sendCatalogAuthUpdate(
           "EServiceRiskAnalysisUpdated",
           "EServiceRiskAnalysisDeleted",
           "EServiceDescriptorQuotasUpdated",
-          "EServiceDescriptionUpdated"
+          "EServiceDescriptionUpdated",
+          "EServiceDelegationAssigned",
+          "EServiceDelegationRevoked"
         ),
       },
       () => {

--- a/packages/catalog-outbound-writer/src/converters/toOutboundEventV2.ts
+++ b/packages/catalog-outbound-writer/src/converters/toOutboundEventV2.ts
@@ -133,6 +133,22 @@ export function toOutboundEventV2(
       })
     )
     .with(
+      { type: "EServiceDelegationAssigned" },
+      { type: "EServiceDelegationRevoked" },
+      (msg) => ({
+        event_version: msg.event_version,
+        type: msg.type,
+        version: msg.version,
+        data: {
+          delegationId: msg.data.delegationId,
+          eservice:
+            msg.data.eservice && toOutboundEServiceV2(msg.data.eservice),
+        },
+        stream_id: msg.stream_id,
+        timestamp: new Date(),
+      })
+    )
+    .with(
       { type: "EServiceRiskAnalysisAdded" },
       { type: "EServiceRiskAnalysisDeleted" },
       { type: "EServiceRiskAnalysisUpdated" },

--- a/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
+++ b/packages/catalog-readmodel-writer/src/consumerServiceV2.ts
@@ -41,6 +41,8 @@ export async function handleMessageV2(
       { type: "EServiceRiskAnalysisUpdated" },
       { type: "EServiceRiskAnalysisDeleted" },
       { type: "EServiceDescriptionUpdated" },
+      { type: "EServiceDelegationAssigned" },
+      { type: "EServiceDelegationRevoked" },
       async (message) =>
         await eservices.updateOne(
           {

--- a/packages/models/proto/v2/eservice/eservice.proto
+++ b/packages/models/proto/v2/eservice/eservice.proto
@@ -12,6 +12,7 @@ message EServiceV2 {
   int64 createdAt = 7;
   repeated EServiceRiskAnalysisV2 riskAnalysis = 8;
   EServiceModeV2 mode = 9;
+  optional string delegationId = 10;
 }
 
 

--- a/packages/models/proto/v2/eservice/events.proto
+++ b/packages/models/proto/v2/eservice/events.proto
@@ -117,3 +117,13 @@ message EServiceRiskAnalysisDeletedV2 {
 message EServiceDescriptionUpdatedV2 {
     EServiceV2 eservice = 1;
 }
+
+message EServiceDelegationAssignedV2 {
+  string delegationId = 1;
+  EServiceV2 eservice = 2;
+}
+
+message EServiceDelegationRevokedV2 {
+  string delegationId = 1;
+  EServiceV2 eservice = 2;
+}

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 import {
   AttributeId,
+  DelegationId,
   DescriptorId,
   EServiceDocumentId,
   EServiceId,
@@ -105,5 +106,6 @@ export const EService = z.object({
   createdAt: z.coerce.date(),
   riskAnalysis: z.array(RiskAnalysis),
   mode: EServiceMode,
+  delegationId: DelegationId.optional(),
 });
 export type EService = z.infer<typeof EService>;

--- a/packages/models/src/eservice/eserviceEvents.ts
+++ b/packages/models/src/eservice/eserviceEvents.ts
@@ -41,6 +41,8 @@ import {
   EServiceRiskAnalysisUpdatedV2,
   EServiceRiskAnalysisDeletedV2,
   EServiceDescriptionUpdatedV2,
+  EServiceDelegationAssignedV2,
+  EServiceDelegationRevokedV2,
 } from "../gen/v2/eservice/events.js";
 
 export function catalogEventToBinaryData(event: EServiceEvent): Uint8Array {
@@ -163,6 +165,12 @@ export function catalogEventToBinaryDataV2(event: EServiceEventV2): Uint8Array {
       EServiceRiskAnalysisDeletedV2.toBinary(data)
     )
     .with({ type: "EServiceDescriptionUpdated" }, ({ data }) =>
+      EServiceDescriptionUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceDelegationAssigned" }, ({ data }) =>
+      EServiceDescriptionUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceDelegationRevoked" }, ({ data }) =>
       EServiceDescriptionUpdatedV2.toBinary(data)
     )
     .exhaustive();
@@ -352,6 +360,16 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("EServiceDescriptionUpdated"),
     data: protobufDecoder(EServiceDescriptionUpdatedV2),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDelegationAssigned"),
+    data: protobufDecoder(EServiceDelegationAssignedV2),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDelegationRevoked"),
+    data: protobufDecoder(EServiceDelegationRevokedV2),
   }),
 ]);
 export type EServiceEventV2 = z.infer<typeof EServiceEventV2>;

--- a/packages/models/src/eservice/protobufConverterFromV2.ts
+++ b/packages/models/src/eservice/protobufConverterFromV2.ts
@@ -1,4 +1,4 @@
-import { unsafeBrandId } from "../brandedIds.js";
+import { DelegationId, unsafeBrandId } from "../brandedIds.js";
 import {
   AgreementApprovalPolicyV2,
   EServiceAttributeV2,
@@ -163,4 +163,7 @@ export const fromEServiceV2 = (input: EServiceV2): EService => ({
   createdAt: bigIntToDate(input.createdAt),
   riskAnalysis: input.riskAnalysis.map(fromRiskAnalysisV2),
   mode: fromEServiceModeV2(input.mode),
+  delegationId: input.delegationId
+    ? unsafeBrandId<DelegationId>(input.delegationId)
+    : undefined,
 });

--- a/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationConverter.ts
+++ b/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationConverter.ts
@@ -241,4 +241,10 @@ export const toCatalogItemEventNotification = (
         catalogRiskAnalysisId: e.data.riskAnalysisId,
       })
     )
+    // TODO: For now we skip those event, they will be handled with task PIN-5424
+    .with(
+      { type: "EServiceDelegationAssigned" },
+      { type: "EServiceDelegationRevoked" },
+      (): CatalogItemRiskAnalysisNotification => undefined as never
+    )
     .exhaustive();

--- a/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationMessage.ts
+++ b/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationMessage.ts
@@ -57,6 +57,13 @@ export const eventV2TypeMapper = (
       "EServiceRiskAnalysisDeleted",
       () => "catalog_item_risk_analysis_deleted"
     )
+    // TODO: For now we skip those event, they will be handled with task PIN-5424
+    .with(
+      "EServiceDelegationAssigned",
+      "EServiceDelegationRevoked",
+      () => undefined as never
+    )
+
     .exhaustive();
 
 /* 


### PR DESCRIPTION
Closes [PIN-5410](https://pagopa.atlassian.net/browse/PIN-5410)

This PR is dependent on https://github.com/pagopa/interop-outbound-models/pull/11 from the interop-outbound-models repo.

[PIN-5410]: https://pagopa.atlassian.net/browse/PIN-5410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ