### PR TITLE
Fix BFF e-service producer assertions

### DIFF
--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -61,6 +61,7 @@ import { getAllBulkAttributes } from "./attributeService.js";
 import {
   assertNotDelegatedEservice,
   assertRequesterIsProducer,
+  assertRequesterCanActAsProducer,
 } from "./validators.js";
 
 export type CatalogService = ReturnType<typeof catalogServiceBuilder>;
@@ -261,7 +262,12 @@ export function catalogServiceBuilder(
           headers,
         });
 
-      assertRequesterIsProducer(requesterId, eservice);
+      await assertRequesterCanActAsProducer(
+        delegationProcessClient,
+        headers,
+        requesterId,
+        eservice
+      );
 
       const descriptor = retrieveEserviceDescriptor(eservice, descriptorId);
 
@@ -278,10 +284,10 @@ export function catalogServiceBuilder(
         descriptor
       );
 
-      const requesterTenant = await tenantProcessClient.tenant.getTenant({
+      const producerTenant = await tenantProcessClient.tenant.getTenant({
         headers,
         params: {
-          id: requesterId,
+          id: eservice.producerId,
         },
       });
 
@@ -302,7 +308,7 @@ export function catalogServiceBuilder(
         attributes: descriptorAttributes,
         eservice: toBffCatalogApiProducerDescriptorEService(
           eservice,
-          requesterTenant
+          producerTenant
         ),
       };
     },
@@ -323,7 +329,12 @@ export function catalogServiceBuilder(
           headers,
         });
 
-      assertRequesterIsProducer(requesterId, eservice);
+      await assertRequesterCanActAsProducer(
+        delegationProcessClient,
+        headers,
+        requesterId,
+        eservice
+      );
 
       return {
         id: eservice.id,

--- a/packages/backend-for-frontend/src/services/validators.ts
+++ b/packages/backend-for-frontend/src/services/validators.ts
@@ -54,7 +54,7 @@ export async function assertRequesterCanActAsProducer(
   try {
     assertRequesterIsProducer(requesterId, eservice);
   } catch {
-    const delegations = await getAllDelegations(
+    const producerDelegations = await getAllDelegations(
       delegationProcessClient,
       headers,
       {
@@ -64,7 +64,7 @@ export async function assertRequesterCanActAsProducer(
         delegationStates: [toDelegationState(delegationState.active)],
       }
     );
-    if (delegations.length === 0) {
+    if (producerDelegations.length === 0) {
       throw invalidEServiceRequester(eservice.id, requesterId);
     }
   }

--- a/packages/backend-for-frontend/src/services/validators.ts
+++ b/packages/backend-for-frontend/src/services/validators.ts
@@ -45,11 +45,36 @@ export function assertRequesterIsProducer(
   }
 }
 
+export async function assertRequesterCanActAsProducer(
+  delegationProcessClient: DelegationProcessClient,
+  headers: BffAppContext["headers"],
+  requesterId: TenantId,
+  eservice: catalogApi.EService
+): Promise<void> {
+  try {
+    assertRequesterIsProducer(requesterId, eservice);
+  } catch {
+    const delegations = await getAllDelegations(
+      delegationProcessClient,
+      headers,
+      {
+        kind: toDelegationKind(delegationKind.delegatedProducer),
+        delegateIds: [requesterId],
+        eserviceIds: [eservice.id],
+        delegationStates: [toDelegationState(delegationState.active)],
+      }
+    );
+    if (delegations.length === 0) {
+      throw invalidEServiceRequester(eservice.id, requesterId);
+    }
+  }
+}
+
 export async function assertNotDelegatedEservice(
   delegationProcessClient: DelegationProcessClient,
   headers: BffAppContext["headers"],
   delegatorId: TenantId,
-  eserviceid: EServiceId
+  eserviceId: EServiceId
 ): Promise<void> {
   const delegations = await getAllDelegations(
     delegationProcessClient,
@@ -57,7 +82,7 @@ export async function assertNotDelegatedEservice(
     {
       kind: toDelegationKind(delegationKind.delegatedProducer),
       delegatorIds: [delegatorId],
-      eserviceIds: [eserviceid],
+      eserviceIds: [eserviceId],
       delegationStates: [
         toDelegationState(delegationState.active),
         toDelegationState(delegationState.waitingForApproval),


### PR DESCRIPTION
Fixed an issue where `getProducerEServiceDescriptor` and `getProducerEServiceDetails` requester assertions were not taking into account producer delegations.

Added new `assertRequesterCanActAsProducer` assertion that checks whatever the requester is a direct producer or a delegated one.