### PR TITLE
Minor fixes on BFF delegations

### DIFF
--- a/collections/bff/delegation/consumer/Approve Consumer Delegation.bru
+++ b/collections/bff/delegation/consumer/Approve Consumer Delegation.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Approve producer delegation
+  name: Approve consumer delegation
   type: http
   seq: 1
 }
@@ -15,6 +15,6 @@ params:path {
 }
 
 headers {
-  Authorization: {{JWT}}
+  Authorization: {{JWT2}}
   X-Correlation-Id: {{correlation-id}}
 }

--- a/collections/bff/delegation/consumer/Create Consumer Delegation.bru
+++ b/collections/bff/delegation/consumer/Create Consumer Delegation.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Create new delegation
+  name: Create consumer delegation
   type: http
   seq: 1
 }
@@ -10,6 +10,11 @@ post {
   auth: none
 }
 
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}
+
 body:json {
   {
     "eserviceId": "{{eserviceId}}",
@@ -17,7 +22,6 @@ body:json {
   }
 }
 
-headers {
-  Authorization: {{JWT}}
-  X-Correlation-Id: {{correlation-id}}
+vars:post-response {
+  delegationId: res.body.id
 }

--- a/collections/bff/delegation/consumer/Reject Consumer Delegation.bru
+++ b/collections/bff/delegation/consumer/Reject Consumer Delegation.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Reject delegation
+  name: Reject consumer delegation
   type: http
   seq: 1
 }
@@ -21,6 +21,6 @@ params:path {
 }
 
 headers {
-  Authorization: {{JWT}}
+  Authorization: {{JWT2}}
   X-Correlation-Id: {{correlation-id}}
 }

--- a/collections/bff/delegation/consumer/Revoke Consumer Delegation.bru
+++ b/collections/bff/delegation/consumer/Revoke Consumer Delegation.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Revoke a delegation by ID
+  name: Revoke consumer delegation
   type: http
   seq: 1
 }

--- a/collections/bff/delegation/producer/Approve Producer Delegation.bru
+++ b/collections/bff/delegation/producer/Approve Producer Delegation.bru
@@ -15,6 +15,6 @@ params:path {
 }
 
 headers {
-  Authorization: {{JWT}}
+  Authorization: {{JWT2}}
   X-Correlation-Id: {{correlation-id}}
 }

--- a/collections/bff/delegation/producer/Create Producer Delegation.bru
+++ b/collections/bff/delegation/producer/Create Producer Delegation.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Create new delegation
+  name: Create producer delegation
   type: http
   seq: 1
 }
@@ -10,6 +10,11 @@ post {
   auth: none
 }
 
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}
+
 body:json {
   {
     "eserviceId": "{{eserviceId}}",
@@ -17,7 +22,6 @@ body:json {
   }
 }
 
-headers {
-  Authorization: {{JWT}}
-  X-Correlation-Id: {{correlation-id}}
+vars:post-response {
+  delegationId: res.body.id
 }

--- a/collections/bff/delegation/producer/Reject Producer Delegation.bru
+++ b/collections/bff/delegation/producer/Reject Producer Delegation.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Reject delegation
+  name: Reject producer delegation
   type: http
   seq: 1
 }
@@ -21,6 +21,6 @@ params:path {
 }
 
 headers {
-  Authorization: {{JWT}}
+  Authorization: {{JWT2}}
   X-Correlation-Id: {{correlation-id}}
 }

--- a/collections/bff/delegation/producer/Revoke Producer Delegation.bru
+++ b/collections/bff/delegation/producer/Revoke Producer Delegation.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Revoke a delegation by ID
+  name: Revoke producer delegation
   type: http
   seq: 1
 }

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -12900,7 +12900,7 @@ paths:
       tags:
         - producerDelegations
       summary: Producer delegation creation
-      description: creates the producer delegation
+      description: creates a producer delegation
       operationId: createProducerDelegation
       requestBody:
         content:
@@ -13197,7 +13197,7 @@ paths:
       tags:
         - consumerDelegations
       summary: Consumer delegation creation
-      description: creates the consumer delegation
+      description: creates a consumer delegation
       operationId: createConsumerDelegation
       requestBody:
         content:
@@ -13504,7 +13504,7 @@ paths:
       operationId: getDelegation
       responses:
         "200":
-          description: Producer delegation retrieved
+          description: delegation retrieved
           content:
             application/json:
               schema:

--- a/packages/backend-for-frontend/src/routers/consumerDelegationRouter.ts
+++ b/packages/backend-for-frontend/src/routers/consumerDelegationRouter.ts
@@ -60,7 +60,7 @@ const consumerDelegationRouter = (
     .post("/consumer/delegations/:delegationId/approve", async (req, res) => {
       const ctx = fromBffAppContext(req.ctx, req.headers);
       try {
-        await delegationService.delegateApproveConsumerDelegation(
+        await delegationService.approveConsumerDelegation(
           unsafeBrandId(req.params.delegationId),
           ctx
         );
@@ -81,7 +81,7 @@ const consumerDelegationRouter = (
     .post("/consumer/delegations/:delegationId/reject", async (req, res) => {
       const ctx = fromBffAppContext(req.ctx, req.headers);
       try {
-        await delegationService.delegateRejectConsumerDelegation(
+        await delegationService.rejectConsumerDelegation(
           unsafeBrandId(req.params.delegationId),
           req.body,
           ctx
@@ -104,7 +104,7 @@ const consumerDelegationRouter = (
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
       try {
-        await delegationService.delegatorRevokeConsumerDelegation(
+        await delegationService.revokeConsumerDelegation(
           unsafeBrandId(req.params.delegationId),
           ctx
         );

--- a/packages/backend-for-frontend/src/routers/delegationRouter.ts
+++ b/packages/backend-for-frontend/src/routers/delegationRouter.ts
@@ -83,7 +83,7 @@ const delegationRouter = (
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
       try {
-        const delegation = await delegationService.getDelegationById(
+        const delegation = await delegationService.getDelegation(
           unsafeBrandId(req.params.delegationId),
           ctx
         );

--- a/packages/backend-for-frontend/src/routers/producerDelegationRouter.ts
+++ b/packages/backend-for-frontend/src/routers/producerDelegationRouter.ts
@@ -60,7 +60,7 @@ const producerDelegationRouter = (
     .post("/producer/delegations/:delegationId/approve", async (req, res) => {
       const ctx = fromBffAppContext(req.ctx, req.headers);
       try {
-        await delegationService.delegateApproveProducerDelegation(
+        await delegationService.approveProducerDelegation(
           unsafeBrandId(req.params.delegationId),
           ctx
         );
@@ -81,7 +81,7 @@ const producerDelegationRouter = (
     .post("/producer/delegations/:delegationId/reject", async (req, res) => {
       const ctx = fromBffAppContext(req.ctx, req.headers);
       try {
-        await delegationService.delegateRejectProducerDelegation(
+        await delegationService.rejectProducerDelegation(
           unsafeBrandId(req.params.delegationId),
           req.body,
           ctx
@@ -104,7 +104,7 @@ const producerDelegationRouter = (
       const ctx = fromBffAppContext(req.ctx, req.headers);
 
       try {
-        await delegationService.delegatorRevokeProducerDelegation(
+        await delegationService.revokeProducerDelegation(
           unsafeBrandId(req.params.delegationId),
           ctx
         );

--- a/packages/backend-for-frontend/src/services/delegationService.ts
+++ b/packages/backend-for-frontend/src/services/delegationService.ts
@@ -196,7 +196,7 @@ export function delegationServiceBuilder(
   fileManager: FileManager
 ) {
   return {
-    async getDelegationById(
+    async getDelegation(
       delegationId: DelegationId,
       { headers, logger }: WithLogger<BffAppContext>
     ): Promise<bffApi.Delegation> {
@@ -328,7 +328,7 @@ export function delegationServiceBuilder(
 
       return { id: delegation.id };
     },
-    async delegatorRevokeProducerDelegation(
+    async revokeProducerDelegation(
       delegationId: DelegationId,
       { headers }: WithLogger<BffAppContext>
     ): Promise<void> {
@@ -339,7 +339,7 @@ export function delegationServiceBuilder(
         headers,
       });
     },
-    async delegatorRevokeConsumerDelegation(
+    async revokeConsumerDelegation(
       delegationId: DelegationId,
       { headers }: WithLogger<BffAppContext>
     ): Promise<void> {
@@ -350,7 +350,7 @@ export function delegationServiceBuilder(
         headers,
       });
     },
-    async delegateRejectProducerDelegation(
+    async rejectProducerDelegation(
       delegationId: DelegationId,
       rejectBody: bffApi.RejectDelegationPayload,
       { headers }: WithLogger<BffAppContext>
@@ -362,7 +362,7 @@ export function delegationServiceBuilder(
         headers,
       });
     },
-    async delegateRejectConsumerDelegation(
+    async rejectConsumerDelegation(
       delegationId: DelegationId,
       rejectBody: bffApi.RejectDelegationPayload,
       { headers }: WithLogger<BffAppContext>
@@ -374,7 +374,7 @@ export function delegationServiceBuilder(
         headers,
       });
     },
-    async delegateApproveProducerDelegation(
+    async approveProducerDelegation(
       delegationId: DelegationId,
       { headers }: WithLogger<BffAppContext>
     ): Promise<void> {
@@ -385,7 +385,7 @@ export function delegationServiceBuilder(
         headers,
       });
     },
-    async delegateApproveConsumerDelegation(
+    async approveConsumerDelegation(
       delegationId: DelegationId,
       { headers }: WithLogger<BffAppContext>
     ): Promise<void> {


### PR DESCRIPTION
- Fixing some naming in Bruno calls and adding vars on creation to simplify local testing
- Removing delegate/delegator prefixes from delegationService.ts calls in BFF to align to the naming in delegation-process and the operationId fields in the bff API spec. Also, these prefixes were misleading, in my opinion: if we have `delegateRejectConsumerDelegation,` it seems that we could also have some other reject that is not for the delegate, while it's actually only the delegate that can reject (the same goes for other methods; only one of the tenants can perform them, either the delegate or the delegator).