### PR TITLE
[PIN-6132]: Remove error handling from getConsumerDelegators

### DIFF
--- a/packages/api-clients/src/bffApi.ts
+++ b/packages/api-clients/src/bffApi.ts
@@ -19,4 +19,8 @@ export type BffGetConsumerDelegatorsQueryParam = QueryParametersByAlias<
   "getConsumerDelegators"
 >;
 
+export type BffgetConsumerDelegatedEservicesQueryParam = QueryParametersByAlias<
+  BffConsumerDelegationApi,
+  "getConsumerDelegatedEservices"
+>;
 export * from "./generated/bffApi.js";

--- a/packages/api-clients/src/bffApi.ts
+++ b/packages/api-clients/src/bffApi.ts
@@ -1,16 +1,22 @@
 import * as bffApi from "./generated/bffApi.js";
 import { QueryParametersByAlias } from "./utils.js";
 
-type BffApi = typeof bffApi.eservicesApi.api;
+type BffEservicesApi = typeof bffApi.eservicesApi.api;
+type BffConsumerDelegationApi = typeof bffApi.consumerDelegationsApi.api;
 
 export type BffGetCatalogQueryParam = QueryParametersByAlias<
-  BffApi,
+  BffEservicesApi,
   "getEServicesCatalog"
 >;
 
 export type BffGetProducersEservicesQueryParam = QueryParametersByAlias<
-  BffApi,
+  BffEservicesApi,
   "getProducerEServices"
+>;
+
+export type BffGetConsumerDelegatorsQueryParam = QueryParametersByAlias<
+  BffConsumerDelegationApi,
+  "getConsumerDelegators"
 >;
 
 export * from "./generated/bffApi.js";

