### PR TITLE
Renamed `EServiceIntendedTarget` to `EServiceTemplateIntendedTarget`

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -15636,7 +15636,7 @@ paths:
       tags:
         - eserviceTemplates
       summary: Update an e-service template intended target description
-      operationId: updateEServiceIntendedTarget
+      operationId: updateEServiceTemplateIntendedTarget
       parameters:
         - name: eServiceTemplateId
           in: path

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -920,7 +920,7 @@ paths:
       tags:
         - process
       summary: Update a published e-service template intended target description
-      operationId: updateEServiceIntendedTarget
+      operationId: updateEServiceTemplateIntendedTarget
       parameters:
         - name: templateId
           in: path

--- a/packages/backend-for-frontend/src/routers/eserviceTemplateRouter.ts
+++ b/packages/backend-for-frontend/src/routers/eserviceTemplateRouter.ts
@@ -268,7 +268,7 @@ const eserviceTemplateRouter = (
         const { eServiceTemplateId } = req.params;
 
         try {
-          await eserviceTemplateService.updateEServiceIntendedTarget(
+          await eserviceTemplateService.updateEServiceTemplateIntendedTarget(
             unsafeBrandId(eServiceTemplateId),
             req.body,
             ctx

--- a/packages/backend-for-frontend/src/services/eserviceTemplateService.ts
+++ b/packages/backend-for-frontend/src/services/eserviceTemplateService.ts
@@ -170,7 +170,7 @@ export function eserviceTemplateServiceBuilder(
         },
       });
     },
-    updateEServiceIntendedTarget: async (
+    updateEServiceTemplateIntendedTarget: async (
       templateId: EServiceTemplateId,
       seed: bffApi.EServiceTemplateDescriptionUpdateSeed,
       { logger, headers }: WithLogger<BffAppContext>
@@ -178,7 +178,7 @@ export function eserviceTemplateServiceBuilder(
       logger.info(
         `Updating EService template ${templateId} intended target description`
       );
-      await eserviceTemplateClient.updateEServiceIntendedTarget(seed, {
+      await eserviceTemplateClient.updateEServiceTemplateIntendedTarget(seed, {
         headers,
         params: {
           templateId,

--- a/packages/eservice-template-instances-updater/src/eserviceTemplateInstancesUpdaterConsumerServiceV2.ts
+++ b/packages/eservice-template-instances-updater/src/eserviceTemplateInstancesUpdaterConsumerServiceV2.ts
@@ -343,7 +343,7 @@ export async function handleMessageV2({
     })
     .with(
       { type: "EServiceTemplateAdded" },
-      { type: "EServiceIntendedTargetUpdated" },
+      { type: "EServiceTemplateIntendedTargetUpdated" },
       { type: "EServiceTemplateDeleted" },
       { type: "EServiceTemplateDraftUpdated" },
       { type: "EServiceTemplateDraftVersionDeleted" },

--- a/packages/eservice-template-instances-updater/test/eserviceTemplateInstancesUpdaterConsumerServiceV2.test.ts
+++ b/packages/eservice-template-instances-updater/test/eserviceTemplateInstancesUpdaterConsumerServiceV2.test.ts
@@ -863,7 +863,7 @@ describe("eserviceTemplateUpdaterConsumerServiceV2", () => {
 
   it.each([
     "EServiceTemplateAdded",
-    "EServiceIntendedTargetUpdated",
+    "EServiceTemplateIntendedTargetUpdated",
     "EServiceTemplateDeleted",
     "EServiceTemplateDraftUpdated",
     "EServiceTemplateDraftVersionDeleted",

--- a/packages/eservice-template-process/src/model/domain/toEvent.ts
+++ b/packages/eservice-template-process/src/model/domain/toEvent.ts
@@ -331,7 +331,7 @@ export const toCreateEventEServiceTemplateNameUpdated = (
   correlationId,
 });
 
-export const toCreateEventEServiceIntendedTargetUpdated = (
+export const toCreateEventEServiceTemplateIntendedTargetUpdated = (
   streamId: string,
   version: number,
   eserviceTemplate: EServiceTemplate,
@@ -340,7 +340,7 @@ export const toCreateEventEServiceIntendedTargetUpdated = (
   streamId,
   version,
   event: {
-    type: "EServiceIntendedTargetUpdated",
+    type: "EServiceTemplateIntendedTargetUpdated",
     event_version: 2,
     data: {
       eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -25,7 +25,7 @@ import {
   activateEServiceTemplateVersionErrorMapper,
   suspendEServiceTemplateVersionErrorMapper,
   updateEServiceTemplateNameErrorMapper,
-  updateEServiceIntendedTargetErrorMapper,
+  updateEServiceTemplateIntendedTargetErrorMapper,
   updateEServiceTemplateDescriptionErrorMapper,
   updateEServiceTemplateVersionQuotasErrorMapper,
   updateEServiceTemplateVersionAttributesErrorMapper,
@@ -612,7 +612,7 @@ const eserviceTemplatesRouter = (
 
         try {
           const updatedEServiceTemplate =
-            await eserviceTemplateService.updateEServiceIntendedTarget(
+            await eserviceTemplateService.updateEServiceTemplateIntendedTarget(
               unsafeBrandId(req.params.templateId),
               req.body.description,
               ctx
@@ -627,7 +627,7 @@ const eserviceTemplatesRouter = (
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
-            updateEServiceIntendedTargetErrorMapper,
+            updateEServiceTemplateIntendedTargetErrorMapper,
             ctx.logger,
             ctx.correlationId
           );

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -68,7 +68,7 @@ import {
   toCreateEventEServiceTemplateVersionSuspended,
   toCreateEventEServiceTemplateNameUpdated,
   toCreateEventEServiceTemplateDraftVersionUpdated,
-  toCreateEventEServiceIntendedTargetUpdated,
+  toCreateEventEServiceTemplateIntendedTargetUpdated,
   toCreateEventEServiceTemplateDescriptionUpdated,
   toCreateEventEServiceTemplateVersionQuotasUpdated,
   toCreateEventEServiceTemplateVersionAttributesUpdated,
@@ -666,7 +666,7 @@ export function eserviceTemplateServiceBuilder(
       );
       return updatedEserviceTemplate;
     },
-    async updateEServiceIntendedTarget(
+    async updateEServiceTemplateIntendedTarget(
       eserviceTemplateId: EServiceTemplateId,
       intendedTarget: string,
       { authData, correlationId, logger }: WithLogger<AppContext>
@@ -691,7 +691,7 @@ export function eserviceTemplateServiceBuilder(
         intendedTarget,
       };
       await repository.createEvent(
-        toCreateEventEServiceIntendedTargetUpdated(
+        toCreateEventEServiceTemplateIntendedTargetUpdated(
           eserviceTemplate.data.id,
           eserviceTemplate.metadata.version,
           updatedEserviceTemplate,

--- a/packages/eservice-template-process/src/utilities/errorMappers.ts
+++ b/packages/eservice-template-process/src/utilities/errorMappers.ts
@@ -83,7 +83,7 @@ export const updateEServiceTemplateNameErrorMapper = (
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
-export const updateEServiceIntendedTargetErrorMapper = (
+export const updateEServiceTemplateIntendedTargetErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)

--- a/packages/eservice-template-process/test/updateEServiceTemplateIntendedTarget.test.ts
+++ b/packages/eservice-template-process/test/updateEServiceTemplateIntendedTarget.test.ts
@@ -14,7 +14,7 @@ import {
   eserviceTemplateVersionState,
   EServiceTemplate,
   toEServiceTemplateV2,
-  EServiceIntendedTargetUpdatedV2,
+  EServiceTemplateIntendedTargetUpdatedV2,
 } from "pagopa-interop-models";
 import { expect, describe, it } from "vitest";
 import {
@@ -27,7 +27,7 @@ import {
   readLastEserviceTemplateEvent,
 } from "./utils.js";
 
-describe("updateEServiceIntendedTarget", () => {
+describe("updateEServiceTemplateIntendedTarget", () => {
   it("should write on event-store for the update of the eService template description", async () => {
     const eserviceTemplateVersion: EServiceTemplateVersion = {
       ...getMockEServiceTemplateVersion(),
@@ -41,7 +41,7 @@ describe("updateEServiceIntendedTarget", () => {
     await addOneEServiceTemplate(eserviceTemplate);
     const updatedTemplateDescription = "eservice template new description";
     const returnedEServiceTemplate =
-      await eserviceTemplateService.updateEServiceIntendedTarget(
+      await eserviceTemplateService.updateEServiceTemplateIntendedTarget(
         eserviceTemplate.id,
         updatedTemplateDescription,
         {
@@ -61,11 +61,11 @@ describe("updateEServiceIntendedTarget", () => {
     expect(writtenEvent).toMatchObject({
       stream_id: eserviceTemplate.id,
       version: "1",
-      type: "EServiceIntendedTargetUpdated",
+      type: "EServiceTemplateIntendedTargetUpdated",
       event_version: 2,
     });
     const writtenPayload = decodeProtobufPayload({
-      messageType: EServiceIntendedTargetUpdatedV2,
+      messageType: EServiceTemplateIntendedTargetUpdatedV2,
       payload: writtenEvent.data,
     });
     expect(writtenPayload.eserviceTemplate).toEqual(
@@ -79,7 +79,7 @@ describe("updateEServiceIntendedTarget", () => {
   it("should throw eServiceTemplateNotFound if the eservice template doesn't exist", async () => {
     const eserviceTemplate = getMockEServiceTemplate();
     expect(
-      eserviceTemplateService.updateEServiceIntendedTarget(
+      eserviceTemplateService.updateEServiceTemplateIntendedTarget(
         eserviceTemplate.id,
         "eservice template new description",
         {
@@ -95,7 +95,7 @@ describe("updateEServiceIntendedTarget", () => {
     const eserviceTemplate = getMockEServiceTemplate();
     await addOneEServiceTemplate(eserviceTemplate);
     expect(
-      eserviceTemplateService.updateEServiceIntendedTarget(
+      eserviceTemplateService.updateEServiceTemplateIntendedTarget(
         eserviceTemplate.id,
         "eservice template new description",
         {
@@ -111,7 +111,7 @@ describe("updateEServiceIntendedTarget", () => {
     const eserviceTemplate = getMockEServiceTemplate();
     await addOneEServiceTemplate(eserviceTemplate);
     expect(
-      eserviceTemplateService.updateEServiceIntendedTarget(
+      eserviceTemplateService.updateEServiceTemplateIntendedTarget(
         eserviceTemplate.id,
         "eservice template new description",
         {
@@ -137,7 +137,7 @@ describe("updateEServiceIntendedTarget", () => {
     };
     await addOneEServiceTemplate(eserviceTemplate);
     expect(
-      eserviceTemplateService.updateEServiceIntendedTarget(
+      eserviceTemplateService.updateEServiceTemplateIntendedTarget(
         eserviceTemplate.id,
         "eservice template new description",
         {

--- a/packages/eservice-template-readmodel-writer/src/consumerServiceV2.ts
+++ b/packages/eservice-template-readmodel-writer/src/consumerServiceV2.ts
@@ -21,7 +21,7 @@ export async function handleMessageV2(
     .with(
       { type: "EServiceTemplateVersionActivated" },
       { type: "EServiceTemplateAdded" },
-      { type: "EServiceIntendedTargetUpdated" },
+      { type: "EServiceTemplateIntendedTargetUpdated" },
       { type: "EServiceTemplateDescriptionUpdated" },
       { type: "EServiceTemplateDraftVersionDeleted" },
       { type: "EServiceTemplateDraftVersionUpdated" },

--- a/packages/models/proto/v2/eservice-template/events.proto
+++ b/packages/models/proto/v2/eservice-template/events.proto
@@ -86,7 +86,7 @@ message EServiceTemplateNameUpdatedV2 {
   EServiceTemplateV2 eserviceTemplate = 1;
 }
 
-message EServiceIntendedTargetUpdatedV2 {
+message EServiceTemplateIntendedTargetUpdatedV2 {
   EServiceTemplateV2 eserviceTemplate = 1;
 }
 

--- a/packages/models/src/eservice-template/eserviceTemplateEvents.ts
+++ b/packages/models/src/eservice-template/eserviceTemplateEvents.ts
@@ -4,7 +4,7 @@ import { match } from "ts-pattern";
 import {
   EServiceTemplateVersionActivatedV2,
   EServiceTemplateAddedV2,
-  EServiceIntendedTargetUpdatedV2,
+  EServiceTemplateIntendedTargetUpdatedV2,
   EServiceTemplateDescriptionUpdatedV2,
   EServiceTemplateDeletedV2,
   EServiceTemplateDraftVersionDeletedV2,
@@ -112,8 +112,8 @@ export const EServiceTemplateEventV2 = z.discriminatedUnion("type", [
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceIntendedTargetUpdated"),
-    data: protobufDecoder(EServiceIntendedTargetUpdatedV2),
+    type: z.literal("EServiceTemplateIntendedTargetUpdated"),
+    data: protobufDecoder(EServiceTemplateIntendedTargetUpdatedV2),
   }),
   z.object({
     type: z.literal("EServiceTemplateDescriptionUpdated"),
@@ -159,8 +159,8 @@ export function eserviceTemplateEventToBinaryDataV2(
     .with({ type: "EServiceTemplateAdded" }, ({ data }) =>
       EServiceTemplateAddedV2.toBinary(data)
     )
-    .with({ type: "EServiceIntendedTargetUpdated" }, ({ data }) =>
-      EServiceIntendedTargetUpdatedV2.toBinary(data)
+    .with({ type: "EServiceTemplateIntendedTargetUpdated" }, ({ data }) =>
+      EServiceTemplateIntendedTargetUpdatedV2.toBinary(data)
     )
     .with({ type: "EServiceTemplateDescriptionUpdated" }, ({ data }) =>
       EServiceTemplateDescriptionUpdatedV2.toBinary(data)


### PR DESCRIPTION
Fix missing `Template` in everything related to the `IntentedTarget` data