### PR TITLE
Fix missing e-service template update logic

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -17231,6 +17231,8 @@ components:
       properties:
         name:
           type: string
+        instanceId:
+          type: string
         description:
           type: string
         technology:

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -1811,6 +1811,10 @@ components:
           type: string
           minLength: 5
           maxLength: 60
+        instanceId:
+          type: string
+          minLength: 5
+          maxLength: 60  
         description:
           type: string
           minLength: 10

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -815,17 +815,15 @@ export function catalogServiceBuilder(
 
       const updatedEService: EService = {
         ...eservice.data,
-        description: isTemplateInstance
-          ? eservice.data.description
-          : eserviceSeed.description,
         name: updatedName,
-        technology: isTemplateInstance
-          ? eservice.data.technology
-          : updatedTechnology,
-        mode: isTemplateInstance ? eservice.data.mode : updatedMode,
-        riskAnalysis: isTemplateInstance
-          ? eservice.data.riskAnalysis
-          : checkedRiskAnalysis,
+        ...(!isTemplateInstance
+          ? {
+              description: eserviceSeed.description,
+              technology: updatedTechnology,
+              mode: updatedMode,
+              riskAnalysis: checkedRiskAnalysis,
+            }
+          : {}),
         descriptors: interfaceHasToBeDeleted
           ? eservice.data.descriptors.map((d) => ({
               ...d,

--- a/packages/catalog-process/test/updateDraftDescriptor.test.ts
+++ b/packages/catalog-process/test/updateDraftDescriptor.test.ts
@@ -191,7 +191,196 @@ describe("update draft descriptor", () => {
     });
     expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
   });
+  it("should write on event-store for the update of a template instance draft descriptor ignoring attribute update", async () => {
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+      attributes: {
+        certified: [],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      templateRef: {
+        id: generateId(),
+      },
+    };
 
+    await addOneEService(eservice);
+    const attribute: Attribute = {
+      name: "Attribute name",
+      id: generateId(),
+      kind: "Declared",
+      description: "Attribute Description",
+      creationTime: new Date(),
+    };
+    await addOneAttribute(attribute);
+
+    const expectedDescriptorSeed: catalogApi.UpdateEServiceDescriptorSeed = {
+      ...buildUpdateDescriptorSeed(descriptor),
+      attributes: {
+        certified: [],
+        declared: [
+          [{ id: attribute.id, explicitAttributeVerification: false }],
+        ],
+        verified: [],
+      },
+    };
+
+    const updatedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          attributes: {
+            certified: [],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+    await catalogService.updateDraftDescriptor(
+      eservice.id,
+      descriptor.id,
+      expectedDescriptorSeed,
+      {
+        authData: getMockAuthData(eservice.producerId),
+        correlationId: generateId(),
+        serviceName: "",
+        logger: genericLogger,
+      }
+    );
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: eservice.id,
+      version: "1",
+      type: "EServiceDraftDescriptorUpdated",
+      event_version: 2,
+    });
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDraftDescriptorUpdatedV2,
+      payload: writtenEvent.data,
+    });
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
+  });
+  it("should write on event-store for the update of a template instance draft descriptor ignoring description update", async () => {
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      templateRef: {
+        id: generateId(),
+      },
+    };
+
+    await addOneEService(eservice);
+
+    const expectedDescriptorSeed: catalogApi.UpdateEServiceDescriptorSeed = {
+      ...buildUpdateDescriptorSeed(descriptor),
+      description: "Descriptor Description Update",
+    };
+
+    const updatedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          attributes: {
+            certified: [],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+    await catalogService.updateDraftDescriptor(
+      eservice.id,
+      descriptor.id,
+      expectedDescriptorSeed,
+      {
+        authData: getMockAuthData(eservice.producerId),
+        correlationId: generateId(),
+        serviceName: "",
+        logger: genericLogger,
+      }
+    );
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: eservice.id,
+      version: "1",
+      type: "EServiceDraftDescriptorUpdated",
+      event_version: 2,
+    });
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDraftDescriptorUpdatedV2,
+      payload: writtenEvent.data,
+    });
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
+  });
+  it("should write on event-store for the update of a template instance draft descriptor ignoring voucherLifespan update", async () => {
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      templateRef: {
+        id: generateId(),
+      },
+    };
+
+    await addOneEService(eservice);
+
+    const expectedDescriptorSeed: catalogApi.UpdateEServiceDescriptorSeed = {
+      ...buildUpdateDescriptorSeed(descriptor),
+      voucherLifespan: 999,
+    };
+
+    const updatedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          attributes: {
+            certified: [],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+    await catalogService.updateDraftDescriptor(
+      eservice.id,
+      descriptor.id,
+      expectedDescriptorSeed,
+      {
+        authData: getMockAuthData(eservice.producerId),
+        correlationId: generateId(),
+        serviceName: "",
+        logger: genericLogger,
+      }
+    );
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: eservice.id,
+      version: "1",
+      type: "EServiceDraftDescriptorUpdated",
+      event_version: 2,
+    });
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDraftDescriptorUpdatedV2,
+      payload: writtenEvent.data,
+    });
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
+  });
   it("should throw eServiceNotFound if the eservice doesn't exist", () => {
     const descriptor: Descriptor = {
       ...mockDescriptor,


### PR DESCRIPTION
We decided to rely on the e-service draft and e-service descriptor draft update calls to update e-service instances.
But e-service instances have some fields that should not be updated by the producer.

## `updateEService`
- Added possibility to update `instanceId`;
- Updated name conflict to take into account the newly passed `instanceId`;
- The `description`, `technology` and `mode` property in the passed seed are ignored since they are not updatable in a e-service template instance.

## `updateDraftDescriptor`
- The `voucherLifespan`, `attributes` and `description` property in the passed seed are ignored since they are not updatable in a e-service template instance;
-`attributes` seed check is skipped if the e-service is a template instance.
