### PR TITLE
Removed double call from bff to tenant-process getTenant service

### DIFF
--- a/packages/backend-for-frontend/src/services/authorizationService.ts
+++ b/packages/backend-for-frontend/src/services/authorizationService.ts
@@ -174,12 +174,7 @@ export function authorizationServiceBuilder(
         });
       const tenantId = unsafeBrandId<TenantId>(tenantBySelfcareId.id);
 
-      const tenant = await tenantProcessClient.tenant.getTenant({
-        params: { id: tenantId },
-        headers: internalHeaders,
-      });
-
-      assertTenantAllowed(selfcareId, tenant.externalId.origin);
+      assertTenantAllowed(selfcareId, tenantBySelfcareId.externalId.origin);
 
       const { limitReached, ...rateLimiterStatus } =
         await rateLimiter.rateLimitByOrganization(tenantId, logger);
@@ -197,8 +192,8 @@ export function authorizationServiceBuilder(
         roles,
         tenantId,
         selfcareId,
-        tenant.externalId.origin,
-        tenant.externalId.value
+        tenantBySelfcareId.externalId.origin,
+        tenantBySelfcareId.externalId.value
       );
 
       const { serialized: sessionToken } =


### PR DESCRIPTION
**Jira Link**: https://pagopa.atlassian.net/browse/PIN-6468

I removed the duplicate call to tenant-process because I verified that the data returned by both was the same, and the tenant properties used by other functions within the BFF service did not have different values between the two services.