### PR TITLE
Hotfix: Removed self consumer attributes check and updated `authorization-updater`

### DIFF
--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -593,7 +593,10 @@ export function agreementServiceBuilder(
         readModelService
       );
 
-      if (eservice.producerId !== agreementToBeUpgraded.data.consumerId) {
+      const isSelfConsumer =
+        eservice.producerId === agreementToBeUpgraded.data.consumerId;
+
+      if (!isSelfConsumer) {
         validateCertifiedAttributes({
           descriptor: newDescriptor,
           consumer,
@@ -621,6 +624,8 @@ export function agreementServiceBuilder(
         correlationId
       );
 
+      const canBeUpgraded = isSelfConsumer || (verifiedValid && declaredValid);
+
       const [agreement, events] = await createUpgradeOrNewDraft({
         agreement: agreementToBeUpgraded,
         newDescriptor,
@@ -628,7 +633,7 @@ export function agreementServiceBuilder(
         consumer,
         producer,
         readModelService,
-        canBeUpgraded: verifiedValid && declaredValid,
+        canBeUpgraded,
         copyFile: fileManager.copy,
         authData,
         contractBuilder: contractBuilderInstance,

--- a/packages/agreement-process/test/upgradeAgreement.test.ts
+++ b/packages/agreement-process/test/upgradeAgreement.test.ts
@@ -341,6 +341,204 @@ describe("upgrade Agreement", () => {
     }
   });
 
+  it.only("should succeed with invalid Verified and Declared attributes when consumer and producer are the same", async () => {
+    const producerAndConsumerId = generateId<TenantId>();
+
+    const producerAndConsumer: Tenant = {
+      ...getMockTenant(),
+      id: producerAndConsumerId,
+      selfcareId: generateId(),
+      attributes: [],
+    };
+    await addOneTenant(producerAndConsumer);
+
+    const authData = getRandomAuthData(producerAndConsumer.id);
+
+    const certifiedDescriptorAttribute = getMockEServiceAttribute();
+    const verifiedDescriptorAttribute = getMockEServiceAttribute();
+    const declaredDescriptorAttribute = getMockEServiceAttribute();
+
+    const newPublishedDescriptor: Descriptor = {
+      ...getMockDescriptorPublished(),
+      version: "2",
+      attributes: {
+        certified: [[certifiedDescriptorAttribute]],
+        declared: [[verifiedDescriptorAttribute]],
+        verified: [[declaredDescriptorAttribute]],
+      },
+    };
+
+    const currentDescriptor: Descriptor = {
+      ...getMockDescriptorPublished(),
+      state: descriptorState.deprecated,
+      version: "1",
+    };
+    const eservice: EService = {
+      ...getMockEService(),
+      producerId: producerAndConsumer.id,
+      descriptors: [newPublishedDescriptor, currentDescriptor],
+    };
+    await addOneEService(eservice);
+
+    const agreementId: AgreementId = generateId<AgreementId>();
+
+    const docsNumber = Math.floor(Math.random() * 10) + 1;
+    const agreementConsumerDocuments = Array.from({ length: docsNumber }, () =>
+      getMockConsumerDocument(agreementId)
+    );
+
+    const agreement: Agreement = {
+      ...getMockAgreement(
+        eservice.id,
+        producerAndConsumer.id,
+        randomArrayItem(agreementUpgradableStates)
+      ),
+      id: agreementId,
+      producerId: eservice.producerId,
+      descriptorId: currentDescriptor.id,
+      createdAt: new Date(),
+      consumerDocuments: agreementConsumerDocuments,
+      suspendedByConsumer: randomBoolean(),
+      suspendedByProducer: randomBoolean(),
+      stamps: {
+        submission: createStamp(authData.userId),
+        activation: createStamp(authData.userId),
+        suspensionByConsumer: createStamp(authData.userId),
+        suspensionByProducer: createStamp(authData.userId),
+      },
+      contract: getMockContract(
+        agreementId,
+        producerAndConsumer.id,
+        producerAndConsumer.id
+      ),
+      suspendedAt: new Date(),
+    };
+    await addOneAgreement(agreement);
+
+    for (const doc of agreementConsumerDocuments) {
+      await uploadDocument(agreementId, doc.id, doc.name);
+    }
+
+    const returnedAgreement = await agreementService.upgradeAgreement(
+      agreement.id,
+      {
+        authData,
+        serviceName: "",
+        correlationId: generateId(),
+        logger: genericLogger,
+      }
+    );
+    const newAgreementId = unsafeBrandId<AgreementId>(returnedAgreement.id);
+
+    const actualAgreementArchivedEvent = await readAgreementEventByVersion(
+      agreement.id,
+      1
+    );
+
+    expect(actualAgreementArchivedEvent).toMatchObject({
+      type: "AgreementArchivedByUpgrade",
+      event_version: 2,
+      version: "1",
+      stream_id: agreement.id,
+    });
+
+    const actualAgreementArchived = decodeProtobufPayload({
+      messageType: AgreementArchivedByUpgradeV2,
+      payload: actualAgreementArchivedEvent.data,
+    }).agreement;
+
+    const expectedAgreementArchived: Agreement = {
+      ...agreement,
+      state: agreementState.archived,
+      stamps: {
+        ...agreement.stamps,
+        archiving: {
+          who: authData.userId,
+          when: new Date(),
+        },
+      },
+    };
+
+    expect(actualAgreementArchived).toEqual(
+      toAgreementV2(expectedAgreementArchived)
+    );
+
+    expect(newAgreementId).toBeDefined();
+
+    const actualAgreementUpgradedEvent = await readAgreementEventByVersion(
+      newAgreementId,
+      0
+    );
+
+    expect(actualAgreementUpgradedEvent).toMatchObject({
+      type: "AgreementUpgraded",
+      event_version: 2,
+      version: "0",
+      stream_id: newAgreementId,
+    });
+
+    const actualAgreementUpgraded: Agreement = fromAgreementV2(
+      decodeProtobufPayload({
+        messageType: AgreementUpgradedV2,
+        payload: actualAgreementUpgradedEvent.data,
+      }).agreement!
+    );
+
+    const contractDocumentId = actualAgreementUpgraded.contract!.id;
+    const contractCreatedAt = actualAgreementUpgraded.contract!.createdAt;
+    const contractDocumentName = `${producerAndConsumer.id}_${
+      producerAndConsumer.id
+    }_${formatDateyyyyMMddHHmmss(contractCreatedAt)}_agreement_contract.pdf`;
+
+    const expectedContract = {
+      id: contractDocumentId,
+      contentType: "application/pdf",
+      createdAt: contractCreatedAt,
+      path: `${config.agreementContractsPath}/${actualAgreementUpgraded.id}/${contractDocumentId}/${contractDocumentName}`,
+      prettyName: "Richiesta di fruizione",
+      name: contractDocumentName,
+    };
+
+    const expectedUpgradedAgreement = {
+      ...agreement,
+      id: newAgreementId,
+      descriptorId: newPublishedDescriptor.id,
+      createdAt: agreement.createdAt,
+      stamps: {
+        ...agreement.stamps,
+        upgrade: {
+          who: authData.userId,
+          when: new Date(),
+        },
+      },
+      verifiedAttributes: [],
+      certifiedAttributes: [],
+      declaredAttributes: [],
+      consumerDocuments: agreementConsumerDocuments.map<AgreementDocument>(
+        (doc, i) => ({
+          ...doc,
+          id: actualAgreementUpgraded?.consumerDocuments[i].id,
+          path: actualAgreementUpgraded?.consumerDocuments[i].path,
+        })
+      ),
+      contract: expectedContract,
+      suspendedByPlatform: undefined,
+      updatedAt: undefined,
+      rejectionReason: undefined,
+    };
+
+    expect(actualAgreementUpgraded).toEqual(expectedUpgradedAgreement);
+    expect(actualAgreementUpgraded).toEqual(returnedAgreement);
+
+    for (const agreementDoc of expectedUpgradedAgreement.consumerDocuments) {
+      const expectedUploadedDocumentPath = `${config.consumerDocumentsPath}/${newAgreementId}/${agreementDoc.id}/${agreementDoc.name}`;
+
+      expect(
+        await fileManager.listFiles(config.s3Bucket, genericLogger)
+      ).toContainEqual(expectedUploadedDocumentPath);
+    }
+  });
+
   it("should succeed with valid Verified, Certified, and Declared attributes when consumer and producer are different", async () => {
     const producer = getMockTenant();
 


### PR DESCRIPTION
This PR fixes two bug occurred in PROD.

A user upgraded their agreement for an e-service produced by him. 
However the agreement-process service didn’t skip the attribute check, causing the new agreement to enter the DRAFT state instead of proceeding smoothly. (First bug)

After the user activated the agreement (moving it to ACTIVE), the authorization-updater didn’t trigger, leaving the e-service state outdated in the authorization management. (Second bug)