### PR TITLE
Fix `getJWK` api-gateway 500 error

### DIFF
--- a/packages/api-clients/open-api/apiGatewayApi.yml
+++ b/packages/api-clients/open-api/apiGatewayApi.yml
@@ -1935,9 +1935,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/ClientJWK"
-                  - $ref: "#/components/schemas/ProducerKeychainJWK"
+                $ref: "#/components/schemas/JWK"
           headers:
             "X-Rate-Limit-Limit":
               schema:
@@ -2810,26 +2808,6 @@ components:
       required:
         - kty
         - kid
-    ClientJWK: 
-      allOf:
-        - $ref: '#/components/schemas/JWK'
-        - type: object
-          properties:
-            clientId:
-              type: string
-              format: uuid        
-          required:
-            - clientId
-    ProducerKeychainJWK: 
-      allOf:
-        - $ref: '#/components/schemas/JWK'
-        - type: object
-          properties:
-            producerKeychainId:
-              type: string
-              format: uuid        
-          required:
-            - producerKeychainId
     OtherPrimeInfo:
       title: OtherPrimeInfo
       type: object

--- a/packages/api-clients/open-api/apiGatewayApi.yml
+++ b/packages/api-clients/open-api/apiGatewayApi.yml
@@ -1935,7 +1935,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JWK"
+                oneOf:
+                  - $ref: "#/components/schemas/ClientJWK"
+                  - $ref: "#/components/schemas/ProducerKeychainJWK"
           headers:
             "X-Rate-Limit-Limit":
               schema:
@@ -2808,6 +2810,26 @@ components:
       required:
         - kty
         - kid
+    ClientJWK: 
+      allOf:
+        - $ref: '#/components/schemas/JWK'
+        - type: object
+          properties:
+            clientId:
+              type: string
+              format: uuid        
+          required:
+            - clientId
+    ProducerKeychainJWK: 
+      allOf:
+        - $ref: '#/components/schemas/JWK'
+        - type: object
+          properties:
+            producerKeychainId:
+              type: string
+              format: uuid        
+          required:
+            - producerKeychainId
     OtherPrimeInfo:
       title: OtherPrimeInfo
       type: object

--- a/packages/api-gateway/src/services/readModelService.ts
+++ b/packages/api-gateway/src/services/readModelService.ts
@@ -5,6 +5,7 @@ import {
   ClientJWKKey,
   ProducerJWKKey,
 } from "pagopa-interop-models";
+import { z } from "zod";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function readModelServiceBuilder(
@@ -23,11 +24,12 @@ export function readModelServiceBuilder(
         ),
       ]);
 
-      const data: apiGatewayApi.JWK | undefined =
-        keyData?.data ?? producerKeyData?.data;
+      const data = keyData?.data ?? producerKeyData?.data;
 
       if (data) {
-        const result = apiGatewayApi.JWK.safeParse(data);
+        const result = z
+          .union([apiGatewayApi.ClientJWK, apiGatewayApi.ProducerKeychainJWK])
+          .safeParse(data);
 
         if (!result.success) {
           throw genericInternalError(

--- a/packages/api-gateway/src/services/readModelService.ts
+++ b/packages/api-gateway/src/services/readModelService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable fp/no-delete */
 import { apiGatewayApi } from "pagopa-interop-api-clients";
 import { ReadModelRepository } from "pagopa-interop-commons";
 import {
@@ -5,7 +6,6 @@ import {
   ClientJWKKey,
   ProducerJWKKey,
 } from "pagopa-interop-models";
-import { z } from "zod";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function readModelServiceBuilder(
@@ -24,12 +24,18 @@ export function readModelServiceBuilder(
         ),
       ]);
 
-      const data = keyData?.data ?? producerKeyData?.data;
+      const data: apiGatewayApi.JWK | undefined =
+        keyData?.data ?? producerKeyData?.data;
 
       if (data) {
-        const result = z
-          .union([apiGatewayApi.ClientJWK, apiGatewayApi.ProducerKeychainJWK])
-          .safeParse(data);
+        if ("clientId" in data) {
+          delete data?.clientId;
+        }
+        if ("producerKeychainId" in data) {
+          delete data?.producerKeychainId;
+        }
+
+        const result = apiGatewayApi.JWK.safeParse(data);
 
         if (!result.success) {
           throw genericInternalError(


### PR DESCRIPTION
The zod typecheck failure was due to the missing `clientId` in the `apiGateway.JWK` model

Previously, this issue did not surface because Zod’s passthrough mode allowed the presence of unexpected properties without strict validation. However, https://github.com/pagopa/interop-be-monorepo/pull/1350 enforces strict type checking on all API models, making the error happen