### PR TITLE
Fix ClientPurposeAdded in authorization-platformstate-writer

### DIFF
--- a/packages/authorization-platformstate-writer/src/consumerServiceV1.ts
+++ b/packages/authorization-platformstate-writer/src/consumerServiceV1.ts
@@ -37,7 +37,7 @@ import {
   deleteEntriesFromTokenGenStatesByGSIPKClientIdPurposeId,
   extractAgreementIdFromAgreementPK,
   extractKidFromTokenGenStatesEntryPK,
-  readConsumerClientEntriesInTokenGenerationStates,
+  readConsumerClientsInTokenGenStatesV1,
   readPlatformClientEntry,
   retrievePlatformStatesByPurpose,
   setClientPurposeIdsInPlatformStatesEntry,
@@ -342,15 +342,11 @@ export async function handleMessageV1(
         logger
       );
 
-      const GSIPK_clientId = clientId;
       const tokenGenStatesConsumerClients =
-        await readConsumerClientEntriesInTokenGenerationStates(
-          GSIPK_clientId,
-          dynamoDBClient
-        );
+        await readConsumerClientsInTokenGenStatesV1(clientId, dynamoDBClient);
       if (tokenGenStatesConsumerClients.length === 0) {
         logger.info(
-          `Skipping token-generation-states update. Reason: no entries found for GSIPK_clientId ${GSIPK_clientId}`
+          `Skipping token-generation-states update. Reason: no entries found for client ${clientId}`
         );
         return Promise.resolve();
       } else {
@@ -372,8 +368,9 @@ export async function handleMessageV1(
             .with(0, async () => {
               const newTokenGenStatesConsumerClient =
                 createTokenGenStatesConsumerClient({
-                  tokenGenStatesClient: entry,
+                  consumerId: entry.consumerId,
                   kid: extractKidFromTokenGenStatesEntryPK(entry.PK),
+                  publicKey: entry.publicKey,
                   clientId,
                   purposeId,
                   purposeEntry,
@@ -398,8 +395,9 @@ export async function handleMessageV1(
               if (!seenKids.has(kid)) {
                 const newTokenGenStatesConsumerClient =
                   createTokenGenStatesConsumerClient({
-                    tokenGenStatesClient: entry,
+                    consumerId: entry.consumerId,
                     kid,
+                    publicKey: entry.publicKey,
                     clientId,
                     purposeId,
                     purposeEntry,
@@ -511,9 +509,8 @@ export async function handleMessageV1(
       const pk = makePlatformStatesClientPK(clientId);
       await deleteClientEntryFromPlatformStates(pk, dynamoDBClient, logger);
 
-      const GSIPK_clientId = clientId;
       await deleteEntriesFromTokenGenStatesByClientIdV1(
-        GSIPK_clientId,
+        clientId,
         dynamoDBClient,
         logger
       );

--- a/packages/authorization-platformstate-writer/src/consumerServiceV2.ts
+++ b/packages/authorization-platformstate-writer/src/consumerServiceV2.ts
@@ -21,7 +21,7 @@ import {
   TokenGenerationStatesConsumerClient,
   unsafeBrandId,
 } from "pagopa-interop-models";
-import { match, P } from "ts-pattern";
+import { match } from "ts-pattern";
 import { Logger } from "pagopa-interop-commons";
 import {
   clientKindToTokenGenerationStatesClientKind,
@@ -31,7 +31,6 @@ import {
   deleteEntriesFromTokenGenStatesByGSIPKClientIdPurposeId,
   readPlatformClientEntry,
   deleteClientEntryFromTokenGenerationStates,
-  extractKidFromTokenGenStatesEntryPK,
   extractAgreementIdFromAgreementPK,
   retrievePlatformStatesByPurpose,
   upsertPlatformClientEntry,
@@ -40,7 +39,6 @@ import {
   setClientPurposeIdsInPlatformStatesEntry,
   updateTokenGenStatesDataForSecondRetrieval,
   createTokenGenStatesConsumerClient,
-  readConsumerClientEntriesInTokenGenerationStates,
   deleteEntriesFromTokenGenStatesByClientIdV2,
 } from "./utils.js";
 
@@ -312,15 +310,9 @@ export async function handleMessageV2(
       }
 
       // token-generation-states
-      const GSIPK_clientId = client.id;
-      const tokenGenStatesConsumerClients =
-        await readConsumerClientEntriesInTokenGenerationStates(
-          GSIPK_clientId,
-          dynamoDBClient
-        );
-      if (tokenGenStatesConsumerClients.length === 0) {
+      if (client.keys.length === 0) {
         logger.info(
-          `Skipping token-generation-states update. Reason: no entries found for GSIPK_clientId ${GSIPK_clientId}`
+          `Skipping token-generation-states update. Reason: client ${client.id} has zero keys`
         );
         return Promise.resolve();
       } else {
@@ -332,71 +324,44 @@ export async function handleMessageV2(
             logger
           );
 
-        const seenKids = new Set<string>();
         const addedTokenGenStatesConsumerClients: TokenGenerationStatesConsumerClient[] =
           [];
 
-        for (const entry of tokenGenStatesConsumerClients) {
-          const addedTokenGenStatesConsumerClient = await match(
-            client.purposes.length
-          )
-            .with(1, async () => {
-              const newTokenGenStatesConsumerClient =
-                createTokenGenStatesConsumerClient({
-                  tokenGenStatesClient: entry,
-                  kid: extractKidFromTokenGenStatesEntryPK(entry.PK),
-                  clientId: client.id,
-                  purposeId,
-                  purposeEntry,
-                  agreementEntry,
-                  catalogEntry,
-                });
+        await Promise.all(
+          client.keys.map(async (key) => {
+            const newTokenGenStatesConsumerClient: TokenGenerationStatesConsumerClient =
+              createTokenGenStatesConsumerClient({
+                consumerId: client.consumerId,
+                kid: key.kid,
+                publicKey: key.encodedPem,
+                clientId: client.id,
+                purposeId,
+                purposeEntry,
+                agreementEntry,
+                catalogEntry,
+              });
 
-              await upsertTokenGenStatesConsumerClient(
-                newTokenGenStatesConsumerClient,
-                dynamoDBClient,
-                logger
-              );
-              await deleteClientEntryFromTokenGenerationStates(
-                entry.PK,
-                dynamoDBClient,
-                logger
-              );
-              return newTokenGenStatesConsumerClient;
-            })
-            .with(P.number.gt(1), async () => {
-              const kid = extractKidFromTokenGenStatesEntryPK(entry.PK);
-              if (!seenKids.has(kid)) {
-                const newTokenGenStatesConsumerClient =
-                  createTokenGenStatesConsumerClient({
-                    tokenGenStatesClient: entry,
-                    kid,
-                    clientId: client.id,
-                    purposeId,
-                    purposeEntry,
-                    agreementEntry,
-                    catalogEntry,
-                  });
+            await upsertTokenGenStatesConsumerClient(
+              newTokenGenStatesConsumerClient,
+              dynamoDBClient,
+              logger
+            );
 
-                await upsertTokenGenStatesConsumerClient(
-                  newTokenGenStatesConsumerClient,
-                  dynamoDBClient,
-                  logger
-                );
-                seenKids.add(kid);
-                return newTokenGenStatesConsumerClient;
-              }
-              return null;
-            })
-            .run();
-
-          if (addedTokenGenStatesConsumerClient) {
             // eslint-disable-next-line functional/immutable-data
             addedTokenGenStatesConsumerClients.push(
-              addedTokenGenStatesConsumerClient
+              newTokenGenStatesConsumerClient
             );
-          }
-        }
+
+            await deleteClientEntryFromTokenGenerationStates(
+              makeTokenGenerationStatesClientKidPK({
+                clientId: client.id,
+                kid: key.kid,
+              }),
+              dynamoDBClient,
+              logger
+            );
+          })
+        );
 
         // Second check for updated fields
         await Promise.all(

--- a/packages/authorization-platformstate-writer/test/consumerServiceV2.integration.test.ts
+++ b/packages/authorization-platformstate-writer/test/consumerServiceV2.integration.test.ts
@@ -1853,10 +1853,13 @@ describe("integration tests V2 events", async () => {
         consumerId,
         versions: [getMockPurposeVersion(purposeVersionState.active)],
       };
+      const key1 = getMockKey();
+      const key2 = getMockKey();
       const client: Client = {
         ...getMockClient(),
         consumerId,
         purposes: [purpose.id],
+        keys: [key1, key2],
       };
 
       const payload: ClientPurposeAddedV2 = {
@@ -1938,15 +1941,13 @@ describe("integration tests V2 events", async () => {
       );
 
       // token-generation-states
-      const kid1 = "KID1";
-      const kid2 = "KID2";
       const tokenClientKidPK1 = makeTokenGenerationStatesClientKidPK({
         clientId: client.id,
-        kid: kid1,
+        kid: key1.kid,
       });
       const tokenClientKidPK2 = makeTokenGenerationStatesClientKidPK({
         clientId: client.id,
-        kid: kid2,
+        kid: key2.kid,
       });
 
       const tokenClientEntry1: TokenGenerationStatesConsumerClient = {
@@ -1955,8 +1956,9 @@ describe("integration tests V2 events", async () => {
         GSIPK_clientId: client.id,
         GSIPK_clientId_kid: makeGSIPKClientIdKid({
           clientId: client.id,
-          kid: kid1,
+          kid: key1.kid,
         }),
+        publicKey: key1.encodedPem,
       };
       const tokenClientEntry2: TokenGenerationStatesConsumerClient = {
         ...getMockTokenGenStatesConsumerClient(tokenClientKidPK2),
@@ -1964,8 +1966,9 @@ describe("integration tests V2 events", async () => {
         GSIPK_clientId: client.id,
         GSIPK_clientId_kid: makeGSIPKClientIdKid({
           clientId: client.id,
-          kid: kid2,
+          kid: key2.kid,
         }),
+        publicKey: key2.encodedPem,
       };
       const tokenConsumerClientWithOtherClient =
         getMockTokenGenStatesConsumerClient();
@@ -2033,7 +2036,7 @@ describe("integration tests V2 events", async () => {
           PK: makeTokenGenerationStatesClientKidPurposePK({
             clientId: client.id,
             purposeId: purpose.id,
-            kid: kid1,
+            kid: key1.kid,
           }),
         };
 
@@ -2044,7 +2047,7 @@ describe("integration tests V2 events", async () => {
           PK: makeTokenGenerationStatesClientKidPurposePK({
             clientId: client.id,
             purposeId: purpose.id,
-            kid: kid2,
+            kid: key2.kid,
           }),
         };
 
@@ -2073,10 +2076,13 @@ describe("integration tests V2 events", async () => {
         versions: [getMockPurposeVersion(purposeVersionState.active)],
       };
 
+      const key1 = getMockKey();
+      const key2 = getMockKey();
       const client: Client = {
         ...getMockClient(),
         consumerId,
         purposes: [purpose1.id, purpose2.id],
+        keys: [key1, key2],
       };
 
       const payload: ClientPurposeAddedV2 = {
@@ -2203,18 +2209,16 @@ describe("integration tests V2 events", async () => {
       );
 
       // token-generation-states
-      const kid1 = "KID1";
-      const kid2 = "KID2";
       const tokenClientKidPurposePK1 =
         makeTokenGenerationStatesClientKidPurposePK({
           clientId: client.id,
-          kid: kid1,
+          kid: key1.kid,
           purposeId: purpose1.id,
         });
       const tokenClientKidPurposePK2 =
         makeTokenGenerationStatesClientKidPurposePK({
           clientId: client.id,
-          kid: kid2,
+          kid: key2.kid,
           purposeId: purpose1.id,
         });
 
@@ -2229,9 +2233,10 @@ describe("integration tests V2 events", async () => {
         GSIPK_clientId: client.id,
         GSIPK_clientId_kid: makeGSIPKClientIdKid({
           clientId: client.id,
-          kid: kid1,
+          kid: key1.kid,
         }),
         GSIPK_purposeId: purpose1.id,
+        publicKey: key1.encodedPem,
       };
       const tokenConsumerClient2: TokenGenerationStatesConsumerClient = {
         ...getMockTokenGenStatesConsumerClient(tokenClientKidPurposePK2),
@@ -2240,9 +2245,10 @@ describe("integration tests V2 events", async () => {
         GSIPK_clientId: client.id,
         GSIPK_clientId_kid: makeGSIPKClientIdKid({
           clientId: client.id,
-          kid: kid2,
+          kid: key2.kid,
         }),
         GSIPK_purposeId: purpose1.id,
+        publicKey: key2.encodedPem,
       };
       const tokenClientEntryWithOtherClient = getMockTokenGenStatesApiClient();
 
@@ -2309,7 +2315,7 @@ describe("integration tests V2 events", async () => {
           PK: makeTokenGenerationStatesClientKidPurposePK({
             clientId: client.id,
             purposeId: purpose2.id,
-            kid: kid1,
+            kid: key1.kid,
           }),
         };
 
@@ -2320,7 +2326,7 @@ describe("integration tests V2 events", async () => {
           PK: makeTokenGenerationStatesClientKidPurposePK({
             clientId: client.id,
             purposeId: purpose2.id,
-            kid: kid2,
+            kid: key2.kid,
           }),
         };
 
@@ -2352,10 +2358,13 @@ describe("integration tests V2 events", async () => {
         versions: [getMockPurposeVersion(purposeVersionState.active)],
       };
 
+      const key1 = getMockKey();
+      const key2 = getMockKey();
       const client: Client = {
         ...getMockClient(),
         consumerId,
         purposes: [purpose1.id, purpose2.id],
+        keys: [key1, key2],
       };
 
       const payload: ClientPurposeAddedV2 = {
@@ -2482,26 +2491,24 @@ describe("integration tests V2 events", async () => {
       );
 
       // token-generation-states
-      const kid1 = "KID1";
-      const kid2 = "KID2";
       const tokenClientKidPK1 = makeTokenGenerationStatesClientKidPurposePK({
         clientId: client.id,
-        kid: kid1,
+        kid: key1.kid,
         purposeId: purpose1.id,
       });
       const tokenClientKidPK2 = makeTokenGenerationStatesClientKidPurposePK({
         clientId: client.id,
-        kid: kid2,
+        kid: key2.kid,
         purposeId: purpose1.id,
       });
       const tokenClientKidPK3 = makeTokenGenerationStatesClientKidPurposePK({
         clientId: client.id,
-        kid: kid1,
+        kid: key1.kid,
         purposeId: purpose2.id,
       });
       const tokenClientKidPK4 = makeTokenGenerationStatesClientKidPurposePK({
         clientId: client.id,
-        kid: kid2,
+        kid: key2.kid,
         purposeId: purpose2.id,
       });
 
@@ -2520,9 +2527,10 @@ describe("integration tests V2 events", async () => {
         GSIPK_clientId: client.id,
         GSIPK_clientId_kid: makeGSIPKClientIdKid({
           clientId: client.id,
-          kid: kid1,
+          kid: key1.kid,
         }),
         GSIPK_purposeId: purpose1.id,
+        publicKey: key1.encodedPem,
       };
       const tokenConsumerClient2: TokenGenerationStatesConsumerClient = {
         ...getMockTokenGenStatesConsumerClient(tokenClientKidPK2),
@@ -2531,9 +2539,10 @@ describe("integration tests V2 events", async () => {
         GSIPK_clientId: client.id,
         GSIPK_clientId_kid: makeGSIPKClientIdKid({
           clientId: client.id,
-          kid: kid2,
+          kid: key2.kid,
         }),
         GSIPK_purposeId: purpose1.id,
+        publicKey: key2.encodedPem,
       };
       const tokenConsumerClient3: TokenGenerationStatesConsumerClient = {
         ...getMockTokenGenStatesConsumerClient(tokenClientKidPK3),
@@ -2542,7 +2551,7 @@ describe("integration tests V2 events", async () => {
         GSIPK_clientId: client.id,
         GSIPK_clientId_kid: makeGSIPKClientIdKid({
           clientId: client.id,
-          kid: kid1,
+          kid: key1.kid,
         }),
         GSIPK_purposeId: purpose2.id,
       };
@@ -2553,7 +2562,7 @@ describe("integration tests V2 events", async () => {
         GSIPK_clientId: client.id,
         GSIPK_clientId_kid: makeGSIPKClientIdKid({
           clientId: client.id,
-          kid: kid2,
+          kid: key2.kid,
         }),
         GSIPK_purposeId: purpose2.id,
       };
@@ -2630,7 +2639,7 @@ describe("integration tests V2 events", async () => {
           PK: makeTokenGenerationStatesClientKidPurposePK({
             clientId: client.id,
             purposeId: purpose2.id,
-            kid: kid1,
+            kid: key1.kid,
           }),
         };
       const expectedTokenConsumerClient2: TokenGenerationStatesConsumerClient =
@@ -2640,7 +2649,7 @@ describe("integration tests V2 events", async () => {
           PK: makeTokenGenerationStatesClientKidPurposePK({
             clientId: client.id,
             purposeId: purpose2.id,
-            kid: kid2,
+            kid: key2.kid,
           }),
         };
 

--- a/packages/authorization-platformstate-writer/test/utils.test.ts
+++ b/packages/authorization-platformstate-writer/test/utils.test.ts
@@ -54,7 +54,6 @@ import {
   TokenGenerationStatesApiClient,
   TokenGenerationStatesConsumerClient,
   TokenGenerationStatesGenericClient,
-  TokenGenStatesConsumerClientGSIClient,
 } from "pagopa-interop-models";
 import {
   afterAll,
@@ -72,7 +71,7 @@ import {
   setClientPurposeIdsInPlatformStatesEntry,
   convertEntriesToClientKidInTokenGenerationStates,
   deleteClientEntryFromPlatformStates,
-  readConsumerClientEntriesInTokenGenerationStates,
+  readConsumerClientsInTokenGenStatesV1,
   readPlatformAgreementEntryByGSIPKConsumerIdEServiceId,
   retrievePlatformStatesByPurpose,
   updateTokenGenStatesDataForSecondRetrieval,
@@ -650,7 +649,7 @@ describe("utils", () => {
     });
   });
 
-  it("readConsumerClientEntriesInTokenGenerationStates", async () => {
+  it("readConsumerClientsInTokenGenStatesV1", async () => {
     const clientId = generateId<ClientId>();
     const pk1 = makeTokenGenerationStatesClientKidPK({ clientId, kid: "" });
     const pk2 = makeTokenGenerationStatesClientKidPurposePK({
@@ -682,19 +681,15 @@ describe("utils", () => {
       dynamoDBClient
     );
 
-    const res = await readConsumerClientEntriesInTokenGenerationStates(
+    const res = await readConsumerClientsInTokenGenStatesV1(
       GSIPK_clientId,
       dynamoDBClient
     );
 
     expect(res).toEqual(
       expect.arrayContaining([
-        TokenGenStatesConsumerClientGSIClient.parse(
-          tokenGenStatesConsumerClientWithoutPurpose
-        ),
-        TokenGenStatesConsumerClientGSIClient.parse(
-          tokenGenStatesConsumerClientWithPurpose
-        ),
+        tokenGenStatesConsumerClientWithoutPurpose,
+        tokenGenStatesConsumerClientWithPurpose,
       ])
     );
   });

--- a/packages/models/src/token-generation-readmodel/token-generation-states-entry.ts
+++ b/packages/models/src/token-generation-readmodel/token-generation-states-entry.ts
@@ -86,39 +86,6 @@ export type TokenGenStatesConsumerClientGSIAgreement = z.infer<
   typeof TokenGenStatesConsumerClientGSIAgreement
 >;
 
-// Client
-export const TokenGenStatesApiClientGSIClient =
-  TokenGenerationStatesApiClient.pick({
-    PK: true,
-    GSIPK_clientId: true,
-    consumerId: true,
-    clientKind: true,
-    publicKey: true,
-    GSIPK_clientId_kid: true,
-  });
-export type TokenGenStatesApiClientGSIClient = z.infer<
-  typeof TokenGenStatesApiClientGSIClient
->;
-
-export const TokenGenStatesConsumerClientGSIClient =
-  TokenGenerationStatesConsumerClient.pick({
-    PK: true,
-    GSIPK_clientId: true,
-    consumerId: true,
-    clientKind: true,
-    publicKey: true,
-    GSIPK_clientId_kid: true,
-  });
-export type TokenGenStatesConsumerClientGSIClient = z.infer<
-  typeof TokenGenStatesConsumerClientGSIClient
->;
-
-export const TokenGenStatesGenericClientGSIClient =
-  TokenGenStatesApiClientGSIClient.or(TokenGenStatesConsumerClientGSIClient);
-export type TokenGenStatesGenericClientGSIClient = z.infer<
-  typeof TokenGenStatesGenericClientGSIClient
->;
-
 // ClientPurpose
 export const TokenGenStatesConsumerClientGSIClientPurpose =
   TokenGenerationStatesConsumerClient.pick({


### PR DESCRIPTION
This pull request is to fix the behavior of `ClientPurposeAdded`:
- events V1: renamed `readConsumerClientEntriesInTokenGenerationStates` to `readConsumerClientsInTokenGenStatesV1` and changed the operation to a `ScanCommand`
- events V2: the consumer no longer reads the `token-generation-states` entries by `GSIPK_clientId`, but upserts and deletes using only the data in the message