### PR TITLE
PIN-5737 - Implementing new agreement contract standard template

### DIFF
--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -15,6 +15,7 @@ import {
   unsafeBrandId,
   TenantId,
   AgreementStamp,
+  AgreementStamps,
 } from "pagopa-interop-models";
 import { agreementApi } from "pagopa-interop-api-clients";
 import { AuthData } from "pagopa-interop-commons";
@@ -410,10 +411,10 @@ export const matchingVerifiedAttributes = (
   ).map((id) => ({ id } as VerifiedAgreementAttribute));
 };
 
-export function assertStampExists<S extends keyof Agreement["stamps"]>(
-  stamps: Agreement["stamps"],
+export function assertStampExists<S extends keyof AgreementStamps>(
+  stamps: AgreementStamps,
   stamp: S
-): asserts stamps is Agreement["stamps"] & {
+): asserts stamps is AgreementStamps & {
   [key in S]: AgreementStamp;
 } {
   if (!stamps[stamp]) {

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -14,6 +14,7 @@ import {
   EServiceId,
   unsafeBrandId,
   TenantId,
+  AgreementStamp,
 } from "pagopa-interop-models";
 import { agreementApi } from "pagopa-interop-api-clients";
 import { AuthData } from "pagopa-interop-commons";
@@ -28,6 +29,7 @@ import {
   agreementActivationFailed,
   agreementAlreadyExists,
   agreementNotInExpectedState,
+  agreementStampNotFound,
   agreementSubmissionFailed,
   descriptorNotFound,
   descriptorNotInExpectedState,
@@ -407,3 +409,14 @@ export const matchingVerifiedAttributes = (
     verifiedAttributes
   ).map((id) => ({ id } as VerifiedAgreementAttribute));
 };
+
+export function assertStampExists<S extends keyof Agreement["stamps"]>(
+  stamps: Agreement["stamps"],
+  stamp: S
+): asserts stamps is Agreement["stamps"] & {
+  [key in S]: AgreementStamp;
+} {
+  if (!stamps[stamp]) {
+    throw agreementStampNotFound(stamp);
+  }
+}

--- a/packages/agreement-process/src/model/domain/errors.ts
+++ b/packages/agreement-process/src/model/domain/errors.ts
@@ -8,9 +8,8 @@ import {
   EServiceId,
   TenantId,
   makeApiProblemBuilder,
-  UserId,
-  SelfcareId,
   AttributeId,
+  Agreement,
 } from "pagopa-interop-models";
 
 export const errorCodes = {
@@ -29,17 +28,14 @@ export const errorCodes = {
   unexpectedVersionFormat: "0013",
   descriptorNotFound: "0014",
   stampNotFound: "0015",
-  missingUserInfo: "0016",
   documentNotFound: "0017",
   documentsChangeNotAllowed: "0018",
-  selfcareIdNotFound: "0019",
   tenantNotFound: "0020",
   notLatestEServiceDescriptor: "0021",
   attributeNotFound: "0022",
   invalidAttributeStructure: "0023",
   consumerWithNotValidEmail: "0024",
   agreementDocumentAlreadyExists: "0025",
-  userNotFound: "0026",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -220,29 +216,13 @@ export function consumerWithNotValidEmail(
   });
 }
 
-export function agreementStampNotFound(stamp: string): ApiError<ErrorCodes> {
-  return new ApiError({
-    detail: `Agreement stamp ${stamp} not found`,
-    code: "stampNotFound",
-    title: "Stamp not found",
-  });
-}
-
-export function agreementMissingUserInfo(userId: string): ApiError<ErrorCodes> {
-  return new ApiError({
-    detail: `Some mandatory info are missing for user ${userId}`,
-    code: "missingUserInfo",
-    title: "Some mandatory info are missing for user",
-  });
-}
-
-export function agreementSelfcareIdNotFound(
-  tenantId: TenantId
+export function agreementStampNotFound(
+  stamp: keyof Agreement["stamps"]
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `Selfcare id not found for tenant ${tenantId}`,
-    code: "selfcareIdNotFound",
-    title: "Selfcare id not found for tenant",
+    detail: `Agreement ${stamp} stamp not found`,
+    code: "stampNotFound",
+    title: "Stamp not found",
   });
 }
 
@@ -285,17 +265,6 @@ export function documentChangeNotAllowed(
     detail: `The requested operation on consumer documents is not allowed on agreement with state ${state}`,
     code: "documentsChangeNotAllowed",
     title: "Document change not allowed",
-  });
-}
-
-export function userNotFound(
-  selfcareId: SelfcareId,
-  userId: UserId
-): ApiError<ErrorCodes> {
-  return new ApiError({
-    detail: `User ${userId} not found for selfcare institution ${selfcareId}`,
-    code: "userNotFound",
-    title: "User not found",
   });
 }
 

