### PR TITLE
Support has to access read endpoint

### DIFF
--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -740,7 +740,7 @@ const agreementRouter = (
 
   agreementRouter.get(
     "/tenants/:tenantId/eservices/:eserviceId/descriptors/:descriptorId/certifiedAttributes/validate",
-    authorizationMiddleware([ADMIN_ROLE]),
+    authorizationMiddleware([ADMIN_ROLE, SUPPORT_ROLE]),
     async (req, res) => {
       const ctx = fromAppContext(req.ctx);
 

--- a/packages/authorization-process/src/routers/AuthorizationRouter.ts
+++ b/packages/authorization-process/src/routers/AuthorizationRouter.ts
@@ -606,7 +606,7 @@ const authorizationRouter = (
   });
   authorizationUserRouter.get(
     "/clients/:clientId/users/:userId/keys",
-    authorizationMiddleware([ADMIN_ROLE]),
+    authorizationMiddleware([ADMIN_ROLE, SUPPORT_ROLE]),
     async (_req, res) => res.status(501).send()
   );
 

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -453,7 +453,7 @@ const eserviceTemplatesRouter = (
     )
     .get(
       "/templates/:templateId/versions/:templateVersionId/documents/:documentId",
-      authorizationMiddleware([API_ROLE, ADMIN_ROLE]),
+      authorizationMiddleware([API_ROLE, ADMIN_ROLE, SUPPORT_ROLE]),
       async (req, res) => {
         const ctx = fromAppContext(req.ctx);
         try {

--- a/packages/purpose-process/src/routers/PurposeRouter.ts
+++ b/packages/purpose-process/src/routers/PurposeRouter.ts
@@ -379,7 +379,7 @@ const purposeRouter = (
     )
     .get(
       "/purposes/:purposeId/versions/:versionId/documents/:documentId",
-      authorizationMiddleware([ADMIN_ROLE]),
+      authorizationMiddleware([ADMIN_ROLE, SUPPORT_ROLE]),
       async (req, res) => {
         const ctx = fromAppContext(req.ctx);
         try {


### PR DESCRIPTION
**Jira Link**: https://pagopa.atlassian.net/browse/PIN-4775

Note that some endpoints didn't have the `authorizationMiddleware` array, meaning that all the roles can access that endpoint, I think.

