### PR TITLE
Fixing two small typos in PDF templates for agreement and delegation

### DIFF
--- a/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
+++ b/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
@@ -56,8 +56,8 @@
       contraddistinta da id <strong>{{descriptorId}}</strong> (di seguito
       “e-service”), reso disponibile dall’aderente
       <strong>{{producerName}}</strong> {{#if producerIpaCode}}(codice IPA:
-      <strong>{{producerIpaCode}}</strong> — di seguito erogatore”){{else}}(di
-      seguito "erogatore”){{/if}} di cui il fruitore soddisfa i seguenti
+      <strong>{{producerIpaCode}}</strong> — di seguito “erogatore”){{else}}(di
+      seguito “erogatore”){{/if}} di cui il fruitore soddisfa i seguenti
       requisiti di fruizione per lo stesso previsti dall’erogatore.
     </div>
     <div class="content">
@@ -86,7 +86,7 @@
         <strong>{{this.assignmentDate}}</strong>
         alle ore
         <strong>{{this.assignmentTime}}</strong>, l’infrastruttura ha registrato
-        la verifica dell'erogatore che il fruitore possegga l’attributo
+        la verifica dell’erogatore che il fruitore possegga l’attributo
         verificato <strong>{{this.attributeName}}</strong>, contraddistinto da
         id <strong>{{this.attributeId}}</strong>, {{#if this.expirationDate}} ed
         avente scadenza il <strong>{{this.expirationDate}}</strong>,{{/if}}

--- a/packages/delegation-process/src/resources/templates/delegationApprovedTemplate.html
+++ b/packages/delegation-process/src/resources/templates/delegationApprovedTemplate.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Delega all'erogazione</title>
+    <title>Delega all’erogazione</title>
     <link rel="stylesheet" href="./delegationTemplate.css" type="text/css" />
     {{{paged-pdf-polyfill}}}
   </head>
@@ -35,20 +35,20 @@
     </div>
 
     <!-- Titolo del documento -->
-    <h1>Delega all'erogazione</h1>
+    <h1>Delega all’erogazione</h1>
 
     <!-- Intro legale -->
     <div class="legal-intro">
       In data <strong>{{todayDate}}</strong> alle ore
       <strong>{{todayTime}}</strong>, l’infrastruttura ha ricevuto la richiesta
-      di delega all'erogazione contraddistinta da id
+      di delega all’erogazione contraddistinta da id
       <strong>{{delegationId}}</strong> (di seguito “delega”), inviata
       dall’aderente <strong>{{delegatorName}}</strong> (codice IPA:
       <strong>{{delegatorCode}}</strong> - di seguito “delegante”), per il
       delegato <strong>{{delegateName}}</strong> (codice IPA:
-      <strong>{{delegateCode}}</strong> - di seguito "delegato all'erogazione")
-      tramite l'operatore amministrativo con identificativo Area Riservata
-      <strong>{{submitterId}}</strong>, per l'e-service
+      <strong>{{delegateCode}}</strong> - di seguito “delegato all’erogazione”)
+      tramite l’operatore amministrativo con identificativo Area Riservata
+      <strong>{{submitterId}}</strong>, per l’e-service
       <strong>{{eserviceName}}</strong>, contraddistinto da id
       <strong>{{eserviceId}}</strong>
       (di seguito “e-service”).
@@ -65,22 +65,22 @@
       <div>
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’Infrastruttura ha ricevuto la
-        dichiarazione di accettazione della delega (di seguito “dischiarazione
-        di accettazione”) inviata dal delegato all'erogazione, tramite
-        l'operatore amministrativo con identificativo Area Riservata
+        dichiarazione di accettazione della delega (di seguito “dichiarazione di
+        accettazione”) inviata dal delegato all’erogazione, tramite l’operatore
+        amministrativo con identificativo Area Riservata
         <strong>{{activatorId}}</strong>.
       </div>
 
       <div>
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’Infrastruttura ha comunicato al
-        delegato all'erogazione la dichiarazione di accettazione.
+        delegato all’erogazione la dichiarazione di accettazione.
       </div>
 
       <div>
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’Infrastruttura ha registrato il
-        delegato all'erogazione quale soggetto titolato ad erogare l'e-service
+        delegato all’erogazione quale soggetto titolato ad erogare l’e-service
         per conto del delegante.
       </div>
     </div>

--- a/packages/delegation-process/src/resources/templates/delegationRevokedTemplate.html
+++ b/packages/delegation-process/src/resources/templates/delegationRevokedTemplate.html
@@ -46,9 +46,9 @@
       dall’aderente <strong>{{delegatorName}}</strong> (codice IPA:
       <strong>{{delegatorCode}}</strong> - di seguito “delegante”), per il
       delegato <strong>{{delegateName}}</strong> (codice IPA:
-      <strong>{{delegateCode}}</strong> - di seguito "delegato all'erogazione")
-      tramite l'operatore amministrativo con identificativo Area Riservata
-      <strong>{{submitterId}}</strong>, per l'e-service
+      <strong>{{delegateCode}}</strong> - di seguito “delegato all’erogazione”)
+      tramite l’operatore amministrativo con identificativo Area Riservata
+      <strong>{{submitterId}}</strong>, per l’e-service
       <strong>{{eserviceName}}</strong>, contraddistinto da id
       <strong>{{eserviceId}}</strong>
       (di seguito “e-service”).


### PR DESCRIPTION
* adding a missing double quote
* typo "dischiarazione" --> "dichiarazione"
* aligning chars used for single/double quotes