### PR TITLE
PIN-5203 - Updated purpose process for producer delegations  

### DIFF
--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -105,6 +105,8 @@ import {
   validateRiskAnalysisOrThrow,
   assertPurposeTitleIsNotDuplicated,
   isOverQuota,
+  assertRequesterIsAllowedInPurpose,
+  assertRequesterIsProducer,
 } from "./validators.js";
 import { riskAnalysisDocumentBuilder } from "./riskAnalysisDocumentBuilder.js";
 
@@ -267,11 +269,15 @@ export function purposeServiceBuilder(
         purpose.data.eserviceId,
         readModelService
       );
-      getOrganizationRole({
+
+      await assertRequesterIsAllowedInPurpose({
+        eserviceId: eservice.id,
         organizationId,
         producerId: eservice.producerId,
         consumerId: purpose.data.consumerId,
+        readModelService,
       });
+
       const version = retrievePurposeVersion(versionId, purpose);
 
       return retrievePurposeVersionDocument(purposeId, version, documentId);
@@ -341,9 +347,13 @@ export function purposeServiceBuilder(
         purpose.data.eserviceId,
         readModelService
       );
-      if (organizationId !== eservice.producerId) {
-        throw organizationIsNotTheProducer(organizationId);
-      }
+
+      await assertRequesterIsProducer({
+        eserviceId: eservice.id,
+        organizationId,
+        producerId: eservice.producerId,
+        readModelService,
+      });
 
       const purposeVersion = retrievePurposeVersion(versionId, purpose);
 
@@ -535,10 +545,12 @@ export function purposeServiceBuilder(
         readModelService
       );
 
-      const suspender = getOrganizationRole({
+      const suspender = await getOrganizationRole({
+        eserviceId: eservice.id,
         organizationId,
         producerId: eservice.producerId,
         consumerId: purpose.data.consumerId,
+        readModelService,
       });
 
       const suspendedPurposeVersion: PurposeVersion = {
@@ -812,10 +824,12 @@ export function purposeServiceBuilder(
         });
       }
 
-      const purposeOwnership = getOrganizationRole({
+      const purposeOwnership = await getOrganizationRole({
+        eserviceId: eservice.id,
         organizationId,
         producerId: eservice.producerId,
         consumerId: purpose.data.consumerId,
+        readModelService,
       });
 
       const { event, updatedPurposeVersion } = await match({
@@ -1331,24 +1345,37 @@ const authorizeRiskAnalysisForm = ({
   }
 };
 
-const getOrganizationRole = ({
+const getOrganizationRole = async ({
+  eserviceId,
   organizationId,
   producerId,
   consumerId,
+  readModelService,
 }: {
+  eserviceId: EServiceId;
   organizationId: TenantId;
   producerId: TenantId;
   consumerId: TenantId;
-}): Ownership => {
+  readModelService: ReadModelService;
+}): Promise<Ownership> => {
   if (producerId === consumerId && organizationId === producerId) {
     return ownership.SELF_CONSUMER;
   } else if (producerId !== consumerId && organizationId === consumerId) {
     return ownership.CONSUMER;
-  } else if (producerId !== consumerId && organizationId === producerId) {
-    return ownership.PRODUCER;
-  } else {
-    throw organizationNotAllowed(organizationId);
   }
+
+  const activeDelegation = await readModelService.getActiveDelegation(
+    eserviceId
+  );
+
+  if (
+    (activeDelegation && organizationId === activeDelegation.delegateId) ||
+    (!activeDelegation && organizationId === producerId)
+  ) {
+    return ownership.PRODUCER;
+  }
+
+  throw organizationNotAllowed(organizationId);
 };
 
 const replacePurposeVersion = (

--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -105,7 +105,7 @@ import {
   validateRiskAnalysisOrThrow,
   assertPurposeTitleIsNotDuplicated,
   isOverQuota,
-  assertRequesterIsAllowedInPurpose,
+  assertRequesterIsAllowedToRetrieveRiskAnalysisDocument,
   assertRequesterIsProducer,
 } from "./validators.js";
 import { riskAnalysisDocumentBuilder } from "./riskAnalysisDocumentBuilder.js";
@@ -270,7 +270,7 @@ export function purposeServiceBuilder(
         readModelService
       );
 
-      await assertRequesterIsAllowedInPurpose({
+      await assertRequesterIsAllowedToRetrieveRiskAnalysisDocument({
         eserviceId: eservice.id,
         organizationId,
         producerId: eservice.producerId,

--- a/packages/purpose-process/src/services/validators.ts
+++ b/packages/purpose-process/src/services/validators.ts
@@ -251,7 +251,7 @@ export async function isOverQuota(
   );
 }
 
-export const assertRequesterIsAllowedInPurpose = async ({
+export const assertRequesterIsAllowedToRetrieveRiskAnalysisDocument = async ({
   eserviceId,
   organizationId,
   producerId,

--- a/packages/purpose-process/test/activatePurposeVersion.test.ts
+++ b/packages/purpose-process/test/activatePurposeVersion.test.ts
@@ -10,7 +10,6 @@ import {
   getMockEService,
   getMockAgreement,
   getMockValidRiskAnalysisForm,
-  writeInReadmodel,
   readLastEventByStreamId,
   decodeProtobufPayload,
   getMockDelegationProducer,
@@ -26,7 +25,6 @@ import {
   Agreement,
   Descriptor,
   agreementState,
-  toReadModelEService,
   TenantKind,
   PurposeActivatedV2,
   toPurposeV2,
@@ -35,9 +33,7 @@ import {
   PurposeVersionOverQuotaUnsuspendedV2,
   PurposeWaitingForApprovalV2,
   eserviceMode,
-  toReadModelAgreement,
   PurposeVersionActivatedV2,
-  toReadModelTenant,
   Delegation,
   delegationState,
 } from "pagopa-interop-models";
@@ -59,12 +55,12 @@ import {
   agreementNotFound,
 } from "../src/model/domain/errors.js";
 import {
-  agreements,
-  delegations,
-  eservices,
+  addOneAgreement,
+  addOneDelegation,
+  addOneEService,
+  addOneTenant,
   postgresDB,
   purposeService,
-  tenants,
 } from "./utils.js";
 import { addOnePurpose } from "./utils.js";
 
@@ -130,10 +126,10 @@ describe("activatePurposeVersion", () => {
 
   it("should write on event-store for the activation of a purpose version in the waiting for approval state", async () => {
     await addOnePurpose(mockPurpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     const purposeVersion = await purposeService.activatePurposeVersion({
       purposeId: mockPurpose.id,
@@ -184,10 +180,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     const purposeVersion = await purposeService.activatePurposeVersion({
       purposeId: mockPurpose.id,
@@ -240,10 +236,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     const purposeVersion = await purposeService.activatePurposeVersion({
       purposeId: mockPurpose.id,
@@ -297,10 +293,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     const purposeVersion = await purposeService.activatePurposeVersion({
       purposeId: mockPurpose.id,
@@ -354,10 +350,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     const purposeVersion = await purposeService.activatePurposeVersion({
       purposeId: mockPurpose.id,
@@ -409,10 +405,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     const purposeVersion = await purposeService.activatePurposeVersion({
       purposeId: mockPurpose.id,
@@ -460,10 +456,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     const purposeVersion = await purposeService.activatePurposeVersion({
       purposeId: mockPurpose.id,
@@ -508,10 +504,10 @@ describe("activatePurposeVersion", () => {
     const purpose: Purpose = { ...mockPurpose, versions: [purposeVersion] };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -532,10 +528,10 @@ describe("activatePurposeVersion", () => {
     const purpose: Purpose = { ...mockPurpose, versions: [purposeVersion] };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -566,10 +562,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(eservice), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(consumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(eservice);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(consumer);
+    await addOneTenant(mockProducer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -594,10 +590,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -612,9 +608,9 @@ describe("activatePurposeVersion", () => {
 
   it("should throw eserviceNotFound if the e-service does not exists in the readmodel", async () => {
     await addOnePurpose(mockPurpose);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -635,9 +631,9 @@ describe("activatePurposeVersion", () => {
     const purpose: Purpose = { ...mockPurpose, versions: [purposeVersion] };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -668,10 +664,10 @@ describe("activatePurposeVersion", () => {
       const purpose: Purpose = { ...mockPurpose, versions: [purposeVersion] };
 
       await addOnePurpose(purpose);
-      await writeInReadmodel(toReadModelEService(mockEService), eservices);
-      await writeInReadmodel(toReadModelAgreement(agreement), agreements);
-      await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-      await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+      await addOneEService(mockEService);
+      await addOneAgreement(agreement);
+      await addOneTenant(mockConsumer);
+      await addOneTenant(mockProducer);
 
       expect(async () => {
         await purposeService.activatePurposeVersion({
@@ -691,11 +687,11 @@ describe("activatePurposeVersion", () => {
     const anotherTenant: Tenant = { ...getMockTenant(), kind: "PA" };
 
     await addOnePurpose(mockPurpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
-    await writeInReadmodel(toReadModelTenant(anotherTenant), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
+    await addOneTenant(anotherTenant);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -710,10 +706,10 @@ describe("activatePurposeVersion", () => {
 
   it("should throw organizationNotAllowed if the caller is the producer but the purpose e-service has an active delegation", async () => {
     await addOnePurpose(mockPurpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     const delegate = getMockAuthData();
     const delegation: Delegation = {
@@ -723,7 +719,7 @@ describe("activatePurposeVersion", () => {
       state: delegationState.active,
     };
 
-    await writeInReadmodel(delegation, delegations);
+    await addOneDelegation(delegation);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -742,10 +738,10 @@ describe("activatePurposeVersion", () => {
     "should throw organizationNotAllowed if the caller is the purpose e-service delegate but the delegation is in %s state",
     async (delegationState) => {
       await addOnePurpose(mockPurpose);
-      await writeInReadmodel(toReadModelEService(mockEService), eservices);
-      await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-      await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-      await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+      await addOneEService(mockEService);
+      await addOneAgreement(mockAgreement);
+      await addOneTenant(mockConsumer);
+      await addOneTenant(mockProducer);
 
       const delegate = getMockAuthData();
       const delegation: Delegation = {
@@ -755,7 +751,7 @@ describe("activatePurposeVersion", () => {
         state: delegationState,
       };
 
-      await writeInReadmodel(delegation, delegations);
+      await addOneDelegation(delegation);
 
       expect(async () => {
         await purposeService.activatePurposeVersion({
@@ -781,10 +777,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -811,10 +807,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(mockProducer);
 
     const result = validateRiskAnalysis(
       riskAnalysisFormToRiskAnalysisFormToValidate(riskAnalysisForm),
@@ -848,9 +844,9 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(purpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockProducer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -865,9 +861,9 @@ describe("activatePurposeVersion", () => {
 
   it("should throw tenantNotFound if the purpose producer is not found in the readmodel", async () => {
     await addOnePurpose(mockPurpose);
-    await writeInReadmodel(toReadModelEService(mockEService), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
+    await addOneEService(mockEService);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -888,10 +884,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(mockPurpose);
-    await writeInReadmodel(toReadModelEService(eservice), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(consumer), tenants);
-    await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+    await addOneEService(eservice);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(consumer);
+    await addOneTenant(mockProducer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -912,10 +908,10 @@ describe("activatePurposeVersion", () => {
     };
 
     await addOnePurpose(mockPurpose);
-    await writeInReadmodel(toReadModelEService(eservice), eservices);
-    await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-    await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-    await writeInReadmodel(toReadModelTenant(producer), tenants);
+    await addOneEService(eservice);
+    await addOneAgreement(mockAgreement);
+    await addOneTenant(mockConsumer);
+    await addOneTenant(producer);
 
     expect(async () => {
       await purposeService.activatePurposeVersion({
@@ -942,10 +938,10 @@ describe("activatePurposeVersion", () => {
       const purpose: Purpose = { ...mockPurpose, versions: [purposeVersion] };
 
       await addOnePurpose(purpose);
-      await writeInReadmodel(toReadModelEService(mockEService), eservices);
-      await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-      await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-      await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+      await addOneEService(mockEService);
+      await addOneAgreement(mockAgreement);
+      await addOneTenant(mockConsumer);
+      await addOneTenant(mockProducer);
 
       expect(async () => {
         await purposeService.activatePurposeVersion({
@@ -973,10 +969,10 @@ describe("activatePurposeVersion", () => {
       const purpose: Purpose = { ...mockPurpose, versions: [purposeVersion] };
 
       await addOnePurpose(purpose);
-      await writeInReadmodel(toReadModelEService(mockEService), eservices);
-      await writeInReadmodel(toReadModelAgreement(mockAgreement), agreements);
-      await writeInReadmodel(toReadModelTenant(mockConsumer), tenants);
-      await writeInReadmodel(toReadModelTenant(mockProducer), tenants);
+      await addOneEService(mockEService);
+      await addOneAgreement(mockAgreement);
+      await addOneTenant(mockConsumer);
+      await addOneTenant(mockProducer);
 
       expect(async () => {
         await purposeService.activatePurposeVersion({

--- a/packages/purpose-process/test/getRiskAnalysisDocument.test.ts
+++ b/packages/purpose-process/test/getRiskAnalysisDocument.test.ts
@@ -4,6 +4,8 @@ import {
   getMockPurposeVersion,
   getMockPurpose,
   writeInReadmodel,
+  getMockAuthData,
+  getMockDelegationProducer,
 } from "pagopa-interop-commons-test";
 import {
   Purpose,
@@ -13,6 +15,8 @@ import {
   PurposeVersionId,
   PurposeVersionDocumentId,
   TenantId,
+  Delegation,
+  delegationState,
 } from "pagopa-interop-models";
 import { describe, expect, it } from "vitest";
 import { genericLogger } from "pagopa-interop-commons";
@@ -28,31 +32,88 @@ import {
   addOnePurpose,
   eservices,
   purposeService,
+  delegations,
 } from "./utils.js";
 
 describe("getRiskAnalysisDocument", () => {
-  it("should get the purpose version document", async () => {
+  it("should get the purpose version document (consumer)", async () => {
     const mockDocument = getMockPurposeVersionDocument();
     const mockEService = getMockEService();
     const mockPurposeVersion = {
       ...getMockPurposeVersion(),
       riskAnalysis: mockDocument,
     };
-    const mockPurpose1: Purpose = {
+    const mockPurpose: Purpose = {
       ...getMockPurpose(),
       eserviceId: mockEService.id,
       versions: [mockPurposeVersion],
     };
-    const mockPurpose2 = getMockPurpose();
-    await addOnePurpose(mockPurpose1);
-    await addOnePurpose(mockPurpose2);
+    await addOnePurpose(mockPurpose);
     await writeInReadmodel(toReadModelEService(mockEService), eservices);
 
     const result = await purposeService.getRiskAnalysisDocument({
-      purposeId: mockPurpose1.id,
+      purposeId: mockPurpose.id,
+      versionId: mockPurposeVersion.id,
+      documentId: mockDocument.id,
+      organizationId: mockPurpose.consumerId,
+      logger: genericLogger,
+    });
+    expect(result).toEqual(mockDocument);
+  });
+  it("should get the purpose version document (producer)", async () => {
+    const mockDocument = getMockPurposeVersionDocument();
+    const mockEService = getMockEService();
+    const mockPurposeVersion = {
+      ...getMockPurposeVersion(),
+      riskAnalysis: mockDocument,
+    };
+    const mockPurpose: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      versions: [mockPurposeVersion],
+    };
+    await addOnePurpose(mockPurpose);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+    const result = await purposeService.getRiskAnalysisDocument({
+      purposeId: mockPurpose.id,
       versionId: mockPurposeVersion.id,
       documentId: mockDocument.id,
       organizationId: mockEService.producerId,
+      logger: genericLogger,
+    });
+    expect(result).toEqual(mockDocument);
+  });
+  it("should get the purpose version document (delegate)", async () => {
+    const mockDocument = getMockPurposeVersionDocument();
+    const mockEService = getMockEService();
+    const mockPurposeVersion = {
+      ...getMockPurposeVersion(),
+      riskAnalysis: mockDocument,
+    };
+    const mockPurpose: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      versions: [mockPurposeVersion],
+    };
+    await addOnePurpose(mockPurpose);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+    const delegate = getMockAuthData();
+    const delegation: Delegation = {
+      ...getMockDelegationProducer(),
+      eserviceId: mockEService.id,
+      delegateId: delegate.organizationId,
+      state: delegationState.active,
+    };
+
+    await writeInReadmodel(delegation, delegations);
+
+    const result = await purposeService.getRiskAnalysisDocument({
+      purposeId: mockPurpose.id,
+      versionId: mockPurposeVersion.id,
+      documentId: mockDocument.id,
+      organizationId: delegate.organizationId,
       logger: genericLogger,
     });
     expect(result).toEqual(mockDocument);
@@ -134,7 +195,7 @@ describe("getRiskAnalysisDocument", () => {
       )
     );
   });
-  it("should throw organizationNotAllowed if the requester is not the producer nor the consumer", async () => {
+  it("should throw organizationNotAllowed if the requester is not the producer nor the consumer nor the delegate", async () => {
     const randomId: TenantId = generateId();
     const mockDocument = getMockPurposeVersionDocument();
     const mockEService = getMockEService();
@@ -161,4 +222,45 @@ describe("getRiskAnalysisDocument", () => {
       })
     ).rejects.toThrowError(organizationNotAllowed(randomId));
   });
+  it.each(
+    Object.values(delegationState).filter((s) => s !== delegationState.active)
+  )(
+    "should throw organizationNotAllowed if the requester is the delegate but the delegation is in %s state",
+    async (delegationState) => {
+      const mockDocument = getMockPurposeVersionDocument();
+      const mockEService = getMockEService();
+      const mockPurposeVersion = {
+        ...getMockPurposeVersion(),
+        riskAnalysis: mockDocument,
+      };
+      const mockPurpose: Purpose = {
+        ...getMockPurpose(),
+        eserviceId: mockEService.id,
+        versions: [mockPurposeVersion],
+      };
+
+      await addOnePurpose(mockPurpose);
+      await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+      const delegate = getMockAuthData();
+      const delegation: Delegation = {
+        ...getMockDelegationProducer(),
+        eserviceId: mockEService.id,
+        delegateId: delegate.organizationId,
+        state: delegationState,
+      };
+
+      await writeInReadmodel(delegation, delegations);
+
+      expect(
+        purposeService.getRiskAnalysisDocument({
+          purposeId: mockPurpose.id,
+          versionId: mockPurposeVersion.id,
+          documentId: mockDocument.id,
+          organizationId: delegate.organizationId,
+          logger: genericLogger,
+        })
+      ).rejects.toThrowError(organizationNotAllowed(delegate.organizationId));
+    }
+  );
 });

--- a/packages/purpose-process/test/rejectPurposeVersion.test.ts
+++ b/packages/purpose-process/test/rejectPurposeVersion.test.ts
@@ -4,6 +4,8 @@ import {
   getMockPurpose,
   writeInReadmodel,
   decodeProtobufPayload,
+  getMockAuthData,
+  getMockDelegationProducer,
 } from "pagopa-interop-commons-test";
 import {
   purposeVersionState,
@@ -15,6 +17,8 @@ import {
   toPurposeV2,
   PurposeId,
   PurposeVersionId,
+  Delegation,
+  delegationState,
 } from "pagopa-interop-models";
 import { describe, expect, it, vi } from "vitest";
 import { genericLogger } from "pagopa-interop-commons";
@@ -31,10 +35,11 @@ import {
   readLastPurposeEvent,
   eservices,
   purposeService,
+  delegations,
 } from "./utils.js";
 
 describe("rejectPurposeVersion", () => {
-  it("should write on event-store for the rejection of a purpose version", async () => {
+  it("should write on event-store for the rejection of a purpose version ", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date());
 
@@ -57,6 +62,73 @@ describe("rejectPurposeVersion", () => {
       versionId: mockPurposeVersion.id,
       rejectionReason: "test",
       organizationId: mockEService.producerId,
+      correlationId: generateId(),
+      logger: genericLogger,
+    });
+
+    const writtenEvent = await readLastPurposeEvent(mockPurpose.id);
+
+    expect(writtenEvent).toMatchObject({
+      stream_id: mockPurpose.id,
+      version: "1",
+      type: "PurposeVersionRejected",
+      event_version: 2,
+    });
+
+    const writtenPayload = decodeProtobufPayload({
+      messageType: PurposeVersionRejectedV2,
+      payload: writtenEvent.data,
+    });
+
+    const expectedPurposeVersion: PurposeVersion = {
+      ...mockPurposeVersion,
+      state: purposeVersionState.rejected,
+      rejectionReason: "test",
+      updatedAt: new Date(),
+    };
+    const expectedPurpose: Purpose = {
+      ...mockPurpose,
+      versions: [expectedPurposeVersion],
+      updatedAt: new Date(),
+    };
+
+    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+
+    vi.useRealTimers();
+  });
+  it("should write on event-store for the rejection of a purpose version when the requester is delegate", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date());
+
+    const mockEService = getMockEService();
+    const mockPurposeVersion = {
+      ...getMockPurposeVersion(),
+      state: purposeVersionState.waitingForApproval,
+    };
+    const mockPurpose: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      versions: [mockPurposeVersion],
+    };
+
+    await addOnePurpose(mockPurpose);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+    const delegate = getMockAuthData();
+    const delegation: Delegation = {
+      ...getMockDelegationProducer(),
+      eserviceId: mockEService.id,
+      delegateId: delegate.organizationId,
+      state: delegationState.active,
+    };
+
+    await writeInReadmodel(delegation, delegations);
+
+    await purposeService.rejectPurposeVersion({
+      purposeId: mockPurpose.id,
+      versionId: mockPurposeVersion.id,
+      rejectionReason: "test",
+      organizationId: delegate.organizationId,
       correlationId: generateId(),
       logger: genericLogger,
     });
@@ -137,7 +209,7 @@ describe("rejectPurposeVersion", () => {
       })
     ).rejects.toThrowError(eserviceNotFound(mockEService.id));
   });
-  it("should throw organizationIsNotTheProducer if the requester is not the producer", async () => {
+  it("should throw organizationIsNotTheProducer if the requester is not the producer nor delegate", async () => {
     const mockEService = getMockEService();
     const mockPurposeVersion = getMockPurposeVersion();
     const mockPurpose: Purpose = {
@@ -162,6 +234,118 @@ describe("rejectPurposeVersion", () => {
       organizationIsNotTheProducer(mockPurpose.consumerId)
     );
   });
+  it("should throw organizationIsNotTheProducer if the purpose e-service has an active delegation and the requester is the producer", async () => {
+    const mockEService = getMockEService();
+    const mockPurposeVersion = getMockPurposeVersion();
+    const mockPurpose: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      versions: [mockPurposeVersion],
+    };
+
+    await addOnePurpose(mockPurpose);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+    const delegate = getMockAuthData();
+    const delegation: Delegation = {
+      ...getMockDelegationProducer(),
+      eserviceId: mockEService.id,
+      delegateId: delegate.organizationId,
+      state: delegationState.active,
+    };
+
+    await writeInReadmodel(delegation, delegations);
+
+    expect(
+      purposeService.rejectPurposeVersion({
+        purposeId: mockPurpose.id,
+        versionId: mockPurposeVersion.id,
+        rejectionReason: "test",
+        organizationId: mockEService.producerId,
+        correlationId: generateId(),
+        logger: genericLogger,
+      })
+    ).rejects.toThrowError(
+      organizationIsNotTheProducer(mockEService.producerId)
+    );
+  });
+  it("should throw organizationIsNotTheProducer if the purpose e-service has an active delegation and the requester is not the producer nor the delegate", async () => {
+    const mockEService = getMockEService();
+    const mockPurposeVersion = getMockPurposeVersion();
+    const mockPurpose: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      versions: [mockPurposeVersion],
+    };
+
+    await addOnePurpose(mockPurpose);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+    const delegate = getMockAuthData();
+    const delegation: Delegation = {
+      ...getMockDelegationProducer(),
+      eserviceId: mockEService.id,
+      delegateId: delegate.organizationId,
+      state: delegationState.active,
+    };
+
+    await writeInReadmodel(delegation, delegations);
+
+    const randomCaller = getMockAuthData();
+
+    expect(
+      purposeService.rejectPurposeVersion({
+        purposeId: mockPurpose.id,
+        versionId: mockPurposeVersion.id,
+        rejectionReason: "test",
+        organizationId: randomCaller.organizationId,
+        correlationId: generateId(),
+        logger: genericLogger,
+      })
+    ).rejects.toThrowError(
+      organizationIsNotTheProducer(randomCaller.organizationId)
+    );
+  });
+  it.each(
+    Object.values(delegationState).filter((s) => s !== delegationState.active)
+  )(
+    "should throw organizationIsNotTheProducer if the requester is the e-service delegate but the delegation is in %s state",
+    async (delegationState) => {
+      const mockEService = getMockEService();
+      const mockPurposeVersion = getMockPurposeVersion();
+      const mockPurpose: Purpose = {
+        ...getMockPurpose(),
+        eserviceId: mockEService.id,
+        versions: [mockPurposeVersion],
+      };
+
+      await addOnePurpose(mockPurpose);
+      await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+      const delegate = getMockAuthData();
+      const delegation: Delegation = {
+        ...getMockDelegationProducer(),
+        eserviceId: mockEService.id,
+        delegateId: delegate.organizationId,
+        state: delegationState,
+      };
+
+      await writeInReadmodel(delegation, delegations);
+
+      expect(
+        purposeService.rejectPurposeVersion({
+          purposeId: mockPurpose.id,
+          versionId: mockPurposeVersion.id,
+          rejectionReason: "test",
+          organizationId: delegate.organizationId,
+          correlationId: generateId(),
+          logger: genericLogger,
+        })
+      ).rejects.toThrowError(
+        organizationIsNotTheProducer(delegate.organizationId)
+      );
+    }
+  );
   it("should throw purposeVersionNotFound if the purpose version doesn't exist", async () => {
     const mockEService = getMockEService();
     const mockPurposeVersion = getMockPurposeVersion();

--- a/packages/purpose-process/test/suspendPurposeVersion.test.ts
+++ b/packages/purpose-process/test/suspendPurposeVersion.test.ts
@@ -5,6 +5,8 @@ import {
   getMockPurpose,
   writeInReadmodel,
   decodeProtobufPayload,
+  getMockAuthData,
+  getMockDelegationProducer,
 } from "pagopa-interop-commons-test";
 import {
   PurposeVersion,
@@ -19,6 +21,8 @@ import {
   PurposeVersionId,
   TenantId,
   toPurposeVersionV2,
+  Delegation,
+  delegationState,
 } from "pagopa-interop-models";
 import { genericLogger } from "pagopa-interop-commons";
 import {
@@ -29,6 +33,7 @@ import {
 } from "../src/model/domain/errors.js";
 import {
   addOnePurpose,
+  delegations,
   eservices,
   getMockEService,
   purposeService,
@@ -119,6 +124,78 @@ describe("suspendPurposeVersion", () => {
       purposeId: mockPurpose.id,
       versionId: mockPurposeVersion1.id,
       organizationId: mockEService.producerId,
+      correlationId: generateId(),
+      logger: genericLogger,
+    });
+
+    const writtenEvent = await readLastPurposeEvent(mockPurpose.id);
+
+    expect(writtenEvent).toMatchObject({
+      stream_id: mockPurpose.id,
+      version: "1",
+      type: "PurposeVersionSuspendedByProducer",
+      event_version: 2,
+    });
+
+    const expectedPurpose: Purpose = {
+      ...mockPurpose,
+      versions: [
+        {
+          ...mockPurposeVersion1,
+          state: purposeVersionState.suspended,
+          suspendedAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      suspendedByProducer: true,
+      updatedAt: new Date(),
+    };
+
+    const writtenPayload = decodeProtobufPayload({
+      messageType: PurposeVersionSuspendedByProducerV2,
+      payload: writtenEvent.data,
+    });
+
+    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(
+      writtenPayload.purpose?.versions.find(
+        (v) => v.id === returnedPurposeVersion.id
+      )
+    ).toEqual(toPurposeVersionV2(returnedPurposeVersion));
+
+    vi.useRealTimers();
+  });
+  it("should write on event-store for the suspension of a purpose version by the delegated producer", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date());
+
+    const mockEService = getMockEService();
+    const mockPurposeVersion1: PurposeVersion = {
+      ...getMockPurposeVersion(),
+      state: purposeVersionState.active,
+    };
+    const mockPurpose: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      versions: [mockPurposeVersion1],
+    };
+    await addOnePurpose(mockPurpose);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+    const delegate = getMockAuthData();
+    const delegation: Delegation = {
+      ...getMockDelegationProducer(),
+      eserviceId: mockEService.id,
+      delegateId: delegate.organizationId,
+      state: delegationState.active,
+    };
+
+    await writeInReadmodel(delegation, delegations);
+
+    const returnedPurposeVersion = await purposeService.suspendPurposeVersion({
+      purposeId: mockPurpose.id,
+      versionId: mockPurposeVersion1.id,
+      organizationId: delegate.organizationId,
       correlationId: generateId(),
       logger: genericLogger,
     });
@@ -289,6 +366,115 @@ describe("suspendPurposeVersion", () => {
         logger: genericLogger,
       })
     ).rejects.toThrowError(organizationNotAllowed(randomId));
+  });
+  it("should throw organizationNotAllowed if the requester is not the e-service active delegation delegate", async () => {
+    const mockEService = getMockEService();
+    const mockPurposeVersion: PurposeVersion = {
+      ...getMockPurposeVersion(),
+      state: purposeVersionState.active,
+    };
+    const mockPurpose: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      versions: [mockPurposeVersion],
+    };
+    await addOnePurpose(mockPurpose);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+    const delegate = getMockAuthData();
+    const delegation: Delegation = {
+      ...getMockDelegationProducer(),
+      eserviceId: mockEService.id,
+      delegateId: delegate.organizationId,
+      state: delegationState.active,
+    };
+
+    await writeInReadmodel(delegation, delegations);
+
+    const randomCaller = getMockAuthData();
+
+    expect(
+      purposeService.suspendPurposeVersion({
+        purposeId: mockPurpose.id,
+        versionId: mockPurposeVersion.id,
+        organizationId: randomCaller.organizationId,
+        correlationId: generateId(),
+        logger: genericLogger,
+      })
+    ).rejects.toThrowError(organizationNotAllowed(randomCaller.organizationId));
+  });
+  it.each(
+    Object.values(delegationState).filter((s) => s !== delegationState.active)
+  )(
+    "should throw organizationNotAllowed if the requester is the e-service delegate but the delegation is in %s state",
+    async (delegationState) => {
+      const mockEService = getMockEService();
+      const mockPurposeVersion: PurposeVersion = {
+        ...getMockPurposeVersion(),
+        state: purposeVersionState.active,
+      };
+      const mockPurpose: Purpose = {
+        ...getMockPurpose(),
+        eserviceId: mockEService.id,
+        versions: [mockPurposeVersion],
+      };
+      await addOnePurpose(mockPurpose);
+      await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+      const delegate = getMockAuthData();
+      const delegation: Delegation = {
+        ...getMockDelegationProducer(),
+        eserviceId: mockEService.id,
+        delegateId: delegate.organizationId,
+        state: delegationState,
+      };
+
+      await writeInReadmodel(delegation, delegations);
+
+      expect(
+        purposeService.suspendPurposeVersion({
+          purposeId: mockPurpose.id,
+          versionId: mockPurposeVersion.id,
+          organizationId: delegate.organizationId,
+          correlationId: generateId(),
+          logger: genericLogger,
+        })
+      ).rejects.toThrowError(organizationNotAllowed(delegate.organizationId));
+    }
+  );
+  it("should throw organizationNotAllowed if the requester is the producer but the purpose e-service has an active delegation", async () => {
+    const mockEService = getMockEService();
+    const mockPurposeVersion: PurposeVersion = {
+      ...getMockPurposeVersion(),
+      state: purposeVersionState.active,
+    };
+    const mockPurpose: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      versions: [mockPurposeVersion],
+    };
+    await addOnePurpose(mockPurpose);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+
+    const delegate = getMockAuthData();
+    const delegation: Delegation = {
+      ...getMockDelegationProducer(),
+      eserviceId: mockEService.id,
+      delegateId: delegate.organizationId,
+      state: delegationState.active,
+    };
+
+    await writeInReadmodel(delegation, delegations);
+
+    expect(
+      purposeService.suspendPurposeVersion({
+        purposeId: mockPurpose.id,
+        versionId: mockPurposeVersion.id,
+        organizationId: mockEService.producerId,
+        correlationId: generateId(),
+        logger: genericLogger,
+      })
+    ).rejects.toThrowError(organizationNotAllowed(mockEService.producerId));
   });
   it.each(
     Object.values(purposeVersionState).filter(

--- a/packages/purpose-process/test/utils.ts
+++ b/packages/purpose-process/test/utils.ts
@@ -46,6 +46,7 @@ export const eservices = readModelRepository.eservices;
 export const tenants = readModelRepository.tenants;
 export const attributes = readModelRepository.attributes;
 export const purposes = readModelRepository.purposes;
+export const delegations = readModelRepository.delegations;
 
 export const readModelService = readModelServiceBuilder(readModelRepository);
 

--- a/packages/purpose-process/test/utils.ts
+++ b/packages/purpose-process/test/utils.ts
@@ -24,6 +24,12 @@ import {
   unsafeBrandId,
   toReadModelPurpose,
   PurposeId,
+  toReadModelEService,
+  Tenant,
+  toReadModelTenant,
+  toReadModelAgreement,
+  Agreement,
+  Delegation,
 } from "pagopa-interop-models";
 import { purposeApi } from "pagopa-interop-api-clients";
 import { afterAll, afterEach, inject, vi } from "vitest";
@@ -73,6 +79,24 @@ export const purposeService = purposeServiceBuilder(
 export const addOnePurpose = async (purpose: Purpose): Promise<void> => {
   await writePurposeInEventstore(purpose);
   await writeInReadmodel(toReadModelPurpose(purpose), purposes);
+};
+
+export const addOneEService = async (eservice: EService): Promise<void> => {
+  await writeInReadmodel(toReadModelEService(eservice), eservices);
+};
+
+export const addOneTenant = async (tenant: Tenant): Promise<void> => {
+  await writeInReadmodel(toReadModelTenant(tenant), tenants);
+};
+
+export const addOneAgreement = async (agreement: Agreement): Promise<void> => {
+  await writeInReadmodel(toReadModelAgreement(agreement), agreements);
+};
+
+export const addOneDelegation = async (
+  delegation: Delegation
+): Promise<void> => {
+  await writeInReadmodel(delegation, delegations);
 };
 
 export const writePurposeInEventstore = async (


### PR DESCRIPTION
Closes [PIN-5509](https://pagopa.atlassian.net/browse/PIN-5509)
Closes [PIN-5510](https://pagopa.atlassian.net/browse/PIN-5510)
Closes [PIN-5511](https://pagopa.atlassian.net/browse/PIN-5511)
Closes [PIN-5512](https://pagopa.atlassian.net/browse/PIN-5512)

With this PR a delegate can also:
- Reject a new purpose version;
- Activate a new purpose version;
- Retrieve the purpose's risk analysis document;
- Suspend a purpose;

### Changes in `getOrganizationRoles`
- Updated to return `PRODUCER` ownership if the requester is either the delegate or the producer.
- Added validation: Throws an error if the requester is the producer but an active delegation exists for the e-service.

### Updates to `rejectPurposeVersion`
- Introduced a new assertion, `assertRequesterIsProducer`, to validate requester roles:
  - If the e-service has an active delegation, the requester must be the delegate.
  - If no active delegation exists, the requester must be the producer; otherwise, an error is thrown.

### Updates to `getRiskAnalysisDocument`
- Replaced `getOrganizationRole` with a new assertion, `assertRequesterIsAllowedToRetrieveRiskAnalysisDocument`, to better handle permission checks.
- This assertion allows both the delegate and producer to access the document.


[PIN-5509]: https://pagopa.atlassian.net/browse/PIN-5509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-5510]: https://pagopa.atlassian.net/browse/PIN-5510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-5511]: https://pagopa.atlassian.net/browse/PIN-5511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-5512]: https://pagopa.atlassian.net/browse/PIN-5512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