### PR TITLE
PIN-5605 - Allow delegate to retrieve purpose in api-gateway

### DIFF
--- a/packages/api-gateway/.env
+++ b/packages/api-gateway/.env
@@ -20,6 +20,7 @@ TENANT_PROCESS_URL="http://localhost:3500"
 PURPOSE_PROCESS_URL="http://localhost:3400"
 ATTRIBUTE_REGISTRY_PROCESS_URL="http://localhost:3200"
 AUTHORIZATION_PROCESS_URL="http://localhost:3300"
+DELEGATION_PROCESS_URL="http://localhost:3800"
 NOTIFIER_URL="http://localhost:9999"
 
 READMODEL_DB_HOST=localhost

--- a/packages/api-gateway/src/clients/clientsProvider.ts
+++ b/packages/api-gateway/src/clients/clientsProvider.ts
@@ -6,6 +6,7 @@ import {
   attributeRegistryApi,
   notifierApi,
   authorizationApi,
+  delegationApi,
 } from "pagopa-interop-api-clients";
 import { config } from "../config/config.js";
 
@@ -38,6 +39,10 @@ export type AuthorizationProcessClient = {
   client: ReturnType<typeof authorizationApi.createClientApiClient>;
 };
 
+export type DelegationProcessClient = ReturnType<
+  typeof delegationApi.createDelegationApiClient
+>;
+
 export type PagoPAInteropBeClients = {
   catalogProcessClient: CatalogProcessClient;
   agreementProcessClient: AgreementProcessClient;
@@ -46,6 +51,7 @@ export type PagoPAInteropBeClients = {
   attributeProcessClient: AttributeProcessClient;
   notifierEventsClient: NotifierEventsClient;
   authorizationProcessClient: AuthorizationProcessClient;
+  delegationProcessClient: DelegationProcessClient;
 };
 
 export function getInteropBeClients(): PagoPAInteropBeClients {
@@ -72,5 +78,8 @@ export function getInteropBeClients(): PagoPAInteropBeClients {
         config.authorizationProcessUrl
       ),
     },
+    delegationProcessClient: delegationApi.createDelegationApiClient(
+      config.delegationProcessUrl
+    ),
   };
 }

--- a/packages/api-gateway/src/config/config.ts
+++ b/packages/api-gateway/src/config/config.ts
@@ -72,6 +72,17 @@ export type AuthorizationProcessServerConfig = z.infer<
   typeof AuthorizationProcessServerConfig
 >;
 
