### PR TITLE
Fix `getProducerKeychainById` parsing error

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -16271,7 +16271,7 @@ components:
         eservices:
           type: array
           items:
-            $ref: "#/components/schemas/CompactEServiceLight"
+            $ref: "#/components/schemas/CompactEService"
         description:
           type: string
       required:


### PR DESCRIPTION
This PR addresses a parsing error caused by the absence of the kind property in the CompactEServiceLight model.

Previously, this issue did not surface because Zod’s passthrough mode allowed the presence of unexpected properties without strict validation. However, [this PR](https://github.com/pagopa/interop-be-monorepo/pull/1350) enforces strict type checking on all API models, making the error happen