### PR TITLE
PIN-5818 - Fix purpose risk analysis visibility for producer delegate

### DIFF
--- a/packages/purpose-process/test/getPurposeById.test.ts
+++ b/packages/purpose-process/test/getPurposeById.test.ts
@@ -3,6 +3,8 @@ import {
   getMockTenant,
   getMockPurpose,
   writeInReadmodel,
+  getMockValidRiskAnalysisForm,
+  getMockDelegation,
 } from "pagopa-interop-commons-test";
 import {
   tenantKind,
@@ -13,6 +15,10 @@ import {
   EServiceId,
   TenantId,
   toReadModelTenant,
+  EService,
+  Delegation,
+  delegationKind,
+  delegationState,
 } from "pagopa-interop-models";
 import { describe, expect, it } from "vitest";
 import { genericLogger } from "pagopa-interop-commons";
@@ -28,6 +34,7 @@ import {
   eservices,
   purposeService,
   tenants,
+  delegations,
 } from "./utils.js";
 
 describe("getPurposeById", () => {
@@ -62,6 +69,176 @@ describe("getPurposeById", () => {
       isRiskAnalysisValid: false,
     });
   });
+  it("should get the purpose with the risk analysis form if the requester is the active e-service producer", async () => {
+    const mockTenant = {
+      ...getMockTenant(),
+      kind: tenantKind.PA,
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+      producerId: mockTenant.id,
+    };
+    const mockPurpose1: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      riskAnalysisForm: getMockValidRiskAnalysisForm(tenantKind.PA),
+    };
+
+    await addOnePurpose(mockPurpose1);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+    await writeInReadmodel(toReadModelTenant(mockTenant), tenants);
+
+    const result = await purposeService.getPurposeById(
+      mockPurpose1.id,
+      mockTenant.id,
+      genericLogger
+    );
+    expect(result).toMatchObject({
+      purpose: mockPurpose1,
+      isRiskAnalysisValid: true,
+    });
+  });
+  it("should get the purpose with the risk analysis form if the requester is the purpose agreement consumer", async () => {
+    const mockTenant = {
+      ...getMockTenant(),
+      kind: tenantKind.PA,
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+    };
+    const mockPurpose1: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      consumerId: mockTenant.id,
+      riskAnalysisForm: getMockValidRiskAnalysisForm(tenantKind.PA),
+    };
+
+    await addOnePurpose(mockPurpose1);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+    await writeInReadmodel(toReadModelTenant(mockTenant), tenants);
+
+    const result = await purposeService.getPurposeById(
+      mockPurpose1.id,
+      mockTenant.id,
+      genericLogger
+    );
+    expect(result).toMatchObject({
+      purpose: mockPurpose1,
+      isRiskAnalysisValid: true,
+    });
+  });
+  it("should get the purpose with the risk analysis form if the requester is an e-service delegated producer", async () => {
+    const mockTenant = {
+      ...getMockTenant(),
+      kind: tenantKind.PA,
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+    };
+    const mockPurpose1: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      riskAnalysisForm: getMockValidRiskAnalysisForm(tenantKind.PA),
+    };
+
+    const mockProducerDelegation: Delegation = {
+      ...getMockDelegation({ kind: delegationKind.delegatedProducer }),
+      delegatorId: mockEService.producerId,
+      eserviceId: mockEService.id,
+      delegateId: mockTenant.id,
+      state: delegationState.active,
+    };
+
+    await addOnePurpose(mockPurpose1);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+    await writeInReadmodel(toReadModelTenant(mockTenant), tenants);
+    await writeInReadmodel(mockProducerDelegation, delegations);
+
+    const result = await purposeService.getPurposeById(
+      mockPurpose1.id,
+      mockTenant.id,
+      genericLogger
+    );
+    expect(result).toMatchObject({
+      purpose: mockPurpose1,
+      isRiskAnalysisValid: true,
+    });
+  });
+  it("should get the purpose without the risk analysis form if the requester is not the producer nor the consumer", async () => {
+    const mockTenant = {
+      ...getMockTenant(),
+      kind: tenantKind.PA,
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+    };
+    const mockPurpose1: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: mockEService.id,
+      riskAnalysisForm: getMockValidRiskAnalysisForm(tenantKind.PA),
+    };
+
+    await addOnePurpose(mockPurpose1);
+    await writeInReadmodel(toReadModelEService(mockEService), eservices);
+    await writeInReadmodel(toReadModelTenant(mockTenant), tenants);
+
+    const result = await purposeService.getPurposeById(
+      mockPurpose1.id,
+      mockTenant.id,
+      genericLogger
+    );
+    expect(result).toMatchObject({
+      purpose: { ...mockPurpose1, riskAnalysisForm: undefined },
+      isRiskAnalysisValid: false,
+    });
+  });
+  it.each(
+    Object.values(delegationState).filter((s) => s !== delegationState.active)
+  )(
+    "should get the purpose without the risk analysis form if the requester has a producer delegation with state %s with the e-service purpose",
+    async (delegationState) => {
+      const mockTenant = {
+        ...getMockTenant(),
+        kind: tenantKind.PA,
+      };
+
+      const mockEService: EService = {
+        ...getMockEService(),
+      };
+      const mockPurpose1: Purpose = {
+        ...getMockPurpose(),
+        eserviceId: mockEService.id,
+        riskAnalysisForm: getMockValidRiskAnalysisForm(tenantKind.PA),
+      };
+
+      const mockProducerDelegation: Delegation = {
+        ...getMockDelegation({ kind: delegationKind.delegatedProducer }),
+        delegatorId: mockEService.producerId,
+        eserviceId: mockEService.id,
+        delegateId: mockTenant.id,
+        state: delegationState,
+      };
+
+      await addOnePurpose(mockPurpose1);
+      await writeInReadmodel(toReadModelEService(mockEService), eservices);
+      await writeInReadmodel(toReadModelTenant(mockTenant), tenants);
+      await writeInReadmodel(mockProducerDelegation, delegations);
+
+      const result = await purposeService.getPurposeById(
+        mockPurpose1.id,
+        mockTenant.id,
+        genericLogger
+      );
+      expect(result).toMatchObject({
+        purpose: { ...mockPurpose1, riskAnalysisForm: undefined },
+        isRiskAnalysisValid: false,
+      });
+    }
+  );
   it("should throw purposeNotFound if the purpose doesn't exist", async () => {
     const notExistingId: PurposeId = generateId();
     const mockTenant = getMockTenant();


### PR DESCRIPTION
This PR makes the purpose risk analysis visible for the e-service active producer delegate.
Added a lot of tests that covers all the cases where the risk analysis is visible or not.