### PR TITLE
Removing unused method in delegation process

### DIFF
--- a/packages/delegation-process/src/services/readModelService.ts
+++ b/packages/delegation-process/src/services/readModelService.ts
@@ -144,12 +144,6 @@ export function readModelServiceBuilder(
     ): Promise<WithMetadata<EService> | undefined> {
       return this.getEService(eservices, { "data.id": id });
     },
-    async createDelegation(delegation: Delegation): Promise<void> {
-      await delegations.insertOne({
-        data: delegation,
-        metadata: { version: 0 },
-      });
-    },
     async getTenantById(tenantId: string): Promise<Tenant | undefined> {
       const data = await tenants.findOne(
         { "data.id": tenantId },


### PR DESCRIPTION
Unused and also shall not exist: we never create objects in our readmodel services.