### PR TITLE
Fix missing `templateVersionRef` after interface upload in e-service template instance

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -18413,6 +18413,9 @@ components:
           type: array
           items:
             type: string
+        templateVersionId:
+          type: string
+          format: uuid
     TemplateInstanceInterfaceMetadata:
       type: object
       additionalProperties: false
@@ -20517,7 +20520,7 @@ components:
           format: uuid
         producerName:
           type: string
-        activeDescriptor:
+        latestDescriptor:
           $ref: "#/components/schemas/CompactDescriptor"
         descriptors:
           type: array

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -372,6 +372,7 @@ export function toCompactDescriptor(
     audience: descriptor.audience,
     state: descriptor.state,
     version: descriptor.version,
+    templateVersionId: descriptor.templateVersionRef?.id,
   };
 }
 
@@ -398,17 +399,21 @@ export function toBffEServiceTemplateInstance(
   eservice: catalogApi.EService,
   producer: tenantApi.Tenant
 ): bffApi.EServiceTemplateInstance {
-  const activeDescriptor = getLatestActiveDescriptor(eservice);
+  const descriptors = eservice.descriptors
+    .filter(isValidDescriptor)
+    .map(toCompactDescriptor);
+
+  const latestDescriptor = [...descriptors]
+    .sort((a, b) => Number(a.version) - Number(b.version))
+    .at(-1);
 
   return {
     id: eservice.id,
     name: eservice.name,
     producerId: producer.id,
     producerName: producer.name,
-    activeDescriptor: activeDescriptor
-      ? toCompactDescriptor(activeDescriptor)
-      : undefined,
-    descriptors: eservice.descriptors.map(toCompactDescriptor),
+    latestDescriptor,
+    descriptors,
     instanceLabel: eservice.templateRef?.instanceLabel,
   };
 }

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -399,21 +399,18 @@ export function toBffEServiceTemplateInstance(
   eservice: catalogApi.EService,
   producer: tenantApi.Tenant
 ): bffApi.EServiceTemplateInstance {
-  const descriptors = eservice.descriptors
+  const validDescriptors = [...eservice.descriptors]
     .filter(isValidDescriptor)
-    .map(toCompactDescriptor);
-
-  const latestDescriptor = [...descriptors]
     .sort((a, b) => Number(a.version) - Number(b.version))
-    .at(-1);
+    .map(toCompactDescriptor);
 
   return {
     id: eservice.id,
     name: eservice.name,
     producerId: producer.id,
     producerName: producer.name,
-    latestDescriptor,
-    descriptors,
+    latestDescriptor: validDescriptors.at(-1),
+    descriptors: validDescriptors,
     instanceLabel: eservice.templateRef?.instanceLabel,
   };
 }

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -632,37 +632,6 @@ async function innerAddDocumentToEserviceEvent(
     uploadDate: new Date(),
   };
 