--- a/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
+++ b/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
@@ -48,7 +48,7 @@
       di fruizione contraddistinta da id <strong>{{agreementId}}</strong> (di
       seguito “richiesta di fruizione”), inviata dall’aderente
       <strong>{{consumerName}}</strong> {{#if consumerIpaCode}}(codice IPA:
-      <strong>{{consumerIpaCode}}</strong> -- di seguito “fruitore”){{else}}(di
+      <strong>{{consumerIpaCode}}</strong> — di seguito “fruitore”){{else}}(di
       seguito “fruitore”){{/if}}, tramite l’operatore amministrativo con
       identificativo Area Riservata <strong>{{submitterId}}</strong>, per
       l’e-service <strong>{{eserviceName}}</strong>, contraddistinto da id
@@ -56,7 +56,7 @@
       contraddistinta da id <strong>{{descriptorId}}</strong> (di seguito
       “e-service”), reso disponibile dall’aderente
       <strong>{{producerName}}</strong> {{#if producerIpaCode}}(codice IPA:
-      <strong>{{producerIpaCode}}</strong> -- di seguito erogatore”){{else}}(di
+      <strong>{{producerIpaCode}}</strong> — di seguito erogatore”){{else}}(di
       seguito "erogatore”){{/if}} di cui il fruitore soddisfa i seguenti
       requisiti di fruizione per lo stesso previsti dall’erogatore.
     </div>
@@ -89,9 +89,9 @@
         la verifica dell'erogatore che il fruitore possegga l’attributo
         verificato <strong>{{this.attributeName}}</strong>, contraddistinto da
         id <strong>{{this.attributeId}}</strong>, {{#if this.expirationDate}} ed
-        avente scadenza il {{this.expirationDate}},{{/if}} necessario a
-        soddisfare il requisito di fruizione stabilito dall’erogatore per
-        l’accesso all’e-service.
+        avente scadenza il <strong>{{this.expirationDate}}</strong>,{{/if}}
+        necessario a soddisfare il requisito di fruizione stabilito
+        dall’erogatore per l’accesso all’e-service.
       </div>
 
       {{/each}} {{/if}} {{#if certifiedAttributes}}
@@ -116,7 +116,7 @@
       <div>
         In data <strong>{{submissionDate}}</strong> alle ore
         <strong>{{submissionTime}}</strong>, l’Infrastruttura ha trasmesso
-        all’erogatore la Richiesta di Fruizione.
+        all’erogatore la richiesta di fruizione.
       </div>
 
       <div>

--- a/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
+++ b/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
@@ -46,13 +46,19 @@
       In data <strong>{{todayDate}}</strong> alle ore
       <strong>{{todayTime}}</strong>, l’Infrastruttura ha ricevuto la richiesta
       di fruizione contraddistinta da id <strong>{{agreementId}}</strong> (di
-      seguito “Richiesta di Fruizione”), inviata dall’aderente
-      <strong>{{consumerText}}</strong> (di seguito “Fruitore”), tramite
-      l’operatore amministrativo <strong>{{submitter}}</strong>, per l’E-service
-      <strong>{{eServiceName}}</strong> reso disponibile dall’aderente
-      <strong>{{producerText}}</strong>
-      (di seguito “Erogatore”) di cui il Fruitore soddisfa i seguenti requisiti
-      di fruizione per lo stesso previsti dall’Erogatore.
+      seguito “richiesta di fruizione”), inviata dall’aderente
+      <strong>{{consumerName}}</strong> {{#if consumerIpaCode}}(codice IPA:
+      <strong>{{consumerIpaCode}}</strong> -- di seguito “fruitore”){{else}}(di
+      seguito “fruitore”){{/if}}, tramite l’operatore amministrativo con
+      identificativo Area Riservata <strong>{{submitterId}}</strong>, per
+      l’e-service <strong>{{eserviceName}}</strong>, contraddistinto da id
+      <strong>{{eserviceId}}</strong>, versione {{descriptorVersion}},
+      contraddistinta da id <strong>{{descriptorId}}</strong> (di seguito
+      “e-service”), reso disponibile dall’aderente
+      <strong>{{producerName}}</strong> {{#if producerIpaCode}}(codice IPA:
+      <strong>{{producerIpaCode}}</strong> -- di seguito erogatore”){{else}}(di
+      seguito "erogatore”){{/if}} di cui il fruitore soddisfa i seguenti
+      requisiti di fruizione per lo stesso previsti dall’erogatore.
     </div>
     <div class="content">
       {{#if declaredAttributes}}
@@ -110,27 +116,28 @@
       <div>
         In data <strong>{{submissionDate}}</strong> alle ore
         <strong>{{submissionTime}}</strong>, l’Infrastruttura ha trasmesso
-        all’Erogatore la Richiesta di Fruizione.
+        all’erogatore la Richiesta di Fruizione.
       </div>
 
       <div>
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’Infrastruttura ha ricevuto la
-        dichiarazione di accettazione della Richiesta di Fruizione (di seguito
-        “Dichiarazione Accettazione”) inviata dall’Erogatore, tramite
-        l’operatore amministrativo <strong>{{activator}}</strong>.
+        dichiarazione di accettazione della richiesta di fruizione (di seguito
+        “dichiarazione di accettazione”) inviata dall’erogatore, tramite
+        l’operatore amministrativo con identificativo Area Riservata
+        <strong>{{activatorId}}</strong>.
       </div>
 
       <div>
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’Infrastruttura ha comunicato al
-        Fruitore la Dichiarazione Accettazione inviata dall’Erogatore.
+        fruitore la dichiarazione di accettazione inviata dall’erogatore.
       </div>
 
       <div>
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’Infrastruttura ha registrato il
-        Fruitore quale soggetto titolato ad accedere all’E-service.
+        fruitore quale soggetto titolato ad accedere all’e-service.
       </div>
     </div>
   </body>

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -19,7 +19,6 @@ import {
   unsafeBrandId,
 } from "pagopa-interop-models";
 import { agreementApi } from "pagopa-interop-api-clients";
-import { selfcareV2UsersClientBuilder } from "pagopa-interop-api-clients";
 import {
   agreementDocumentToApiAgreementDocument,
   agreementToApiAgreement,
@@ -65,8 +64,7 @@ const agreementService = agreementServiceBuilder(
   }),
   readModelService,
   initFileManager(config),
-  pdfGenerator,
-  selfcareV2UsersClientBuilder(config)
+  pdfGenerator
 );
 
 const {

--- a/packages/agreement-process/src/services/agreementContractBuilder.ts
+++ b/packages/agreement-process/src/services/agreementContractBuilder.ts
@@ -17,57 +17,27 @@ import {
   CertifiedTenantAttribute,
   DeclaredTenantAttribute,
   EService,
-  SelfcareId,
   Tenant,
   TenantAttributeType,
   TenantId,
   VerifiedTenantAttribute,
-  UserId,
   generateId,
   tenantAttributeType,
-  unsafeBrandId,
   AgreementDocument,
-  CorrelationId,
+  PUBLIC_ADMINISTRATIONS_IDENTIFIER,
 } from "pagopa-interop-models";
-import {
-  selfcareV2ClientApi,
-  SelfcareV2UsersClient,
-} from "pagopa-interop-api-clients";
 import { match } from "ts-pattern";
-import { isAxiosError } from "axios";
 import { getVerifiedAttributeExpirationDate } from "pagopa-interop-agreement-lifecycle";
 import {
-  agreementMissingUserInfo,
-  agreementSelfcareIdNotFound,
-  agreementStampNotFound,
   attributeNotFound,
-  userNotFound,
+  descriptorNotFound,
 } from "../model/domain/errors.js";
 import { AgreementProcessConfig } from "../config/config.js";
+import { assertStampExists } from "../model/domain/agreement-validators.js";
 import { ReadModelService } from "./readModelService.js";
 
 const CONTENT_TYPE_PDF = "application/pdf";
 const AGREEMENT_CONTRACT_PRETTY_NAME = "Richiesta di fruizione";
-
-const retrieveUser = async (
-  selfcareV2Client: SelfcareV2UsersClient,
-  selfcareId: SelfcareId,
-  id: UserId,
-  correlationId: CorrelationId
-): Promise<selfcareV2ClientApi.UserResponse> => {
-  const user = await selfcareV2Client.getUserInfoUsingGET({
-    queries: { institutionId: selfcareId },
-    params: { id },
-    headers: {
-      "X-Correlation-Id": correlationId,
-    },
-  });
-
-  if (!user) {
-    throw userNotFound(selfcareId, id);
-  }
-  return user;
-};
 
 const createAgreementDocumentName = (
   consumerId: TenantId,
@@ -162,133 +132,19 @@ const getAttributesData = async (
   };
 };
 
-const getSubmissionInfo = async (
-  selfcareV2Client: SelfcareV2UsersClient,
-  consumer: Tenant,
-  agreement: Agreement,
-  correlationId: CorrelationId
-): Promise<[string, Date]> => {
-  const submission = agreement.stamps.submission;
-  if (!submission) {
-    throw agreementStampNotFound("submission");
-  }
-
-  if (!consumer.selfcareId) {
-    throw agreementSelfcareIdNotFound(consumer.id);
-  }
-
-  const consumerSelfcareId: SelfcareId = unsafeBrandId(consumer.selfcareId);
-
-  const consumerUser: selfcareV2ClientApi.UserResponse = await retrieveUser(
-    selfcareV2Client,
-    consumerSelfcareId,
-    submission.who,
-    correlationId
-  );
-  if (consumerUser.name && consumerUser.surname && consumerUser.taxCode) {
-    return [
-      `${consumerUser.name} ${consumerUser.surname} (${consumerUser.taxCode})`,
-      submission.when,
-    ];
-  }
-
-  throw agreementMissingUserInfo(submission.who);
-};
-
-const getActivationInfo = async (
-  selfcareV2Client: SelfcareV2UsersClient,
-  producer: Tenant,
-  consumer: Tenant,
-  agreement: Agreement,
-  correlationId: CorrelationId
-): Promise<[string, Date]> => {
-  const activation = agreement.stamps.activation;
-  if (!activation) {
-    throw agreementStampNotFound("activation");
-  }
-
-  if (!producer.selfcareId) {
-    throw agreementSelfcareIdNotFound(producer.id);
-  }
-  if (!consumer.selfcareId) {
-    throw agreementSelfcareIdNotFound(consumer.id);
-  }
-
-  const producerSelfcareId: SelfcareId = unsafeBrandId(producer.selfcareId);
-  const consumerSelfcareId: SelfcareId = unsafeBrandId(consumer.selfcareId);
-
-  /**
-   * The user that activated the agreement, the one in the activation.who stamp, could both belong to the producer institution or the consumer institution.
-   * In case the user is not found with the producer institutionId, we try to retrieve it from the consumer selfcare.
-   */
-
-  // eslint-disable-next-line functional/no-let, @typescript-eslint/no-non-null-assertion
-  let user: selfcareV2ClientApi.UserResponse = undefined!;
-
-  try {
-    user = await retrieveUser(
-      selfcareV2Client,
-      producerSelfcareId,
-      activation.who,
-      correlationId
-    );
-  } catch (e) {
-    if (isAxiosError(e) && e.response?.status === 404) {
-      user = await retrieveUser(
-        selfcareV2Client,
-        consumerSelfcareId,
-        activation.who,
-        correlationId
-      );
-    } else {
-      throw e;
-    }
-  }
-
-  if (user.name && user.surname && user.taxCode) {
-    return [`${user.name} ${user.surname} (${user.taxCode})`, activation.when];
-  }
-
-  throw agreementMissingUserInfo(activation.who);
-};
-
 const getPdfPayload = async (
   agreement: Agreement,
   eservice: EService,
   consumer: Tenant,
   producer: Tenant,
-  readModelService: ReadModelService,
-  selfcareV2Client: SelfcareV2UsersClient,
-  correlationId: CorrelationId
+  readModelService: ReadModelService
 ): Promise<AgreementContractPDFPayload> => {
-  const getTenantText = (name: string, origin: string, value: string): string =>
-    origin === "IPA" ? `${name} (codice IPA: ${value})` : name;
+  const getIpaCode = (tenant: Tenant): string | undefined =>
+    tenant.externalId.origin === PUBLIC_ADMINISTRATIONS_IDENTIFIER
+      ? tenant.externalId.value
+      : undefined;
 
   const today = new Date();
-  const producerText = getTenantText(
-    producer.name,
-    producer.externalId.origin,
-    producer.externalId.value
-  );
-
-  const consumerText = getTenantText(
-    consumer.name,
-    consumer.externalId.origin,
-    consumer.externalId.value
-  );
-  const [submitter, submissionTimestamp] = await getSubmissionInfo(
-    selfcareV2Client,
-    consumer,
-    agreement,
-    correlationId
-  );
-  const [activator, activationTimestamp] = await getActivationInfo(
-    selfcareV2Client,
-    producer,
-    consumer,
-    agreement,
-    correlationId
-  );
 
   const { certified, declared, verified } = await getAttributesData(
     consumer,
@@ -296,19 +152,35 @@ const getPdfPayload = async (
     readModelService
   );
 
+  const descriptor = eservice.descriptors.find(
+    (d) => d.id === agreement.descriptorId
+  );
+
+  if (!descriptor) {
+    throw descriptorNotFound(eservice.id, agreement.descriptorId);
+  }
+
+  assertStampExists(agreement.stamps, "submission");
+  assertStampExists(agreement.stamps, "activation");
+
   return {
     todayDate: dateAtRomeZone(today),
     todayTime: timeAtRomeZone(today),
     agreementId: agreement.id,
-    submitter,
-    submissionDate: dateAtRomeZone(submissionTimestamp),
-    submissionTime: timeAtRomeZone(submissionTimestamp),
-    activator,
-    activationDate: dateAtRomeZone(activationTimestamp),
-    activationTime: timeAtRomeZone(activationTimestamp),
-    eServiceName: eservice.name,
-    producerText,
-    consumerText,
+    submitterId: agreement.stamps.submission.who,
+    submissionDate: dateAtRomeZone(agreement.stamps.submission.when),
+    submissionTime: timeAtRomeZone(agreement.stamps.submission.when),
+    activatorId: agreement.stamps.activation.who,
+    activationDate: dateAtRomeZone(agreement.stamps.activation.when),
+    activationTime: timeAtRomeZone(agreement.stamps.activation.when),
+    eserviceId: eservice.id,
+    eserviceName: eservice.name,
+    descriptorId: agreement.descriptorId,
+    descriptorVersion: descriptor.version,
+    producerName: producer.name,
+    producerIpaCode: getIpaCode(producer),
+    consumerName: consumer.name,
+    consumerIpaCode: getIpaCode(consumer),
     certifiedAttributes: certified.map(({ attribute, tenantAttribute }) => ({
       assignmentDate: dateAtRomeZone(tenantAttribute.assignmentTimestamp),
       assignmentTime: timeAtRomeZone(tenantAttribute.assignmentTimestamp),
@@ -345,10 +217,8 @@ export const contractBuilder = (
   readModelService: ReadModelService,
   pdfGenerator: PDFGenerator,
   fileManager: FileManager,
-  selfcareV2Client: SelfcareV2UsersClient,
   config: AgreementProcessConfig,
-  logger: Logger,
-  correlationId: CorrelationId
+  logger: Logger
 ) => {
   const filename = fileURLToPath(import.meta.url);
   const dirname = path.dirname(filename);
@@ -371,9 +241,7 @@ export const contractBuilder = (
         eservice,
         consumer,
         producer,
-        readModelService,
-        selfcareV2Client,
-        correlationId
+        readModelService
       );
 
       const pdfBuffer: Buffer = await pdfGenerator.generate(

--- a/packages/agreement-process/src/services/agreementContractBuilder.ts
+++ b/packages/agreement-process/src/services/agreementContractBuilder.ts
@@ -28,13 +28,11 @@ import {
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { getVerifiedAttributeExpirationDate } from "pagopa-interop-agreement-lifecycle";
-import {
-  attributeNotFound,
-  descriptorNotFound,
-} from "../model/domain/errors.js";
+import { attributeNotFound } from "../model/domain/errors.js";
 import { AgreementProcessConfig } from "../config/config.js";
 import { assertStampExists } from "../model/domain/agreement-validators.js";
 import { ReadModelService } from "./readModelService.js";
+import { retrieveDescriptor } from "./agreementService.js";
 
 const CONTENT_TYPE_PDF = "application/pdf";
 const AGREEMENT_CONTRACT_PRETTY_NAME = "Richiesta di fruizione";
@@ -152,13 +150,7 @@ const getPdfPayload = async (
     readModelService
   );
 
-  const descriptor = eservice.descriptors.find(
-    (d) => d.id === agreement.descriptorId
-  );
-
-  if (!descriptor) {
-    throw descriptorNotFound(eservice.id, agreement.descriptorId);
-  }
+  const descriptor = retrieveDescriptor(agreement.descriptorId, eservice);
 
   assertStampExists(agreement.stamps, "submission");
   assertStampExists(agreement.stamps, "activation");

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -9,10 +9,7 @@ import {
   WithLogger,
   eventRepository,
 } from "pagopa-interop-commons";
-import {
-  agreementApi,
-  SelfcareV2UsersClient,
-} from "pagopa-interop-api-clients";
+import { agreementApi } from "pagopa-interop-api-clients";
 import {
   Agreement,
   AgreementDocument,
@@ -204,8 +201,7 @@ export function agreementServiceBuilder(
   dbInstance: DB,
   readModelService: ReadModelService,
   fileManager: FileManager,
-  pdfGenerator: PDFGenerator,
-  selfcareV2Client: SelfcareV2UsersClient
+  pdfGenerator: PDFGenerator
 ) {
   const repository = eventRepository(dbInstance, agreementEventToBinaryData);
   return {
@@ -471,10 +467,8 @@ export function agreementServiceBuilder(
         readModelService,
         pdfGenerator,
         fileManager,
-        selfcareV2Client,
         config,
-        logger,
-        correlationId
+        logger
       );
 
       const isFirstActivation =
@@ -615,10 +609,8 @@ export function agreementServiceBuilder(
         readModelService,
         pdfGenerator,
         fileManager,
-        selfcareV2Client,
         config,
-        logger,
-        correlationId
+        logger
       );
 
       const [agreement, events] = await createUpgradeOrNewDraft({
@@ -936,10 +928,8 @@ export function agreementServiceBuilder(
         readModelService,
         pdfGenerator,
         fileManager,
-        selfcareV2Client,
         config,
-        logger,
-        correlationId
+        logger
       );
 
       const agreement = await retrieveAgreement(agreementId, readModelService);

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -169,7 +169,7 @@ export const retrieveTenant = async (
   return tenant;
 };
 
-const retrieveDescriptor = (
+export const retrieveDescriptor = (
   descriptorId: DescriptorId,
   eservice: EService
 ): Descriptor => {

--- a/packages/agreement-process/test/activateAgreement.test.ts
+++ b/packages/agreement-process/test/activateAgreement.test.ts
@@ -48,7 +48,7 @@ import {
   fromAgreementV2,
   generateId,
 } from "pagopa-interop-models";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { addDays } from "date-fns";
 import {
   agreementActivableStates,
@@ -158,16 +158,6 @@ describe("activate agreement", () => {
       stream_id: relatedAgreements.nonArchivableRelatedAgreement.id,
     });
   }
-
-  const testDate = new Date();
-  beforeAll(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(testDate);
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
-  });
 
   describe("Agreement Pending", () => {
     it("Agreement Pending, Requester === Producer, valid attributes -- success case: Pending >> Activated", async () => {
@@ -345,8 +335,8 @@ describe("activate agreement", () => {
           "agreementContractTemplate.html"
         ),
         {
-          todayDate: dateAtRomeZone(testDate),
-          todayTime: timeAtRomeZone(testDate),
+          todayDate: expect.any(String),
+          todayTime: expect.any(String),
           agreementId: expectedActivatedAgreement.id,
           submitterId: expectedActivatedAgreement.stamps.submission!.who,
           submissionDate: dateAtRomeZone(

--- a/packages/agreement-process/test/activateAgreement.test.ts
+++ b/packages/agreement-process/test/activateAgreement.test.ts
@@ -335,8 +335,8 @@ describe("activate agreement", () => {
           "agreementContractTemplate.html"
         ),
         {
-          todayDate: expect.any(String),
-          todayTime: expect.any(String),
+          todayDate: expect.stringMatching(/^\d{2}\/\d{2}\/\d{4}$/),
+          todayTime: expect.stringMatching(/^\d{2}:\d{2}:\d{2}$/),
           agreementId: expectedActivatedAgreement.id,
           submitterId: expectedActivatedAgreement.stamps.submission!.who,
           submissionDate: dateAtRomeZone(

--- a/packages/agreement-process/test/agreementStatesFlows.test.ts
+++ b/packages/agreement-process/test/agreementStatesFlows.test.ts
@@ -29,8 +29,7 @@ import {
   toReadModelEService,
   toReadModelTenant,
 } from "pagopa-interop-models";
-import { selfcareV2ClientApi } from "pagopa-interop-api-clients";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { addDays, subDays } from "date-fns";
 import {
   addOneAttribute,
@@ -39,24 +38,10 @@ import {
   agreementService,
   agreements,
   eservices,
-  selfcareV2ClientMock,
   tenants,
 } from "./utils.js";
 
 describe("Agreeement states flows", () => {
-  const mockSelfcareUserResponse: selfcareV2ClientApi.UserResponse = {
-    email: "test@test.com",
-    name: "Test Name",
-    surname: "Test Surname",
-    id: generateId(),
-    taxCode: "TSTTSTTSTTSTTSTT",
-  };
-  beforeEach(async () => {
-    selfcareV2ClientMock.getUserInfoUsingGET = vi.fn(
-      async () => mockSelfcareUserResponse
-    );
-  });
-
   async function updateAgreementInReadModel(
     agreement: Agreement
   ): Promise<void> {

--- a/packages/agreement-process/test/submitAgreement.test.ts
+++ b/packages/agreement-process/test/submitAgreement.test.ts
@@ -47,7 +47,7 @@ import {
   tenantMailKind,
   toAgreementStateV2,
 } from "pagopa-interop-models";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { agreementSubmissionConflictingStates } from "../src/model/domain/agreement-validators.js";
 import {
   agreementAlreadyExists,
@@ -155,16 +155,6 @@ describe("submit agreement", () => {
       stream_id: relatedAgreements.nonArchivableRelatedAgreement.id,
     });
   }
-
-  const testDate = new Date();
-  beforeAll(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(testDate);
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
-  });
 
   it("should throw an agreementNotFound when Agreement not found", async () => {
     await addOneAgreement(getMockAgreement());
@@ -1252,8 +1242,8 @@ describe("submit agreement", () => {
         "agreementContractTemplate.html"
       ),
       {
-        todayDate: dateAtRomeZone(testDate),
-        todayTime: timeAtRomeZone(testDate),
+        todayDate: expect.stringMatching(/^\d{2}\/\d{2}\/\d{4}$/),
+        todayTime: expect.stringMatching(/^\d{2}:\d{2}:\d{2}$/),
         agreementId: expectedAgreement.id,
         submitterId: expectedAgreement.stamps.submission.who,
         submissionDate: dateAtRomeZone(

--- a/packages/agreement-process/test/upgradeAgreement.test.ts
+++ b/packages/agreement-process/test/upgradeAgreement.test.ts
@@ -42,17 +42,7 @@ import {
   toAgreementV2,
   unsafeBrandId,
 } from "pagopa-interop-models";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
-import { selfcareV2ClientApi } from "pagopa-interop-api-clients";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { addDays } from "date-fns";
 import { agreementUpgradableStates } from "../src/model/domain/agreement-validators.js";
 import {
@@ -80,7 +70,6 @@ import {
   getMockConsumerDocument,
   getMockContract,
   readAgreementEventByVersion,
-  selfcareV2ClientMock,
   uploadDocument,
 } from "./utils.js";
 
@@ -91,25 +80,6 @@ describe("upgrade Agreement", () => {
   });
   afterAll(() => {
     vi.useRealTimers();
-  });
-
-  const mockSelfcareUserResponse: selfcareV2ClientApi.UserResponse = {
-    email: "test@test.com",
-    name: "Test Name",
-    surname: "Test Surname",
-    taxCode: "TSTTSTTSTTSTTSTT",
-    id: generateId(),
-  };
-
-  beforeEach(async () => {
-    // eslint-disable-next-line functional/immutable-data
-    selfcareV2ClientMock.getUserInfoUsingGET = vi.fn(
-      async () => mockSelfcareUserResponse
-    );
-  });
-
-  afterEach(async () => {
-    vi.clearAllMocks();
   });
 
   it("should succeed with valid Verified and Declared attributes when consumer and producer are the same", async () => {

--- a/packages/agreement-process/test/utils.ts
+++ b/packages/agreement-process/test/utils.ts
@@ -28,10 +28,7 @@ import {
   toReadModelAttribute,
   TenantId,
 } from "pagopa-interop-models";
-import {
-  agreementApi,
-  SelfcareV2UsersClient,
-} from "pagopa-interop-api-clients";
+import { agreementApi } from "pagopa-interop-api-clients";
 import {
   formatDateyyyyMMddHHmmss,
   genericLogger,
@@ -71,16 +68,13 @@ export const attributes = readModelRepository.attributes;
 
 export const readModelService = readModelServiceBuilder(readModelRepository);
 
-export const selfcareV2ClientMock: SelfcareV2UsersClient =
-  {} as SelfcareV2UsersClient;
 export const pdfGenerator = await initPDFGenerator();
 
 export const agreementService = agreementServiceBuilder(
   postgresDB,
   readModelService,
   fileManager,
-  pdfGenerator,
-  selfcareV2ClientMock
+  pdfGenerator
 );
 export const writeAgreementInEventstore = async (
   agreement: Agreement

--- a/packages/models/src/agreement/agreement.ts
+++ b/packages/models/src/agreement/agreement.ts
@@ -81,16 +81,21 @@ export type Agreement = z.infer<typeof Agreement>;
 export type AgreementContractPDFPayload = {
   todayDate: string;
   todayTime: string;
-  agreementId: string;
-  submitter: string;
+  agreementId: AgreementId;
+  submitterId: UserId;
   submissionDate: string;
   submissionTime: string;
-  activator: string;
+  activatorId: UserId;
   activationDate: string;
   activationTime: string;
-  eServiceName: string;
-  producerText: string;
-  consumerText: string;
+  eserviceId: EServiceId;
+  eserviceName: string;
+  descriptorId: DescriptorId;
+  descriptorVersion: string;
+  producerName: string;
+  producerIpaCode: string | undefined;
+  consumerName: string;
+  consumerIpaCode: string | undefined;
   certifiedAttributes: Array<{
     assignmentDate: string;
     assignmentTime: string;


### PR DESCRIPTION
Based on #1153 

- [x] maybe add a spyOn of pdfGenerator.generate to check that it's called with the right params?
- [x] manual test
- [x] validate that we don't need the self-care anymore --> waiting for Slack thread response https://pagopaspa.slack.com/archives/C06D24MANNN/p1732530647757939

## Reference [on Figma](https://www.figma.com/design/QlabxYPLjCE0QZmc7xtbw7/Interop-%E2%80%94-v0.11-LLGG-2024-Vol.-II?node-id=15235-25050&t=3PLbUU2lzDCEWdx2-4)

This updates the new standard agreement template (the one without any delegation) to match the Figma template.

# Test

Manual test generated the following contract:

[69e2865e-65ab-4e48-a638-2037a9ee2ee7_69e2865e-65ab-4e48-a638-2037a9ee2ee7_20241125154756_agreement_contract.pdf](https://github.com/user-attachments/files/17904632/69e2865e-65ab-4e48-a638-2037a9ee2ee7_69e2865e-65ab-4e48-a638-2037a9ee2ee7_20241125154756_agreement_contract.pdf)


<img width="608" alt="image" src="https://github.com/user-attachments/assets/8c80b68a-d9ad-42c3-896c-400fa840293a">

