### PR TITLE
PIN-6157: Auth server - Allow unknown claims in client assertion

### DIFF
--- a/packages/authorization-server/src/services/tokenService.ts
+++ b/packages/authorization-server/src/services/tokenService.ts
@@ -112,7 +112,8 @@ export function tokenServiceBuilder({
         verifyClientAssertion(
           request.client_assertion,
           request.client_id,
-          config.clientAssertionAudience
+          config.clientAssertionAudience,
+          logger
         );
 
       if (clientAssertionErrors) {

--- a/packages/backend-for-frontend/src/services/toolService.ts
+++ b/packages/backend-for-frontend/src/services/toolService.ts
@@ -77,7 +77,8 @@ export function toolsServiceBuilder(clients: PagoPAInteropBeClients) {
         verifyClientAssertion(
           clientAssertion,
           clientId,
-          config.clientAssertionAudience
+          config.clientAssertionAudience,
+          ctx.logger
         );
 
       if (parametersErrors || clientAssertionErrors) {

--- a/packages/client-assertion-validation/src/validation.ts
+++ b/packages/client-assertion-validation/src/validation.ts
@@ -140,7 +140,11 @@ export const verifyClientAssertion = (
       const payloadStrictParseResult =
         ClientAssertionPayloadStrict.safeParse(decodedPayload);
       if (!payloadStrictParseResult.success) {
-        logger.warn(`Invalid claims in client assertion payload: ${payloadStrictParseResult.error.message}`);
+        logger.warn(
+          `Invalid claims in client assertion payload: ${JSON.stringify(
+            JSON.parse(payloadStrictParseResult.error.message)
+          )}`
+        );
       }
 
       const headerParseResult = ClientAssertionHeader.safeParse(decodedHeader);

--- a/packages/client-assertion-validation/src/validation.ts
+++ b/packages/client-assertion-validation/src/validation.ts
@@ -4,6 +4,7 @@ import {
   ClientAssertion,
   ClientAssertionHeader,
   ClientAssertionPayload,
+  ClientAssertionPayloadStrict,
   TokenGenerationStatesGenericClient,
 } from "pagopa-interop-models";
 import * as jose from "jose";
@@ -15,7 +16,7 @@ import {
   JWTExpired,
   JWTInvalid,
 } from "jose/errors";
-import { createPublicKey } from "pagopa-interop-commons";
+import { createPublicKey, Logger } from "pagopa-interop-commons";
 import {
   failedValidation,
   successfulValidation,
@@ -77,7 +78,8 @@ export const validateRequestParameters = (
 export const verifyClientAssertion = (
   clientAssertionJws: string,
   clientId: string | undefined,
-  expectedAudiences: string[]
+  expectedAudiences: string[],
+  logger: Logger
 ): ValidationResult<ClientAssertion> => {
   try {
     const decodedPayload = jose.decodeJwt(clientAssertionJws);
@@ -133,6 +135,12 @@ export const verifyClientAssertion = (
         return failedValidation([
           clientAssertionInvalidClaims(payloadParseResult.error.message),
         ]);
+      }
+
+      const payloadStrictParseResult =
+        ClientAssertionPayloadStrict.safeParse(decodedPayload);
+      if (!payloadStrictParseResult.success) {
+        logger.warn(`Invalid claims in client assertion payload: ${payloadStrictParseResult.error.message}`);
       }
 
       const headerParseResult = ClientAssertionHeader.safeParse(decodedHeader);

--- a/packages/client-assertion-validation/test/validation.test.ts
+++ b/packages/client-assertion-validation/test/validation.test.ts
@@ -17,7 +17,7 @@ import {
   getMockTokenGenStatesApiClient,
   getMockTokenGenStatesConsumerClient,
 } from "pagopa-interop-commons-test";
-import { dateToSeconds } from "pagopa-interop-commons";
+import { dateToSeconds, genericLogger } from "pagopa-interop-commons";
 import {
   validateClientKindAndPlatformState,
   validateRequestParameters,
@@ -121,7 +121,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeUndefined();
     });
@@ -135,7 +136,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
 
       expect(errors).toBeDefined();
@@ -143,7 +145,8 @@ describe("validation test", async () => {
       expect(errors![0].code).toEqual(clientAssertionInvalidClaims("").code);
     });
 
-    it("clientAssertionInvalidClaims - payload", async () => {
+    // Note: this test is skipped to temporarily accept all claims in client assertion payload
+    it.skip("clientAssertionInvalidClaims - payload", async () => {
       const { jws } = await getMockClientAssertion({
         customClaims: {
           wrongPayloadProp: "wrong",
@@ -152,11 +155,27 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
       expect(errors![0].code).toEqual(clientAssertionInvalidClaims("").code);
+    });
+
+    it("ignore unexpected claims in client assertion payload", async () => {
+      const { jws } = await getMockClientAssertion({
+        customClaims: {
+          wrongPayloadProp: "wrong",
+        },
+      });
+      const { errors } = verifyClientAssertion(
+        jws,
+        undefined,
+        expectedAudiences,
+        genericLogger
+      );
+      expect(errors).toBeUndefined();
     });
 
     it("wrong signature", async () => {
@@ -166,7 +185,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         clientAssertionWithWrongSignature,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeUndefined();
     });
@@ -181,7 +201,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         clientAssertionWithWrongSignature,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeUndefined();
     });
@@ -190,7 +211,8 @@ describe("validation test", async () => {
       const { errors: errors1 } = verifyClientAssertion(
         "too.many.substrings.in.client.assertion",
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors1).toBeDefined();
       expect(errors1).toHaveLength(1);
@@ -199,7 +221,8 @@ describe("validation test", async () => {
       const { errors: errors2 } = verifyClientAssertion(
         "not a jwt",
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors2).toBeDefined();
       expect(errors2).toHaveLength(1);
@@ -208,7 +231,8 @@ describe("validation test", async () => {
       const { errors: errors3 } = verifyClientAssertion(
         "not.a.jwt",
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors3).toBeDefined();
       expect(errors3).toHaveLength(1);
@@ -221,7 +245,8 @@ describe("validation test", async () => {
       const { errors: errors4 } = verifyClientAssertion(
         "signature.missing",
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors4).toBeDefined();
       expect(errors4).toHaveLength(1);
@@ -236,7 +261,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -251,7 +277,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -266,7 +293,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -290,7 +318,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
 
       expect(errors).toBeDefined();
@@ -309,7 +338,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -325,7 +355,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -341,7 +372,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -355,7 +387,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -369,7 +402,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(2);
@@ -383,7 +417,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -398,7 +433,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         generateId<ClientId>(),
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -414,7 +450,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         clientId,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -431,7 +468,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -444,7 +482,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         notClientId,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -461,7 +500,8 @@ describe("validation test", async () => {
       const verifiedClientAssertion = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(verifiedClientAssertion.errors).toBeUndefined();
       expect(verifiedClientAssertion.data?.payload.digest).toBeUndefined();
@@ -477,7 +517,8 @@ describe("validation test", async () => {
       const verifiedClientAssertion = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(verifiedClientAssertion.errors).toBeUndefined();
       expect(verifiedClientAssertion.data?.payload.digest).toBeUndefined();
@@ -490,7 +531,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -506,7 +548,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -522,7 +565,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -538,7 +582,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(2);
@@ -556,7 +601,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -571,7 +617,8 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
@@ -585,54 +632,58 @@ describe("validation test", async () => {
       const { errors } = verifyClientAssertion(
         jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
       expect(errors![0]).toEqual(invalidKidFormat());
     });
 
-    it("ignore client_id claim", async () => {
-      const { jws } = await getMockClientAssertion({
-        customClaims: {
-          client_id: "somevalue",
-        },
-      });
-      const { errors } = verifyClientAssertion(
-        jws,
-        undefined,
-        expectedAudiences
-      );
-      expect(errors).toBeUndefined();
-    });
+    // it("ignore client_id claim", async () => {
+    //   const { jws } = await getMockClientAssertion({
+    //     customClaims: {
+    //       client_id: "somevalue",
+    //     },
+    //   });
+    //   const { errors } = verifyClientAssertion(
+    //     jws,
+    //     undefined,
+    //     expectedAudiences,
+    //     genericLogger
+    //   );
+    //   expect(errors).toBeUndefined();
+    // });
 
-    it("ignore nbf claim", async () => {
-      const { jws } = await getMockClientAssertion({
-        customClaims: {
-          nbf: 999999999999,
-        },
-      });
-      const { errors } = verifyClientAssertion(
-        jws,
-        undefined,
-        expectedAudiences
-      );
-      expect(errors).toBeUndefined();
-    });
+    // it("ignore nbf claim", async () => {
+    //   const { jws } = await getMockClientAssertion({
+    //     customClaims: {
+    //       nbf: 999999999999,
+    //     },
+    //   });
+    //   const { errors } = verifyClientAssertion(
+    //     jws,
+    //     undefined,
+    //     expectedAudiences,
+    //     genericLogger
+    //   );
+    //   expect(errors).toBeUndefined();
+    // });
 
-    it("ignore nbt claim", async () => {
-      const { jws } = await getMockClientAssertion({
-        customClaims: {
-          nbt: "something",
-        },
-      });
-      const { errors } = verifyClientAssertion(
-        jws,
-        undefined,
-        expectedAudiences
-      );
-      expect(errors).toBeUndefined();
-    });
+    // it("ignore nbt claim", async () => {
+    //   const { jws } = await getMockClientAssertion({
+    //     customClaims: {
+    //       nbt: "something",
+    //     },
+    //   });
+    //   const { errors } = verifyClientAssertion(
+    //     jws,
+    //     undefined,
+    //     expectedAudiences,
+    //     genericLogger
+    //   );
+    //   expect(errors).toBeUndefined();
+    // });
   });
 
   describe("verifyClientAssertionSignature", async () => {
@@ -934,7 +985,8 @@ describe("validation test", async () => {
           })
         ).jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       if (!mockClientAssertion) {
         fail();
@@ -959,7 +1011,8 @@ describe("validation test", async () => {
           })
         ).jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       if (!mockClientAssertion) {
         fail();
@@ -981,7 +1034,8 @@ describe("validation test", async () => {
       const { data: mockClientAssertion } = verifyClientAssertion(
         (await getMockClientAssertion()).jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       if (!mockClientAssertion) {
         fail();
@@ -1008,7 +1062,8 @@ describe("validation test", async () => {
           })
         ).jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       if (!mockClientAssertion) {
         fail();
@@ -1033,7 +1088,8 @@ describe("validation test", async () => {
           })
         ).jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       if (!mockClientAssertion) {
         fail();
@@ -1060,7 +1116,8 @@ describe("validation test", async () => {
           })
         ).jws,
         undefined,
-        expectedAudiences
+        expectedAudiences,
+        genericLogger
       );
       if (!mockClientAssertion) {
         fail();

--- a/packages/client-assertion-validation/test/validation.test.ts
+++ b/packages/client-assertion-validation/test/validation.test.ts
@@ -639,51 +639,6 @@ describe("validation test", async () => {
       expect(errors).toHaveLength(1);
       expect(errors![0]).toEqual(invalidKidFormat());
     });
-
-    // it("ignore client_id claim", async () => {
-    //   const { jws } = await getMockClientAssertion({
-    //     customClaims: {
-    //       client_id: "somevalue",
-    //     },
-    //   });
-    //   const { errors } = verifyClientAssertion(
-    //     jws,
-    //     undefined,
-    //     expectedAudiences,
-    //     genericLogger
-    //   );
-    //   expect(errors).toBeUndefined();
-    // });
-
-    // it("ignore nbf claim", async () => {
-    //   const { jws } = await getMockClientAssertion({
-    //     customClaims: {
-    //       nbf: 999999999999,
-    //     },
-    //   });
-    //   const { errors } = verifyClientAssertion(
-    //     jws,
-    //     undefined,
-    //     expectedAudiences,
-    //     genericLogger
-    //   );
-    //   expect(errors).toBeUndefined();
-    // });
-
-    // it("ignore nbt claim", async () => {
-    //   const { jws } = await getMockClientAssertion({
-    //     customClaims: {
-    //       nbt: "something",
-    //     },
-    //   });
-    //   const { errors } = verifyClientAssertion(
-    //     jws,
-    //     undefined,
-    //     expectedAudiences,
-    //     genericLogger
-    //   );
-    //   expect(errors).toBeUndefined();
-    // });
   });
 
   describe("verifyClientAssertionSignature", async () => {

--- a/packages/models/src/client-assertion/clientAssertionValidation.ts
+++ b/packages/models/src/client-assertion/clientAssertionValidation.ts
@@ -28,13 +28,11 @@ export const ClientAssertionPayload = z
     exp: z.number(),
     digest: ClientAssertionDigest.nullish(),
     purposeId: PurposeId.optional(),
-    // Note: these claims are not part of the spec. Added to provide backward compatibility for organizations that already send them
-    client_id: z.string().optional(),
-    nbf: z.number().optional(),
-    nbt: z.any().nullish(),
   })
-  .strict();
 export type ClientAssertionPayload = z.infer<typeof ClientAssertionPayload>;
+
+export const ClientAssertionPayloadStrict = ClientAssertionPayload.strict();
+export type ClientAssertionPayloadStrict = z.infer<typeof ClientAssertionPayloadStrict>;
 
 export const ClientAssertion = z
   .object({

--- a/packages/models/src/client-assertion/clientAssertionValidation.ts
+++ b/packages/models/src/client-assertion/clientAssertionValidation.ts
@@ -18,21 +18,22 @@ export const ClientAssertionHeader = z
   .strict();
 export type ClientAssertionHeader = z.infer<typeof ClientAssertionHeader>;
 
-export const ClientAssertionPayload = z
-  .object({
-    sub: ClientId,
-    jti: z.string(),
-    iat: z.number(),
-    iss: z.string(),
-    aud: z.array(z.string()).or(z.string()),
-    exp: z.number(),
-    digest: ClientAssertionDigest.nullish(),
-    purposeId: PurposeId.optional(),
-  })
+export const ClientAssertionPayload = z.object({
+  sub: ClientId,
+  jti: z.string(),
+  iat: z.number(),
+  iss: z.string(),
+  aud: z.array(z.string()).or(z.string()),
+  exp: z.number(),
+  digest: ClientAssertionDigest.nullish(),
+  purposeId: PurposeId.optional(),
+});
 export type ClientAssertionPayload = z.infer<typeof ClientAssertionPayload>;
 
 export const ClientAssertionPayloadStrict = ClientAssertionPayload.strict();
-export type ClientAssertionPayloadStrict = z.infer<typeof ClientAssertionPayloadStrict>;
+export type ClientAssertionPayloadStrict = z.infer<
+  typeof ClientAssertionPayloadStrict
+>;
 
 export const ClientAssertion = z
   .object({


### PR DESCRIPTION
This PR removes the strictness on client assertion claims checks.
Before this change, the validation blocked a client assertion containing claims unexpected and not listed in the documentation.
With this PR, any additional claim is ignored, but logged