-  function evaluateTemplateVersionRef(
-    descriptor: Descriptor
-  ): Descriptor["templateVersionRef"] {
-    if (
-      !isInterface ||
-      !descriptor.templateVersionRef ||
-      !documentSeed.interfaceTemplateMetadata
-    ) {
-      return descriptor.templateVersionRef;
-    }
-
-    const {
-      contactEmail,
-      contactName,
-      contactUrl,
-      serverUrls,
-      termsAndConditionsUrl,
-    } = documentSeed.interfaceTemplateMetadata;
-
-    return {
-      id: descriptor.templateVersionRef.id,
-      interfaceMetadata: {
-        contactEmail,
-        contactName,
-        contactUrl,
-        serverUrls,
-        termsAndConditionsUrl,
-      },
-    };
-  }
-
   const updatedEService: EService = {
     ...eService.data,
     descriptors: eService.data.descriptors.map((d: Descriptor) =>
@@ -672,7 +641,7 @@ async function innerAddDocumentToEserviceEvent(
             interface: isInterface ? newDocument : d.interface,
             docs: isInterface ? d.docs : [...d.docs, newDocument],
             serverUrls: isInterface ? documentSeed.serverUrls : d.serverUrls,
-            templateVersionRef: evaluateTemplateVersionRef(d),
+            templateVersionRef: evaluateTemplateVersionRef(d, documentSeed),
           }
         : d
     ),
@@ -3334,6 +3303,38 @@ function updateEServiceDescriptorAttributeInAdd(
     ...verifiedAttributes,
     ...declaredAttributes,
   ].map(unsafeBrandId<AttributeId>);
+}
+
+function evaluateTemplateVersionRef(
+  descriptor: Descriptor,
+  documentSeed: catalogApi.CreateEServiceDescriptorDocumentSeed
+): Descriptor["templateVersionRef"] {
+  if (
+    documentSeed.kind !== "INTERFACE" ||
+    !descriptor.templateVersionRef ||
+    !documentSeed.interfaceTemplateMetadata
+  ) {
+    return descriptor.templateVersionRef;
+  }
+
+  const {
+    contactEmail,
+    contactName,
+    contactUrl,
+    serverUrls,
+    termsAndConditionsUrl,
+  } = documentSeed.interfaceTemplateMetadata;
+
+  return {
+    id: descriptor.templateVersionRef.id,
+    interfaceMetadata: {
+      contactEmail,
+      contactName,
+      contactUrl,
+      serverUrls,
+      termsAndConditionsUrl,
+    },
+  };
 }
 
 export type CatalogService = ReturnType<typeof catalogServiceBuilder>;

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -641,15 +641,15 @@ async function innerAddDocumentToEserviceEvent(
             interface: isInterface ? newDocument : d.interface,
             docs: isInterface ? d.docs : [...d.docs, newDocument],
             serverUrls: isInterface ? documentSeed.serverUrls : d.serverUrls,
-            templateVersionRef: d.templateVersionRef
-              ? {
-                  ...d.templateVersionRef,
-                  interfaceMetadata:
-                    isInterface && documentSeed.interfaceTemplateMetadata
-                      ? documentSeed.interfaceTemplateMetadata
-                      : d.templateVersionRef?.interfaceMetadata,
-                }
-              : undefined,
+            templateVersionRef:
+              isInterface &&
+              d.templateVersionRef &&
+              documentSeed.interfaceTemplateMetadata
+                ? {
+                    ...d.templateVersionRef,
+                    interfaceMetadata: documentSeed.interfaceTemplateMetadata,
+                  }
+                : d.templateVersionRef,
           }
         : d
     ),

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -632,6 +632,37 @@ async function innerAddDocumentToEserviceEvent(
     uploadDate: new Date(),
   };
 
+  function evaluateTemplateVersionRef(
+    descriptor: Descriptor
+  ): Descriptor["templateVersionRef"] {
+    if (
+      !isInterface ||
+      !descriptor.templateVersionRef ||
+      !documentSeed.interfaceTemplateMetadata
+    ) {
+      return descriptor.templateVersionRef;
+    }
+
+    const {
+      contactEmail,
+      contactName,
+      contactUrl,
+      serverUrls,
+      termsAndConditionsUrl,
+    } = documentSeed.interfaceTemplateMetadata;
+
+    return {
+      id: descriptor.templateVersionRef.id,
+      interfaceMetadata: {
+        contactEmail,
+        contactName,
+        contactUrl,
+        serverUrls,
+        termsAndConditionsUrl,
+      },
+    };
+  }
+
   const updatedEService: EService = {
     ...eService.data,
     descriptors: eService.data.descriptors.map((d: Descriptor) =>
@@ -641,15 +672,7 @@ async function innerAddDocumentToEserviceEvent(
             interface: isInterface ? newDocument : d.interface,
             docs: isInterface ? d.docs : [...d.docs, newDocument],
             serverUrls: isInterface ? documentSeed.serverUrls : d.serverUrls,
-            templateVersionRef:
-              isInterface &&
-              d.templateVersionRef &&
-              documentSeed.interfaceTemplateMetadata
-                ? {
-                    ...d.templateVersionRef,
-                    interfaceMetadata: documentSeed.interfaceTemplateMetadata,
-                  }
-                : d.templateVersionRef,
+            templateVersionRef: evaluateTemplateVersionRef(d),
           }
         : d
     ),


### PR DESCRIPTION
This PR fixes a bug where `templateVersionRef` go missing when the user tries to upload an e-service template