### PR TITLE
Fix e-service templates [Part 2]

### DIFF
--- a/collections/eservice-template/Update EService Template  Intended Target.bru
+++ b/collections/eservice-template/Update EService Template  Intended Target.bru
@@ -21,6 +21,6 @@ headers {
 
 body:json {
   {
-      "description": "Test EService Intended target",
+      "intendedTarget": "Test EService Intended target",
   }
 }

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -15651,7 +15651,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EServiceTemplateDescriptionUpdateSeed"
+              $ref: "#/components/schemas/EServiceTemplateIntendedTargetUpdateSeed"
       responses:
         "204":
           description: EService template intended target description updated
@@ -20246,6 +20246,14 @@ components:
           type: string
       required:
         - description
+    EServiceTemplateIntendedTargetUpdateSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        intendedTarget:
+          type: string
+      required:
+        - intendedTarget
     EServiceTemplateVersionState:
       type: string
       description: EService Descriptor State

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -2373,7 +2373,6 @@ components:
           format: uuid
         instanceLabel:
           type: string
-          format: uuid
     EServiceTemplateVersionRef:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -932,15 +932,15 @@ paths:
             type: string
             format: uuid
       requestBody:
-        description: A payload containing the new description
+        description: A payload containing the new intended target description
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EServiceTemplateDescriptionUpdateSeed"
+              $ref: "#/components/schemas/EServiceTemplateIntendedTargetUpdateSeed"
       responses:
         "200":
-          description: EService template description updated
+          description: EService template intended target updated
           content:
             application/json:
               schema:
@@ -1611,6 +1611,16 @@ components:
           maxLength: 250
       required:
         - description
+    EServiceTemplateIntendedTargetUpdateSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        intendedTarget:
+          type: string
+          minLength: 10
+          maxLength: 250
+      required:
+        - intendedTarget
     EServiceTemplateNameUpdateSeed:
       type: object
       additionalProperties: false

--- a/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
@@ -91,8 +91,12 @@ export function toBffProducerEServiceTemplate(
     id: eserviceTemplate.id,
     name: eserviceTemplate.name,
     mode: eserviceTemplate.mode,
-    activeVersion,
-    draftVersion,
+    activeVersion: activeVersion
+      ? toBffCompactEServiceTemplateVersion(activeVersion)
+      : undefined,
+    draftVersion: draftVersion
+      ? toBffCompactEServiceTemplateVersion(draftVersion)
+      : undefined,
   };
 }
 

--- a/packages/backend-for-frontend/src/routers/eserviceTemplateRouter.ts
+++ b/packages/backend-for-frontend/src/routers/eserviceTemplateRouter.ts
@@ -644,7 +644,7 @@ const eserviceTemplateRouter = (
             req.body,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -668,7 +668,7 @@ const eserviceTemplateRouter = (
             unsafeBrandId(req.params.documentId),
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/backend-for-frontend/src/routers/eserviceTemplateRouter.ts
+++ b/packages/backend-for-frontend/src/routers/eserviceTemplateRouter.ts
@@ -224,7 +224,7 @@ const eserviceTemplateRouter = (
         const { eServiceTemplateId, eServiceTemplateVersionId } = req.params;
 
         try {
-          await eserviceTemplateService.deleteEServiceTemplateEServiceRiskAnalysis(
+          await eserviceTemplateService.deleteEServiceTemplateVersion(
             unsafeBrandId(eServiceTemplateId),
             unsafeBrandId(eServiceTemplateVersionId),
             ctx

--- a/packages/backend-for-frontend/src/services/eserviceTemplateService.ts
+++ b/packages/backend-for-frontend/src/services/eserviceTemplateService.ts
@@ -172,7 +172,7 @@ export function eserviceTemplateServiceBuilder(
     },
     updateEServiceTemplateIntendedTarget: async (
       templateId: EServiceTemplateId,
-      seed: bffApi.EServiceTemplateDescriptionUpdateSeed,
+      seed: bffApi.EServiceTemplateIntendedTargetUpdateSeed,
       { logger, headers }: WithLogger<BffAppContext>
     ): Promise<void> => {
       logger.info(

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -1047,7 +1047,7 @@ const eservicesRouter = (
             req.body.name,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -1071,7 +1071,7 @@ const eservicesRouter = (
             req.body.description,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -1096,7 +1096,7 @@ const eservicesRouter = (
             req.body.voucherLifespan,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -1121,7 +1121,7 @@ const eservicesRouter = (
             req.body,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -1146,7 +1146,7 @@ const eservicesRouter = (
             req.body,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -1171,7 +1171,7 @@ const eservicesRouter = (
             req.body,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -1197,7 +1197,7 @@ const eservicesRouter = (
             req.body,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -1222,7 +1222,7 @@ const eservicesRouter = (
             req.body,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -744,8 +744,8 @@ const eserviceTemplatesRouter = (
           const { results, totalCount } =
             await eserviceTemplateService.getEServiceTemplateCreators(
               creatorName,
-              offset,
               limit,
+              offset,
               ctx
             );
 

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -493,7 +493,7 @@ const eserviceTemplatesRouter = (
             unsafeBrandId(req.params.documentId),
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
@@ -519,7 +519,7 @@ const eserviceTemplatesRouter = (
             req.body,
             ctx
           );
-          return res.status(204);
+          return res.status(204).send();
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -614,7 +614,7 @@ const eserviceTemplatesRouter = (
           const updatedEServiceTemplate =
             await eserviceTemplateService.updateEServiceTemplateIntendedTarget(
               unsafeBrandId(req.params.templateId),
-              req.body.description,
+              req.body.intendedTarget,
               ctx
             );
           return res

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -1456,7 +1456,7 @@ export function eserviceTemplateServiceBuilder(
       { logger }: WithLogger<AppContext>
     ): Promise<ListResult<eserviceTemplateApi.CompactOrganization>> {
       logger.info(
-        `Retrieving producers from agreements with producer name ${creatorName}, limit ${limit}, offset ${offset}`
+        `Retrieving eservice template creator with name ${creatorName}, limit ${limit}, offset ${offset}`
       );
       return await readModelService.getCreators(creatorName, limit, offset);
     },


### PR DESCRIPTION
- Fix Parsing error in ProducerEServiceTemplate.
- Update intended target service payload. Replaced incorrect "description" field with "intendedTarget".
- Fix calling wrong `eserviceTemplateService` in delete e-service template version route
- Fix wrong parameter order (offset/limit) in get e-service creators call
- Removed format uuid `instanceLabel` from api
- Fix missing `send` on res status 204





