### PR TITLE
Added missing delegation param to agreement activation

### DIFF
--- a/packages/agreement-process/src/services/agreementActivationProcessor.ts
+++ b/packages/agreement-process/src/services/agreementActivationProcessor.ts
@@ -6,7 +6,7 @@ import {
   AgreementEventV2,
   AgreementState,
   CorrelationId,
-  DelegationId,
+  Delegation,
   Descriptor,
   EService,
   Tenant,
@@ -49,7 +49,7 @@ export function createActivationUpdateAgreementSeed({
   suspendedByConsumer,
   suspendedByProducer,
   suspendedByPlatform,
-  producerDelegationId,
+  producerDelegation,
 }: {
   isFirstActivation: boolean;
   newState: AgreementState;
@@ -61,9 +61,9 @@ export function createActivationUpdateAgreementSeed({
   suspendedByConsumer: boolean | undefined;
   suspendedByProducer: boolean | undefined;
   suspendedByPlatform: boolean | undefined;
-  producerDelegationId?: DelegationId | undefined;
+  producerDelegation: Delegation | undefined;
 }): UpdateAgreementSeed {
-  const stamp = createStamp(authData.userId, producerDelegationId);
+  const stamp = createStamp(authData.userId, producerDelegation?.id);
 
   return isFirstActivation
     ? {
@@ -99,7 +99,8 @@ export function createActivationUpdateAgreementSeed({
             agreement,
             authData.organizationId,
             agreementState.active,
-            stamp
+            stamp,
+            producerDelegation?.delegateId
           ),
         },
         suspendedByPlatform,

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -1081,7 +1081,7 @@ export function agreementServiceBuilder(
           suspendedByConsumer,
           suspendedByProducer,
           suspendedByPlatform,
-          producerDelegationId: activeProducerDelegation?.id,
+          producerDelegation: activeProducerDelegation,
         });
 
       const updatedAgreementWithoutContract: Agreement = {

--- a/packages/agreement-process/src/services/agreementStampUtils.ts
+++ b/packages/agreement-process/src/services/agreementStampUtils.ts
@@ -35,7 +35,7 @@ export const suspendedByProducerStamp = (
   requesterOrgId: TenantId,
   destinationState: AgreementState,
   stamp: AgreementStamp,
-  delegateProducerId?: TenantId | undefined
+  delegateProducerId: TenantId | undefined
 ): AgreementStamp | undefined =>
   match<[TenantId | undefined, AgreementState]>([
     requesterOrgId,

--- a/packages/agreement-process/test/activateAgreement.test.ts
+++ b/packages/agreement-process/test/activateAgreement.test.ts
@@ -74,7 +74,6 @@ import {
   tenantNotFound,
 } from "../src/model/domain/errors.js";
 import { config } from "../src/config/config.js";
-import { suspendedByProducerFlag } from "../src/services/agreementStateProcessor.js";
 import {
   addOneAgreement,
   addOneAttribute,

--- a/packages/agreement-process/test/activateAgreement.test.ts
+++ b/packages/agreement-process/test/activateAgreement.test.ts
@@ -74,6 +74,7 @@ import {
   tenantNotFound,
 } from "../src/model/domain/errors.js";
 import { config } from "../src/config/config.js";
+import { suspendedByProducerFlag } from "../src/services/agreementStateProcessor.js";
 import {
   addOneAgreement,
   addOneAttribute,
@@ -898,6 +899,7 @@ describe("activate agreement", () => {
         consumerId: consumer.id,
         descriptors: [getMockDescriptorPublished()],
       };
+      const mockAgreement = getMockAgreement(eservice.id);
       const agreement: Agreement = {
         ...getMockAgreement(eservice.id),
         state: agreementState.suspended,
@@ -906,8 +908,15 @@ describe("activate agreement", () => {
         consumerId: consumer.id,
         suspendedAt: new Date(),
         suspendedByConsumer: false,
-        suspendedByProducer: false,
+        suspendedByProducer: true,
         suspendedByPlatform: false,
+        stamps: {
+          ...mockAgreement.stamps,
+          suspensionByProducer: {
+            who: authData.userId,
+            when: new Date(),
+          },
+        },
       };
       const delegation = getMockDelegation({
         kind: delegationKind.delegatedProducer,
@@ -941,6 +950,11 @@ describe("activate agreement", () => {
         declaredAttributes: actualAgreement.declaredAttributes,
         verifiedAttributes: actualAgreement.verifiedAttributes,
         suspendedAt: undefined,
+        suspendedByProducer: false,
+        stamps: {
+          ...agreement.stamps,
+          suspensionByProducer: undefined,
+        },
       };
 
       expect(actualAgreement).toEqual(expectedAgreement);


### PR DESCRIPTION
Bug found while implementing tests for incaricato in #1277 (feature Capofila).

## Bug Description
The delegationId parameter was not passed to the function that adds/removes the `suspendedByProducer` stamp on activation or suspension, meaning that in case the caller is the delegate producer, the `suspendedByProducer`  stamp is not added on suspension or removed on activation.