### PR TITLE
Add some last missing correlationId branded types

### DIFF
--- a/packages/agreement-email-sender/src/index.ts
+++ b/packages/agreement-email-sender/src/index.ts
@@ -11,7 +11,10 @@ import {
 } from "pagopa-interop-commons";
 import {
   AgreementEvent,
+  CorrelationId,
+  generateId,
   missingKafkaMessageDataError,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { readModelServiceBuilder } from "./services/readModelService.js";
@@ -47,7 +50,9 @@ export async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
   loggerInstance.debug(decodedMessage);
 

--- a/packages/agreement-outbound-writer/src/index.ts
+++ b/packages/agreement-outbound-writer/src/index.ts
@@ -6,7 +6,12 @@ import {
   encodeOutboundAgreementEvent,
   AgreementEvent as AgreementOutboundEvent,
 } from "@pagopa/interop-outbound-models";
-import { AgreementEvent } from "pagopa-interop-models";
+import {
+  AgreementEvent,
+  CorrelationId,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { config } from "./config/config.js";
 import { toOutboundEventV1 } from "./converters/toOutboundEventV1.js";
 import { toOutboundEventV2 } from "./converters/toOutboundEventV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: msg.type,
     eventVersion: msg.event_version,
     streamId: msg.stream_id,
-    correlationId: msg.correlation_id,
+    correlationId: msg.correlation_id
+      ? unsafeBrandId<CorrelationId>(msg.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   const outboundEvent: AgreementOutboundEvent = match(msg)

--- a/packages/agreement-readmodel-writer/src/index.ts
+++ b/packages/agreement-readmodel-writer/src/index.ts
@@ -5,7 +5,12 @@ import {
   logger,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { AgreementEvent } from "pagopa-interop-models";
+import {
+  AgreementEvent,
+  CorrelationId,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { handleMessageV1 } from "./consumerServiceV1.js";
 import { handleMessageV2 } from "./consumerServiceV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: msg.type,
     eventVersion: msg.event_version,
     streamId: msg.stream_id,
-    correlationId: msg.correlation_id,
+    correlationId: msg.correlation_id
+      ? unsafeBrandId<CorrelationId>(msg.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   await match(msg)

--- a/packages/anac-certified-attributes-importer/src/index.ts
+++ b/packages/anac-certified-attributes-importer/src/index.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidv4 } from "uuid";
 import {
   InteropTokenGenerator,
   ReadModelRepository,
   RefreshableInteropToken,
   logger,
 } from "pagopa-interop-commons";
+import { CorrelationId, generateId } from "pagopa-interop-models";
 import { config } from "./config/config.js";
 import { SftpClient } from "./service/sftpService.js";
 import { ReadModelQueries } from "./service/readmodelQueriesService.js";
@@ -21,9 +21,10 @@ const tokenGenerator = new InteropTokenGenerator(config);
 const refreshableToken = new RefreshableInteropToken(tokenGenerator);
 const tenantProcess = new TenantProcessService(config.tenantProcessUrl);
 
+const correlationId: CorrelationId = generateId();
 const loggerInstance = logger({
   serviceName: "anac-certified-attributes-importer",
-  correlationId: uuidv4(),
+  correlationId,
 });
 
 await importAttributes(
@@ -33,5 +34,6 @@ await importAttributes(
   refreshableToken,
   config.recordsProcessBatchSize,
   config.anacTenantId,
-  loggerInstance
+  loggerInstance,
+  correlationId
 );

--- a/packages/anac-certified-attributes-importer/test/processor.test.ts
+++ b/packages/anac-certified-attributes-importer/test/processor.test.ts
@@ -7,7 +7,7 @@ import {
   RefreshableInteropToken,
   genericLogger,
 } from "pagopa-interop-commons";
-import { Tenant, unsafeBrandId } from "pagopa-interop-models";
+import { generateId, Tenant, unsafeBrandId } from "pagopa-interop-models";
 import { TenantProcessService } from "../src/service/tenantProcessService.js";
 import { SftpClient } from "../src/service/sftpService.js";
 import { ReadModelQueries } from "../src/service/readmodelQueriesService.js";
@@ -70,7 +70,8 @@ describe("ANAC Certified Attributes Importer", () => {
       refreshableTokenMock,
       10,
       "anac-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
   const refreshableInternalTokenSpy = vi
@@ -295,7 +296,8 @@ describe("ANAC Certified Attributes Importer", () => {
       refreshableTokenMock,
       1,
       "anac-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(downloadCSVSpy).toBeCalledTimes(1);

--- a/packages/api-gateway/src/utilities/context.ts
+++ b/packages/api-gateway/src/utilities/context.ts
@@ -1,8 +1,9 @@
 import { IncomingHttpHeaders } from "http";
 import { AppContext, WithLogger, logger } from "pagopa-interop-commons";
+import { CorrelationId } from "pagopa-interop-models";
 
 export type Headers = {
-  "X-Correlation-Id": string;
+  "X-Correlation-Id": CorrelationId;
   Authorization: string | undefined;
 };
 

--- a/packages/attribute-registry-readmodel-writer/src/index.ts
+++ b/packages/attribute-registry-readmodel-writer/src/index.ts
@@ -4,7 +4,12 @@ import {
   decodeKafkaMessage,
   logger,
 } from "pagopa-interop-commons";
-import { AttributeEvent } from "pagopa-interop-models";
+import {
+  AttributeEvent,
+  CorrelationId,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { runConsumer } from "kafka-iam-auth";
 import { handleMessage } from "./attributeRegistryConsumerService.js";
 import { config } from "./config/config.js";
@@ -22,7 +27,9 @@ async function processMessage({
     eventType: msg.type,
     eventVersion: msg.event_version,
     streamId: msg.stream_id,
-    correlationId: msg.correlation_id,
+    correlationId: msg.correlation_id
+      ? unsafeBrandId<CorrelationId>(msg.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   await handleMessage(msg, attributes);

--- a/packages/backend-for-frontend/src/services/clientService.ts
+++ b/packages/backend-for-frontend/src/services/clientService.ts
@@ -169,7 +169,7 @@ export function clientServiceBuilder(
     async getClientKeys(
       clientId: string,
       userIds: string[],
-      { logger, headers, authData }: WithLogger<BffAppContext>
+      { logger, headers, authData, correlationId }: WithLogger<BffAppContext>
     ): Promise<bffApi.PublicKeys> {
       logger.info(`Retrieve keys of client ${clientId}`);
 
@@ -192,7 +192,7 @@ export function clientServiceBuilder(
             k,
             authData.selfcareId,
             users,
-            headers["X-Correlation-Id"]
+            correlationId
           )
         )
       );
@@ -216,7 +216,7 @@ export function clientServiceBuilder(
     async getClientUsers(
       clientId: string,
       selfcareId: string,
-      { logger, headers }: WithLogger<BffAppContext>
+      { logger, headers, correlationId }: WithLogger<BffAppContext>
     ): Promise<bffApi.CompactUsers> {
       logger.info(`Retrieving users for client ${clientId}`);
 
@@ -231,7 +231,7 @@ export function clientServiceBuilder(
             selfcareUsersClient,
             id,
             selfcareId,
-            headers["X-Correlation-Id"]
+            correlationId
           ),
           id
         )
@@ -243,7 +243,7 @@ export function clientServiceBuilder(
       clientId: string,
       keyId: string,
       selfcareId: string,
-      { logger, headers }: WithLogger<BffAppContext>
+      { logger, headers, correlationId }: WithLogger<BffAppContext>
     ): Promise<bffApi.PublicKey> {
       logger.info(`Retrieve key ${keyId} for client ${clientId}`);
 
@@ -263,7 +263,7 @@ export function clientServiceBuilder(
         key,
         selfcareId,
         users,
-        headers["X-Correlation-Id"]
+        correlationId
       );
     },
 

--- a/packages/backend-for-frontend/src/services/selfcareService.ts
+++ b/packages/backend-for-frontend/src/services/selfcareService.ts
@@ -38,7 +38,7 @@ export function selfcareServiceBuilder(
       {
         authData: { selfcareId: institutionId, userId, organizationId },
         logger,
-        headers,
+        correlationId,
       }: WithLogger<BffAppContext>
     ): Promise<bffApi.User> {
       logger.info(
@@ -52,7 +52,7 @@ export function selfcareServiceBuilder(
           userId: userIdQuery,
         },
         headers: {
-          "X-Correlation-Id": headers["X-Correlation-Id"],
+          "X-Correlation-Id": correlationId,
         },
       });
 
@@ -66,7 +66,7 @@ export function selfcareServiceBuilder(
     async getSelfcareInstitutionsProducts({
       authData: { selfcareId: institutionId, userId },
       logger,
-      headers,
+      correlationId,
     }: WithLogger<BffAppContext>): Promise<bffApi.SelfcareProduct[]> {
       logger.info(
         `Retrieving Products for Institution ${institutionId} and User ${userId}`
@@ -76,7 +76,7 @@ export function selfcareServiceBuilder(
           params: { institutionId },
           queries: { userId },
           headers: {
-            "X-Correlation-Id": headers["X-Correlation-Id"],
+            "X-Correlation-Id": correlationId,
           },
         });
 
@@ -86,14 +86,14 @@ export function selfcareServiceBuilder(
     async getSelfcareInstitutions({
       authData: { userId },
       logger,
-      headers,
+      correlationId,
     }: WithLogger<BffAppContext>): Promise<bffApi.SelfcareInstitution[]> {
       logger.info(`Retrieving Institutions for User ${userId}`);
 
       const institutions = await selfcareV2Client.getInstitutionsUsingGET({
         queries: { userIdForAuth: userId },
         headers: {
-          "X-Correlation-Id": headers["X-Correlation-Id"],
+          "X-Correlation-Id": correlationId,
         },
       });
 
@@ -105,14 +105,16 @@ export function selfcareServiceBuilder(
       userId: string | undefined,
       roles: string[],
       query: string | undefined,
-      { authData, logger, headers }: WithLogger<BffAppContext>
+      { authData, logger, correlationId }: WithLogger<BffAppContext>
     ): Promise<bffApi.Users> {
       logger.info(`Retrieving users for institutions ${tenantId}`);
 
       const requesterId = authData.organizationId;
       const tenant = await tenantProcessClient.tenant.getTenant({
         params: { id: tenantId },
-        headers,
+        headers: {
+          "X-Correlation-Id": correlationId,
+        },
       });
 
       if (!tenant.selfcareId) {
@@ -129,7 +131,7 @@ export function selfcareServiceBuilder(
             productRoles: roles,
           },
           headers: {
-            "X-Correlation-Id": headers["X-Correlation-Id"],
+            "X-Correlation-Id": correlationId,
           },
         });
 

--- a/packages/catalog-outbound-writer/src/index.ts
+++ b/packages/catalog-outbound-writer/src/index.ts
@@ -6,7 +6,12 @@ import {
   encodeOutboundEServiceEvent,
   EServiceEvent as EServiceOutboundEvent,
 } from "@pagopa/interop-outbound-models";
-import { EServiceEvent } from "pagopa-interop-models";
+import {
+  CorrelationId,
+  EServiceEvent,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { config } from "./config/config.js";
 import { toOutboundEventV1 } from "./converters/toOutboundEventV1.js";
 import { toOutboundEventV2 } from "./converters/toOutboundEventV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: msg.type,
     eventVersion: msg.event_version,
     streamId: msg.stream_id,
-    correlationId: msg.correlation_id,
+    correlationId: msg.correlation_id
+      ? unsafeBrandId<CorrelationId>(msg.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   const outboundEvent: EServiceOutboundEvent | undefined = match(msg)

--- a/packages/catalog-platformstate-writer/src/index.ts
+++ b/packages/catalog-platformstate-writer/src/index.ts
@@ -1,7 +1,12 @@
 import { EachMessagePayload } from "kafkajs";
 import { logger, decodeKafkaMessage } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { EServiceEvent } from "pagopa-interop-models";
+import {
+  CorrelationId,
+  EServiceEvent,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { handleMessageV1 } from "./consumerServiceV1.js";
@@ -21,7 +26,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   await match(decodedMessage)

--- a/packages/catalog-readmodel-writer/src/index.ts
+++ b/packages/catalog-readmodel-writer/src/index.ts
@@ -5,7 +5,12 @@ import {
   decodeKafkaMessage,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { EServiceEvent } from "pagopa-interop-models";
+import {
+  CorrelationId,
+  EServiceEvent,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { handleMessageV1 } from "./consumerServiceV1.js";
 import { handleMessageV2 } from "./consumerServiceV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   await match(decodedMessage)

--- a/packages/client-readmodel-writer/src/index.ts
+++ b/packages/client-readmodel-writer/src/index.ts
@@ -5,7 +5,12 @@ import {
   decodeKafkaMessage,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { AuthorizationEvent } from "pagopa-interop-models";
+import {
+  AuthorizationEvent,
+  CorrelationId,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { handleMessageV1 } from "./clientConsumerServiceV1.js";
 import { handleMessageV2 } from "./clientConsumerServiceV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
   await match(decodedMessage)
     .with({ event_version: 1 }, (msg) => handleMessageV1(msg, clients))

--- a/packages/commons/src/context/interopHeaders.ts
+++ b/packages/commons/src/context/interopHeaders.ts
@@ -2,7 +2,7 @@ import { CorrelationId } from "pagopa-interop-models";
 import { z } from "zod";
 
 export const InteropHeaders = z.object({
-  "X-Correlation-Id": z.string(),
+  "X-Correlation-Id": CorrelationId,
   Authorization: z.string(),
 });
 

--- a/packages/commons/src/logging/index.ts
+++ b/packages/commons/src/logging/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import winston from "winston";
+import { CorrelationId } from "pagopa-interop-models";
 import { LoggerConfig } from "../config/loggerConfig.js";
 import { bigIntReplacer } from "./utils.js";
 
@@ -7,7 +8,7 @@ export type LoggerMetadata = {
   serviceName?: string;
   userId?: string;
   organizationId?: string;
-  correlationId?: string | null;
+  correlationId?: CorrelationId | null;
   eventType?: string;
   eventVersion?: number;
   streamId?: string;

--- a/packages/datalake-data-export/src/index.ts
+++ b/packages/datalake-data-export/src/index.ts
@@ -3,14 +3,14 @@ import {
   logger,
   ReadModelRepository,
 } from "pagopa-interop-commons";
-import { v4 as uuidv4 } from "uuid";
+import { generateId, CorrelationId } from "pagopa-interop-models";
 import { datalakeServiceBuilder } from "./services/datalakeService.js";
 import { readModelServiceBuilder } from "./services/readModelService.js";
 import { config } from "./config/config.js";
 
 const log = logger({
   serviceName: "datalake-data-export",
-  correlationId: uuidv4(),
+  correlationId: generateId<CorrelationId>(),
 });
 
 const fileManager = initFileManager(config);

--- a/packages/ivass-certified-attributes-importer/src/index.ts
+++ b/packages/ivass-certified-attributes-importer/src/index.ts
@@ -5,16 +5,17 @@ import {
   initFileManager,
   logger,
 } from "pagopa-interop-commons";
-import { v4 as uuidv4 } from "uuid";
+import { CorrelationId, generateId } from "pagopa-interop-models";
 import { config } from "./config/config.js";
 import { TenantProcessService } from "./service/tenantProcessService.js";
 import { importAttributes } from "./service/processor.js";
 import { downloadCSV } from "./service/fileDownloader.js";
 import { ReadModelQueries } from "./service/readModelQueriesService.js";
 
+const correlationId = generateId<CorrelationId>();
 const loggerInstance = logger({
   serviceName: "ivass-certified-attributes-importer",
-  correlationId: uuidv4(),
+  correlationId,
 });
 
 const fileManager = initFileManager(config);
@@ -43,5 +44,6 @@ await importAttributes(
   refreshableToken,
   config.recordsProcessBatchSize,
   config.ivassTenantId,
-  loggerInstance
+  loggerInstance,
+  correlationId
 );

--- a/packages/ivass-certified-attributes-importer/test/processor.test.ts
+++ b/packages/ivass-certified-attributes-importer/test/processor.test.ts
@@ -8,7 +8,7 @@ import {
   RefreshableInteropToken,
   genericLogger,
 } from "pagopa-interop-commons";
-import { Tenant, unsafeBrandId } from "pagopa-interop-models";
+import { generateId, Tenant, unsafeBrandId } from "pagopa-interop-models";
 import { TenantProcessService } from "../src/service/tenantProcessService.js";
 import { ReadModelQueries } from "../src/service/readModelQueriesService.js";
 import { importAttributes } from "../src/service/processor.js";
@@ -44,7 +44,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       10,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
   const interopToken: InteropToken = {
@@ -145,7 +146,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       10,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(localDownloadCSVMock).toBeCalledTimes(1);
@@ -208,7 +210,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       10,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(localDownloadCSVMock).toBeCalledTimes(1);
@@ -286,7 +289,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       10,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(localDownloadCSVMock).toBeCalledTimes(1);
@@ -340,7 +344,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       10,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(localDownloadCSVMock).toBeCalledTimes(1);
@@ -386,7 +391,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       10,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(localDownloadCSVMock).toBeCalledTimes(1);
@@ -449,7 +455,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       1,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(localDownloadCSVMock).toBeCalledTimes(1);
@@ -479,7 +486,8 @@ describe("IVASS Certified Attributes Importer", () => {
         refreshableTokenMock,
         1,
         "ivass-tenant-id",
-        genericLogger
+        genericLogger,
+        generateId()
       )
     ).rejects.toThrowError("CSV Retrieve error");
 
@@ -562,7 +570,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       10,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(localDownloadCSVMock).toBeCalledTimes(1);
@@ -639,7 +648,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       10,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(localDownloadCSVMock).toBeCalledTimes(1);
@@ -713,7 +723,8 @@ describe("IVASS Certified Attributes Importer", () => {
       refreshableTokenMock,
       1,
       "ivass-tenant-id",
-      genericLogger
+      genericLogger,
+      generateId()
     );
 
     expect(localDownloadCSVMock).toBeCalledTimes(1);
@@ -749,7 +760,8 @@ describe("IVASS Certified Attributes Importer", () => {
         refreshableTokenMock,
         10,
         "ivass-tenant-id",
-        genericLogger
+        genericLogger,
+        generateId()
       )
     ).rejects.toThrowError("File does not contain valid assignments");
 

--- a/packages/key-readmodel-writer/src/index.ts
+++ b/packages/key-readmodel-writer/src/index.ts
@@ -5,7 +5,12 @@ import {
   decodeKafkaMessage,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { AuthorizationEvent } from "pagopa-interop-models";
+import {
+  AuthorizationEvent,
+  CorrelationId,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { handleMessageV1 } from "./keyConsumerServiceV1.js";
 import { handleMessageV2 } from "./keyConsumerServiceV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
   await match(decodedMessage)
     .with({ event_version: 1 }, (msg) => handleMessageV1(msg, keys))

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -58,7 +58,7 @@ type Problem = {
   type: string;
   status: number;
   title: string;
-  correlationId?: string;
+  correlationId?: string; // TODO maybe make mandatory and use also here branding
   detail: string;
   errors: ProblemError[];
   toString: () => string;

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -58,7 +58,7 @@ type Problem = {
   type: string;
   status: number;
   title: string;
-  correlationId?: string; // TODO maybe make mandatory and use also here branding
+  correlationId?: string;
   detail: string;
   errors: ProblemError[];
   toString: () => string;

--- a/packages/notifier-seeder/src/index.ts
+++ b/packages/notifier-seeder/src/index.ts
@@ -7,8 +7,11 @@ import { match } from "ts-pattern";
 import {
   AgreementEventV2,
   AuthorizationEventV2,
+  CorrelationId,
   EServiceEventV2,
+  generateId,
   PurposeEventV2,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { toCatalogItemEventNotification } from "./models/catalog/catalogItemEventNotificationConverter.js";
 import { buildCatalogMessage } from "./models/catalog/catalogItemEventNotificationMessage.js";
@@ -82,7 +85,9 @@ async function processMessage(kafkaMessage: EachMessagePayload): Promise<void> {
       eventType: decodedMessage.type,
       eventVersion: decodedMessage.event_version,
       streamId: decodedMessage.stream_id,
-      correlationId: decodedMessage.correlation_id,
+      correlationId: decodedMessage.correlation_id
+        ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+        : generateId<CorrelationId>(),
     });
     if (decodedMessage.event_version !== 2) {
       loggerInstance.info(

--- a/packages/one-trust-notices/src/index.ts
+++ b/packages/one-trust-notices/src/index.ts
@@ -1,9 +1,9 @@
-import { randomUUID } from "crypto";
 import {
   initFileManager,
   logger,
   withExecutionTime,
 } from "pagopa-interop-commons";
+import { CorrelationId, generateId } from "../../models/dist/brandedIds.js";
 import { html2json } from "./services/html2json.js";
 import { OneTrustNoticeDBSchema } from "./models/index.js";
 
@@ -21,7 +21,7 @@ import { DynamoDbTableClient } from "./services/storage.js";
 
 const loggerInstance = logger({
   serviceName: "one-trust-notices",
-  correlationId: randomUUID(),
+  correlationId: generateId<CorrelationId>(),
 });
 const fileManager = initFileManager(config);
 

--- a/packages/pn-consumers/src/index.ts
+++ b/packages/pn-consumers/src/index.ts
@@ -4,7 +4,7 @@ import {
   logger,
   withExecutionTime,
 } from "pagopa-interop-commons";
-import { v4 as uuidv4 } from "uuid";
+import { CorrelationId, generateId } from "pagopa-interop-models";
 import { config } from "./configs/config.js";
 import { ReadModelQueriesClient } from "./services/readModelQueriesService.js";
 import { toCSV, toCsvDataRow } from "./utils/helpersUtils.js";
@@ -12,7 +12,7 @@ import { CSV_FILENAME, MAIL_BODY, MAIL_SUBJECT } from "./configs/constants.js";
 
 const loggerInstance = logger({
   serviceName: "pn-consumers",
-  correlationId: uuidv4(),
+  correlationId: generateId<CorrelationId>(),
 });
 
 async function main(): Promise<void> {

--- a/packages/producer-key-events-writer/src/index.ts
+++ b/packages/producer-key-events-writer/src/index.ts
@@ -1,7 +1,12 @@
 import { EachMessagePayload } from "kafkajs";
 import { logger, decodeKafkaMessage, initDB } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { AuthorizationEvent } from "pagopa-interop-models";
+import {
+  AuthorizationEvent,
+  CorrelationId,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { handleMessageV2 } from "./producerKeyConsumerServiceV2.js";
 import { config } from "./config/config.js";
@@ -27,7 +32,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   await match(decodedMessage)

--- a/packages/producer-key-readmodel-writer/src/index.ts
+++ b/packages/producer-key-readmodel-writer/src/index.ts
@@ -5,7 +5,12 @@ import {
   decodeKafkaMessage,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { AuthorizationEvent } from "pagopa-interop-models";
+import {
+  AuthorizationEvent,
+  CorrelationId,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { handleMessageV2 } from "./producerKeyConsumerServiceV2.js";
 import { config } from "./config/config.js";
@@ -23,7 +28,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
   await match(decodedMessage)
     .with({ event_version: 2 }, (msg) => handleMessageV2(msg, producerKeys))

--- a/packages/producer-keychain-readmodel-writer/src/index.ts
+++ b/packages/producer-keychain-readmodel-writer/src/index.ts
@@ -5,7 +5,12 @@ import {
   decodeKafkaMessage,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { AuthorizationEvent } from "pagopa-interop-models";
+import {
+  AuthorizationEvent,
+  CorrelationId,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { handleMessageV2 } from "./producerKeychainConsumerServiceV2.js";
 import { config } from "./config/config.js";
@@ -23,7 +28,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
   await match(decodedMessage)
     .with({ event_version: 2 }, (msg) =>

--- a/packages/purpose-outbound-writer/src/index.ts
+++ b/packages/purpose-outbound-writer/src/index.ts
@@ -6,7 +6,12 @@ import {
   encodeOutboundPurposeEvent,
   PurposeEvent as PurposeOutboundEvent,
 } from "@pagopa/interop-outbound-models";
-import { PurposeEvent } from "pagopa-interop-models";
+import {
+  CorrelationId,
+  generateId,
+  PurposeEvent,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { config } from "./config/config.js";
 import { toOutboundEventV1 } from "./converters/toOutboundEventV1.js";
 import { toOutboundEventV2 } from "./converters/toOutboundEventV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: msg.type,
     eventVersion: msg.event_version,
     streamId: msg.stream_id,
-    correlationId: msg.correlation_id,
+    correlationId: msg.correlation_id
+      ? unsafeBrandId<CorrelationId>(msg.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   const outboundEvent: PurposeOutboundEvent | undefined = match(msg)

--- a/packages/purpose-platformstate-writer/src/index.ts
+++ b/packages/purpose-platformstate-writer/src/index.ts
@@ -1,7 +1,12 @@
 import { EachMessagePayload } from "kafkajs";
 import { logger, decodeKafkaMessage } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { PurposeEvent } from "pagopa-interop-models";
+import {
+  CorrelationId,
+  generateId,
+  PurposeEvent,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { handleMessageV1 } from "./consumerServiceV1.js";
@@ -20,7 +25,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   await match(decodedMessage)

--- a/packages/purpose-readmodel-writer/src/index.ts
+++ b/packages/purpose-readmodel-writer/src/index.ts
@@ -5,7 +5,12 @@ import {
   decodeKafkaMessage,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { PurposeEvent } from "pagopa-interop-models";
+import {
+  CorrelationId,
+  generateId,
+  PurposeEvent,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { handleMessageV1 } from "./purposeConsumerServiceV1.js";
 import { handleMessageV2 } from "./purposeConsumerServiceV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
   await match(decodedMessage)
     .with({ event_version: 1 }, (msg) => handleMessageV1(msg, purposes))

--- a/packages/tenant-outbound-writer/src/index.ts
+++ b/packages/tenant-outbound-writer/src/index.ts
@@ -6,7 +6,12 @@ import {
   encodeOutboundTenantEvent,
   TenantEvent as TenantOutboundEvent,
 } from "@pagopa/interop-outbound-models";
-import { TenantEvent } from "pagopa-interop-models";
+import {
+  CorrelationId,
+  generateId,
+  TenantEvent,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { config } from "./config/config.js";
 import { toOutboundEventV1 } from "./converters/toOutboundEventV1.js";
 import { toOutboundEventV2 } from "./converters/toOutboundEventV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: msg.type,
     eventVersion: msg.event_version,
     streamId: msg.stream_id,
-    correlationId: msg.correlation_id,
+    correlationId: msg.correlation_id
+      ? unsafeBrandId<CorrelationId>(msg.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   const outboundEvent: TenantOutboundEvent | undefined = match(msg)

--- a/packages/tenant-readmodel-writer/src/index.ts
+++ b/packages/tenant-readmodel-writer/src/index.ts
@@ -6,7 +6,12 @@ import {
   ReadModelRepository,
 } from "pagopa-interop-commons";
 import { runConsumer } from "kafka-iam-auth";
-import { TenantEvent } from "pagopa-interop-models";
+import {
+  CorrelationId,
+  generateId,
+  TenantEvent,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { config } from "./config/config.js";
 import { handleMessageV1 } from "./tenantConsumerServiceV1.js";
 import { handleMessageV2 } from "./tenantConsumerServiceV2.js";
@@ -24,7 +29,9 @@ async function processMessage({
     eventType: decodedMessage.type,
     eventVersion: decodedMessage.event_version,
     streamId: decodedMessage.stream_id,
-    correlationId: decodedMessage.correlation_id,
+    correlationId: decodedMessage.correlation_id
+      ? unsafeBrandId<CorrelationId>(decodedMessage.correlation_id)
+      : generateId<CorrelationId>(),
   });
 
   await match(decodedMessage)


### PR DESCRIPTION
Using the `CorrelationId` branded type everywhere (there were still some leftovers from #1117):
- the context headers in `api-gateway`
- the correlationId in the `LoggerMetadata` used to create a logger instance