### PR TITLE
Fixing agreement service delegate operations validators

### DIFF
--- a/packages/agreement-process/src/model/domain/agreement-validators.ts
+++ b/packages/agreement-process/src/model/domain/agreement-validators.ts
@@ -196,9 +196,9 @@ export const assertRequesterCanRetrieveConsumerDocuments = async (
         );
       } catch (error) {
         const activeConsumerDelegation =
-          await readModelService.getActiveConsumerDelegationByAgreement({
-            agreement,
-          });
+          await readModelService.getActiveConsumerDelegationByAgreement(
+            agreement
+          );
 
         assertRequesterIsDelegateConsumer(
           agreement,

--- a/packages/agreement-process/src/services/agreementContractBuilder.ts
+++ b/packages/agreement-process/src/services/agreementContractBuilder.ts
@@ -2,7 +2,6 @@
 import path from "path";
 import { fileURLToPath } from "url";
 import {
-  AuthData,
   FileManager,
   Logger,
   PDFGenerator,
@@ -266,7 +265,6 @@ export const contractBuilder = (
       eservice: EService,
       consumer: Tenant,
       producer: Tenant,
-      authData: AuthData,
       retrievedActiveDelegations: ActiveDelegations
     ): Promise<AgreementDocument> => {
       /*
@@ -278,7 +276,6 @@ export const contractBuilder = (
       const { producerDelegation, consumerDelegation } =
         await getActiveConsumerAndProducerDelegations(
           agreement,
-          authData,
           readModelService,
           retrievedActiveDelegations
         );

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -1314,7 +1314,7 @@ export function agreementServiceBuilder(
 
       await assertRequesterCanCreateAgrementForTenant(
         {
-          requesterId: authData.organizationId,
+          authData,
           tenantIdToVerify: tenantId,
           eserviceId,
         },

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -228,9 +228,7 @@ export const getActiveConsumerAndProducerDelegations = async (
     )),
   consumerDelegation:
     cachedActiveDelegations?.consumerDelegation ??
-    (await readModelService.getActiveConsumerDelegationByAgreement({
-      agreement,
-    })),
+    (await readModelService.getActiveConsumerDelegationByAgreement(agreement)),
 });
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, max-params
@@ -361,9 +359,9 @@ export function agreementServiceBuilder(
       );
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreement({
-          agreement: agreementToBeUpdated.data,
-        });
+        await readModelService.getActiveConsumerDelegationByAgreement(
+          agreementToBeUpdated.data
+        );
       assertRequesterCanActAsConsumer(
         agreementToBeUpdated.data,
         authData,
@@ -400,9 +398,9 @@ export function agreementServiceBuilder(
       );
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreement({
-          agreement: agreement.data,
-        });
+        await readModelService.getActiveConsumerDelegationByAgreement(
+          agreement.data
+        );
       assertRequesterCanActAsConsumer(
         agreement.data,
         authData,
@@ -734,9 +732,9 @@ export function agreementServiceBuilder(
       );
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreement({
-          agreement: agreementToBeCloned.data,
-        });
+        await readModelService.getActiveConsumerDelegationByAgreement(
+          agreementToBeCloned.data
+        );
       assertRequesterCanActAsConsumer(
         agreementToBeCloned.data,
         authData,
@@ -817,9 +815,9 @@ export function agreementServiceBuilder(
       }
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreement({
-          agreement: agreement.data,
-        });
+        await readModelService.getActiveConsumerDelegationByAgreement(
+          agreement.data
+        );
       assertRequesterCanActAsConsumer(
         agreement.data,
         authData,
@@ -952,9 +950,9 @@ export function agreementServiceBuilder(
       assertCanWorkOnConsumerDocuments(agreement.data.state);
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreement({
-          agreement: agreement.data,
-        });
+        await readModelService.getActiveConsumerDelegationByAgreement(
+          agreement.data
+        );
       assertRequesterCanActAsConsumer(
         agreement.data,
         authData,
@@ -1246,9 +1244,9 @@ export function agreementServiceBuilder(
       );
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreement({
-          agreement: agreement.data,
-        });
+        await readModelService.getActiveConsumerDelegationByAgreement(
+          agreement.data
+        );
       assertRequesterCanActAsConsumer(
         agreement.data,
         authData,

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -218,7 +218,6 @@ function retrieveAgreementDocument(
 
 export const getActiveConsumerAndProducerDelegations = async (
   agreement: Agreement,
-  authData: AuthData,
   readModelService: ReadModelService,
   cachedActiveDelegations?: ActiveDelegations
 ): Promise<ActiveDelegations> => ({
@@ -229,12 +228,9 @@ export const getActiveConsumerAndProducerDelegations = async (
     )),
   consumerDelegation:
     cachedActiveDelegations?.consumerDelegation ??
-    (await readModelService.getActiveConsumerDelegationByAgreementAndDelegateId(
-      {
-        agreement,
-        delegateId: authData.organizationId,
-      }
-    )),
+    (await readModelService.getActiveConsumerDelegationByAgreement({
+      agreement,
+    })),
 });
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, max-params
@@ -365,12 +361,9 @@ export function agreementServiceBuilder(
       );
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreementAndDelegateId(
-          {
-            agreement: agreementToBeUpdated.data,
-            delegateId: authData.organizationId,
-          }
-        );
+        await readModelService.getActiveConsumerDelegationByAgreement({
+          agreement: agreementToBeUpdated.data,
+        });
       assertRequesterCanActAsConsumer(
         agreementToBeUpdated.data,
         authData,
@@ -407,12 +400,9 @@ export function agreementServiceBuilder(
       );
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreementAndDelegateId(
-          {
-            agreement: agreement.data,
-            delegateId: authData.organizationId,
-          }
-        );
+        await readModelService.getActiveConsumerDelegationByAgreement({
+          agreement: agreement.data,
+        });
       assertRequesterCanActAsConsumer(
         agreement.data,
         authData,
@@ -444,7 +434,6 @@ export function agreementServiceBuilder(
 
       const activeDelegations = await getActiveConsumerAndProducerDelegations(
         agreement.data,
-        authData,
         readModelService
       );
       assertRequesterCanActAsConsumer(
@@ -566,7 +555,6 @@ export function agreementServiceBuilder(
         consumer,
         producer,
         updatedAgreement,
-        authData,
         activeDelegations
       );
 
@@ -630,7 +618,6 @@ export function agreementServiceBuilder(
 
       const activeDelegations = await getActiveConsumerAndProducerDelegations(
         agreementToBeUpgraded.data,
-        authData,
         readModelService
       );
       assertRequesterCanActAsConsumer(
@@ -747,12 +734,9 @@ export function agreementServiceBuilder(
       );
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreementAndDelegateId(
-          {
-            agreement: agreementToBeCloned.data,
-            delegateId: authData.organizationId,
-          }
-        );
+        await readModelService.getActiveConsumerDelegationByAgreement({
+          agreement: agreementToBeCloned.data,
+        });
       assertRequesterCanActAsConsumer(
         agreementToBeCloned.data,
         authData,
@@ -833,12 +817,9 @@ export function agreementServiceBuilder(
       }
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreementAndDelegateId(
-          {
-            agreement: agreement.data,
-            delegateId: authData.organizationId,
-          }
-        );
+        await readModelService.getActiveConsumerDelegationByAgreement({
+          agreement: agreement.data,
+        });
       assertRequesterCanActAsConsumer(
         agreement.data,
         authData,
@@ -898,7 +879,6 @@ export function agreementServiceBuilder(
 
       const activeDelegations = await getActiveConsumerAndProducerDelegations(
         agreement.data,
-        authData,
         readModelService
       );
       assertRequesterCanActAsConsumerOrProducer(
@@ -972,12 +952,9 @@ export function agreementServiceBuilder(
       assertCanWorkOnConsumerDocuments(agreement.data.state);
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreementAndDelegateId(
-          {
-            agreement: agreement.data,
-            delegateId: authData.organizationId,
-          }
-        );
+        await readModelService.getActiveConsumerDelegationByAgreement({
+          agreement: agreement.data,
+        });
       assertRequesterCanActAsConsumer(
         agreement.data,
         authData,
@@ -1102,7 +1079,6 @@ export function agreementServiceBuilder(
 
       const activeDelegations = await getActiveConsumerAndProducerDelegations(
         agreement.data,
-        authData,
         readModelService
       );
 
@@ -1225,7 +1201,6 @@ export function agreementServiceBuilder(
         consumer,
         producer,
         updatedAgreementWithoutContract,
-        authData,
         activeDelegations
       );
 
@@ -1271,12 +1246,9 @@ export function agreementServiceBuilder(
       );
 
       const activeConsumerDelegation =
-        await readModelService.getActiveConsumerDelegationByAgreementAndDelegateId(
-          {
-            agreement: agreement.data,
-            delegateId: authData.organizationId,
-          }
-        );
+        await readModelService.getActiveConsumerDelegationByAgreement({
+          agreement: agreement.data,
+        });
       assertRequesterCanActAsConsumer(
         agreement.data,
         authData,
@@ -1464,7 +1436,6 @@ async function addContractOnFirstActivation(
   consumer: Tenant,
   producer: Tenant,
   agreement: Agreement,
-  authData: AuthData,
   activeDelegations: ActiveDelegations
 ): Promise<Agreement> {
   if (isFirstActivation) {
@@ -1473,7 +1444,6 @@ async function addContractOnFirstActivation(
       eservice,
       consumer,
       producer,
-      authData,
       activeDelegations
     );
 

--- a/packages/agreement-process/src/services/agreementUpgradeProcessor.ts
+++ b/packages/agreement-process/src/services/agreementUpgradeProcessor.ts
@@ -118,7 +118,6 @@ export async function createUpgradeOrNewDraft({
       eservice,
       consumer,
       producer,
-      authData,
       activeDelegations
     );
 

--- a/packages/agreement-process/src/services/readModelService.ts
+++ b/packages/agreement-process/src/services/readModelService.ts
@@ -666,17 +666,28 @@ export function readModelServiceBuilder(
       }
       return result.data;
     },
-    async getActiveConsumerDelegationByAgreementAndDelegateId({
+    async getActiveConsumerDelegationByAgreement({
       agreement,
-      delegateId,
     }: {
-      agreement: Pick<Agreement, "eserviceId" | "consumerId">;
-      delegateId?: TenantId;
+      agreement: Agreement;
     }): Promise<Delegation | undefined> {
       return getDelegation(delegations, {
         "data.eserviceId": agreement.eserviceId,
         "data.delegatorId": agreement.consumerId,
-        "data.delegateId": delegateId,
+        "data.state": delegationState.active,
+        "data.kind": delegationKind.delegatedConsumer,
+      });
+    },
+    async getActiveConsumerDelegationByEserviceAndDelegator({
+      eserviceId,
+      delegatorId,
+    }: {
+      eserviceId: EServiceId;
+      delegatorId: TenantId;
+    }): Promise<Delegation | undefined> {
+      return getDelegation(delegations, {
+        "data.eserviceId": eserviceId,
+        "data.delegatorId": delegatorId,
         "data.state": delegationState.active,
         "data.kind": delegationKind.delegatedConsumer,
       });

--- a/packages/agreement-process/src/services/readModelService.ts
+++ b/packages/agreement-process/src/services/readModelService.ts
@@ -666,11 +666,9 @@ export function readModelServiceBuilder(
       }
       return result.data;
     },
-    async getActiveConsumerDelegationByAgreement({
-      agreement,
-    }: {
-      agreement: Agreement;
-    }): Promise<Delegation | undefined> {
+    async getActiveConsumerDelegationByAgreement(
+      agreement: Agreement
+    ): Promise<Delegation | undefined> {
       return getDelegation(delegations, {
         "data.eserviceId": agreement.eserviceId,
         "data.delegatorId": agreement.consumerId,

--- a/packages/agreement-process/src/services/readModelService.ts
+++ b/packages/agreement-process/src/services/readModelService.ts
@@ -667,25 +667,11 @@ export function readModelServiceBuilder(
       return result.data;
     },
     async getActiveConsumerDelegationByAgreement(
-      agreement: Agreement
+      agreement: Pick<Agreement, "consumerId" | "eserviceId">
     ): Promise<Delegation | undefined> {
       return getDelegation(delegations, {
         "data.eserviceId": agreement.eserviceId,
         "data.delegatorId": agreement.consumerId,
-        "data.state": delegationState.active,
-        "data.kind": delegationKind.delegatedConsumer,
-      });
-    },
-    async getActiveConsumerDelegationByEserviceAndDelegator({
-      eserviceId,
-      delegatorId,
-    }: {
-      eserviceId: EServiceId;
-      delegatorId: TenantId;
-    }): Promise<Delegation | undefined> {
-      return getDelegation(delegations, {
-        "data.eserviceId": eserviceId,
-        "data.delegatorId": delegatorId,
         "data.state": delegationState.active,
         "data.kind": delegationKind.delegatedConsumer,
       });


### PR DESCRIPTION
This PR fixes an issue identified by @sandrotaje while implementing #1275.

## How to reproduce the bug

Imagine Consumer C delegates delegate tenant D to consume Eservice E.
C tries to upgrade an existing agreement for E (same would apply to any other operation allowed by the consumer or delegate consumer)

### Expected
C is not allowed to upgrade because there is an active delegation, and D shall operate instead of C.

### Actual
The query as it was implemented before this fix was:
1. getting the active delegation with delegateId === to the caller tenant https://github.com/pagopa/interop-be-monorepo/pull/1274/files#diff-71db2d22095ae81787fc9ee7ffb2606a4a832b763fb13e3c5d19646434e3d951L753
2. In this case, the caller is C, so a delegation cannot be found, and the result is undefined (the delegation exists for the agreement but the delegate is D, not C)
3. the `assertRequesterCanActAsConsuemer` is thus called with an `undefined` delegation
4. no delegation, to it ends up in the first branch of the if and checks if caller is the consumer https://github.com/pagopa/interop-be-monorepo/pull/1274/files#diff-e4f3ebd287081c5c5c0a081e0f8b52a44687efde74d5cb7e63e6ba1364b903b5L348
5. C is the consumer so the result is that they are allowed to perform the operation