### PR TITLE
Removing delegation info from state processors

### DIFF
--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -410,13 +410,11 @@ export function agreementServiceBuilder(
           agreement.data.eserviceId,
           readModelService
         );
-      const delegateProducerId = activeProducerDelegation?.delegateId;
 
       const nextStateByAttributes = nextStateByAttributesFSM(
         agreement.data,
         descriptor,
-        consumer,
-        delegateProducerId
+        consumer
       );
 
       const suspendedByPlatform = suspendedByPlatformFlag(

--- a/packages/agreement-process/src/services/agreementStateProcessor.ts
+++ b/packages/agreement-process/src/services/agreementStateProcessor.ts
@@ -42,13 +42,9 @@ const {
 const nextStateFromDraft = (
   agreement: Agreement,
   descriptor: Descriptor,
-  tenant: Tenant | CompactTenant,
-  delegateProducerId: TenantId | undefined
+  tenant: Tenant | CompactTenant
 ): AgreementState => {
-  if (
-    agreement.consumerId === agreement.producerId ||
-    agreement.consumerId === delegateProducerId
-  ) {
+  if (agreement.consumerId === agreement.producerId) {
     return active;
   }
   if (!certifiedAttributesSatisfied(descriptor.attributes, tenant.attributes)) {
@@ -98,13 +94,9 @@ const nextStateFromPending = (
 const nextStateFromActiveOrSuspended = (
   agreement: Agreement,
   descriptor: Descriptor,
-  tenant: Tenant | CompactTenant,
-  delegateProducerId: TenantId | undefined
+  tenant: Tenant | CompactTenant
 ): AgreementState => {
-  if (
-    agreement.consumerId === agreement.producerId ||
-    agreement.consumerId === delegateProducerId
-  ) {
+  if (agreement.consumerId === agreement.producerId) {
     return active;
   }
   if (
@@ -134,23 +126,17 @@ const nextStateFromMissingCertifiedAttributes = (
 export const nextStateByAttributesFSM = (
   agreement: Agreement,
   descriptor: Descriptor,
-  tenant: Tenant | CompactTenant,
-  delegateProducerId?: TenantId | undefined
+  tenant: Tenant | CompactTenant
 ): AgreementState =>
   match(agreement.state)
     .with(agreementState.draft, () =>
-      nextStateFromDraft(agreement, descriptor, tenant, delegateProducerId)
+      nextStateFromDraft(agreement, descriptor, tenant)
     )
     .with(agreementState.pending, () =>
       nextStateFromPending(agreement, descriptor, tenant)
     )
     .with(agreementState.active, agreementState.suspended, () =>
-      nextStateFromActiveOrSuspended(
-        agreement,
-        descriptor,
-        tenant,
-        delegateProducerId
-      )
+      nextStateFromActiveOrSuspended(agreement, descriptor, tenant)
     )
     .with(agreementState.archived, () => archived)
     .with(agreementState.missingCertifiedAttributes, () =>

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -49,8 +49,7 @@ export function createSuspensionUpdatedAgreement({
   const nextStateByAttributes = nextStateByAttributesFSM(
     agreement,
     descriptor,
-    consumer,
-    producerDelegation?.delegateId
+    consumer
   );
 
   const suspendedByConsumer = suspendedByConsumerFlag(

--- a/packages/agreement-process/test/upgradeAgreement.test.ts
+++ b/packages/agreement-process/test/upgradeAgreement.test.ts
@@ -554,7 +554,7 @@ describe("upgrade Agreement", () => {
     }
   });
 
-  it("should succeed with valid Verified, Certified, and Declared attributes when consumer and producer are different and requester is a delegate", async () => {
+  it("should succeed with valid Verified, Certified, and Declared attributes when consumer and producer are different, requester is consumer, an active producer delegation exists and is taken into account for the PDF contract generation", async () => {
     const producer = getMockTenant();
 
     const validVerifiedTenantAttribute = {

--- a/packages/agreement-process/test/upgradeAgreement.test.ts
+++ b/packages/agreement-process/test/upgradeAgreement.test.ts
@@ -3,11 +3,9 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable fp/no-delete */
 import {
-  dateAtRomeZone,
   FileManagerError,
   formatDateyyyyMMddHHmmss,
   genericLogger,
-  timeAtRomeZone,
 } from "pagopa-interop-commons";
 import {
   decodeProtobufPayload,
@@ -15,7 +13,6 @@ import {
   getMockAttribute,
   getMockCertifiedTenantAttribute,
   getMockDeclaredTenantAttribute,
-  getMockDelegation,
   getMockDescriptorPublished,
   getMockEService,
   getMockEServiceAttribute,
@@ -29,20 +26,16 @@ import {
   Agreement,
   AgreementAddedV2,
   AgreementArchivedByUpgradeV2,
-  AgreementContractPDFPayload,
   AgreementDocument,
   AgreementId,
   AgreementUpgradedV2,
   Descriptor,
   EService,
   EServiceId,
-  PUBLIC_ADMINISTRATIONS_IDENTIFIER,
   Tenant,
   TenantId,
   agreementState,
   attributeKind,
-  delegationKind,
-  delegationState,
   descriptorState,
   fromAgreementV2,
   generateId,
@@ -70,14 +63,12 @@ import { createStamp } from "../src/services/agreementStampUtils.js";
 import {
   addOneAgreement,
   addOneAttribute,
-  addOneDelegation,
   addOneEService,
   addOneTenant,
   agreementService,
   fileManager,
   getMockConsumerDocument,
   getMockContract,
-  pdfGenerator,
   readAgreementEventByVersion,
   uploadDocument,
 } from "./utils.js";
@@ -543,335 +534,6 @@ describe("upgrade Agreement", () => {
     };
 
     expect(actualAgreementUpgraded).toEqual(expectedUpgradedAgreement);
-    expect(actualAgreementUpgraded).toEqual(returnedAgreement);
-
-    for (const agreementDoc of expectedUpgradedAgreement.consumerDocuments) {
-      const expectedUploadedDocumentPath = `${config.consumerDocumentsPath}/${newAgreementId}/${agreementDoc.id}/${agreementDoc.name}`;
-
-      expect(
-        await fileManager.listFiles(config.s3Bucket, genericLogger)
-      ).toContainEqual(expectedUploadedDocumentPath);
-    }
-  });
-
-  it("should succeed with valid Verified, Certified, and Declared attributes when consumer and producer are different and requester is a delegate", async () => {
-    const producer = getMockTenant();
-
-    const validVerifiedTenantAttribute = {
-      ...getMockVerifiedTenantAttribute(),
-      verifiedBy: [
-        {
-          id: producer.id,
-          verificationDate: new Date(),
-          expirationDate: undefined,
-          extensionDate: undefined,
-        },
-      ],
-    };
-    const verifiedAttribute = getMockAttribute(
-      attributeKind.verified,
-      validVerifiedTenantAttribute.id
-    );
-    await addOneAttribute(verifiedAttribute);
-
-    const validDeclaredTenantAttribute = {
-      ...getMockDeclaredTenantAttribute(),
-      revocationTimestamp: undefined,
-    };
-
-    const declaredAttribute = getMockAttribute(
-      attributeKind.declared,
-      validDeclaredTenantAttribute.id
-    );
-    await addOneAttribute(declaredAttribute);
-
-    const validCertifiedTenantAttribute = {
-      ...getMockCertifiedTenantAttribute(),
-      revocationTimestamp: undefined,
-    };
-    const certifiedAttribute = getMockAttribute(
-      attributeKind.certified,
-      validCertifiedTenantAttribute.id
-    );
-    await addOneAttribute(certifiedAttribute);
-
-    const consumer: Tenant = {
-      ...getMockTenant(),
-      selfcareId: generateId(),
-      attributes: [
-        validCertifiedTenantAttribute,
-        validDeclaredTenantAttribute,
-        validVerifiedTenantAttribute,
-      ],
-    };
-
-    const delegate: Tenant = getMockTenant();
-
-    await addOneTenant(consumer);
-    await addOneTenant(producer);
-    await addOneTenant(delegate);
-
-    const authData = getRandomAuthData(consumer.id);
-
-    const newPublishedDescriptor: Descriptor = {
-      ...getMockDescriptorPublished(),
-      version: "2",
-      attributes: {
-        certified: [
-          [getMockEServiceAttribute(validCertifiedTenantAttribute.id)],
-        ],
-        declared: [[getMockEServiceAttribute(validDeclaredTenantAttribute.id)]],
-        verified: [[getMockEServiceAttribute(validVerifiedTenantAttribute.id)]],
-      },
-    };
-
-    const currentDescriptor: Descriptor = {
-      ...getMockDescriptorPublished(),
-      state: descriptorState.deprecated,
-      version: "1",
-    };
-    const eservice: EService = {
-      ...getMockEService(),
-      producerId: producer.id,
-      descriptors: [newPublishedDescriptor, currentDescriptor],
-    };
-    await addOneEService(eservice);
-
-    const delegation = getMockDelegation({
-      kind: delegationKind.delegatedProducer,
-      state: delegationState.active,
-      eserviceId: eservice.id,
-      delegateId: delegate.id,
-      delegatorId: producer.id,
-    });
-    await addOneDelegation(delegation);
-
-    const agreementId: AgreementId = generateId<AgreementId>();
-
-    const docsNumber = Math.floor(Math.random() * 10) + 1;
-    const agreementConsumerDocuments = Array.from({ length: docsNumber }, () =>
-      getMockConsumerDocument(agreementId)
-    );
-
-    const submitterId = authData.userId;
-    const activatorId = authData.userId;
-    const agreement: Agreement = {
-      ...getMockAgreement(
-        eservice.id,
-        consumer.id,
-        randomArrayItem(agreementUpgradableStates)
-      ),
-      id: agreementId,
-      producerId: eservice.producerId,
-      descriptorId: currentDescriptor.id,
-      createdAt: new Date(),
-      consumerDocuments: agreementConsumerDocuments,
-      suspendedByConsumer: randomBoolean(),
-      suspendedByProducer: randomBoolean(),
-      stamps: {
-        submission: createStamp(submitterId),
-        activation: createStamp(activatorId),
-        suspensionByConsumer: createStamp(authData.userId),
-        suspensionByProducer: createStamp(authData.userId),
-      },
-      contract: getMockContract(agreementId, consumer.id, producer.id),
-      suspendedAt: new Date(),
-    };
-    await addOneAgreement(agreement);
-
-    for (const doc of agreementConsumerDocuments) {
-      await uploadDocument(agreementId, doc.id, doc.name);
-    }
-
-    vi.spyOn(pdfGenerator, "generate");
-    const returnedAgreement = await agreementService.upgradeAgreement(
-      agreement.id,
-      {
-        authData,
-        serviceName: "",
-        correlationId: generateId(),
-        logger: genericLogger,
-      }
-    );
-    const newAgreementId = unsafeBrandId<AgreementId>(returnedAgreement.id);
-
-    const actualAgreementArchivedEvent = await readAgreementEventByVersion(
-      agreement.id,
-      1
-    );
-
-    expect(actualAgreementArchivedEvent).toMatchObject({
-      type: "AgreementArchivedByUpgrade",
-      event_version: 2,
-      version: "1",
-      stream_id: agreement.id,
-    });
-
-    const actualAgreementArchived = decodeProtobufPayload({
-      messageType: AgreementArchivedByUpgradeV2,
-      payload: actualAgreementArchivedEvent.data,
-    }).agreement;
-
-    const expectedAgreementArchived: Agreement = {
-      ...agreement,
-      state: agreementState.archived,
-      stamps: {
-        ...agreement.stamps,
-        archiving: {
-          delegationId: undefined,
-          who: authData.userId,
-          when: new Date(),
-        },
-      },
-    };
-
-    expect(actualAgreementArchived).toEqual(
-      toAgreementV2(expectedAgreementArchived)
-    );
-
-    expect(newAgreementId).toBeDefined();
-
-    const actualAgreementUpgradedEvent = await readAgreementEventByVersion(
-      newAgreementId,
-      0
-    );
-
-    expect(actualAgreementUpgradedEvent).toMatchObject({
-      type: "AgreementUpgraded",
-      event_version: 2,
-      version: "0",
-      stream_id: newAgreementId,
-    });
-
-    const actualAgreementUpgraded: Agreement = fromAgreementV2(
-      decodeProtobufPayload({
-        messageType: AgreementUpgradedV2,
-        payload: actualAgreementUpgradedEvent.data,
-      }).agreement!
-    );
-
-    const contractDocumentId = actualAgreementUpgraded.contract!.id;
-    const contractCreatedAt = actualAgreementUpgraded.contract!.createdAt;
-    const contractDocumentName = `${consumer.id}_${
-      producer.id
-    }_${formatDateyyyyMMddHHmmss(contractCreatedAt)}_agreement_contract.pdf`;
-
-    const expectedContract = {
-      id: contractDocumentId,
-      contentType: "application/pdf",
-      createdAt: contractCreatedAt,
-      path: `${config.agreementContractsPath}/${actualAgreementUpgraded.id}/${contractDocumentId}/${contractDocumentName}`,
-      prettyName: "Richiesta di fruizione",
-      name: contractDocumentName,
-    };
-
-    const expectedUpgradedAgreement = {
-      ...agreement,
-      id: newAgreementId,
-      descriptorId: newPublishedDescriptor.id,
-      createdAt: agreement.createdAt,
-      stamps: {
-        ...agreement.stamps,
-        archiving: undefined,
-        rejection: undefined,
-        upgrade: {
-          who: authData.userId,
-          when: new Date(),
-          delegationId: delegation.id,
-        },
-      },
-      verifiedAttributes: [{ id: validVerifiedTenantAttribute.id }],
-      certifiedAttributes: [{ id: validCertifiedTenantAttribute.id }],
-      declaredAttributes: [{ id: validDeclaredTenantAttribute.id }],
-      consumerDocuments: agreementConsumerDocuments.map<AgreementDocument>(
-        (doc, i) => ({
-          ...doc,
-          id: actualAgreementUpgraded?.consumerDocuments[i].id,
-          path: actualAgreementUpgraded?.consumerDocuments[i].path,
-        })
-      ),
-      contract: expectedContract,
-      suspendedByPlatform: undefined,
-      updatedAt: undefined,
-    };
-
-    // expect(actualAgreementUpgraded).toEqual(expectedUpgradedAgreement);
-    expect(actualAgreementUpgraded).toEqual(returnedAgreement);
-
-    expect(submitterId).toEqual(actualAgreementUpgraded.stamps.submission?.who);
-    expect(activatorId).toEqual(actualAgreementUpgraded.stamps.activation?.who);
-
-    const getIpaCode = (tenant: Tenant): string | undefined =>
-      tenant.externalId.origin === PUBLIC_ADMINISTRATIONS_IDENTIFIER
-        ? tenant.externalId.value
-        : undefined;
-
-    const expectedAgreementContractPDFPayload: AgreementContractPDFPayload = {
-      todayDate: dateAtRomeZone(currentExecutionTime),
-      todayTime: timeAtRomeZone(currentExecutionTime),
-      agreementId: newAgreementId,
-      submitterId,
-      submissionDate: dateAtRomeZone(currentExecutionTime),
-      submissionTime: timeAtRomeZone(currentExecutionTime),
-      activatorId,
-      activationDate: dateAtRomeZone(currentExecutionTime),
-      activationTime: timeAtRomeZone(currentExecutionTime),
-      eserviceName: eservice.name,
-      eserviceId: eservice.id,
-      descriptorId: eservice.descriptors[0].id,
-      descriptorVersion: eservice.descriptors[0].version,
-      producerName: producer.name,
-      producerIpaCode: getIpaCode(producer),
-      consumerName: consumer.name,
-      consumerIpaCode: getIpaCode(consumer),
-      producerDelegationId: delegation.id,
-      producerDelegatorName: producer.name,
-      producerDelegatorIpaCode: getIpaCode(producer),
-      producerDelegateName: delegate.name,
-      producerDelegateIpaCode: getIpaCode(delegate),
-      certifiedAttributes: [
-        {
-          assignmentDate: dateAtRomeZone(
-            validCertifiedTenantAttribute.assignmentTimestamp
-          ),
-          assignmentTime: timeAtRomeZone(
-            validCertifiedTenantAttribute.assignmentTimestamp
-          ),
-          attributeName: certifiedAttribute.name,
-          attributeId: certifiedAttribute.id,
-        },
-      ],
-      declaredAttributes: [
-        {
-          assignmentDate: dateAtRomeZone(
-            validDeclaredTenantAttribute.assignmentTimestamp
-          ),
-          assignmentTime: timeAtRomeZone(
-            validDeclaredTenantAttribute.assignmentTimestamp
-          ),
-          attributeName: declaredAttribute.name,
-          attributeId: declaredAttribute.id,
-        },
-      ],
-      verifiedAttributes: [
-        {
-          assignmentDate: dateAtRomeZone(
-            validVerifiedTenantAttribute.assignmentTimestamp
-          ),
-          assignmentTime: timeAtRomeZone(
-            validVerifiedTenantAttribute.assignmentTimestamp
-          ),
-          attributeName: verifiedAttribute.name,
-          attributeId: verifiedAttribute.id,
-          expirationDate: undefined,
-        },
-      ],
-    };
-
-    expect(pdfGenerator.generate).toHaveBeenCalledWith(
-      expect.any(String),
-      expectedAgreementContractPDFPayload
-    );
     expect(actualAgreementUpgraded).toEqual(returnedAgreement);
 
     for (const agreementDoc of expectedUpgradedAgreement.consumerDocuments) {

--- a/packages/agreement-process/test/upgradeAgreement.test.ts
+++ b/packages/agreement-process/test/upgradeAgreement.test.ts
@@ -3,9 +3,11 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable fp/no-delete */
 import {
+  dateAtRomeZone,
   FileManagerError,
   formatDateyyyyMMddHHmmss,
   genericLogger,
+  timeAtRomeZone,
 } from "pagopa-interop-commons";
 import {
   decodeProtobufPayload,
@@ -13,6 +15,7 @@ import {
   getMockAttribute,
   getMockCertifiedTenantAttribute,
   getMockDeclaredTenantAttribute,
+  getMockDelegation,
   getMockDescriptorPublished,
   getMockEService,
   getMockEServiceAttribute,
@@ -26,16 +29,20 @@ import {
   Agreement,
   AgreementAddedV2,
   AgreementArchivedByUpgradeV2,
+  AgreementContractPDFPayload,
   AgreementDocument,
   AgreementId,
   AgreementUpgradedV2,
   Descriptor,
   EService,
   EServiceId,
+  PUBLIC_ADMINISTRATIONS_IDENTIFIER,
   Tenant,
   TenantId,
   agreementState,
   attributeKind,
+  delegationKind,
+  delegationState,
   descriptorState,
   fromAgreementV2,
   generateId,
@@ -63,12 +70,14 @@ import { createStamp } from "../src/services/agreementStampUtils.js";
 import {
   addOneAgreement,
   addOneAttribute,
+  addOneDelegation,
   addOneEService,
   addOneTenant,
   agreementService,
   fileManager,
   getMockConsumerDocument,
   getMockContract,
+  pdfGenerator,
   readAgreementEventByVersion,
   uploadDocument,
 } from "./utils.js";
@@ -534,6 +543,335 @@ describe("upgrade Agreement", () => {
     };
 
     expect(actualAgreementUpgraded).toEqual(expectedUpgradedAgreement);
+    expect(actualAgreementUpgraded).toEqual(returnedAgreement);
+
+    for (const agreementDoc of expectedUpgradedAgreement.consumerDocuments) {
+      const expectedUploadedDocumentPath = `${config.consumerDocumentsPath}/${newAgreementId}/${agreementDoc.id}/${agreementDoc.name}`;
+
+      expect(
+        await fileManager.listFiles(config.s3Bucket, genericLogger)
+      ).toContainEqual(expectedUploadedDocumentPath);
+    }
+  });
+
+  it("should succeed with valid Verified, Certified, and Declared attributes when consumer and producer are different and requester is a delegate", async () => {
+    const producer = getMockTenant();
+
+    const validVerifiedTenantAttribute = {
+      ...getMockVerifiedTenantAttribute(),
+      verifiedBy: [
+        {
+          id: producer.id,
+          verificationDate: new Date(),
+          expirationDate: undefined,
+          extensionDate: undefined,
+        },
+      ],
+    };
+    const verifiedAttribute = getMockAttribute(
+      attributeKind.verified,
+      validVerifiedTenantAttribute.id
+    );
+    await addOneAttribute(verifiedAttribute);
+
+    const validDeclaredTenantAttribute = {
+      ...getMockDeclaredTenantAttribute(),
+      revocationTimestamp: undefined,
+    };
+
+    const declaredAttribute = getMockAttribute(
+      attributeKind.declared,
+      validDeclaredTenantAttribute.id
+    );
+    await addOneAttribute(declaredAttribute);
+
+    const validCertifiedTenantAttribute = {
+      ...getMockCertifiedTenantAttribute(),
+      revocationTimestamp: undefined,
+    };
+    const certifiedAttribute = getMockAttribute(
+      attributeKind.certified,
+      validCertifiedTenantAttribute.id
+    );
+    await addOneAttribute(certifiedAttribute);
+
+    const consumer: Tenant = {
+      ...getMockTenant(),
+      selfcareId: generateId(),
+      attributes: [
+        validCertifiedTenantAttribute,
+        validDeclaredTenantAttribute,
+        validVerifiedTenantAttribute,
+      ],
+    };
+
+    const delegate: Tenant = getMockTenant();
+
+    await addOneTenant(consumer);
+    await addOneTenant(producer);
+    await addOneTenant(delegate);
+
+    const authData = getRandomAuthData(consumer.id);
+
+    const newPublishedDescriptor: Descriptor = {
+      ...getMockDescriptorPublished(),
+      version: "2",
+      attributes: {
+        certified: [
+          [getMockEServiceAttribute(validCertifiedTenantAttribute.id)],
+        ],
+        declared: [[getMockEServiceAttribute(validDeclaredTenantAttribute.id)]],
+        verified: [[getMockEServiceAttribute(validVerifiedTenantAttribute.id)]],
+      },
+    };
+
+    const currentDescriptor: Descriptor = {
+      ...getMockDescriptorPublished(),
+      state: descriptorState.deprecated,
+      version: "1",
+    };
+    const eservice: EService = {
+      ...getMockEService(),
+      producerId: producer.id,
+      descriptors: [newPublishedDescriptor, currentDescriptor],
+    };
+    await addOneEService(eservice);
+
+    const delegation = getMockDelegation({
+      kind: delegationKind.delegatedProducer,
+      state: delegationState.active,
+      eserviceId: eservice.id,
+      delegateId: delegate.id,
+      delegatorId: producer.id,
+    });
+    await addOneDelegation(delegation);
+
+    const agreementId: AgreementId = generateId<AgreementId>();
+
+    const docsNumber = Math.floor(Math.random() * 10) + 1;
+    const agreementConsumerDocuments = Array.from({ length: docsNumber }, () =>
+      getMockConsumerDocument(agreementId)
+    );
+
+    const submitterId = authData.userId;
+    const activatorId = authData.userId;
+    const agreement: Agreement = {
+      ...getMockAgreement(
+        eservice.id,
+        consumer.id,
+        randomArrayItem(agreementUpgradableStates)
+      ),
+      id: agreementId,
+      producerId: eservice.producerId,
+      descriptorId: currentDescriptor.id,
+      createdAt: new Date(),
+      consumerDocuments: agreementConsumerDocuments,
+      suspendedByConsumer: randomBoolean(),
+      suspendedByProducer: randomBoolean(),
+      stamps: {
+        submission: createStamp(submitterId),
+        activation: createStamp(activatorId),
+        suspensionByConsumer: createStamp(authData.userId),
+        suspensionByProducer: createStamp(authData.userId),
+      },
+      contract: getMockContract(agreementId, consumer.id, producer.id),
+      suspendedAt: new Date(),
+    };
+    await addOneAgreement(agreement);
+
+    for (const doc of agreementConsumerDocuments) {
+      await uploadDocument(agreementId, doc.id, doc.name);
+    }
+
+    vi.spyOn(pdfGenerator, "generate");
+    const returnedAgreement = await agreementService.upgradeAgreement(
+      agreement.id,
+      {
+        authData,
+        serviceName: "",
+        correlationId: generateId(),
+        logger: genericLogger,
+      }
+    );
+    const newAgreementId = unsafeBrandId<AgreementId>(returnedAgreement.id);
+
+    const actualAgreementArchivedEvent = await readAgreementEventByVersion(
+      agreement.id,
+      1
+    );
+
+    expect(actualAgreementArchivedEvent).toMatchObject({
+      type: "AgreementArchivedByUpgrade",
+      event_version: 2,
+      version: "1",
+      stream_id: agreement.id,
+    });
+
+    const actualAgreementArchived = decodeProtobufPayload({
+      messageType: AgreementArchivedByUpgradeV2,
+      payload: actualAgreementArchivedEvent.data,
+    }).agreement;
+
+    const expectedAgreementArchived: Agreement = {
+      ...agreement,
+      state: agreementState.archived,
+      stamps: {
+        ...agreement.stamps,
+        archiving: {
+          delegationId: undefined,
+          who: authData.userId,
+          when: new Date(),
+        },
+      },
+    };
+
+    expect(actualAgreementArchived).toEqual(
+      toAgreementV2(expectedAgreementArchived)
+    );
+
+    expect(newAgreementId).toBeDefined();
+
+    const actualAgreementUpgradedEvent = await readAgreementEventByVersion(
+      newAgreementId,
+      0
+    );
+
+    expect(actualAgreementUpgradedEvent).toMatchObject({
+      type: "AgreementUpgraded",
+      event_version: 2,
+      version: "0",
+      stream_id: newAgreementId,
+    });
+
+    const actualAgreementUpgraded: Agreement = fromAgreementV2(
+      decodeProtobufPayload({
+        messageType: AgreementUpgradedV2,
+        payload: actualAgreementUpgradedEvent.data,
+      }).agreement!
+    );
+
+    const contractDocumentId = actualAgreementUpgraded.contract!.id;
+    const contractCreatedAt = actualAgreementUpgraded.contract!.createdAt;
+    const contractDocumentName = `${consumer.id}_${
+      producer.id
+    }_${formatDateyyyyMMddHHmmss(contractCreatedAt)}_agreement_contract.pdf`;
+
+    const expectedContract = {
+      id: contractDocumentId,
+      contentType: "application/pdf",
+      createdAt: contractCreatedAt,
+      path: `${config.agreementContractsPath}/${actualAgreementUpgraded.id}/${contractDocumentId}/${contractDocumentName}`,
+      prettyName: "Richiesta di fruizione",
+      name: contractDocumentName,
+    };
+
+    const expectedUpgradedAgreement = {
+      ...agreement,
+      id: newAgreementId,
+      descriptorId: newPublishedDescriptor.id,
+      createdAt: agreement.createdAt,
+      stamps: {
+        ...agreement.stamps,
+        archiving: undefined,
+        rejection: undefined,
+        upgrade: {
+          who: authData.userId,
+          when: new Date(),
+          delegationId: delegation.id,
+        },
+      },
+      verifiedAttributes: [{ id: validVerifiedTenantAttribute.id }],
+      certifiedAttributes: [{ id: validCertifiedTenantAttribute.id }],
+      declaredAttributes: [{ id: validDeclaredTenantAttribute.id }],
+      consumerDocuments: agreementConsumerDocuments.map<AgreementDocument>(
+        (doc, i) => ({
+          ...doc,
+          id: actualAgreementUpgraded?.consumerDocuments[i].id,
+          path: actualAgreementUpgraded?.consumerDocuments[i].path,
+        })
+      ),
+      contract: expectedContract,
+      suspendedByPlatform: undefined,
+      updatedAt: undefined,
+    };
+
+    // expect(actualAgreementUpgraded).toEqual(expectedUpgradedAgreement);
+    expect(actualAgreementUpgraded).toEqual(returnedAgreement);
+
+    expect(submitterId).toEqual(actualAgreementUpgraded.stamps.submission?.who);
+    expect(activatorId).toEqual(actualAgreementUpgraded.stamps.activation?.who);
+
+    const getIpaCode = (tenant: Tenant): string | undefined =>
+      tenant.externalId.origin === PUBLIC_ADMINISTRATIONS_IDENTIFIER
+        ? tenant.externalId.value
+        : undefined;
+
+    const expectedAgreementContractPDFPayload: AgreementContractPDFPayload = {
+      todayDate: dateAtRomeZone(currentExecutionTime),
+      todayTime: timeAtRomeZone(currentExecutionTime),
+      agreementId: newAgreementId,
+      submitterId,
+      submissionDate: dateAtRomeZone(currentExecutionTime),
+      submissionTime: timeAtRomeZone(currentExecutionTime),
+      activatorId,
+      activationDate: dateAtRomeZone(currentExecutionTime),
+      activationTime: timeAtRomeZone(currentExecutionTime),
+      eserviceName: eservice.name,
+      eserviceId: eservice.id,
+      descriptorId: eservice.descriptors[0].id,
+      descriptorVersion: eservice.descriptors[0].version,
+      producerName: producer.name,
+      producerIpaCode: getIpaCode(producer),
+      consumerName: consumer.name,
+      consumerIpaCode: getIpaCode(consumer),
+      producerDelegationId: delegation.id,
+      producerDelegatorName: producer.name,
+      producerDelegatorIpaCode: getIpaCode(producer),
+      producerDelegateName: delegate.name,
+      producerDelegateIpaCode: getIpaCode(delegate),
+      certifiedAttributes: [
+        {
+          assignmentDate: dateAtRomeZone(
+            validCertifiedTenantAttribute.assignmentTimestamp
+          ),
+          assignmentTime: timeAtRomeZone(
+            validCertifiedTenantAttribute.assignmentTimestamp
+          ),
+          attributeName: certifiedAttribute.name,
+          attributeId: certifiedAttribute.id,
+        },
+      ],
+      declaredAttributes: [
+        {
+          assignmentDate: dateAtRomeZone(
+            validDeclaredTenantAttribute.assignmentTimestamp
+          ),
+          assignmentTime: timeAtRomeZone(
+            validDeclaredTenantAttribute.assignmentTimestamp
+          ),
+          attributeName: declaredAttribute.name,
+          attributeId: declaredAttribute.id,
+        },
+      ],
+      verifiedAttributes: [
+        {
+          assignmentDate: dateAtRomeZone(
+            validVerifiedTenantAttribute.assignmentTimestamp
+          ),
+          assignmentTime: timeAtRomeZone(
+            validVerifiedTenantAttribute.assignmentTimestamp
+          ),
+          attributeName: verifiedAttribute.name,
+          attributeId: verifiedAttribute.id,
+          expirationDate: undefined,
+        },
+      ],
+    };
+
+    expect(pdfGenerator.generate).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedAgreementContractPDFPayload
+    );
     expect(actualAgreementUpgraded).toEqual(returnedAgreement);
 
     for (const agreementDoc of expectedUpgradedAgreement.consumerDocuments) {


### PR DESCRIPTION
When there are active delegations, the attribute checks shall happen only on the delegator tenant, not considering the 
attributes of the delegate.
The `nextState...` methods in the agreement service perform attribute checks and based on the initial/target state and attributes, choose the next state. Thus, they should not consider delegate tenants but only the original consumer and producer.

The current implementation **could** cause a bug, that can be reproduced as follows:
1. Tenant A delegates Tenant B as the producer
2. Tenant B creates an agreement for themself, not as the delegate of Tenant A, the draft agreement will have consumerId = Tenant B
3. Tenant B submits the agreement
4. nextStateFromDraft [checks also the delegateId](https://github.com/pagopa/interop-be-monorepo/pull/1260/files#diff-f4e47e1b0eba3394aa8fbaa83c1527169d7098f93f93498cb42909ab618ed12aL48) because a delegation exists, and skips all the attribute checks

Is it a bug? 
It's probably an edge case that cannot happen...
And it is probably prevented by the validators called before `nextStateFromDraft`...
but still, I think we should not include the delegate in the state/attribute checks, all tests pass