### PR TITLE
Re-adding local KMS key to local well-known

### DIFF
--- a/collections/bff/authorization/get Session Token.bru
+++ b/collections/bff/authorization/get Session Token.bru
@@ -11,7 +11,6 @@ post {
 }
 
 headers {
-  Authorization: {{JWT}}
   x-correlation-id: {{correlation-id}}
 }
 

--- a/docker/local-kms-seed/jwks.json
+++ b/docker/local-kms-seed/jwks.json
@@ -6,6 +6,13 @@
       "e": "AQAB",
       "alg": "RS256",
       "kid": "41e3a8e9-5982-4a6d-b531-850774bfd961"
+    },
+    {
+      "kty": "RSA",
+      "n": "k5JxTIGte3mNfH5l7PuJCzZ3q2Ri7XuMop8SKQqFE7-xbrjmdM5pFK9gznrbsHWr2FB-w9C_oSGBDn4vyKGmnPWR2lTzBD9lmsEpEUKOs3ZlMSbpkWJOHCELocgq4kRAGxifTodqfj4uakGWHBFzIQ-79QVYzZ0B_3dsaUU9AOOa7TgiV9bbyhkWVWGzT8uGhi-F84M1VwVnsG8I3NI9YhwOs_JRufuh-ZvFnRcPuWTVAgcDYoZW94mpXvl0Kw8l2YoyTrl9xqvDOObA_axu1EWptJOD-65BQDDG-YLMvfxV9fnIlX59o6kbc2I6qFtrtvZCGLDPs_jE-k8_6hfAJw",
+      "e": "AQAB",
+      "alg": "RS256",
+      "kid": "ffcc9b5b-4612-49b1-9374-9d203a3834f2"
     }
   ]
 }

--- a/packages/agreement-process/.env
+++ b/packages/agreement-process/.env
@@ -17,7 +17,7 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui,dev.interop.pagopa.it/m2m,refactor.dev.interop.pagopa.it/m2m"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,dev.interop.pagopa.it/ui,dev.interop.pagopa.it/m2m,dev.interop.pagopa.it/m2m"
 
 S3_BUCKET=interop-local-bucket
 S3_CUSTOM_SERVER=true

--- a/packages/anac-certified-attributes-importer/.env
+++ b/packages/anac-certified-attributes-importer/.env
@@ -15,9 +15,9 @@ SFTP_PATH=""
 FORCE_REMOTE_FILE_NAME="anac-test-csv.csv"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-eservice-descriptors-archiver"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-eservice-descriptors-archiver"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 TENANT_PROCESS_URL="http://localhost:3500"

--- a/packages/api-gateway/.env
+++ b/packages/api-gateway/.env
@@ -4,7 +4,7 @@ LOG_LEVEL=info
 API_GATEWAY_INTERFACE_VERSION="0.0"
 
 WELL_KNOWN_URLS="http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/m2m,refactor.dev.interop.pagopa.it/m2m"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/m2m,dev.interop.pagopa.it/m2m"
 AWS_CONFIG_FILE=aws.config.local
 
 RATE_LIMITER_BURST_PERCENTAGE="1.0"

--- a/packages/attribute-registry-process/.env
+++ b/packages/attribute-registry-process/.env
@@ -17,6 +17,6 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui,dev.interop.pagopa.it/m2m,refactor.dev.interop.pagopa.it/m2m"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,dev.interop.pagopa.it/ui,dev.interop.pagopa.it/m2m,dev.interop.pagopa.it/m2m"
 
 PRODUCER_ALLOWED_ORIGINS="IPA"

--- a/packages/authorization-process/.env
+++ b/packages/authorization-process/.env
@@ -17,7 +17,7 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui,dev.interop.pagopa.it/m2m,refactor.dev.interop.pagopa.it/m2m"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,dev.interop.pagopa.it/ui,dev.interop.pagopa.it/m2m,dev.interop.pagopa.it/m2m"
 
 SELFCARE_V2_URL=localhost
 SELFCARE_V2_API_KEY=key