--- a/packages/backend-for-frontend/src/services/delegationService.ts
+++ b/packages/backend-for-frontend/src/services/delegationService.ts
@@ -463,30 +463,22 @@ export function delegationServiceBuilder(
       };
     },
     async getConsumerDelegatedEservices(
-      {
-        delegatorId,
-        q,
-        offset,
-        limit,
-      }: {
-        delegatorId: string;
-        q?: string;
-        offset: number;
-        limit: number;
-      },
+      filters: bffApi.BffgetConsumerDelegatedEservicesQueryParam,
       { headers, logger }: WithLogger<BffAppContext>
     ): Promise<bffApi.CompactEServices> {
       logger.info(
-        `Retrieving consumer delegated eservices of delegator ${delegatorId} with name ${q}, limit ${limit}, offset ${offset}`
+        `Retrieving consumer delegated eservices with filters ${JSON.stringify(
+          filters
+        )}`
       );
 
       const eservicesData =
         await delegationClients.consumer.getConsumerEservices({
           queries: {
-            delegatorId,
-            eserviceName: q,
-            offset,
-            limit,
+            delegatorId: filters.delegatorId,
+            eserviceName: filters.q,
+            offset: filters.offset,
+            limit: filters.limit,
           },
           headers,
         });
@@ -515,8 +507,8 @@ export function delegationServiceBuilder(
       return {
         results: eservicesWithProducerData,
         pagination: {
-          offset,
-          limit,
+          offset: filters.offset,
+          limit: filters.limit,
           totalCount: eservicesData.totalCount,
         },
       };

--- a/packages/backend-for-frontend/src/services/delegationService.ts
+++ b/packages/backend-for-frontend/src/services/delegationService.ts
@@ -398,30 +398,22 @@ export function delegationServiceBuilder(
       });
     },
     async getConsumerDelegators(
-      {
-        q,
-        eserviceIds,
-        offset,
-        limit,
-      }: {
-        q?: string;
-        eserviceIds: string[];
-        offset: number;
-        limit: number;
-      },
+      filters: bffApi.BffGetConsumerDelegatorsQueryParam,
       { headers, authData, logger }: WithLogger<BffAppContext>
     ): Promise<bffApi.DelegationTenants> {
       logger.info(
-        `Retrieving consumer delegators of requester ${authData.organizationId} with name ${q}, eserviceIds ${eserviceIds}, limit ${limit}, offset ${offset}`
+        `Retrieving consumer delegators of requester ${
+          authData.organizationId
+        } with filters ${JSON.stringify(filters)}`
       );
 
       const delegatorsData =
         await delegationClients.consumer.getConsumerDelegators({
           queries: {
-            delegatorName: q,
-            eserviceIds,
-            offset,
-            limit,
+            delegatorName: filters.q,
+            eserviceIds: filters.eserviceIds,
+            offset: filters.offset,
+            limit: filters.limit,
           },
           headers,
         });
@@ -429,8 +421,8 @@ export function delegationServiceBuilder(
       return {
         results: delegatorsData.results,
         pagination: {
-          offset,
-          limit,
+          offset: filters.offset,
+          limit: filters.limit,
           totalCount: delegatorsData.totalCount,
         },
       };

--- a/packages/delegation-process/src/model/domain/errors.ts
+++ b/packages/delegation-process/src/model/domain/errors.ts
@@ -27,9 +27,8 @@ export const errorCodes = {
   incorrectState: "0011",
   differentEserviceProducer: "0012",
   delegationContractNotFound: "0013",
-  requesterIsNotConsumerDelegate: "0014",
-  eserviceNotConsumerDelegable: "0015",
-  delegationRelatedAgreementExists: "0016",
+  eserviceNotConsumerDelegable: "0014",
+  delegationRelatedAgreementExists: "0015",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -175,19 +174,6 @@ export function delegationStampNotFound(
     detail: `Delegation ${stamp} stamp not found`,
     code: "stampNotFound",
     title: "Stamp not found",
-  });
-}
-
-export function requesterIsNotConsumerDelegate(
-  requesterId: TenantId,
-  delegatorId?: TenantId
-): ApiError<ErrorCodes> {
-  return new ApiError({
-    detail: `Requester ${requesterId} is not a Consumer delegate${
-      delegatorId ? ` for delegator ${delegatorId}` : ""
-    }`,
-    code: "requesterIsNotConsumerDelegate",
-    title: "Requester is not a delegate",
   });
 }
 

--- a/packages/delegation-process/src/services/delegationService.ts
+++ b/packages/delegation-process/src/services/delegationService.ts
@@ -35,7 +35,6 @@ import {
   eserviceNotFound,
   tenantNotFound,
   delegationContractNotFound,
-  requesterIsNotConsumerDelegate,
 } from "../model/domain/errors.js";
 import {
   toCreateEventConsumerDelegationApproved,
@@ -645,19 +644,6 @@ export function delegationServiceBuilder(
           filters
         )}`
       );
-
-      const delegation = await readModelService.findDelegations({
-        delegatorId: filters.delegatorId,
-        delegateId: filters.requesterId,
-        delegationKind: delegationKind.delegatedConsumer,
-        states: [delegationState.active],
-      });
-      if (!delegation || delegation.length === 0) {
-        throw requesterIsNotConsumerDelegate(
-          filters.requesterId,
-          filters.delegatorId
-        );
-      }
 
       return await readModelService.getConsumerEservices(filters);
     },

--- a/packages/delegation-process/src/services/delegationService.ts
+++ b/packages/delegation-process/src/services/delegationService.ts
@@ -610,15 +610,6 @@ export function delegationServiceBuilder(
         )}`
       );
 
