### PR TITLE
Handling health before any other middleware

### DIFF
--- a/packages/agreement-process/src/app.ts
+++ b/packages/agreement-process/src/app.ts
@@ -16,8 +16,8 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware(serviceName));
 app.use(healthRouter);
+app.use(contextMiddleware(serviceName));
 app.use(authenticationMiddleware(config));
 app.use(loggerMiddleware(serviceName));
 app.use(agreementRouter(zodiosCtx));

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -31,11 +31,10 @@ const redisRateLimiter = await initRedisRateLimiter({
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware(serviceName, false));
-
 app.use(
   `/api-gateway/${config.apiGatewayInterfaceVersion}`,
   healthRouter,
+  contextMiddleware(serviceName, false),
   authenticationMiddleware(config),
   // Authenticated routes - rate limiter and logger rely on auth data to work
   loggerMiddleware(serviceName),

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -31,13 +31,14 @@ const redisRateLimiter = await initRedisRateLimiter({
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
+app.use(loggerMiddleware(serviceName));
+
 app.use(
   `/api-gateway/${config.apiGatewayInterfaceVersion}`,
   healthRouter,
   contextMiddleware(serviceName, false),
   authenticationMiddleware(config),
-  // Authenticated routes - rate limiter and logger rely on auth data to work
-  loggerMiddleware(serviceName),
+  // Authenticated routes - rate limiter relies on auth data to work
   rateLimiterMiddleware(redisRateLimiter),
   apiGatewayRouter(zodiosCtx, clients)
 );

--- a/packages/attribute-registry-process/src/app.ts
+++ b/packages/attribute-registry-process/src/app.ts
@@ -16,8 +16,8 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware(serviceName));
 app.use(healthRouter);
+app.use(contextMiddleware(serviceName));
 app.use(authenticationMiddleware(config));
 app.use(loggerMiddleware(serviceName));
 app.use(attributeRouter(zodiosCtx));

--- a/packages/authorization-process/src/app.ts
+++ b/packages/authorization-process/src/app.ts
@@ -15,8 +15,8 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware(serviceName));
 app.use(healthRouter);
+app.use(contextMiddleware(serviceName));
 app.use(authenticationMiddleware(config));
 app.use(authorizationRouter(zodiosCtx));
 

--- a/packages/backend-for-frontend/src/app.ts
+++ b/packages/backend-for-frontend/src/app.ts
@@ -60,12 +60,11 @@ app.use(fromFilesToBodyMiddleware);
 // parse application/x-www-form-urlencoded and put it in req.body
 app.use(express.urlencoded({ extended: true }));
 
-app.use(contextMiddleware(serviceName, false));
-app.use(loggerMiddleware(serviceName));
-
 app.use(
   `/backend-for-frontend/${config.backendForFrontendInterfaceVersion}`,
   healthRouter,
+  contextMiddleware(serviceName, false),
+  loggerMiddleware(serviceName),
   authorizationRouter(zodiosCtx, clients, allowList, redisRateLimiter),
   authenticationMiddleware(config),
   // Authenticated routes - rate limiter relies on auth data to work

--- a/packages/backend-for-frontend/src/app.ts
+++ b/packages/backend-for-frontend/src/app.ts
@@ -60,11 +60,12 @@ app.use(fromFilesToBodyMiddleware);
 // parse application/x-www-form-urlencoded and put it in req.body
 app.use(express.urlencoded({ extended: true }));
 
+app.use(loggerMiddleware(serviceName));
+
 app.use(
   `/backend-for-frontend/${config.backendForFrontendInterfaceVersion}`,
   healthRouter,
   contextMiddleware(serviceName, false),
-  loggerMiddleware(serviceName),
   authorizationRouter(zodiosCtx, clients, allowList, redisRateLimiter),
   authenticationMiddleware(config),
   // Authenticated routes - rate limiter relies on auth data to work

--- a/packages/catalog-process/src/app.ts
+++ b/packages/catalog-process/src/app.ts
@@ -16,8 +16,8 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware(serviceName));
 app.use(healthRouter);
+app.use(contextMiddleware(serviceName));
 app.use(authenticationMiddleware(config));
 app.use(loggerMiddleware(serviceName));
 app.use(eservicesRouter(zodiosCtx));

--- a/packages/purpose-process/src/app.ts
+++ b/packages/purpose-process/src/app.ts
@@ -16,8 +16,8 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware(serviceName));
 app.use(healthRouter);
+app.use(contextMiddleware(serviceName));
 app.use(authenticationMiddleware(config));
 app.use(loggerMiddleware(serviceName));
 app.use(purposeRouter(zodiosCtx));

--- a/packages/tenant-process/src/app.ts
+++ b/packages/tenant-process/src/app.ts
@@ -16,8 +16,8 @@ const app = zodiosCtx.app();
 // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
 app.disable("x-powered-by");
 
-app.use(contextMiddleware(serviceName));
 app.use(healthRouter);
+app.use(contextMiddleware(serviceName));
 app.use(authenticationMiddleware(config));
 app.use(loggerMiddleware(serviceName));
 app.use(tenantRouter(zodiosCtx));


### PR DESCRIPTION
## Before

Processes were failing on status for missing correlation id:
<img width="515" alt="image" src="https://github.com/user-attachments/assets/9d0dec96-2158-4e08-b9c2-d5965bb71155">

<img width="482" alt="image" src="https://github.com/user-attachments/assets/79212bdd-0944-4ae9-aefb-60635f23b329">

## After
<img width="462" alt="image" src="https://github.com/user-attachments/assets/690caae0-67b1-4400-8699-36d6ba95724a">

<img width="375" alt="image" src="https://github.com/user-attachments/assets/d4033ab6-4594-44cd-91c4-209453e3f6b4">

<img width="374" alt="image" src="https://github.com/user-attachments/assets/047cf17e-dd97-4db1-b031-2174d1e047bd">

<img width="302" alt="image" src="https://github.com/user-attachments/assets/13809df2-f297-4ead-a500-1001081d55a5">
