### PR TITLE
Pin 5902: getConsumerDelegators minor fixes

### DIFF
--- a/collections/delegation/consumer/getConsumerDelegators.bru
+++ b/collections/delegation/consumer/getConsumerDelegators.bru
@@ -13,7 +13,6 @@ get {
 params:query {
   offset: 0
   limit: 10
-  delegateId: {{tenantId}}
   ~delegatorName: 
 }
 

--- a/packages/api-clients/open-api/delegationApi.yml
+++ b/packages/api-clients/open-api/delegationApi.yml
@@ -97,12 +97,6 @@ paths:
         schema:
           type: string
       - in: query
-        name: delegateId
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - in: query
         name: offset
         required: true
         schema:

--- a/packages/backend-for-frontend/src/services/delegationService.ts
+++ b/packages/backend-for-frontend/src/services/delegationService.ts
@@ -415,7 +415,6 @@ export function delegationServiceBuilder(
       const delegatorsData =
         await delegationClients.consumer.getConsumerDelegators({
           queries: {
-            delegateId: authData.organizationId,
             delegatorName: q,
             offset,
             limit,

--- a/packages/delegation-process/src/model/domain/errors.ts
+++ b/packages/delegation-process/src/model/domain/errors.ts
@@ -177,10 +177,12 @@ export function delegationStampNotFound(
 
 export function requesterIsNotConsumerDelegate(
   requesterId: TenantId,
-  delegatorId: TenantId
+  delegatorId?: TenantId
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `Requester ${requesterId} is not a Consumer delegate for delegator ${delegatorId}`,
+    detail: `Requester ${requesterId} is not a Consumer delegate${
+      delegatorId ? ` for delegator ${delegatorId}` : ""
+    }`,
     code: "requesterIsNotConsumerDelegate",
     title: "Requester is not a delegate",
   });

--- a/packages/delegation-process/src/routers/DelegationRouter.ts
+++ b/packages/delegation-process/src/routers/DelegationRouter.ts
@@ -432,12 +432,12 @@ const delegationRouter = (
     .get("/consumer/delegators", async (req, res) => {
       const ctx = fromAppContext(req.ctx);
 
-      const { delegateId, delegatorName, limit, offset } = req.query;
+      const { delegatorName, limit, offset } = req.query;
 
       try {
         const delegators = await delegationService.getConsumerDelegators(
           {
-            delegateId: unsafeBrandId(delegateId),
+            organizationId: ctx.authData.organizationId,
             delegatorName,
             limit,
             offset,

--- a/packages/delegation-process/src/services/delegationService.ts
+++ b/packages/delegation-process/src/services/delegationService.ts
@@ -571,7 +571,7 @@ export function delegationServiceBuilder(
     },
     async getConsumerDelegators(
       filters: {
-        delegateId: TenantId;
+        organizationId: TenantId;
         limit: number;
         offset: number;
         delegatorName?: string;
@@ -583,6 +583,16 @@ export function delegationServiceBuilder(
           filters
         )}`
       );
+
+      const delegation = await readModelService.findDelegations({
+        delegateId: filters.organizationId,
+        delegationKind: delegationKind.delegatedConsumer,
+        states: [delegationState.active],
+      });
+      if (!delegation || delegation.length === 0) {
+        throw requesterIsNotConsumerDelegate(filters.organizationId);
+      }
+
       return await readModelService.getConsumerDelegators(filters);
     },
     async getConsumerEservices(

--- a/packages/delegation-process/src/services/readModelService.ts
+++ b/packages/delegation-process/src/services/readModelService.ts
@@ -265,7 +265,7 @@ export function readModelServiceBuilder(
       return result.data;
     },
     async getConsumerDelegators(filters: {
-      delegateId: TenantId;
+      organizationId: TenantId;
       limit: number;
       offset: number;
       delegatorName?: string;
@@ -275,7 +275,7 @@ export function readModelServiceBuilder(
           $match: {
             "data.kind": delegationKind.delegatedConsumer,
             "data.state": delegationState.active,
-            "data.delegateId": filters.delegateId,
+            "data.delegateId": filters.organizationId,
           } satisfies ReadModelFilter<Delegation>,
         },
         {


### PR DESCRIPTION
[Closes [PIN-5902](https://pagopa.atlassian.net/browse/PIN-5902)]

In this PR, the `delegateId` parameter has been removed, and a check to verify if the requester is a delegate has been added, consistent with the [getConsumerEservices](https://github.com/pagopa/interop-be-monorepo/pull/1306#discussion_r1905229889) implementation