### PR TITLE
PIN-6164: Added new Fields for some BFF route

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,6 +78,7 @@ jobs:
     needs: [find_dockerfiles]
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 5
       fail-fast: false
       matrix:
         package: ${{ fromJson(needs.find_dockerfiles.outputs.packages) }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,10 @@ name: PR validation
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   formatting:
     name: Check formatting
@@ -57,6 +61,7 @@ jobs:
 
   find_dockerfiles:
     name: Find Dockerfiles
+    needs: [formatting, lint, check, test]
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.set_packages_output.outputs.packages }}

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -12825,6 +12825,12 @@ components:
           $ref: "#/components/schemas/ProducerDescriptorEService"
         attributes:
           $ref: "#/components/schemas/DescriptorAttributes"
+        publishedAt:
+          type: string
+          format: date-time
+        deprecatedAt:
+          type: string
+          format: date-time
     ProducerDescriptorEService:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -14363,6 +14363,8 @@ components:
         selfcareId:
           type: string
           format: uuid
+        kind:
+          $ref: "#/components/schemas/TenantKind"
         externalId:
           $ref: "#/components/schemas/ExternalId"
         features:

--- a/packages/backend-for-frontend/src/api/tenantApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/tenantApiConverter.ts
@@ -178,6 +178,7 @@ export function toBffApiTenant(
     id: tenant.id,
     selfcareId: tenant.selfcareId,
     externalId: tenant.externalId,
+    kind: tenant.kind,
     createdAt: tenant.createdAt,
     updatedAt: tenant.updatedAt,
     name: tenant.name,

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -311,6 +311,8 @@ export function catalogServiceBuilder(
           eservice,
           requesterTenant
         ),
+        publishedAt: descriptor.publishedAt,
+        deprecatedAt: descriptor.deprecatedAt,
       };
     },
     getProducerEServiceDetails: async (


### PR DESCRIPTION
This PR add information needed by front-end applications:
- `TenantKind`for organization (route: `/tenants/:TenantId`)
-  `DeprecatedAt, PublishedAt` (route: `/eservices/:eserviceId/descriptors/:descriptorId`)