### PR TITLE
Improve mockMessage type in tests

### DIFF
--- a/packages/client-readmodel-writer/test/consumerServiceV1.test.ts
+++ b/packages/client-readmodel-writer/test/consumerServiceV1.test.ts
@@ -36,14 +36,12 @@ import { clients } from "./utils.js";
 
 describe("Events V1", async () => {
   const mockClient = getMockClient();
-  const mockMessage: AuthorizationEventEnvelopeV1 = {
+  const mockMessage: Omit<AuthorizationEventEnvelopeV1, "type" | "data"> = {
     event_version: 1,
     stream_id: mockClient.id,
     version: 1,
     sequence_num: 1,
     log_date: new Date(),
-    type: "ClientAdded",
-    data: {},
   };
 
   it("ClientAdded", async () => {

--- a/packages/client-readmodel-writer/test/consumerServiceV2.test.ts
+++ b/packages/client-readmodel-writer/test/consumerServiceV2.test.ts
@@ -26,14 +26,12 @@ import { clients } from "./utils.js";
 
 describe("Events V2", async () => {
   const mockClient = getMockClient();
-  const mockMessage: AuthorizationEventEnvelopeV2 = {
+  const mockMessage: Omit<AuthorizationEventEnvelopeV2, "type" | "data"> = {
     event_version: 2,
     stream_id: mockClient.id,
     version: 1,
     sequence_num: 1,
     log_date: new Date(),
-    type: "ClientAdded",
-    data: {},
   };
 
   it("ClientAdded", async () => {

--- a/packages/delegation-readmodel-writer/test/consumerServiceV2.test.ts
+++ b/packages/delegation-readmodel-writer/test/consumerServiceV2.test.ts
@@ -19,14 +19,12 @@ describe("Events V2", async () => {
   const mockDelegation = getMockDelegation({
     kind: randomArrayItem(Object.values(delegationKind)),
   });
-  const mockMessage: DelegationEventEnvelopeV2 = {
+  const mockMessage: Omit<DelegationEventEnvelopeV2, "type" | "data"> = {
     event_version: 2,
     stream_id: mockDelegation.id,
     version: 1,
     sequence_num: 1,
     log_date: new Date(),
-    type: "ProducerDelegationApproved",
-    data: {},
   };
 
   it("ProducerDelegationApproved", async () => {

--- a/packages/producer-keychain-readmodel-writer/test/consumerServiceV2.test.ts
+++ b/packages/producer-keychain-readmodel-writer/test/consumerServiceV2.test.ts
@@ -26,14 +26,12 @@ import { producerKeychains } from "./utils.js";
 
 describe("Events V2", async () => {
   const mockProducerKeychain = getMockProducerKeychain();
-  const mockMessage: AuthorizationEventEnvelopeV2 = {
+  const mockMessage: Omit<AuthorizationEventEnvelopeV2, "type" | "data"> = {
     event_version: 2,
     stream_id: mockProducerKeychain.id,
     version: 1,
     sequence_num: 1,
     log_date: new Date(),
-    type: "ProducerKeychainAdded",
-    data: {},
   };
 
   it("ProducerKeychainAdded", async () => {

--- a/packages/tenant-readmodel-writer/test/consumerServiceV2.test.ts
+++ b/packages/tenant-readmodel-writer/test/consumerServiceV2.test.ts
@@ -37,14 +37,12 @@ import { tenants } from "./utils.js";
 
 describe("Tenant Events V2", async () => {
   const mockTenant = getMockTenant();
-  const mockMessage: TenantEventEnvelopeV2 = {
+  const mockMessage: Omit<TenantEventEnvelopeV2, "type" | "data"> = {
     event_version: 2,
     stream_id: mockTenant.id,
     version: 1,
     sequence_num: 1,
     log_date: new Date(),
-    type: "TenantOnboarded",
-    data: {},
   };
 
   it("TenantOnboarded", async () => {


### PR DESCRIPTION
In my opinion, this improves the code by:

- removing unused properties to prevent mistakes when creating a new test, as the object might otherwise have incorrect `type` and `data` properties

- make it more clear that, when adding a new test, the correct `type` and `data` should be added

This was already approved for the consumer service in #1228 