### PR TITLE
IMN-879 - Refactoring headers parsing and improving auth

### DIFF
--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -31,7 +31,7 @@ const redisRateLimiter = await initRedisRateLimiter({
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware(serviceName, true));
+app.use(contextMiddleware(serviceName, false));
 
 // Unauthenticated routes
 app.use(healthRouter);

--- a/packages/backend-for-frontend/src/app.ts
+++ b/packages/backend-for-frontend/src/app.ts
@@ -53,8 +53,6 @@ app.disable("x-powered-by");
 
 app.disable("etag");
 
-app.use(loggerMiddleware(serviceName));
-
 // parse files from multipart/form-data and put them in req.body
 app.use(multerMiddleware);
 app.use(fromFilesToBodyMiddleware);
@@ -63,6 +61,7 @@ app.use(fromFilesToBodyMiddleware);
 app.use(express.urlencoded({ extended: true }));
 
 app.use(contextMiddleware(serviceName, false));
+app.use(loggerMiddleware(serviceName));
 
 app.use(
   `/backend-for-frontend/${config.backendForFrontendInterfaceVersion}`,

--- a/packages/backend-for-frontend/src/app.ts
+++ b/packages/backend-for-frontend/src/app.ts
@@ -62,7 +62,7 @@ app.use(fromFilesToBodyMiddleware);
 // parse application/x-www-form-urlencoded and put it in req.body
 app.use(express.urlencoded({ extended: true }));
 
-app.use(contextMiddleware(serviceName, true));
+app.use(contextMiddleware(serviceName, false));
 
 app.use(
   `/backend-for-frontend/${config.backendForFrontendInterfaceVersion}`,

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -57,7 +57,7 @@ export const authenticationMiddleware: (
           match(err.code)
             .with("unauthorizedError", () => 401)
             .with("operationForbidden", () => 403)
-            .with("missingHeader", "badBearer", () => 400)
+            .with("missingHeader", "badBearerToken", () => 400)
             .otherwise(() => 500),
         loggerInstance
       );

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -7,11 +7,11 @@ import {
 import { match } from "ts-pattern";
 import {
   ExpressContext,
+  fromAppContext,
   getJwksClients,
   JWTConfig,
   jwtFromAuthHeader,
 } from "../index.js";
-import { logger } from "../logging/index.js";
 import { AuthData } from "./authData.js";
 import { readAuthDataFromJwtToken, verifyJwtToken } from "./jwt.js";
 
@@ -24,29 +24,23 @@ export const authenticationMiddleware: (
   async (req, res, next): Promise<unknown> => {
     // We assume that:
     // - contextMiddleware already set ctx.serviceName and ctx.correlationId
-    const loggerInstance = logger({
-      serviceName: req.ctx.serviceName,
-      correlationId: req.ctx.correlationId,
-    });
+    const ctx = fromAppContext(req.ctx);
 
     try {
       const jwksClients = getJwksClients(config);
 
-      const jwtToken = jwtFromAuthHeader(req, loggerInstance);
+      const jwtToken = jwtFromAuthHeader(req, ctx.logger);
       const valid = await verifyJwtToken(
         jwtToken,
         jwksClients,
         config,
-        loggerInstance
+        ctx.logger
       );
       if (!valid) {
         throw unauthorizedError("Invalid token");
       }
 
-      const authData: AuthData = readAuthDataFromJwtToken(
-        jwtToken,
-        loggerInstance
-      );
+      const authData: AuthData = readAuthDataFromJwtToken(jwtToken, ctx.logger);
       // eslint-disable-next-line functional/immutable-data
       req.ctx.authData = authData;
       return next();
@@ -59,7 +53,7 @@ export const authenticationMiddleware: (
             .with("operationForbidden", () => 403)
             .with("missingHeader", "badBearerToken", () => 400)
             .otherwise(() => 500),
-        loggerInstance
+        ctx.logger
       );
       return res.status(problem.status).send(problem);
     }

--- a/packages/commons/src/auth/authenticationMiddleware.ts
+++ b/packages/commons/src/auth/authenticationMiddleware.ts
@@ -57,7 +57,7 @@ export const authenticationMiddleware: (
           match(err.code)
             .with("unauthorizedError", () => 401)
             .with("operationForbidden", () => 403)
-            .with("missingHeader", () => 400)
+            .with("missingHeader", "badBearer", () => 400)
             .otherwise(() => 500),
         loggerInstance
       );

--- a/packages/commons/src/auth/headers.ts
+++ b/packages/commons/src/auth/headers.ts
@@ -1,5 +1,5 @@
 import { Request } from "express";
-import { missingBearer, missingHeader } from "pagopa-interop-models";
+import { badBearer, missingHeader } from "pagopa-interop-models";
 import { z } from "zod";
 import { Logger } from "../logging/index.js";
 
@@ -31,9 +31,9 @@ export function jwtFromAuthHeader(req: Request, logger: Logger): string {
   const authHeaderParts = authHeader.split(" ");
   if (authHeaderParts.length !== 2 || authHeaderParts[0] !== "Bearer") {
     logger.warn(
-      `No authentication provided for this call ${req.method} ${req.url}`
+      `Invalid authentication provided for this call ${req.method} ${req.url}`
     );
-    throw missingBearer;
+    throw badBearer;
   }
 
   return authHeaderParts[1];

--- a/packages/commons/src/auth/headers.ts
+++ b/packages/commons/src/auth/headers.ts
@@ -1,5 +1,5 @@
 import { Request } from "express";
-import { badBearer, missingHeader } from "pagopa-interop-models";
+import { badBearerToken, missingHeader } from "pagopa-interop-models";
 import { z } from "zod";
 import { Logger } from "../logging/index.js";
 
@@ -33,7 +33,7 @@ export function jwtFromAuthHeader(req: Request, logger: Logger): string {
     logger.warn(
       `Invalid authentication provided for this call ${req.method} ${req.url}`
     );
-    throw badBearer;
+    throw badBearerToken;
   }
 
   return authHeaderParts[1];

--- a/packages/commons/src/auth/jwt.ts
+++ b/packages/commons/src/auth/jwt.ts
@@ -78,12 +78,12 @@ export const verifyJwtToken = async (
     const jwtHeader = decodeJwtTokenHeaders(jwtToken, logger);
     if (!jwtHeader?.kid) {
       logger.warn("Token verification failed: missing kid");
-      return Promise.reject(false);
+      return Promise.resolve(false);
     }
 
     const secret: Secret = await getKey(jwksClients, jwtHeader.kid, logger);
 
-    return new Promise((resolve, _reject) => {
+    return new Promise((resolve) => {
       jwt.verify(
         jwtToken,
         secret,
@@ -101,7 +101,7 @@ export const verifyJwtToken = async (
     });
   } catch (error) {
     logger.error(`Error verifying JWT token: ${error}`);
-    return Promise.reject(false);
+    return Promise.resolve(false);
   }
 };
 

--- a/packages/commons/src/context/context.ts
+++ b/packages/commons/src/context/context.ts
@@ -55,7 +55,7 @@ export const contextMiddleware =
         return res.status(problem.status).send(problem);
       }
 
-      setCtx(correlationIdHeader || uuidv4());
+      setCtx(correlationIdHeader);
     } else {
       setCtx(uuidv4());
     }

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -193,7 +193,7 @@ const errorCodes = {
   tooManyRequestsError: "10004",
   notAllowedCertificateException: "10005",
   jwksSigningKeyError: "10006",
-  badBearer: "10007",
+  badBearerToken: "10007",
 } as const;
 
 export type CommonErrorCodes = keyof typeof errorCodes;
@@ -361,9 +361,9 @@ export function missingHeader(headerName?: string): ApiError<CommonErrorCodes> {
   });
 }
 
-export const badBearer: ApiError<CommonErrorCodes> = new ApiError({
+export const badBearerToken: ApiError<CommonErrorCodes> = new ApiError({
   detail: `Bad Bearer Token format in Authorization header`,
-  code: "badBearer",
+  code: "badBearerToken",
   title: "Bad Bearer Token format",
 });
 

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -193,6 +193,7 @@ const errorCodes = {
   tooManyRequestsError: "10004",
   notAllowedCertificateException: "10005",
   jwksSigningKeyError: "10006",
+  badBearer: "10007",
 } as const;
 
 export type CommonErrorCodes = keyof typeof errorCodes;
@@ -360,10 +361,10 @@ export function missingHeader(headerName?: string): ApiError<CommonErrorCodes> {
   });
 }
 
-export const missingBearer: ApiError<CommonErrorCodes> = new ApiError({
-  detail: `Mising Bearer in Authorization header`,
-  code: "missingHeader",
-  title: "Bearer token has not been passed",
+export const badBearer: ApiError<CommonErrorCodes> = new ApiError({
+  detail: `Bad Bearer Token format in Authorization header`,
+  code: "badBearer",
+  title: "Bad Bearer Token format",
 });
 
 export const operationForbidden: ApiError<CommonErrorCodes> = new ApiError({

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -354,16 +354,14 @@ export function jwtDecodingError(error: unknown): ApiError<CommonErrorCodes> {
 export function missingHeader(headerName?: string): ApiError<CommonErrorCodes> {
   const title = "Header has not been passed";
   return new ApiError({
-    detail: headerName
-      ? `Header ${headerName} not existing in this request`
-      : title,
+    detail: headerName ? `Missing ${headerName} request header` : title,
     code: "missingHeader",
     title,
   });
 }
 
 export const missingBearer: ApiError<CommonErrorCodes> = new ApiError({
-  detail: `Authorization Illegal header key.`,
+  detail: `Mising Bearer in Authorization header`,
   code: "missingHeader",
   title: "Bearer token has not been passed",
 });


### PR DESCRIPTION
Closes [IMN-879](https://pagopa.atlassian.net/browse/IMN-879)
Closes [IMN-878](https://pagopa.atlassian.net/browse/IMN-878)

This PR separates the correlationId parsing from the authentication/authorization.
CorrelationId parsing was moved into the contextMiddleware, where it's also possible to specify that correlationId should not be read from headers but just generated in place.
It also fixes an issue in authentication that was causing `500` instead of `401` on invalid token.

[IMN-879]: https://pagopa.atlassian.net/browse/IMN-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[IMN-878]: https://pagopa.atlassian.net/browse/IMN-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