### PR TITLE
Permissions for API_ROLE and SECURITY_ROLE have been removed for the …

### DIFF
--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -270,13 +270,7 @@ const tenantsRouter = (
 
     .get(
       "/tenants/attributes/certified",
-      authorizationMiddleware([
-        ADMIN_ROLE,
-        API_ROLE,
-        SECURITY_ROLE,
-        M2M_ROLE,
-        SUPPORT_ROLE,
-      ]),
+      authorizationMiddleware([ADMIN_ROLE, M2M_ROLE, SUPPORT_ROLE]),
       async (req, res) => {
         const ctx = fromAppContext(req.ctx);
 


### PR DESCRIPTION
Permissions for **API_ROLE** and **SECURITY_ROLE** have been removed for the **GET /tenants/attributes/certified** API.

Link to Jira: https://pagopa.atlassian.net/browse/PIN-5070