### PR TITLE
PIN-5776 descriptor state waiting approval

### DIFF
--- a/packages/api-gateway/src/api/catalogApiConverter.ts
+++ b/packages/api-gateway/src/api/catalogApiConverter.ts
@@ -5,12 +5,15 @@ import {
 } from "pagopa-interop-api-clients";
 import { Logger } from "pagopa-interop-commons";
 import {
-  assertNonDraftDescriptor,
+  assertNonValidDescriptor,
   assertRegistryAttributeExists,
 } from "../services/validators.js";
 
-export type NonDraftCatalogApiDescriptor = catalogApi.EServiceDescriptor & {
-  state: Exclude<catalogApi.EServiceDescriptorState, "DRAFT">;
+export type validCatalogApiDescriptor = catalogApi.EServiceDescriptor & {
+  state: Exclude<
+    catalogApi.EServiceDescriptorState,
+    "DRAFT" | "WAITING_FOR_APPROVAL"
+  >;
 };
 
 export function toApiGatewayCatalogEservice(
@@ -94,12 +97,12 @@ export function toApiGatewayDescriptorDocument(
   };
 }
 
-export function toApiGatewayDescriptorIfNotDraft(
+export function toApiGatewayDescriptorIfIsValid(
   descriptor: catalogApi.EServiceDescriptor,
   eserviceId: catalogApi.EService["id"],
   logger: Logger
 ): apiGatewayApi.EServiceDescriptor {
-  assertNonDraftDescriptor(descriptor, descriptor.id, eserviceId, logger);
+  assertNonValidDescriptor(descriptor, eserviceId, logger);
 
   return {
     id: descriptor.id,

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -15,19 +15,19 @@ import {
 import { attributeNotExists } from "../model/errors.js";
 import {
   getLatestActiveDescriptor,
-  getNotDraftDescriptor,
   getLatestTenantContactEmail,
+  getValidDescriptor,
 } from "../model/modelMappingUtils.js";
-import {
-  isRequesterEserviceProducer,
-  isAgreementSubscribed,
-  isAgreementUpgradable,
-  hasCertifiedAttributes,
-} from "../services/validators.js";
 import {
   ConfigurationRiskAnalysis,
   catalogApiDescriptorState,
 } from "../model/types.js";
+import {
+  hasCertifiedAttributes,
+  isAgreementSubscribed,
+  isAgreementUpgradable,
+  isRequesterEserviceProducer,
+} from "../services/validators.js";
 import { toBffCompactAgreement } from "./agreementApiConverter.js";
 
 export function toEserviceCatalogProcessQueryParams(
@@ -105,7 +105,7 @@ export function toBffCatalogDescriptorEService(
     },
     description: eservice.description,
     technology: eservice.technology,
-    descriptors: getNotDraftDescriptor(eservice).map(toCompactDescriptor),
+    descriptors: getValidDescriptor(eservice).map(toCompactDescriptor),
     agreement: agreement && toBffCompactAgreement(agreement, eservice),
     isMine: isRequesterEserviceProducer(requesterTenant.id, eservice),
     hasCertifiedAttributes: hasCertifiedAttributes(descriptor, requesterTenant),

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -373,6 +373,8 @@ export function toCompactProducerDescriptor(
     version: descriptor.version,
     requireCorrections:
       isRequesterProducerDelegate &&
+      // The WAITING_FOR_APPROVAL state is not relevant for the producer descriptor's requireCorrections field,
+      // so we don't consider it when determining whether corrections are required.
       descriptor.state === catalogApi.EServiceDescriptorState.Values.DRAFT &&
       descriptor.rejectionReasons &&
       descriptor.rejectionReasons.length > 0,

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -18,15 +18,14 @@ import {
   getLatestTenantContactEmail,
   getValidDescriptor,
 } from "../model/modelMappingUtils.js";
-import {
-  ConfigurationRiskAnalysis,
-  catalogApiDescriptorState,
-} from "../model/types.js";
+import { ConfigurationRiskAnalysis } from "../model/types.js";
 import {
   hasCertifiedAttributes,
   isAgreementSubscribed,
   isAgreementUpgradable,
+  isInvalidDescriptor,
   isRequesterEserviceProducer,
+  isValidDescriptor,
 } from "../services/validators.js";
 import { toBffCompactAgreement } from "./agreementApiConverter.js";
 
@@ -240,14 +239,10 @@ export function toBffCatalogApiProducerDescriptorEService(
   const producerMail = getLatestTenantContactEmail(producer);
 
   const notDraftDecriptors = eservice.descriptors
-    .filter((d) => d.state !== catalogApiDescriptorState.DRAFT)
+    .filter(isValidDescriptor)
     .map(toCompactDescriptor);
 
-  const draftDescriptor = eservice.descriptors.find(
-    (d) =>
-      d.state === catalogApiDescriptorState.DRAFT ||
-      d.state === catalogApiDescriptorState.WAITING_FOR_APPROVAL
-  );
+  const draftDescriptor = eservice.descriptors.find(isInvalidDescriptor);
 
   return {
     id: eservice.id,

--- a/packages/backend-for-frontend/src/model/modelMappingUtils.ts
+++ b/packages/backend-for-frontend/src/model/modelMappingUtils.ts
@@ -17,6 +17,11 @@ const activeDescriptorStatesFilter: catalogApi.EServiceDescriptorState[] = [
   catalogApiDescriptorState.DEPRECATED,
 ];
 
+const invalidDescriptorState: catalogApi.EServiceDescriptorState[] = [
+  catalogApiDescriptorState.DRAFT,
+  catalogApiDescriptorState.WAITING_FOR_APPROVAL,
+];
+
 export function getLatestActiveDescriptor(
   eservice: catalogApi.EService
 ): catalogApi.EServiceDescriptor | undefined {
@@ -26,11 +31,11 @@ export function getLatestActiveDescriptor(
     .at(-1);
 }
 
-export function getNotDraftDescriptor(
+export function getValidDescriptor(
   eservice: catalogApi.EService
 ): catalogApi.EServiceDescriptor[] {
   return eservice.descriptors.filter(
-    (d) => d.state !== catalogApiDescriptorState.DRAFT
+    (d) => !invalidDescriptorState.includes(d.state)
   );
 }
 

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -52,16 +52,14 @@ import {
   toBffCatalogApiEserviceRiskAnalysisSeed,
   toCompactProducerDescriptor,
 } from "../api/catalogApiConverter.js";
-import {
-  catalogApiDescriptorState,
-  ConfigurationEservice,
-} from "../model/types.js";
+import { ConfigurationEservice } from "../model/types.js";
 import { getAllAgreements, getLatestAgreement } from "./agreementService.js";
 import { getAllBulkAttributes } from "./attributeService.js";
 import {
   assertNotDelegatedEservice,
   assertRequesterIsProducer,
   assertRequesterCanActAsProducer,
+  isInvalidDescriptor,
 } from "./validators.js";
 
 export type CatalogService = ReturnType<typeof catalogServiceBuilder>;
@@ -117,11 +115,7 @@ const enhanceProducerEService = (
   requesterId: TenantId
 ): bffApi.ProducerEService => {
   const activeDescriptor = getLatestActiveDescriptor(eservice);
-  const draftDescriptor = eservice.descriptors.find(
-    (d) =>
-      d.state === catalogApiDescriptorState.DRAFT ||
-      d.state === catalogApiDescriptorState.WAITING_FOR_APPROVAL
-  );
+  const draftDescriptor = eservice.descriptors.find(isInvalidDescriptor);
 
   const isRequesterDelegateProducer = requesterId !== eservice.producerId;
 

--- a/packages/backend-for-frontend/src/services/validators.ts
+++ b/packages/backend-for-frontend/src/services/validators.ts
@@ -29,6 +29,23 @@ import {
 import { BffAppContext } from "../utilities/context.js";
 import { getAllDelegations } from "./delegationService.js";
 
+export const invalidDescriptorStates: catalogApi.EServiceDescriptorState[] = [
+  catalogApi.EServiceDescriptorState.Values.DRAFT,
+  catalogApi.EServiceDescriptorState.Values.WAITING_FOR_APPROVAL,
+];
+
+export function isValidDescriptor(
+  descriptor: catalogApi.EServiceDescriptor
+): boolean {
+  return !invalidDescriptorStates.includes(descriptor.state);
+}
+
+export function isInvalidDescriptor(
+  descriptor: catalogApi.EServiceDescriptor
+): boolean {
+  return invalidDescriptorStates.includes(descriptor.state);
+}
+
 export function isRequesterEserviceProducer(
   requesterId: string,
   eservice: catalogApi.EService
@@ -145,7 +162,7 @@ export function hasCertifiedAttributes(
 export function verifyExportEligibility(
   descriptor: catalogApi.EServiceDescriptor
 ): void {
-  if (descriptor.state === catalogApiDescriptorState.DRAFT) {
+  if (isValidDescriptor(descriptor)) {
     throw notValidDescriptor(descriptor.id, descriptor.state);
   }
 }


### PR DESCRIPTION
Closes [PIN-5776](https://pagopa.atlassian.net/browse/PIN-5776)

# Descrizione
Ecco il documento ristrutturato, con la sintassi e la grammatica corrette, un miglioramento della chiarezza e una formattazione adeguata per una lettura più agevole:

API Gateway

Le seguenti API gestiscono l’enrichment con i servizi esterni (eservice) contenenti descrittori validi (“validi”).

1. Tenant API

	•	GET /organizations/origin/:origin/externalId/:externalId/eservices
Restituisce gli eservice associati a un’organizzazione, con i rispettivi descrittori validi.

2. Catalog API

	•	GET /eservices/:eserviceId
Recupera le informazioni di un eservice specifico.
	•	GET /eservices/:eserviceId/descriptors
In questo metodo viene applicato il filtro isValidDescriptorState, con l’eliminazione dei descrittori che sono nello stato “Waiting for Approval” (WFA).
	•	GET /eservices/:eserviceId/descriptors/:descriptorId
Utilizza l’asserzione assertNonValidDescriptor per verificare che il descrittore sia valido. Il descrittore è considerato valido se non è in stato DRAFT o WFA.

3. BFF (Backend for Frontend)

	•	Converter toBffCatalogDescriptorEService
Filtra i descrittori, applicando una condizione che esclude quelli con stato WFA.
	•	Route /catalog/eservices/:eserviceId/descriptor/:descriptorId
Usa il metodo getCatalogEServiceDescriptor, che applica il filtro sopra descritto.

4. Export Visibility

	•	Metodo verifyExportEligibility
Verifica che un descrittore non sia nello stato WFA, oltre a controllare altre condizioni di idoneità.

5. Validatori

	•	È stata aggiunta una logica nei validatori per identificare i descrittori non validi, ossia quelli in stato DRAFT o WFA. I descrittori con altri stati sono considerati validi.

6. Producer Eservice

	•	Route /producers/eservices
Utilizza il metodo getProducerEServices, che arricchisce i dati con la funzione enhanceProducerEService. Quest’ultima include un campo draftDescriptor, che contiene descrittori in stato DRAFT e WFA.
	•	La funzione che costruisce un ProducerDescriptor compact calcola il valore di requireCorrections solo in relazione allo stato DRAFT, ignorando lo stato WFA.

7. Converter from Event V1

	•	Nel converter protobufConverterFromV1 si utilizza solo lo stato DRAFT per determinare se aggiungere il campo publishedAt. Non verrà aggiunta logica per gestire lo stato WFA, in quanto gli eventi V1 non sono più gestiti.

8. Catalog Process

Tutte le seguenti operazioni richiedono che l’eservice sia nello stato DRAFT per essere eseguite:
	•	updateEService
	•	deleteEService
	•	createRiskAnalysis
	•	updateRiskAnalysis
	•	deleteRiskAnalysis

Non viene considerato lo stato WFA.

9. Reject Descriptor for Delegated Eservice

	•	API per il rifiuto di un DelegatedEServiceDescriptor:
In questo caso viene utilizzato correttamente lo stato DRAFT per aggiornare il descrittore, e sono eseguite le giuste validazioni sullo stato WFA.

10. Upload Document

	•	Attualmente, è possibile caricare un documento solo se lo stato del descrittore è uno dei seguenti: DRAFT, PUBLISHED, SUSPENDED, DEPRECATED.
Non è previsto che sia possibile caricare un documento per descrittori in stato WFA. Tuttavia, questa logica dovrebbe essere verificata considerando se esiste una delega attiva e se il chiamante è il delegato.

11. Delete Document

	•	Se l’operazione riguarda la cancellazione di un documento, viene tenuto conto anche dello stato WFA del descrittore.

12. Delete Draft Descriptor & Update Draft Descriptor

	•	Queste operazioni possono avvenire solo se il descrittore è nello stato DRAFT. Lo stato WFA non è considerato.

13. Publish Descriptor

	•	La pubblicazione di un descrittore può avvenire solo se il descrittore è nello stato DRAFT. Lo stato WFA non è considerato.

14. Clone Descriptor

	•	Il clone di un descrittore avviene sempre se il descrittore è nello stato DRAFT. Lo stato WFA non è considerato.

15. Update Eservice Description

	•	L’operazione di aggiornamento della descrizione di un eservice (updateEServiceDescription) non considera lo stato WFA.

16. Visibility Application

	•	La funzione applyVisibilityToEService considera visibili tutti i descrittori che non sono né in stato DRAFT né in stato WFA.

