### PR TITLE
Allow delegate attribute self verification

### DIFF
--- a/packages/tenant-process/src/services/validators.ts
+++ b/packages/tenant-process/src/services/validators.ts
@@ -19,6 +19,7 @@ import {
   tenantKind,
   SCP,
   Agreement,
+  Delegation,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import {
@@ -28,7 +29,6 @@ import {
   selfcareIdConflict,
   expirationDateNotFoundInVerifier,
   tenantIsNotACertifier,
-  verifiedAttributeSelfVerificationNotAllowed,
   attributeNotFound,
   tenantAlreadyHasDelegatedProducerFeature,
   tenantHasNoDelegatedProducerFeature,
@@ -49,23 +49,25 @@ export function assertVerifiedAttributeExistsInTenant(
 
 export async function assertVerifiedAttributeOperationAllowed({
   requesterId,
-  delegateProducerId,
-  consumerId,
+  producerDelegation,
   attributeId,
   agreement,
   readModelService,
   error,
 }: {
   requesterId: TenantId;
-  delegateProducerId: TenantId | undefined;
-  consumerId: TenantId;
+  producerDelegation: Delegation | undefined;
   attributeId: AttributeId;
   agreement: Agreement;
   readModelService: ReadModelService;
   error: Error;
 }): Promise<void> {
-  if ([requesterId, delegateProducerId].includes(consumerId)) {
-    throw verifiedAttributeSelfVerificationNotAllowed();
+  if (producerDelegation && producerDelegation.delegateId !== requesterId) {
+    throw error;
+  }
+
+  if (!producerDelegation && requesterId !== agreement.producerId) {
+    throw error;
   }
 
   const descriptorId = agreement.descriptorId;
@@ -92,14 +94,6 @@ export async function assertVerifiedAttributeOperationAllowed({
 
   // Check if attribute is allowed
   if (!attributeIds.has(attributeId)) {
-    throw error;
-  }
-
-  if (delegateProducerId && delegateProducerId !== requesterId) {
-    throw error;
-  }
-
-  if (!delegateProducerId && requesterId !== agreement.producerId) {
     throw error;
   }
 }

--- a/packages/tenant-process/test/revokeVerifiedAttribute.test.ts
+++ b/packages/tenant-process/test/revokeVerifiedAttribute.test.ts
@@ -172,7 +172,7 @@ describe("revokeVerifiedAttribute", async () => {
             verifiedBy: [],
             revokedBy: [
               {
-                id: hasDelegation ? delegation.delegatorId : revokerTenant.id,
+                id: revokerTenant.id,
                 delegationId: hasDelegation ? delegation.id : undefined,
                 verificationDate: mockVerifiedBy.verificationDate,
                 revocationDate: new Date(),

--- a/packages/tenant-process/test/verifyVerifiedAttribute.test.ts
+++ b/packages/tenant-process/test/verifyVerifiedAttribute.test.ts
@@ -159,7 +159,7 @@ describe("verifyVerifiedAttribute", async () => {
             assignmentTimestamp: new Date(),
             verifiedBy: [
               {
-                id: hasDelegation ? delegation.delegatorId : requesterTenant.id,
+                id: eService1.producerId,
                 delegationId: hasDelegation ? delegation.id : undefined,
                 verificationDate: new Date(),
                 expirationDate: undefined,
@@ -253,7 +253,7 @@ describe("verifyVerifiedAttribute", async () => {
               { ...mockVerifiedBy },
               {
                 ...mockVerifiedBy,
-                id: hasDelegation ? delegation.delegatorId : requesterTenant.id,
+                id: eService1.producerId,
                 delegationId: hasDelegation ? delegation.id : undefined,
                 verificationDate: new Date(),
               },
@@ -355,7 +355,7 @@ describe("verifyVerifiedAttribute", async () => {
       )
     );
   });
-  it("Should throw verifiedAttributeSelfVerificationNotAllowed if the organizations are not allowed to revoke own attributes", async () => {
+  it.only("Should throw verifiedAttributeSelfVerificationNotAllowed if the organizations are not allowed to revoke own attributes", async () => {
     await addOneTenant(targetTenant);
     await addOneTenant(requesterTenant);
     await addOneEService(eService1);
@@ -364,10 +364,10 @@ describe("verifyVerifiedAttribute", async () => {
     expect(
       tenantService.verifyVerifiedAttribute(
         {
-          tenantId: targetTenant.id,
+          tenantId: agreementEservice1.producerId,
           attributeId: tenantAttributeSeedId,
           agreementId: agreementEservice1.id,
-          organizationId: targetTenant.id,
+          organizationId: agreementEservice1.producerId,
           correlationId: generateId(),
         },
         genericLogger

--- a/packages/tenant-process/test/verifyVerifiedAttribute.test.ts
+++ b/packages/tenant-process/test/verifyVerifiedAttribute.test.ts
@@ -355,7 +355,7 @@ describe("verifyVerifiedAttribute", async () => {
       )
     );
   });
-  it.only("Should throw verifiedAttributeSelfVerificationNotAllowed if the organizations are not allowed to revoke own attributes", async () => {
+  it("Should throw verifiedAttributeSelfVerificationNotAllowed if the organizations are not allowed to revoke own attributes", async () => {
     await addOneTenant(targetTenant);
     await addOneTenant(requesterTenant);
     await addOneEService(eService1);


### PR DESCRIPTION
This PR changes verification and revocation services logic allowing [this](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/1183186970/SRS+Capofila#Edge-case) edge case, as descripted in the SRS.

Plus fixes a bug where, in case the requester was a delegate, the revoker/verifier id assigned to the `revokedBy`/`verifiedBy`, was the delegate's one.