### PR TITLE
Add missing delegation info in agreement template

### DIFF
--- a/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
+++ b/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
@@ -94,7 +94,7 @@
         <strong>{{this.assignmentDate}}</strong>
         alle ore
         <strong>{{this.assignmentTime}}</strong>, l’infrastruttura ha registrato
-        la verifica {{#if delegationId}}del delegato all’erogazione{{else}}dell’erogatore{{/if}}
+        la verifica {{#if producerDelegationId}}del delegato all’erogazione{{else}}dell’erogatore{{/if}}
         che il fruitore possegga l’attributo verificato <strong>{{this.attributeName}}</strong>, 
         contraddistinto da id <strong>{{this.attributeId}}</strong>, {{#if this.expirationDate}} ed
         avente scadenza il <strong>{{this.expirationDate}}</strong>,{{/if}}
@@ -133,7 +133,7 @@
         la dichiarazione di accettazione della richiesta di fruizione
         (di seguito “dichiarazione di accettazione”) inviata {{#if producerDelegationId}}dal delegato all’erogazione,{{else}}inviata dall’erogatore,{{/if}}
         tramite l’operatore amministrativo con identificativo Area Riservata
-        {{#if producerDelegationId}}<strong>{{producerDelegateId}}</strong>.{{else}}<strong>{{activatorId}}</strong>.{{/if}}
+        {{#if producerDelegationId}}<strong>{{activatorId}}</strong>.{{else}}<strong>{{activatorId}}</strong>.{{/if}}
       </div>
       <div>
         In data <strong>{{activationDate}}</strong> alle ore

--- a/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
+++ b/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
@@ -127,26 +127,14 @@
         <strong>{{submissionTime}}</strong>, l’Infrastruttura ha trasmesso
         {{#if producerDelegationId}} al delegante all’erogazione{{else}} all’erogatore{{/if}} la richiesta di fruizione.
       </div>
-      {{#if producerDelegationId}}
       <div>
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’infrastruttura ha ricevuto
         la dichiarazione di accettazione della richiesta di fruizione
-        (di seguito “dichiarazione di accettazione”) inviata dal delegato all’erogazione,
+        (di seguito “dichiarazione di accettazione”) inviata {{#if producerDelegationId}}dal delegato all’erogazione,{{else}}inviata dall’erogatore,{{/if}}
         tramite l’operatore amministrativo con identificativo Area Riservata
-        <strong>{{producerDelegateId}}</strong>.
+        {{#if producerDelegationId}}<strong>{{producerDelegateId}}</strong>.{{else}}<strong>{{activatorId}}</strong>.{{/if}}
       </div>
-      {{else}}
-      <div>
-        In data <strong>{{activationDate}}</strong> alle ore
-        <strong>{{activationTime}}</strong>, l’Infrastruttura ha ricevuto la
-        dichiarazione di accettazione della richiesta di fruizione (di seguito
-        “dichiarazione di accettazione”) inviata dall’erogatore, tramite
-        l’operatore amministrativo con identificativo Area Riservata
-        <strong>{{activatorId}}</strong>.
-      </div>
-      {{/if}}
-
       <div>
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’Infrastruttura ha comunicato al

--- a/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
+++ b/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
@@ -131,7 +131,7 @@
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’infrastruttura ha ricevuto
         la dichiarazione di accettazione della richiesta di fruizione
-        (di seguito “dichiarazione di accettazione”) inviata {{#if producerDelegationId}}dal delegato all’erogazione,{{else}} dall’erogatore,{{/if}}
+        (di seguito “dichiarazione di accettazione”) inviata {{#if producerDelegationId}}dal delegato all’erogazione,{{else}}dall’erogatore,{{/if}}
         tramite l’operatore amministrativo con identificativo Area Riservata
         <strong>{{activatorId}}</strong>.
       </div>

--- a/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
+++ b/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
@@ -131,9 +131,9 @@
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’infrastruttura ha ricevuto
         la dichiarazione di accettazione della richiesta di fruizione
-        (di seguito “dichiarazione di accettazione”) inviata {{#if producerDelegationId}}dal delegato all’erogazione,{{else}}inviata dall’erogatore,{{/if}}
+        (di seguito “dichiarazione di accettazione”) inviata {{#if producerDelegationId}}dal delegato all’erogazione,{{else}} dall’erogatore,{{/if}}
         tramite l’operatore amministrativo con identificativo Area Riservata
-        {{#if producerDelegationId}}<strong>{{activatorId}}</strong>.{{else}}<strong>{{activatorId}}</strong>.{{/if}}
+        <strong>{{activatorId}}</strong>.
       </div>
       <div>
         In data <strong>{{activationDate}}</strong> alle ore

--- a/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
+++ b/packages/agreement-process/src/resources/templates/documents/agreementContractTemplate.html
@@ -125,7 +125,7 @@
       <div>
         In data <strong>{{submissionDate}}</strong> alle ore
         <strong>{{submissionTime}}</strong>, l’Infrastruttura ha trasmesso
-        all’erogatore la richiesta di fruizione.
+        {{#if producerDelegationId}} al delegante all’erogazione{{else}} all’erogatore{{/if}} la richiesta di fruizione.
       </div>
       {{#if producerDelegationId}}
       <div>
@@ -150,7 +150,7 @@
       <div>
         In data <strong>{{activationDate}}</strong> alle ore
         <strong>{{activationTime}}</strong>, l’Infrastruttura ha comunicato al
-        fruitore la dichiarazione di accettazione inviata dall’erogatore.
+        fruitore la dichiarazione di accettazione inviata {{#if producerDelegationId}}dal delegato all’erogazione{{else}}dall’erogatore{{/if}}.
       </div>
 
       <div>


### PR DESCRIPTION
Closes [PIN-5774](https://pagopa.atlassian.net/browse/PIN-5774)

# Description
This PR add missed info in agreement contract template when producer delegation is active.

[PIN-5774]: https://pagopa.atlassian.net/browse/PIN-5774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



# Test 
### Old contract  template with missed info 
<img width="619" alt="Screenshot 2024-12-02 at 12 14 27" src="https://github.com/user-attachments/assets/8a140ee7-f0e6-43be-b47d-f242a423f978">

---- 
### New Contract Template with additional delegation info

<img width="591" alt="Screenshot 2024-12-02 at 12 14 12" src="https://github.com/user-attachments/assets/f962cf72-93ca-4b73-bb1c-ad8a5ebf4dbd">
