### PR TITLE
Fix `getEServices` visibility filter with producer delegation

### DIFF
--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -154,19 +154,14 @@ export function readModelServiceBuilder(
           "data.id": { $in: ids },
         });
 
-      const delegationLookup =
-        producersIds.length > 0 || delegated !== undefined
-          ? [
-              {
-                $lookup: {
-                  from: "delegations",
-                  localField: "data.id",
-                  foreignField: "data.eserviceId",
-                  as: "delegations",
-                },
-              },
-            ]
-          : [];
+      const delegationLookup = {
+        $lookup: {
+          from: "delegations",
+          localField: "data.id",
+          foreignField: "data.eserviceId",
+          as: "delegations",
+        },
+      };
 
       const producersIdsFilter = ReadModelRepository.arrayToFilter(
         producersIds,
@@ -224,13 +219,39 @@ export function readModelServiceBuilder(
             $nor: [
               {
                 $and: [
-                  { "data.producerId": { $ne: authData.organizationId } },
+                  {
+                    $nor: [
+                      { "data.producerId": authData.organizationId },
+                      {
+                        delegations: {
+                          $elemMatch: {
+                            "data.delegateId": authData.organizationId,
+                            "data.state": delegationState.active,
+                            "data.kind": delegationKind.delegatedProducer,
+                          },
+                        },
+                      },
+                    ],
+                  },
                   { "data.descriptors": { $size: 0 } },
                 ],
               },
               {
                 $and: [
-                  { "data.producerId": { $ne: authData.organizationId } },
+                  {
+                    $nor: [
+                      { "data.producerId": authData.organizationId },
+                      {
+                        delegations: {
+                          $elemMatch: {
+                            "data.delegateId": authData.organizationId,
+                            "data.state": delegationState.active,
+                            "data.kind": delegationKind.delegatedProducer,
+                          },
+                        },
+                      },
+                    ],
+                  },
                   { "data.descriptors": { $size: 1 } },
                   {
                     "data.descriptors.state": {
@@ -292,7 +313,7 @@ export function readModelServiceBuilder(
         .otherwise(() => ({}));
 
       const aggregationPipeline = [
-        ...delegationLookup,
+        delegationLookup,
         { $match: nameFilter },
         { $match: idsFilter },
         { $match: producersIdsFilter },

--- a/packages/catalog-process/test/getEservices.test.ts
+++ b/packages/catalog-process/test/getEservices.test.ts
@@ -1215,6 +1215,60 @@ describe("get eservices", () => {
     }
   );
   it.each([descriptorState.draft, descriptorState.waitingForApproval])(
+    "should include eservices whose only descriptor is %s (requester is delegate, admin)",
+    async (state) => {
+      const descriptor9: Descriptor = {
+        ...mockDescriptor,
+        id: generateId(),
+        interface: mockDocument,
+        publishedAt: new Date(),
+        state,
+      };
+      const eservice9: EService = {
+        ...mockEService,
+        id: generateId(),
+        name: "eservice 008",
+        producerId: organizationId1,
+        descriptors: [descriptor9],
+      };
+      const delegation = getMockDelegation({
+        kind: delegationKind.delegatedProducer,
+        delegateId: organizationId2,
+        eserviceId: eservice9.id,
+        state: delegationState.active,
+      });
+      const authData: AuthData = {
+        ...getMockAuthData(organizationId2),
+        userRoles: [userRoles.ADMIN_ROLE],
+      };
+      await addOneEService(eservice9);
+      await addOneDelegation(delegation);
+      const result = await catalogService.getEServices(
+        authData,
+        {
+          eservicesIds: [],
+          producersIds: [],
+          states: [],
+          agreementStates: [],
+          attributesIds: [],
+        },
+        0,
+        50,
+        genericLogger
+      );
+      expect(result.totalCount).toBe(7);
+      expect(result.results).toEqual([
+        eservice1,
+        eservice2,
+        eservice3,
+        eservice4,
+        eservice5,
+        eservice6,
+        eservice9,
+      ]);
+    }
+  );
+  it.each([descriptorState.draft, descriptorState.waitingForApproval])(
     "should not include eservices whose only descriptor is %s (requester is the producer, not admin nor api, nor support)",
     async (state) => {
       const descriptor8: Descriptor = {


### PR DESCRIPTION
This PR fixes an issue where the e-services with no descriptor or one in draft/waiting for approval was not visible for the delegate tenant