### PR TITLE
EService template fixes [Part 1]

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -20429,7 +20429,6 @@ components:
         - description
         - technology
         - mode
-        - version
       properties:
         name:
           type: string

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -155,6 +155,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: E-Service template retrieved
@@ -163,6 +164,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/EServiceTemplate"
         "404":
+          description: E-Service template not found
           content:
             application/json:
               schema:
@@ -1124,7 +1126,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
-  "/templates/creators":
+  "/creators":
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"
     get:

--- a/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
@@ -42,7 +42,9 @@ export function toBffEServiceTemplateDetails(
       toBffCompactEServiceTemplateVersion
     ),
     isSignalHubEnabled: eserviceTemplate.isSignalHubEnabled,
-    draftVersion,
+    draftVersion: draftVersion
+      ? toBffCompactEServiceTemplateVersion(draftVersion)
+      : undefined,
   };
 }
 
@@ -106,3 +108,14 @@ export const toBffCreatedEServiceTemplateVersion = (
     versionId: version.id,
   };
 };
+
+export function toCatalogCreateEServiceTemplateSeed(
+  eServiceTemplateSeed: bffApi.EServiceTemplateSeed
+): eserviceTemplateApi.EServiceTemplateSeed {
+  return {
+    ...eServiceTemplateSeed,
+    version: {
+      voucherLifespan: 60,
+    },
+  };
+}

--- a/packages/backend-for-frontend/src/routers/eserviceTemplateRouter.ts
+++ b/packages/backend-for-frontend/src/routers/eserviceTemplateRouter.ts
@@ -9,7 +9,10 @@ import {
   zodiosValidationErrorToApiProblem,
 } from "pagopa-interop-commons";
 import { unsafeBrandId } from "pagopa-interop-models";
-import { toBffCreatedEServiceTemplateVersion } from "../api/eserviceTemplateApiConverter.js";
+import {
+  toBffCreatedEServiceTemplateVersion,
+  toCatalogCreateEServiceTemplateSeed,
+} from "../api/eserviceTemplateApiConverter.js";
 import { PagoPAInteropBeClients } from "../clients/clientsProvider.js";
 import { emptyErrorMapper, makeApiProblem } from "../model/errors.js";
 import { eserviceTemplateServiceBuilder } from "../services/eserviceTemplateService.js";
@@ -47,7 +50,10 @@ const eserviceTemplateRouter = (
 
       try {
         const eserviceTemplate =
-          await eserviceTemplateService.createEServiceTemplate(req.body, ctx);
+          await eserviceTemplateService.createEServiceTemplate(
+            toCatalogCreateEServiceTemplateSeed(req.body),
+            ctx
+          );
         return res
           .status(200)
           .send(

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -728,7 +728,7 @@ const eserviceTemplatesRouter = (
       }
     )
     .get(
-      "/templates/creators",
+      "/creators",
       authorizationMiddleware([
         ADMIN_ROLE,
         API_ROLE,


### PR DESCRIPTION
- Renamed internal eservice template process path `/templates/creators` to `/creators`
- Removed `version` from `EServiceTemplateSeed`, not needed from FE
- Fixed parsing error in `EServiceTemplateVersion` retrieve route