-      const delegation = await readModelService.findDelegations({
-        delegateId: filters.requesterId,
-        delegationKind: delegationKind.delegatedConsumer,
-        states: [delegationState.active],
-      });
-      if (!delegation || delegation.length === 0) {
-        throw requesterIsNotConsumerDelegate(filters.requesterId);
-      }
-
       return await readModelService.getConsumerDelegators(filters);
     },
     async getConsumerDelegatorsWithAgreements(

--- a/packages/delegation-process/src/utilities/errorMappers.ts
+++ b/packages/delegation-process/src/utilities/errorMappers.ts
@@ -25,9 +25,7 @@ export const getConsumerDelegatorsWithAgreementsErrorMapper =
 export const getConsumerEservicesErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
-  match(error.code)
-    .with("requesterIsNotConsumerDelegate", () => HTTP_STATUS_FORBIDDEN)
-    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+  match(error.code).otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
 export const getDelegationByIdErrorMapper = (
   error: ApiError<ErrorCodes>

--- a/packages/delegation-process/test/getConsumerDelegators.test.ts
+++ b/packages/delegation-process/test/getConsumerDelegators.test.ts
@@ -12,7 +12,6 @@ import {
 } from "pagopa-interop-models";
 import { describe, beforeEach, it, expect } from "vitest";
 import { genericLogger } from "pagopa-interop-commons";
-import { requesterIsNotConsumerDelegate } from "../src/model/domain/errors.js";
 import {
   addOneDelegation,
   addOneEservice,
@@ -198,20 +197,5 @@ describe("getConsumerDelegators", () => {
       ],
       totalCount: 2,
     });
-  });
-  it("should throw requesterIsNotConsumerDelegate if the requester is not a consumer delegate", async () => {
-    const invalidRequesterId = generateId<TenantId>();
-
-    expect(
-      delegationService.getConsumerDelegators(
-        {
-          requesterId: invalidRequesterId,
-          eserviceIds: [],
-          offset: 0,
-          limit: 50,
-        },
-        genericLogger
-      )
-    ).rejects.toThrowError(requesterIsNotConsumerDelegate(invalidRequesterId));
   });
 });

--- a/packages/delegation-process/test/getConsumerDelegators.test.ts
+++ b/packages/delegation-process/test/getConsumerDelegators.test.ts
@@ -198,4 +198,20 @@ describe("getConsumerDelegators", () => {
       totalCount: 2,
     });
   });
+  it("should return an empty array if requester is not a consumer delegate", async () => {
+    expect(
+      await delegationService.getConsumerDelegators(
+        {
+          requesterId: generateId<TenantId>(),
+          eserviceIds: [],
+          offset: 0,
+          limit: 50,
+        },
+        genericLogger
+      )
+    ).toEqual({
+      results: [],
+      totalCount: 0,
+    });
+  });
 });

--- a/packages/delegation-process/test/getConsumerEservices.test.ts
+++ b/packages/delegation-process/test/getConsumerEservices.test.ts
@@ -14,7 +14,6 @@ import {
 } from "pagopa-interop-models";
 import { describe, beforeEach, it, expect } from "vitest";
 import { genericLogger } from "pagopa-interop-commons";
-import { requesterIsNotConsumerDelegate } from "../src/model/domain/errors.js";
 import {
   addOneAgreement,
   addOneDelegation,
@@ -254,21 +253,20 @@ describe("getConsumerEservices", () => {
       totalCount: 1,
     });
   });
-  it("should throw requesterIsNotConsumerDelegate if the requester is not a consumer delegate of the delegator", async () => {
-    const invalidRequesterId = generateId<TenantId>();
-
+  it("should return an empty array if the requester is not a consumer delegate of the delegator", async () => {
     expect(
-      delegationService.getConsumerEservices(
+      await delegationService.getConsumerEservices(
         {
           delegatorId: delegatorId1,
-          requesterId: invalidRequesterId,
+          requesterId: generateId<TenantId>(),
           offset: 0,
           limit: 50,
         },
         genericLogger
       )
-    ).rejects.toThrowError(
-      requesterIsNotConsumerDelegate(invalidRequesterId, delegatorId1)
-    );
+    ).toEqual({
+      results: [],
+      totalCount: 0,
+    });
   });
 });


### PR DESCRIPTION
[Closes: [PIN-6132](https://pagopa.atlassian.net/browse/PIN-6132)]
Refactor the `getConsumerDelegators` function to use a single filter object instead of multiple parameters. Remove the error handling for non-consumer delegates. Update related tests accordingly.

This endpoint shouldn't throw error but instead return an empty array

[PIN-6132]: https://pagopa.atlassian.net/browse/PIN-6132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