+export const DelegationProcessServerConfig = z
+  .object({
+    DELEGATION_PROCESS_URL: APIEndpoint,
+  })
+  .transform((c) => ({
+    delegationProcessUrl: c.DELEGATION_PROCESS_URL,
+  }));
+export type DelegationProcessServerConfig = z.infer<
+  typeof DelegationProcessServerConfig
+>;
+
 export const NotifierServerConfig = z
   .object({
     NOTIFIER_URL: APIEndpoint,
@@ -97,6 +108,7 @@ const ApiGatewayConfig = CommonHTTPServiceConfig.and(RedisRateLimiterConfig)
   .and(TenantProcessServerConfig)
   .and(PurposeProcessServerConfig)
   .and(AuthorizationProcessServerConfig)
+  .and(DelegationProcessServerConfig)
   .and(AttributeRegistryProcessServerConfig)
   .and(NotifierServerConfig)
   .and(ReadModelDbConfig);

--- a/packages/api-gateway/src/models/errors.ts
+++ b/packages/api-gateway/src/models/errors.ts
@@ -28,6 +28,7 @@ export const errorCodes = {
   tenantAttributeNotFound: "0016",
   attributeByCodeNotFound: "0017",
   certifiedAttributeAlreadyAssigned: "0018",
+  multipleActiveDelegationForEservice: "0019",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -266,5 +267,15 @@ export function certifiedAttributeAlreadyAssigned(
     detail: `Certified attribute ${attributeCode} already assigned to Institution (${origin}, ${externalId})`,
     code: "certifiedAttributeAlreadyAssigned",
     title: "Certified attribute already assigned",
+  });
+}
+
+export function multipleActiveDelegationsForEservice(
+  eserviceId: catalogApi.EService["id"]
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Unexpected multiple Active delegation for EService ${eserviceId}`,
+    code: "multipleActiveDelegationForEservice",
+    title: "Multiple active delegation found",
   });
 }

--- a/packages/api-gateway/src/routers/apiGatewayRouter.ts
+++ b/packages/api-gateway/src/routers/apiGatewayRouter.ts
@@ -49,6 +49,7 @@ const apiGatewayRouter = (
     attributeProcessClient,
     notifierEventsClient,
     authorizationProcessClient,
+    delegationProcessClient,
   }: PagoPAInteropBeClients
 ): ZodiosRouter<ZodiosEndpointDefinitions, ExpressContext> => {
   const { M2M_ROLE } = userRoles;
@@ -71,7 +72,8 @@ const apiGatewayRouter = (
   const purposeService = purposeServiceBuilder(
     purposeProcessClient,
     catalogProcessClient,
-    agreementProcessClient
+    agreementProcessClient,
+    delegationProcessClient
   );
 
   const tenantService = tenantServiceBuilder(

--- a/packages/api-gateway/src/services/purposeService.ts
+++ b/packages/api-gateway/src/services/purposeService.ts
@@ -72,13 +72,14 @@ const retrievePurpose = async (
 const retrieveActiveDelegationByEServiceId = async (
   delegationProcessClient: DelegationProcessClient,
   headers: ApiGatewayAppContext["headers"],
-  eserviceId: catalogApi.EService["id"]
+  eserviceId: catalogApi.EService["id"],
+  kind: delegationApi.DelegationKind
 ): Promise<delegationApi.Delegation | undefined> => {
   const result = await delegationProcessClient.getDelegations({
     headers,
     queries: {
       eserviceIds: [eserviceId],
-      kind: delegationApi.DelegationKind.Values.DELEGATED_PRODUCER,
+      kind,
       delegationStates: [delegationApi.DelegationState.Values.ACTIVE],
       limit: 1,
       offset: 0,
@@ -128,7 +129,8 @@ export function purposeServiceBuilder(
           const delegation = await retrieveActiveDelegationByEServiceId(
             delegationProcessClient,
             headers,
-            eservice.id
+            eservice.id,
+            delegationApi.DelegationKind.Values.DELEGATED_PRODUCER
           );
 
           assertIsEserviceProducerDelegate(delegation, organizationId);

--- a/packages/api-gateway/src/services/purposeService.ts
+++ b/packages/api-gateway/src/services/purposeService.ts
@@ -1,8 +1,14 @@
 import { getAllFromPaginated, WithLogger } from "pagopa-interop-commons";
-import { apiGatewayApi, purposeApi } from "pagopa-interop-api-clients";
+import {
+  apiGatewayApi,
+  purposeApi,
+  catalogApi,
+  delegationApi,
+} from "pagopa-interop-api-clients";
 import {
   AgreementProcessClient,
   CatalogProcessClient,
+  DelegationProcessClient,
   PurposeProcessClient,
 } from "../clients/clientsProvider.js";
 import { ApiGatewayAppContext } from "../utilities/context.js";
@@ -14,6 +20,8 @@ import { clientStatusCodeToError } from "../clients/catchClientError.js";
 import { purposeNotFound } from "../models/errors.js";
 import {
   assertIsEserviceProducer,
+  assertIsEserviceProducerDelegate,
+  assertOnlyOneActiveDelegationForEserviceExists,
   assertOnlyOneAgreementForEserviceAndConsumerExists,
 } from "./validators.js";
 import { getAllAgreements } from "./agreementService.js";
@@ -61,11 +69,33 @@ const retrievePurpose = async (
       });
     });
 
+const retrieveActiveDelegationByEServiceId = async (
+  delegationProcessClient: DelegationProcessClient,
+  headers: ApiGatewayAppContext["headers"],
+  eserviceId: catalogApi.EService["id"]
+): Promise<delegationApi.Delegation | undefined> => {
+  const result = await delegationProcessClient.getDelegations({
+    headers,
+    queries: {
+      eserviceIds: [eserviceId],
+      kind: delegationApi.DelegationKind.Values.DELEGATED_PRODUCER,
+      delegationStates: [delegationApi.DelegationState.Values.ACTIVE],
+      limit: 1,
+      offset: 0,
+    },
+  });
+
+  assertOnlyOneActiveDelegationForEserviceExists(result, eserviceId);
+
+  return result.results.at(0);
+};
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function purposeServiceBuilder(
   purposeProcessClient: PurposeProcessClient,
   catalogProcessClient: CatalogProcessClient,
-  agreementProcessClient: AgreementProcessClient
+  agreementProcessClient: AgreementProcessClient,
+  delegationProcessClient: DelegationProcessClient
 ) {
   return {
     getPurpose: async (
@@ -92,7 +122,17 @@ export function purposeServiceBuilder(
           },
         });
 
-        assertIsEserviceProducer(eservice, organizationId);
+        try {
+          assertIsEserviceProducer(eservice, organizationId);
+        } catch {
+          const delegation = await retrieveActiveDelegationByEServiceId(
+            delegationProcessClient,
+            headers,
+            eservice.id
+          );
+
+          assertIsEserviceProducerDelegate(delegation, organizationId);
+        }
       }
 
       return toApiGatewayPurpose(purpose, logger);

--- a/packages/api-gateway/src/services/validators.ts
+++ b/packages/api-gateway/src/services/validators.ts
@@ -3,6 +3,7 @@ import {
   apiGatewayApi,
   attributeRegistryApi,
   catalogApi,
+  delegationApi,
   purposeApi,
 } from "pagopa-interop-api-clients";
 import { operationForbidden, TenantId } from "pagopa-interop-models";
@@ -15,6 +16,7 @@ import {
   missingAvailableDescriptor,
   multipleAgreementForEserviceAndConsumer,
   unexpectedDescriptorState,
+  multipleActiveDelegationsForEservice,
 } from "../models/errors.js";
 import { NonDraftCatalogApiDescriptor } from "../api/catalogApiConverter.js";
 
@@ -91,5 +93,23 @@ export function assertRegistryAttributeExists(
 ): asserts registryAttribute is NonNullable<attributeRegistryApi.Attribute> {
   if (!registryAttribute) {
     throw attributeNotFoundInRegistry(attributeId);
+  }
+}
+
+export function assertIsEserviceProducerDelegate(
+  delegation: delegationApi.Delegation | undefined,
+  organizationId: TenantId
+): void {
+  if (!delegation || delegation.delegateId !== organizationId) {
+    throw operationForbidden;
+  }
+}
+
+export function assertOnlyOneActiveDelegationForEserviceExists(
+  delegations: delegationApi.Delegations,
+  eserviceId: apiGatewayApi.EService["id"]
+): void {
+  if (delegations.totalCount > 1) {
+    throw multipleActiveDelegationsForEservice(eserviceId);
   }
 }


### PR DESCRIPTION
Closes [PIN-5605](https://pagopa.atlassian.net/browse/PIN-5605)

The only needed change I found in the `api-gateway` router was inside the `getPurpose` call, which allowed only the e-service producer or the consumer to access the purpose.
The change has been made to allow also the delegate to access it.
 
[PIN-5605]: https://pagopa.atlassian.net/browse/PIN-5605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