### PR TITLE
Fix AWS SES email sender into Agreement Email Sender

### DIFF
--- a/packages/agreement-email-sender/src/index.ts
+++ b/packages/agreement-email-sender/src/index.ts
@@ -31,7 +31,7 @@ const interopFeBaseUrl = config.interopFeBaseUrl;
 const sesEmailManager: EmailManagerSES = initSesMailManager(config);
 const sesEmailsenderData = {
   label: config.senderLabel,
-  mail: config.senderLabel,
+  mail: config.senderMail,
 };
 
 const pecEmailManager: EmailManagerPEC = initPecEmailManager(config);


### PR DESCRIPTION
# Description
Fix wrong `email` value used for AWS SES service from env var configuration during Agreement Email Sender initialization.  