### PR TITLE
Refactor certified attributes validation endpoint from POST to GET

### DIFF
--- a/collections/agreement/Verify Certified Attributes.bru
+++ b/collections/agreement/Verify Certified Attributes.bru
@@ -4,9 +4,9 @@ meta {
   seq: 21
 }
 
-post {
+get {
   url: {{host-agreement}}/tenants/{tenantId}/eservices/{eserviceId}/descriptors/{descriptorId}/certifiedAttributes/validate
-  body: json
+  body: none
   auth: none
 }
 

--- a/collections/bff/agreements/Verify Certified Attributes.bru
+++ b/collections/bff/agreements/Verify Certified Attributes.bru
@@ -4,9 +4,9 @@ meta {
   seq: 21
 }
 
-post {
+get {
   url: {{host-bff}}/tenants/{tenantId}/eservices/{eserviceId}/descriptors/{descriptorId}/certifiedAttributes/validate
-  body: json
+  body: none
   auth: none
 }
 

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -742,7 +742,7 @@ const agreementRouter = (
     }
   );
 
-  agreementRouter.post(
+  agreementRouter.get(
     "/tenants/:tenantId/eservices/:eserviceId/descriptors/:descriptorId/certifiedAttributes/validate",
     authorizationMiddleware([ADMIN_ROLE]),
     async (req, res) => {

--- a/packages/api-clients/open-api/agreementApi.yml
+++ b/packages/api-clients/open-api/agreementApi.yml
@@ -893,7 +893,7 @@ paths:
   "/tenants/{tenantId}/eservices/{eserviceId}/descriptors/{descriptorId}/certifiedAttributes/validate":
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"
-    post:
+    get:
       tags:
         - agreement
       summary: Verify a Tenant has required certified attributes

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -2181,7 +2181,7 @@ paths:
   "/tenants/{tenantId}/eservices/{eserviceId}/descriptors/{descriptorId}/certifiedAttributes/validate":
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"
-    post:
+    get:
       tags:
         - agreements
       summary: Verify a Tenant has required certified attributes

--- a/packages/backend-for-frontend/src/routers/agreementRouter.ts
+++ b/packages/backend-for-frontend/src/routers/agreementRouter.ts
@@ -538,7 +538,7 @@ const agreementRouter = (
       }
     })
 
-    .post(
+    .get(
       "/tenants/:tenantId/eservices/:eserviceId/descriptors/:descriptorId/certifiedAttributes/validate",
       async (req, res) => {
         const ctx = fromBffAppContext(req.ctx, req.headers);

--- a/packages/backend-for-frontend/src/services/agreementService.ts
+++ b/packages/backend-for-frontend/src/services/agreementService.ts
@@ -583,13 +583,10 @@ export function agreementServiceBuilder(
       logger.info(
         `Veryfing tenant ${tenantId} has required certified attributes for descriptor ${descriptorId} of eservice ${eserviceId}`
       );
-      return await agreementProcessClient.verifyTenantCertifiedAttributes(
-        undefined,
-        {
-          params: { tenantId, eserviceId, descriptorId },
-          headers,
-        }
-      );
+      return await agreementProcessClient.verifyTenantCertifiedAttributes({
+        params: { tenantId, eserviceId, descriptorId },
+        headers,
+      });
     },
   };
 }


### PR DESCRIPTION
Change the certified attributes validation endpoint from a POST request to a GET request