### PR TITLE
Pin 5105 bke in add tenant mail bisogna rimuovere l autorizzazione ad api

### DIFF
--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -476,7 +476,7 @@ const tenantsRouter = (
     )
     .delete(
       "/tenants/:tenantId/mails/:mailId",
-      authorizationMiddleware([ADMIN_ROLE, API_ROLE]),
+      authorizationMiddleware([ADMIN_ROLE]),
       async (req, res) => {
         const ctx = fromAppContext(req.ctx);
         try {

--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -396,7 +396,7 @@ const tenantsRouter = (
     )
     .post(
       "/tenants/:tenantId/mails",
-      authorizationMiddleware([ADMIN_ROLE, API_ROLE]),
+      authorizationMiddleware([ADMIN_ROLE]),
       async (req, res) => {
         const ctx = fromAppContext(req.ctx);
         try {


### PR DESCRIPTION
I simply removed the _API_ROLE_ role from the roles allowed to call the following two APIs:

- POST /tenants/:tenantId/mails
- DELETE /tenants/:tenantId/mails/:mailId

Link to Jira: https://pagopa.atlassian.net/browse/PIN-5105