--- a/packages/authorization-updater/.env
+++ b/packages/authorization-updater/.env
@@ -19,9 +19,9 @@ READMODEL_DB_PORT=27017
 AUTHORIZATION_MANAGEMENT_URL="/authorization-management/0.0"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-authorization-updater"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-authorization-updater"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 AWS_CONFIG_FILE=aws.config.local

--- a/packages/backend-for-frontend/.env
+++ b/packages/backend-for-frontend/.env
@@ -4,7 +4,7 @@ LOG_LEVEL=info
 BACKEND_FOR_FRONTEND_INTERFACE_VERSION="0.0"
 
 WELL_KNOWN_URLS="https://uat.selfcare.pagopa.it/.well-known/jwks.json,https://dev.interop.pagopa.it/.well-known/jwks.json,http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,dev.interop.pagopa.it/ui"
 
 TENANT_PROCESS_URL="http://localhost:3500"
 AGREEMENT_PROCESS_URL="http://localhost:3100"
@@ -27,14 +27,14 @@ ALLOW_LIST_PATH="allow-list"
 ALLOW_LIST_FILE_NAME="allow-list.txt"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-backend-for-frontend"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-backend-for-frontend"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 GENERATED_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-GENERATED_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-GENERATED_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/ui"
+GENERATED_JWT_ISSUER="dev.interop.pagopa.it"
+GENERATED_JWT_AUDIENCE="dev.interop.pagopa.it/ui"
 GENERATED_JWT_SECONDS_DURATION=60
 
 S3_CUSTOM_SERVER=true
@@ -85,7 +85,7 @@ IMPORT_ESERVICE_PATH="local/eservices-import"
 PRESIGNED_URL_GET_DURATION_MINUTES=5000
 PRESIGNED_URL_PUT_DURATION_MINUTES= 5000
 
-CLIENT_ASSERTION_AUDIENCE="auth.refactor.dev.interop.pagopa.it/client-assertion"
+CLIENT_ASSERTION_AUDIENCE="auth.dev.interop.pagopa.it/client-assertion"
 
 INTEROP_SELFCARE_PRODUCT_NAME="prod-interop"
 DELEGATION_CONTRACTS_CONTAINER="interop-local-bucket"

--- a/packages/catalog-process/.env
+++ b/packages/catalog-process/.env
@@ -16,7 +16,7 @@ READMODEL_DB_USERNAME=root
 READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 WELL_KNOWN_URLS="http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/internal,dev.interop.pagopa.it/m2m,refactor.dev.interop.pagopa.it/m2m"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,dev.interop.pagopa.it/ui,dev.interop.pagopa.it/internal,dev.interop.pagopa.it/m2m,dev.interop.pagopa.it/m2m"
 
 AWS_CONFIG_FILE=aws.config.local
 S3_BUCKET=interop-local-bucket

--- a/packages/client-purpose-updater/.env
+++ b/packages/client-purpose-updater/.env
@@ -8,9 +8,9 @@ PURPOSE_TOPIC="event-store.purpose.events"
 AWS_REGION="eu-south-1"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-client-purpose-updater"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-client-purpose-updater"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 AUTHORIZATION_PROCESS_URL="http://localhost:3300"

