### PR TITLE
Added `requireCorrections` and `rejectionReasons` in bff catalog apis

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -13701,6 +13701,10 @@ components:
           $ref: "#/components/schemas/ProducerDescriptorEService"
         attributes:
           $ref: "#/components/schemas/DescriptorAttributes"
+        rejectionReasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptorRejectionReason"
     ProducerDescriptorEService:
       type: object
       additionalProperties: false
@@ -13764,6 +13768,18 @@ components:
       properties:
         prettyName:
           type: string
+    DescriptorRejectionReason:
+      type: object
+      additionalProperties: false
+      properties:
+        rejectionReason:
+          type: string
+        rejectedAt:
+          type: string
+          format: date-time
+      required:
+        - rejectionReason
+        - rejectedAt 
     AgreementApprovalPolicy:
       type: string
       description: |
@@ -14263,6 +14279,28 @@ components:
           format: uri
       required:
         - url
+    CompactProducerDescriptor:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - state
+        - version
+        - audience
+      properties:
+        id:
+          type: string
+          format: uuid
+        state:
+          $ref: "#/components/schemas/EServiceDescriptorState"
+        version:
+          type: string
+        audience:
+          type: array
+          items:
+            type: string
+        requireCorrections:
+          type: boolean
     ProducerEService:
       type: object
       additionalProperties: false
@@ -14279,9 +14317,9 @@ components:
         mode:
           $ref: "#/components/schemas/EServiceMode"
         activeDescriptor:
-          $ref: "#/components/schemas/CompactDescriptor"
+          $ref: "#/components/schemas/CompactProducerDescriptor"
         draftDescriptor:
-          $ref: "#/components/schemas/CompactDescriptor"
+          $ref: "#/components/schemas/CompactProducerDescriptor"
     ProducerEServices:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -1793,6 +1793,10 @@ components:
           format: date-time
         attributes:
           $ref: "#/components/schemas/Attributes"
+        rejectionReasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/RejectionReason"
     Attribute:
       type: object
       additionalProperties: false
@@ -1862,6 +1866,18 @@ components:
         - ARCHIVED
         - MISSING_CERTIFIED_ATTRIBUTES
         - REJECTED
+    RejectionReason:
+      type: object
+      additionalProperties: false
+      properties:
+        rejectionReason:
+          type: string
+        rejectedAt:
+          type: string
+          format: date-time
+      required:
+        - rejectionReason
+        - rejectedAt
     RejectDelegatedEServiceDescriptorSeed:
       type: object
       additionalProperties: false

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -360,3 +360,20 @@ export function toCompactDescriptor(
     version: descriptor.version,
   };
 }
+
+export function toCompactProducerDescriptor(
+  descriptor: catalogApi.EServiceDescriptor,
+  isRequesterProducerDelegate: boolean
+): bffApi.CompactProducerDescriptor {
+  return {
+    id: descriptor.id,
+    audience: descriptor.audience,
+    state: descriptor.state,
+    version: descriptor.version,
+    requireCorrections:
+      isRequesterProducerDelegate &&
+      descriptor.state === catalogApi.EServiceDescriptorState.Values.DRAFT &&
+      descriptor.rejectionReasons &&
+      descriptor.rejectionReasons.length > 0,
+  };
+}

--- a/packages/catalog-process/src/model/domain/apiConverter.ts
+++ b/packages/catalog-process/src/model/domain/apiConverter.ts
@@ -174,6 +174,10 @@ export const descriptorToApiDescriptor = (
     declared: descriptor.attributes.declared,
     verified: descriptor.attributes.verified,
   },
+  rejectionReasons: descriptor.rejectionReasons?.map((reason) => ({
+    rejectionReason: reason.rejectionReason,
+    rejectedAt: reason.rejectedAt.toJSON(),
+  })),
 });
 
 export const eServiceToApiEService = (


### PR DESCRIPTION
- Updated BFF api's component `ProducerEServiceDescriptor`, adding `rejectionReasons` array;
- Updated `ProducerEService` data component, returned from `GET /producers/eservices`, added `requireCorrections` property.