### PR TITLE
Remove platform-states delete from agreement-platformstate-writer

### DIFF
--- a/packages/agreement-platformstate-writer/src/consumerServiceV1.ts
+++ b/packages/agreement-platformstate-writer/src/consumerServiceV1.ts
@@ -19,13 +19,13 @@ import {
   readAgreementEntry,
   agreementStateToItemState,
   updateAgreementStateOnTokenGenStates,
-  deleteAgreementEntry,
   isLatestAgreement,
   updateLatestAgreementOnTokenGenStates,
   extractAgreementTimestamp,
   upsertPlatformStatesAgreementEntry,
-  deleteAgreementEntryByAgreementIdV1,
+  updateAgreementStateInPlatformStatesV1,
   updateAgreementStateInTokenGenStatesV1,
+  updateAgreementStateInPlatformStatesEntry,
 } from "./utils.js";
 
 export async function handleMessageV1(
@@ -60,7 +60,7 @@ export async function handleMessageV1(
           );
         })
         .with(agreementState.archived, async () => {
-          await handleArchiving(agreement, dynamoDBClient, logger);
+          await handleArchiving(agreement, dynamoDBClient, msg.version, logger);
         })
         .with(
           agreementState.draft,
@@ -102,12 +102,14 @@ export async function handleMessageV1(
     })
     .with({ type: "AgreementDeactivated" }, async (msg) => {
       const agreement = parseAgreement(msg.data.agreement);
-      await handleArchiving(agreement, dynamoDBClient, logger);
+      await handleArchiving(agreement, dynamoDBClient, msg.version, logger);
     })
     .with({ type: "AgreementDeleted" }, async (msg) => {
       const agreementId = unsafeBrandId<AgreementId>(msg.data.agreementId);
-      await deleteAgreementEntryByAgreementIdV1(
+      await updateAgreementStateInPlatformStatesV1(
         agreementId,
+        itemState.inactive,
+        msg.version,
         dynamoDBClient,
         logger
       );
@@ -210,6 +212,7 @@ const handleActivationOrSuspension = async (
 const handleArchiving = async (
   agreement: Agreement,
   dynamoDBClient: DynamoDBClient,
+  msgVersion: number,
   logger: Logger
 ): Promise<void> => {
   const primaryKey = makePlatformStatesAgreementPK({
@@ -237,10 +240,11 @@ const handleArchiving = async (
       logger,
     });
 
-    await deleteAgreementEntry(
-      primaryKey,
-      agreementEntry.agreementId,
+    await updateAgreementStateInPlatformStatesEntry(
       dynamoDBClient,
+      primaryKey,
+      agreementStateToItemState(agreement.state),
+      msgVersion,
       logger
     );
   } else {

--- a/packages/agreement-platformstate-writer/test/consumerServiceV1.integration.test.ts
+++ b/packages/agreement-platformstate-writer/test/consumerServiceV1.integration.test.ts
@@ -2055,7 +2055,7 @@ describe("integration tests V1 events", async () => {
   });
 
   describe("Agreement Updated (archived by consumer or by upgrade)", () => {
-    it("should delete the platform-states entry and update token-generation-states if the agreement is the latest", async () => {
+    it("should update agreement state to inactive in token generation read model if the agreement is the latest", async () => {
       const consumerId = generateId<TenantId>();
       const eserviceId = generateId<EServiceId>();
 
@@ -2154,7 +2154,13 @@ describe("integration tests V1 events", async () => {
         platformStatesAgreementPK,
         dynamoDBClient
       );
-      expect(retrievedEntry).toBeUndefined();
+      const expectedPlatformStatesEntry: PlatformStatesAgreementEntry = {
+        ...platformStatesAgreement,
+        state: itemState.inactive,
+        version: 2,
+        updatedAt: new Date().toISOString(),
+      };
+      expect(retrievedEntry).toEqual(expectedPlatformStatesEntry);
 
       // token-generation-states
       const retrievedTokenGenStatesEntries = await readAllTokenGenStatesItems(
@@ -2311,7 +2317,7 @@ describe("integration tests V1 events", async () => {
   });
 
   describe("AgreementDeactivated (archived by consumer or by upgrade)", () => {
-    it("should delete the platform-states entry and update token-generation-states if the agreement is the latest", async () => {
+    it("should update agreement state to inactive in token generation read model if the agreement is the latest", async () => {
       const consumerId = generateId<TenantId>();
       const eserviceId = generateId<EServiceId>();
 
@@ -2406,11 +2412,17 @@ describe("integration tests V1 events", async () => {
       await handleMessageV1(message, dynamoDBClient, genericLogger);
 
       // platform-states
-      const retrievedEntry = await readAgreementEntry(
+      const retrievedPlatformStatesEntry = await readAgreementEntry(
         platformStatesAgreementPK,
         dynamoDBClient
       );
-      expect(retrievedEntry).toBeUndefined();
+      const expectedPlatformStatesEntry: PlatformStatesAgreementEntry = {
+        ...platformStatesAgreement,
+        state: itemState.inactive,
+        version: 2,
+        updatedAt: new Date().toISOString(),
+      };
+      expect(retrievedPlatformStatesEntry).toEqual(expectedPlatformStatesEntry);
 
       // token-generation-states
       const retrievedTokenGenStatesEntries = await readAllTokenGenStatesItems(
@@ -2564,7 +2576,7 @@ describe("integration tests V1 events", async () => {
   });
 
   describe("AgreementDeleted", () => {
-    it("should delete the platform-states entry and update agreement state to inactive in token-generation-states", async () => {
+    it("should update agreement state to inactive in token generation read model", async () => {
       const consumerId = generateId<TenantId>();
       const eserviceId = generateId<EServiceId>();
 
@@ -2647,7 +2659,13 @@ describe("integration tests V1 events", async () => {
         platformStatesAgreementPK,
         dynamoDBClient
       );
-      expect(retrievedEntry).toBeUndefined();
+      const expectedPlatformStatesEntry: PlatformStatesAgreementEntry = {
+        ...platformStatesAgreement,
+        state: itemState.inactive,
+        version: 2,
+        updatedAt: new Date().toISOString(),
+      };
+      expect(retrievedEntry).toEqual(expectedPlatformStatesEntry);
 
       // token-generation-states
       const retrievedTokenGenStatesEntries = await readAllTokenGenStatesItems(

--- a/packages/agreement-platformstate-writer/test/consumerServiceV2.integration.test.ts
+++ b/packages/agreement-platformstate-writer/test/consumerServiceV2.integration.test.ts
@@ -2957,7 +2957,7 @@ describe("integration tests V2 events", async () => {
   });
 
   describe("AgreementArchivedByConsumer", () => {
-    it("should update agreement state to inactive if it exists and the agreement is the latest", async () => {
+    it("should update agreement state to inactive in the token generation read model if the platform-states entry exists and the agreement is the latest", async () => {
       const consumerId = generateId<TenantId>();
       const eserviceId = generateId<EServiceId>();
 

--- a/packages/agreement-platformstate-writer/test/consumerServiceV2.integration.test.ts
+++ b/packages/agreement-platformstate-writer/test/consumerServiceV2.integration.test.ts
@@ -14,7 +14,6 @@ import {
   Agreement,
   AgreementActivatedV2,
   AgreementArchivedByConsumerV2,
-  AgreementArchivedByUpgradeV2,
   AgreementEventEnvelope,
   AgreementSuspendedByConsumerV2,
   AgreementSuspendedByPlatformV2,
@@ -2958,7 +2957,7 @@ describe("integration tests V2 events", async () => {
   });
 
   describe("AgreementArchivedByConsumer", () => {
-    it("should delete the entry if it exists and the agreement is the latest", async () => {
+    it("should update agreement state to inactive if it exists and the agreement is the latest", async () => {
       const consumerId = generateId<TenantId>();
       const eserviceId = generateId<EServiceId>();
 
@@ -2990,6 +2989,8 @@ describe("integration tests V2 events", async () => {
         data: payload,
         log_date: new Date(),
       };
+
+      // platform-states
       const platformStatesAgreementPK = makePlatformStatesAgreementPK({
         consumerId,
         eserviceId,
@@ -3050,11 +3051,18 @@ describe("integration tests V2 events", async () => {
 
       await handleMessageV2(message, dynamoDBClient, genericLogger);
 
+      // platform-states
       const retrievedEntry = await readAgreementEntry(
         platformStatesAgreementPK,
         dynamoDBClient
       );
-      expect(retrievedEntry).toBeUndefined();
+      const expectedPlatformStatesEntry: PlatformStatesAgreementEntry = {
+        ...platformStatesAgreement,
+        state: itemState.inactive,
+        version: 2,
+        updatedAt: new Date().toISOString(),
+      };
+      expect(retrievedEntry).toEqual(expectedPlatformStatesEntry);
 
       // token-generation-states
       const retrievedTokenGenStatesEntries = await readAllTokenGenStatesItems(
@@ -3204,136 +3212,6 @@ describe("integration tests V2 events", async () => {
           tokenGenStatesConsumerClient1,
         ])
       );
-    });
-  });
-
-  describe("AgreementArchivedByUpgrade", () => {
-    it("should delete the entry if it exists and the agreement is the latest", async () => {
-      const consumerId = generateId<TenantId>();
-      const eserviceId = generateId<EServiceId>();
-
-      const agreement: Agreement = {
-        ...getMockAgreement(),
-        consumerId,
-        eserviceId,
-        state: agreementState.active,
-        stamps: {
-          activation: {
-            when: new Date(),
-            who: generateId(),
-          },
-        },
-      };
-      const archivedAgreement: Agreement = {
-        ...agreement,
-        state: agreementState.archived,
-      };
-      const payload: AgreementArchivedByUpgradeV2 = {
-        agreement: toAgreementV2(archivedAgreement),
-      };
-      const message: AgreementEventEnvelope = {
-        sequence_num: 1,
-        stream_id: archivedAgreement.id,
-        version: 2,
-        type: "AgreementArchivedByUpgrade",
-        event_version: 2,
-        data: payload,
-        log_date: new Date(),
-      };
-      const platformStatesAgreementPK = makePlatformStatesAgreementPK({
-        consumerId,
-        eserviceId,
-      });
-      const platformStatesAgreement: PlatformStatesAgreementEntry = {
-        ...getMockPlatformStatesAgreementEntry(
-          platformStatesAgreementPK,
-          agreement.id
-        ),
-        state: itemState.active,
-        agreementTimestamp: agreement.stamps.activation!.when.toISOString(),
-      };
-      await writePlatformAgreementEntry(
-        platformStatesAgreement,
-        dynamoDBClient
-      );
-
-      await handleMessageV2(message, dynamoDBClient, genericLogger);
-
-      const retrievedEntry = await readAgreementEntry(
-        platformStatesAgreementPK,
-        dynamoDBClient
-      );
-      expect(retrievedEntry).toBeUndefined();
-    });
-
-    it("should do no operation if the agreement is not the latest", async () => {
-      const sixHoursAgo = new Date();
-      sixHoursAgo.setHours(sixHoursAgo.getHours() - 6);
-
-      const consumerId = generateId<TenantId>();
-      const eserviceId = generateId<EServiceId>();
-
-      const previousAgreement: Agreement = {
-        ...getMockAgreement(),
-        consumerId,
-        eserviceId,
-        state: agreementState.archived,
-        stamps: {
-          activation: {
-            when: sixHoursAgo,
-            who: generateId(),
-          },
-        },
-      };
-      const latestAgreement: Agreement = {
-        ...getMockAgreement(),
-        consumerId,
-        eserviceId,
-        state: agreementState.active,
-        stamps: {
-          activation: {
-            when: new Date(),
-            who: generateId(),
-          },
-        },
-      };
-      const payload: AgreementArchivedByUpgradeV2 = {
-        agreement: toAgreementV2(previousAgreement),
-      };
-      const message: AgreementEventEnvelope = {
-        sequence_num: 1,
-        stream_id: previousAgreement.id,
-        version: 2,
-        type: "AgreementArchivedByUpgrade",
-        event_version: 2,
-        data: payload,
-        log_date: new Date(),
-      };
-      const platformStatesAgreementPK = makePlatformStatesAgreementPK({
-        consumerId,
-        eserviceId,
-      });
-      const platformStatesAgreement: PlatformStatesAgreementEntry = {
-        ...getMockPlatformStatesAgreementEntry(
-          platformStatesAgreementPK,
-          latestAgreement.id
-        ),
-        state: itemState.active,
-        agreementTimestamp:
-          latestAgreement.stamps.activation!.when.toISOString(),
-      };
-      await writePlatformAgreementEntry(
-        platformStatesAgreement,
-        dynamoDBClient
-      );
-
-      await handleMessageV2(message, dynamoDBClient, genericLogger);
-
-      const retrievedEntry = await readAgreementEntry(
-        platformStatesAgreementPK,
-        dynamoDBClient
-      );
-      expect(retrievedEntry).toEqual(platformStatesAgreement);
     });
   });
 });


### PR DESCRIPTION
Removed `platform-states` delete function from `agreement-platformstate-writer` and changed the logic to set agreement state to inactive when archiving.