--- a/packages/commons-test/test/jwt.unit.test.ts
+++ b/packages/commons-test/test/jwt.unit.test.ts
@@ -40,11 +40,11 @@ const mockUiToken = {
 
 const mockM2MToken = {
   organizationId: "89804b2c-f62e-4867-87a4-3a82f2b03485",
-  aud: "refactor.dev.interop.pagopa.it/m2m",
+  aud: "dev.interop.pagopa.it/m2m",
   sub: "227cadc9-1a2c-4612-b100-a247b48d0464",
   role: "m2m",
   nbf: 1710511524,
-  iss: "refactor.dev.interop.pagopa.it",
+  iss: "dev.interop.pagopa.it",
   exp: 1810511523,
   iat: 1710511524,
   client_id: "227cadc9-1a2c-4612-b100-a247b48d0464",
@@ -52,29 +52,29 @@ const mockM2MToken = {
 };
 
 const mockInternalToken = {
-  aud: "refactor.dev.interop.pagopa.it/m2m",
+  aud: "dev.interop.pagopa.it/m2m",
   sub: "227cadc9-1a2c-4612-b100-a247b48d0464",
   role: "internal",
   nbf: 1710511524,
-  iss: "refactor.dev.interop.pagopa.it",
+  iss: "dev.interop.pagopa.it",
   exp: 1810511523,
   iat: 1710511524,
   jti: "d0c42cfb-8a32-430f-95cf-085067b52695",
 };
 
 const mockMaintenanceToken = {
-  aud: "refactor.dev.interop.pagopa.it/fake",
+  aud: "dev.interop.pagopa.it/fake",
   sub: "227cadc9-1a2c-4612-b100-a247b48d0464",
   role: "maintenance",
   nbf: 1710511524,
-  iss: "refactor.dev.interop.pagopa.it",
+  iss: "dev.interop.pagopa.it",
   exp: 1810511523,
   iat: 1710511524,
   jti: "d0c42cfb-8a32-430f-95cf-085067b52695",
 };
 
 const mockSupportToken = {
-  iss: "refactor.dev.interop.pagopa.it",
+  iss: "dev.interop.pagopa.it",
   externalId: {
     origin: "IPA",
     value: "5N2TR557",

--- a/packages/compute-agreements-consumer/.env
+++ b/packages/compute-agreements-consumer/.env
@@ -10,9 +10,9 @@ AWS_REGION="eu-south-1"
 AGREEMENT_PROCESS_URL="http://0.0.0.0:3000"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-compute-agreements-consumer"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-compute-agreements-consumer"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 AWS_CONFIG_FILE=aws.config.local

--- a/packages/delegation-items-archiver/.env
+++ b/packages/delegation-items-archiver/.env
@@ -8,9 +8,9 @@ DELEGATION_TOPIC="event-store.delegation.events"
 AWS_REGION="eu-south-1"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-delegation-items-archiver"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-delegation-items-archiver"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 READMODEL_DB_HOST="localhost"

--- a/packages/delegation-process/.env
+++ b/packages/delegation-process/.env
@@ -18,7 +18,7 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/internal,dev.interop.pagopa.it/m2m,refactor.dev.interop.pagopa.it/m2m"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,dev.interop.pagopa.it/ui,dev.interop.pagopa.it/internal,dev.interop.pagopa.it/m2m,dev.interop.pagopa.it/m2m"
 
 S3_BUCKET=interop-local-bucket
 S3_CUSTOM_SERVER=true

--- a/packages/eservice-descriptors-archiver/.env
+++ b/packages/eservice-descriptors-archiver/.env
@@ -16,9 +16,9 @@ READMODEL_DB_PORT=27017
 CATALOG_PROCESS_URL="http://0.0.0.0:3000"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-eservice-descriptors-archiver"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-eservice-descriptors-archiver"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 AWS_CONFIG_FILE=aws.config.local

--- a/packages/eservice-template-instances-updater/.env
+++ b/packages/eservice-template-instances-updater/.env
@@ -8,9 +8,9 @@ ESERVICE_TEMPLATE_TOPIC="event-store.eservice-template.events"
 AWS_REGION="eu-south-1"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-eservice-template-instances-updater"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-eservice-template-instances-updater"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 CATALOG_PROCESS_URL="http://localhost:3000"

--- a/packages/eservice-template-process/.env
+++ b/packages/eservice-template-process/.env
@@ -16,7 +16,7 @@ READMODEL_DB_USERNAME=root
 READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 WELL_KNOWN_URLS="http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/internal,dev.interop.pagopa.it/m2m,refactor.dev.interop.pagopa.it/m2m"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,dev.interop.pagopa.it/ui,dev.interop.pagopa.it/internal,dev.interop.pagopa.it/m2m,dev.interop.pagopa.it/m2m"
 
 AWS_CONFIG_FILE=aws.config.local
 S3_BUCKET=interop-local-bucket

--- a/packages/ipa-certified-attributes-importer/.env
+++ b/packages/ipa-certified-attributes-importer/.env
@@ -17,9 +17,9 @@ ATTRIBUTE_REGISTRY_PROCESS_URL="http://localhost:3200"
 TENANT_PROCESS_URL="http://localhost:3500"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-authorization-updater"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-authorization-updater"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 AWS_CONFIG_FILE=aws.config.local

--- a/packages/ivass-certified-attributes-importer/.env
+++ b/packages/ivass-certified-attributes-importer/.env
@@ -7,9 +7,9 @@ READMODEL_DB_PASSWORD="example"
 READMODEL_DB_PORT=27017
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-eservice-descriptors-archiver"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-eservice-descriptors-archiver"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 TENANT_PROCESS_URL="http://localhost:3500"

--- a/packages/purpose-process/.env
+++ b/packages/purpose-process/.env
@@ -25,4 +25,4 @@ S3_SERVER_PORT=9000
 RISK_ANALYSIS_DOCUMENTS_PATH="risk-analysis/docs"
 
 WELL_KNOWN_URLS="http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui,dev.interop.pagopa.it/m2m,refactor.dev.interop.pagopa.it/m2m"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,dev.interop.pagopa.it/ui,dev.interop.pagopa.it/m2m,dev.interop.pagopa.it/m2m"

--- a/packages/selfcare-onboarding-consumer/.env
+++ b/packages/selfcare-onboarding-consumer/.env
@@ -17,9 +17,9 @@ ALLOWED_ORIGINS="IPA"
 TENANT_PROCESS_URL="http://localhost:3500"
 
 INTERNAL_JWT_KID=ffcc9b5b-4612-49b1-9374-9d203a3834f2
-INTERNAL_JWT_SUBJECT="dev-refactor.interop-selfcare-onboarding-consumer"
-INTERNAL_JWT_ISSUER="dev-refactor.interop.pagopa.it"
-INTERNAL_JWT_AUDIENCE="refactor.dev.interop.pagopa.it/internal"
+INTERNAL_JWT_SUBJECT="dev.interop-selfcare-onboarding-consumer"
+INTERNAL_JWT_ISSUER="dev.interop.pagopa.it"
+INTERNAL_JWT_AUDIENCE="dev.interop.pagopa.it/internal"
 INTERNAL_JWT_SECONDS_DURATION=60
 
 AWS_CONFIG_FILE=aws.config.local

--- a/packages/tenant-process/.env
+++ b/packages/tenant-process/.env
@@ -17,4 +17,4 @@ READMODEL_DB_PASSWORD=example
 READMODEL_DB_PORT=27017
 
 WELL_KNOWN_URLS="http://127.0.0.1:4500/jwks.json"
-ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/ui,refactor.dev.interop.pagopa.it/internal,dev.interop.pagopa.it/m2m,refactor.dev.interop.pagopa.it/m2m"
+ACCEPTED_AUDIENCES="dev.interop.pagopa.it/ui,dev.interop.pagopa.it/ui,dev.interop.pagopa.it/internal,dev.interop.pagopa.it/m2m,dev.interop.pagopa.it/m2m"


### PR DESCRIPTION
#1660 removed the discontinued dev key. Still, it also removed from the well-known local [key used by the local KMS instance](https://vscode.dev/github/pagopa/interop-be-monorepo/blob/develop/docker/local-kms-seed/seed.yaml#L6) to generate internal tokens for local development.
This PR:
- re-adds that key
- fixes kids, audiences, subjects, and issuers all around the codebase local env vars

## Tests
Tested locally, I can successfully generate a local internal token and use it to call one of the services 👇 

<img width="680" alt="image" src="https://github.com/user-attachments/assets/277dee6e-d4d7-4a85-bacc-96c1f896e748" />

<img width="678" alt="image" src="https://github.com/user-attachments/assets/ebc02f0b-1985-46ab-9aea-7d01d0dd61f1" />
