### PR TITLE
PIN-5566 - fixing dtd catalog exporter docker run

### DIFF
--- a/packages/dtd-catalog-exporter/package.json
+++ b/packages/dtd-catalog-exporter/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "PagoPA Interoperability catalog exporter job",
+  "main": "dist",
   "type": "module",
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
Closes [PIN-5566](https://pagopa.atlassian.net/browse/PIN-5566 )

Tested locally, docker container now runs correctly.

[PIN-5566]: https://pagopa.atlassian.net/browse/PIN-5566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