### PR TITLE
Standardizing agreement requester validators

### DIFF
--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -139,27 +139,27 @@ export const assertRequesterIsConsumer = (
   }
 };
 
-function assertRequesterIsProducer(
+const assertRequesterIsProducer = (
   agreement: Agreement,
   authData: AuthData
-): void {
+): void => {
   if (
     !authData.userRoles.includes("internal") &&
     authData.organizationId !== agreement.producerId
   ) {
     throw operationNotAllowed(authData.organizationId);
   }
-}
+};
 
-export const assertRequesterCanActAsConsumerOrProducer = async (
+export const assertRequesterCanActAsConsumerOrProducer = (
   agreement: Agreement,
   authData: AuthData,
   activeProducerDelegation: Delegation | undefined
-): Promise<void> => {
+): void => {
   try {
     assertRequesterIsConsumer(agreement, authData);
   } catch (error) {
-    await assertRequesterCanActAsProducer(
+    assertRequesterCanActAsProducer(
       agreement,
       authData,
       activeProducerDelegation
@@ -193,11 +193,11 @@ export const assertRequesterCanRetrieveConsumerDocuments = async (
   }
 };
 
-export const assertRequesterCanActAsProducer = async (
+export const assertRequesterCanActAsProducer = (
   agreement: Agreement,
   authData: AuthData,
   activeProducerDelegation: Delegation | undefined
-): Promise<void> => {
+): void => {
   if (!activeProducerDelegation) {
     // No active producer delegation, requester is auhorized only if they are the producer
     assertRequesterIsProducer(agreement, authData);

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -151,7 +151,7 @@ function assertRequesterIsProducer(
   }
 }
 
-export const assertRequesterCanActAsProducerOrConsumer = async (
+export const assertRequesterCanActAsConsumerOrProducer = async (
   agreement: Agreement,
   authData: AuthData,
   activeProducerDelegation: Delegation | undefined

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -151,20 +151,6 @@ function assertRequesterIsProducer(
   }
 }
 
-export const assertCanActAsProducer = async (
-  agreement: Agreement,
-  authData: AuthData,
-  activeProducerDelegation: Delegation | undefined
-): Promise<void> => {
-  if (!activeProducerDelegation) {
-    // No active producer delegation, requester is auhorized only if they are the producer
-    assertRequesterIsProducer(agreement, authData);
-  } else {
-    // Active producer delegation, requester is authorized only if they are the delegate
-    assertIsDelegateProducer(activeProducerDelegation, agreement, authData);
-  }
-};
-
 export const assertCanActAsProducerOrConsumer = async (
   agreement: Agreement,
   authData: AuthData,
@@ -196,6 +182,20 @@ export const assertCanRetrieveConsumerDocuments = async (
         );
       assertIsDelegateProducer(activeProducerDelegation, agreement, authData);
     }
+  }
+};
+
+export const assertCanActAsProducer = async (
+  agreement: Agreement,
+  authData: AuthData,
+  activeProducerDelegation: Delegation | undefined
+): Promise<void> => {
+  if (!activeProducerDelegation) {
+    // No active producer delegation, requester is auhorized only if they are the producer
+    assertRequesterIsProducer(agreement, authData);
+  } else {
+    // Active producer delegation, requester is authorized only if they are the delegate
+    assertIsDelegateProducer(activeProducerDelegation, agreement, authData);
   }
 };
 

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -151,7 +151,7 @@ function assertRequesterIsProducer(
   }
 }
 
-export const assertCanActAsProducerOrConsumer = async (
+export const assertRequesterCanActAsProducerOrConsumer = async (
   agreement: Agreement,
   authData: AuthData,
   activeProducerDelegation: Delegation | undefined
@@ -159,11 +159,15 @@ export const assertCanActAsProducerOrConsumer = async (
   try {
     assertRequesterIsConsumer(agreement, authData);
   } catch (error) {
-    await assertCanActAsProducer(agreement, authData, activeProducerDelegation);
+    await assertRequesterCanActAsProducer(
+      agreement,
+      authData,
+      activeProducerDelegation
+    );
   }
 };
 
-export const assertCanRetrieveConsumerDocuments = async (
+export const assertRequesterCanRetrieveConsumerDocuments = async (
   agreement: Agreement,
   authData: AuthData,
   readModelService: ReadModelService
@@ -180,12 +184,16 @@ export const assertCanRetrieveConsumerDocuments = async (
         await readModelService.getActiveProducerDelegationByEserviceId(
           agreement.eserviceId
         );
-      assertIsDelegateProducer(activeProducerDelegation, agreement, authData);
+      assertRequesterIsDelegateProducer(
+        activeProducerDelegation,
+        agreement,
+        authData
+      );
     }
   }
 };
 
-export const assertCanActAsProducer = async (
+export const assertRequesterCanActAsProducer = async (
   agreement: Agreement,
   authData: AuthData,
   activeProducerDelegation: Delegation | undefined
@@ -195,11 +203,15 @@ export const assertCanActAsProducer = async (
     assertRequesterIsProducer(agreement, authData);
   } else {
     // Active producer delegation, requester is authorized only if they are the delegate
-    assertIsDelegateProducer(activeProducerDelegation, agreement, authData);
+    assertRequesterIsDelegateProducer(
+      activeProducerDelegation,
+      agreement,
+      authData
+    );
   }
 };
 
-const assertIsDelegateProducer = (
+const assertRequesterIsDelegateProducer = (
   activeProducerDelegation: Delegation | undefined,
   agreement: Agreement,
   authData: AuthData

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -18,6 +18,7 @@ import {
   AgreementStamps,
   delegationKind,
   Delegation,
+  delegationState,
 } from "pagopa-interop-models";
 import { agreementApi } from "pagopa-interop-api-clients";
 import { AuthData } from "pagopa-interop-commons";
@@ -207,6 +208,7 @@ const assertIsDelegateProducer = (
     activeProducerDelegation?.delegateId !== authData.organizationId ||
     activeProducerDelegation?.delegatorId !== agreement.producerId ||
     activeProducerDelegation?.kind !== delegationKind.delegatedProducer ||
+    activeProducerDelegation?.state !== delegationState.active ||
     activeProducerDelegation?.eserviceId !== agreement.eserviceId
   ) {
     throw operationNotAllowed(authData.organizationId);

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -138,15 +138,6 @@ export const assertRequesterIsConsumer = (
   }
 };
 
-const assertRequesterIsDelegate = (
-  delegateId: TenantId | undefined,
-  authData: AuthData
-): void => {
-  if (authData.organizationId !== delegateId) {
-    throw operationNotAllowed(authData.organizationId);
-  }
-};
-
 export const assertRequesterIsProducer = async (
   agreement: Agreement,
   authData: AuthData,
@@ -186,6 +177,15 @@ export async function assertRequesterIsConsumerOrProducer(
     );
   }
 }
+
+const assertRequesterIsDelegate = (
+  delegateId: TenantId | undefined,
+  authData: AuthData
+): void => {
+  if (authData.organizationId !== delegateId) {
+    throw operationNotAllowed(authData.organizationId);
+  }
+};
 
 export const assertSubmittableState = (
   state: AgreementState,

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -181,6 +181,8 @@ export const assertCanRetrieveConsumerDocuments = async (
   authData: AuthData,
   readModelService: ReadModelService
 ): Promise<void> => {
+  // This operation has a dedicated assertion because it's the only operation that
+  // can be performed also by the producer even when there is an active producer delegation
   try {
     assertRequesterIsConsumer(agreement, authData);
   } catch (error) {

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -162,11 +162,11 @@ export const assertRequesterIsProducer = async (
   }
 };
 
-export async function assertRequesterIsConsumerOrProducer(
+export const assertRequesterIsConsumerOrProducer = async (
   agreement: Agreement,
   authData: AuthData,
   activeProducerDelegation: Delegation | undefined
-): Promise<void> {
+): Promise<void> => {
   try {
     assertRequesterIsConsumer(agreement, authData);
   } catch (error) {
@@ -176,7 +176,7 @@ export async function assertRequesterIsConsumerOrProducer(
       activeProducerDelegation
     );
   }
-}
+};
 
 const assertRequesterIsDelegate = (
   delegateId: TenantId | undefined,

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -185,9 +185,9 @@ export const assertRequesterCanRetrieveConsumerDocuments = async (
           agreement.eserviceId
         );
       assertRequesterIsDelegateProducer(
-        activeProducerDelegation,
         agreement,
-        authData
+        authData,
+        activeProducerDelegation
       );
     }
   }
@@ -204,17 +204,17 @@ export const assertRequesterCanActAsProducer = (
   } else {
     // Active producer delegation, requester is authorized only if they are the delegate
     assertRequesterIsDelegateProducer(
-      activeProducerDelegation,
       agreement,
-      authData
+      authData,
+      activeProducerDelegation
     );
   }
 };
 
 const assertRequesterIsDelegateProducer = (
-  activeProducerDelegation: Delegation | undefined,
   agreement: Agreement,
-  authData: AuthData
+  authData: AuthData,
+  activeProducerDelegation: Delegation | undefined
 ): void => {
   if (
     activeProducerDelegation?.delegateId !== authData.organizationId ||

--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -173,7 +173,7 @@ export const assertRequesterCanRetrieveConsumerDocuments = async (
   readModelService: ReadModelService
 ): Promise<void> => {
   // This operation has a dedicated assertion because it's the only operation that
-  // can be performed also by the producer even when there is an active producer delegation
+  // can be performed also by the producer even when an active producer delegation exists
   try {
     assertRequesterIsConsumer(agreement, authData);
   } catch (error) {
@@ -199,10 +199,10 @@ export const assertRequesterCanActAsProducer = (
   activeProducerDelegation: Delegation | undefined
 ): void => {
   if (!activeProducerDelegation) {
-    // No active producer delegation, requester is auhorized only if they are the producer
+    // No active producer delegation, the requester is authorized only if they are the producer
     assertRequesterIsProducer(agreement, authData);
   } else {
-    // Active producer delegation, requester is authorized only if they are the delegate
+    // Active producer delegation, the requester is authorized only if they are the delegate
     assertRequesterIsDelegateProducer(
       agreement,
       authData,

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -788,7 +788,7 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertRequesterCanActAsConsumerOrProducer(
+      assertRequesterCanActAsConsumerOrProducer(
         agreement.data,
         authData,
         activeProducerDelegation
@@ -906,7 +906,7 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertRequesterCanActAsProducer(
+      assertRequesterCanActAsProducer(
         agreementToBeRejected.data,
         authData,
         activeProducerDelegation
@@ -983,7 +983,7 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertRequesterCanActAsConsumerOrProducer(
+      assertRequesterCanActAsConsumerOrProducer(
         agreement.data,
         authData,
         activeProducerDelegation

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -83,9 +83,9 @@ import {
   agreementUpdatableStates,
   agreementUpgradableStates,
   assertActivableState,
-  assertCanActAsProducer,
-  assertCanActAsProducerOrConsumer,
-  assertCanRetrieveConsumerDocuments,
+  assertRequesterCanActAsProducer,
+  assertRequesterCanActAsProducerOrConsumer,
+  assertRequesterCanRetrieveConsumerDocuments,
   assertCanWorkOnConsumerDocuments,
   assertExpectedState,
   assertRequesterIsConsumer,
@@ -767,7 +767,7 @@ export function agreementServiceBuilder(
       );
       const agreement = await retrieveAgreement(agreementId, readModelService);
 
-      await assertCanRetrieveConsumerDocuments(
+      await assertRequesterCanRetrieveConsumerDocuments(
         agreement.data,
         authData,
         readModelService
@@ -788,7 +788,7 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertCanActAsProducerOrConsumer(
+      await assertRequesterCanActAsProducerOrConsumer(
         agreement.data,
         authData,
         activeProducerDelegation
@@ -906,7 +906,7 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertCanActAsProducer(
+      await assertRequesterCanActAsProducer(
         agreementToBeRejected.data,
         authData,
         activeProducerDelegation
@@ -983,7 +983,7 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertCanActAsProducerOrConsumer(
+      await assertRequesterCanActAsProducerOrConsumer(
         agreement.data,
         authData,
         activeProducerDelegation

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -84,7 +84,7 @@ import {
   agreementUpgradableStates,
   assertActivableState,
   assertRequesterCanActAsProducer,
-  assertRequesterCanActAsProducerOrConsumer,
+  assertRequesterCanActAsConsumerOrProducer,
   assertRequesterCanRetrieveConsumerDocuments,
   assertCanWorkOnConsumerDocuments,
   assertExpectedState,
@@ -788,7 +788,7 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertRequesterCanActAsProducerOrConsumer(
+      await assertRequesterCanActAsConsumerOrProducer(
         agreement.data,
         authData,
         activeProducerDelegation
@@ -983,7 +983,7 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertRequesterCanActAsProducerOrConsumer(
+      await assertRequesterCanActAsConsumerOrProducer(
         agreement.data,
         authData,
         activeProducerDelegation

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -788,13 +788,13 @@ export function agreementServiceBuilder(
           readModelService
         );
 
+      const delegateProducerId = activeProducerDelegation?.delegateId;
+
       assertRequesterCanActAsConsumerOrProducer(
         agreement.data,
         authData,
         activeProducerDelegation
       );
-
-      const delegateProducerId = activeProducerDelegation?.delegateId;
 
       assertExpectedState(
         agreementId,
@@ -983,13 +983,13 @@ export function agreementServiceBuilder(
           readModelService
         );
 
+      const delegateProducerId = activeProducerDelegation?.delegateId;
+
       assertRequesterCanActAsConsumerOrProducer(
         agreement.data,
         authData,
         activeProducerDelegation
       );
-
-      const delegateProducerId = activeProducerDelegation?.delegateId;
 
       verifyConsumerDoesNotActivatePending(agreement.data, authData);
       assertActivableState(agreement.data);

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -83,11 +83,12 @@ import {
   agreementUpdatableStates,
   agreementUpgradableStates,
   assertActivableState,
+  assertCanActAsProducer,
+  assertCanActAsProducerOrConsumer,
+  assertCanRetrieveConsumerDocuments,
   assertCanWorkOnConsumerDocuments,
   assertExpectedState,
   assertRequesterIsConsumer,
-  assertRequesterIsConsumerOrProducer,
-  assertRequesterIsProducer,
   assertSubmittableState,
   failOnActivationFailure,
   matchingCertifiedAttributes,
@@ -766,7 +767,7 @@ export function agreementServiceBuilder(
       );
       const agreement = await retrieveAgreement(agreementId, readModelService);
 
-      await assertRequesterIsConsumerOrProducer(
+      await assertCanRetrieveConsumerDocuments(
         agreement.data,
         authData,
         readModelService
@@ -787,10 +788,9 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertRequesterIsConsumerOrProducer(
+      await assertCanActAsProducerOrConsumer(
         agreement.data,
         authData,
-        readModelService,
         activeProducerDelegation
       );
 
@@ -906,10 +906,9 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertRequesterIsProducer(
+      await assertCanActAsProducer(
         agreementToBeRejected.data,
         authData,
-        readModelService,
         activeProducerDelegation
       );
 
@@ -984,10 +983,9 @@ export function agreementServiceBuilder(
           readModelService
         );
 
-      await assertRequesterIsConsumerOrProducer(
+      await assertCanActAsProducerOrConsumer(
         agreement.data,
         authData,
-        readModelService,
         activeProducerDelegation
       );
 

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -766,15 +766,10 @@ export function agreementServiceBuilder(
       );
       const agreement = await retrieveAgreement(agreementId, readModelService);
 
-      const activeProducerDelegation =
-        await retrieveActiveProducerDelegationByEserviceId(
-          agreement.data.eserviceId,
-          readModelService
-        );
       await assertRequesterIsConsumerOrProducer(
         agreement.data,
         authData,
-        activeProducerDelegation
+        readModelService
       );
 
       return retrieveAgreementDocument(agreement.data, documentId);
@@ -795,6 +790,7 @@ export function agreementServiceBuilder(
       await assertRequesterIsConsumerOrProducer(
         agreement.data,
         authData,
+        readModelService,
         activeProducerDelegation
       );
 
@@ -913,6 +909,7 @@ export function agreementServiceBuilder(
       await assertRequesterIsProducer(
         agreementToBeRejected.data,
         authData,
+        readModelService,
         activeProducerDelegation
       );
 
@@ -990,6 +987,7 @@ export function agreementServiceBuilder(
       await assertRequesterIsConsumerOrProducer(
         agreement.data,
         authData,
+        readModelService,
         activeProducerDelegation
       );
 

--- a/packages/agreement-process/src/services/readModelService.ts
+++ b/packages/agreement-process/src/services/readModelService.ts
@@ -25,13 +25,11 @@ import {
   AttributeReadmodel,
   TenantId,
   genericInternalError,
-  DelegationState,
   Delegation,
   delegationState,
   AgreementReadModel,
   DescriptorReadModel,
   EServiceReadModel,
-  DelegationKind,
   delegationKind,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
@@ -615,42 +613,14 @@ export function readModelServiceBuilder(
         ),
       };
     },
-    async getDelegationByDelegateId(
-      delegateId: TenantId,
-      kind: DelegationKind,
-      state: DelegationState = delegationState.active
-    ): Promise<Delegation | undefined> {
-      const data = await delegations.findOne(
-        {
-          "data.delegateId": delegateId,
-          "data.state": state,
-          "data.kind": kind,
-        },
-        { projection: { data: true } }
-      );
-
-      if (!data) {
-        return undefined;
-      }
-      const result = z.object({ data: Delegation }).safeParse(data);
-      if (!result.success) {
-        throw genericInternalError(
-          `Unable to parse delegation item: result ${JSON.stringify(
-            result
-          )} - data ${JSON.stringify(data)} `
-        );
-      }
-      return result.data.data;
-    },
-    async getActiveDelegationByEserviceId(
-      eserviceId: EServiceId,
-      kind: DelegationKind
+    async getActiveProducerDelegationByEserviceId(
+      eserviceId: EServiceId
     ): Promise<Delegation | undefined> {
       const data = await delegations.findOne(
         {
           "data.eserviceId": eserviceId,
           "data.state": delegationState.active,
-          "data.kind": kind,
+          "data.kind": delegationKind.delegatedProducer,
         },
         { projection: { data: true } }
       );

--- a/packages/agreement-process/test/activateAgreement.test.ts
+++ b/packages/agreement-process/test/activateAgreement.test.ts
@@ -892,16 +892,16 @@ describe("activate agreement", () => {
       const producer = getMockTenant();
       const consumer = getMockTenant();
       const authData = getRandomAuthData();
-      const esevice = {
+      const eservice = {
         ...getMockEService(),
         producerId: producer.id,
         consumerId: consumer.id,
         descriptors: [getMockDescriptorPublished()],
       };
       const agreement: Agreement = {
-        ...getMockAgreement(esevice.id),
+        ...getMockAgreement(eservice.id),
         state: agreementState.suspended,
-        descriptorId: esevice.descriptors[0].id,
+        descriptorId: eservice.descriptors[0].id,
         producerId: producer.id,
         consumerId: consumer.id,
         suspendedAt: new Date(),
@@ -913,12 +913,13 @@ describe("activate agreement", () => {
         kind: delegationKind.delegatedProducer,
         eserviceId: agreement.eserviceId,
         delegateId: authData.organizationId,
+        delegatorId: eservice.producerId,
         state: delegationState.active,
       });
 
       await addOneTenant(consumer);
       await addOneTenant(producer);
-      await addOneEService(esevice);
+      await addOneEService(eservice);
       await addOneAgreement(agreement);
       await addOneDelegation(delegation);
 

--- a/packages/agreement-process/test/rejectAgreement.test.ts
+++ b/packages/agreement-process/test/rejectAgreement.test.ts
@@ -195,6 +195,7 @@ describe("reject agreement", () => {
         kind: delegationKind.delegatedProducer,
         delegateId: authData.organizationId,
         eserviceId: eservice.id,
+        delegatorId: eservice.producerId,
         state: delegationState.active,
       });
       if (type === "delegate") {

--- a/packages/agreement-process/test/suspendAgreement.test.ts
+++ b/packages/agreement-process/test/suspendAgreement.test.ts
@@ -439,6 +439,7 @@ describe("suspend agreement", () => {
         kind: delegationKind.delegatedProducer,
         delegateId: authData.organizationId,
         eserviceId: eservice.id,
+        delegatorId: eservice.producerId,
         state: delegationState.active,
       });
 
@@ -624,6 +625,7 @@ describe("suspend agreement", () => {
       kind: delegationKind.delegatedProducer,
       delegateId: delegate.id,
       eserviceId: eservice.id,
+      delegatorId: eservice.producerId,
       state: delegationState.active,
     });
 
@@ -662,6 +664,7 @@ describe("suspend agreement", () => {
       kind: delegationKind.delegatedProducer,
       delegateId: authData.organizationId,
       eserviceId: eservice.id,
+      delegatorId: eservice.producerId,
       state: delegationState.waitingForApproval,
     });
 


### PR DESCRIPTION
In this PR I simplify agreement validators for cases where we must check if the caller is the producer or the delegate producer - this PR is needed on `feature/incaricato` since it simplifies our work in implementing the same logic also for consumer delegations.