### PR TITLE
Bumped outbound models and updated catalog outbound writer

### DIFF
--- a/packages/agreement-outbound-writer/package.json
+++ b/packages/agreement-outbound-writer/package.json
@@ -29,7 +29,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.4.2",
+    "@pagopa/interop-outbound-models": "1.5.4",
     "@protobuf-ts/runtime": "2.9.4",
     "connection-string": "4.4.0",
     "dotenv-flow": "4.1.0",

--- a/packages/catalog-outbound-writer/package.json
+++ b/packages/catalog-outbound-writer/package.json
@@ -29,7 +29,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.4.2",
+    "@pagopa/interop-outbound-models": "1.5.4",
     "@protobuf-ts/runtime": "2.9.4",
     "connection-string": "4.4.0",
     "dotenv-flow": "4.1.0",

--- a/packages/catalog-outbound-writer/src/converters/toOutboundEventV2.ts
+++ b/packages/catalog-outbound-writer/src/converters/toOutboundEventV2.ts
@@ -3,17 +3,23 @@ import {
   EServiceV2,
   EServiceDescriptorV2,
   EServiceDocumentV2,
+  EServiceTemplateRefV2,
+  EServiceTemplateVersionRefV2,
+  TemplateInstanceInterfaceMetadataV2,
 } from "pagopa-interop-models";
 import {
   EServiceEvent as OutboundEServiceEvent,
   EServiceV2 as OutboundEServiceV2,
   EServiceDescriptorV2 as OutboundEServiceDescriptorV2,
   EServiceDocumentV2 as OutboundEServiceDocumentV2,
+  EServiceTemplateRefV2 as OutboundEServiceTemplateRefV2,
+  EServiceTemplateVersionRefV2 as OutboundEServiceTemplateVersionRefV2,
+  TemplateInstanceInterfaceMetadataV2 as OutboundTemplateInstanceInterfaceMetadataV2,
 } from "@pagopa/interop-outbound-models";
 import { match } from "ts-pattern";
 import { Exact } from "pagopa-interop-commons";
 
-function toOuboundEServiceDocumentV2(
+function toOutboundEServiceDocumentV2(
   document: EServiceDocumentV2
 ): Exact<OutboundEServiceDocumentV2, EServiceDocumentV2> {
   return {
@@ -22,15 +28,54 @@ function toOuboundEServiceDocumentV2(
   };
 }
 
+function toOutboundEServiceTemplateRefV2(
+  templateRef: EServiceTemplateRefV2
+): Exact<OutboundEServiceTemplateRefV2, EServiceTemplateRefV2> {
+  return {
+    id: templateRef.id,
+    instanceLabel: templateRef.instanceLabel,
+  };
+}
+
+function toOutboundTemplateInstanceInterfaceMetadataV2(
+  interfaceMetadata: TemplateInstanceInterfaceMetadataV2
+): Exact<
+  OutboundTemplateInstanceInterfaceMetadataV2,
+  TemplateInstanceInterfaceMetadataV2
+> {
+  return {
+    contactEmail: interfaceMetadata.contactEmail,
+    contactName: interfaceMetadata.contactName,
+    contactUrl: interfaceMetadata.contactUrl,
+    termsAndConditionsUrl: interfaceMetadata.termsAndConditionsUrl,
+  };
+}
+
+function toOutboundEServiceTemplateVersionRefV2(
+  templateVersionRef: EServiceTemplateVersionRefV2
+): Exact<OutboundEServiceTemplateVersionRefV2, EServiceTemplateVersionRefV2> {
+  return {
+    id: templateVersionRef.id,
+    interfaceMetadata:
+      templateVersionRef.interfaceMetadata &&
+      toOutboundTemplateInstanceInterfaceMetadataV2(
+        templateVersionRef.interfaceMetadata
+      ),
+  };
+}
+
 function toOutboundDescriptorV2(
   descriptor: EServiceDescriptorV2
 ): Exact<OutboundEServiceDescriptorV2, EServiceDescriptorV2> {
   return {
     ...descriptor,
-    templateVersionRef: undefined, // todo outbound library must be updated
     interface:
-      descriptor.interface && toOuboundEServiceDocumentV2(descriptor.interface),
-    docs: descriptor.docs.map(toOuboundEServiceDocumentV2),
+      descriptor.interface &&
+      toOutboundEServiceDocumentV2(descriptor.interface),
+    docs: descriptor.docs.map(toOutboundEServiceDocumentV2),
+    templateVersionRef:
+      descriptor.templateVersionRef &&
+      toOutboundEServiceTemplateVersionRefV2(descriptor.templateVersionRef),
   };
 }
 
@@ -41,7 +86,9 @@ function toOutboundEServiceV2(
     ...eservice,
     riskAnalysis: undefined,
     descriptors: eservice.descriptors.map(toOutboundDescriptorV2),
-    templateRef: undefined,
+    templateRef:
+      eservice.templateRef &&
+      toOutboundEServiceTemplateRefV2(eservice.templateRef),
   };
 }
 
@@ -59,6 +106,8 @@ export function toOutboundEventV2(
       { type: "EServiceIsClientAccessDelegableEnabled" },
       { type: "EServiceIsClientAccessDelegableDisabled" },
       { type: "EServiceNameUpdated" },
+      { type: "EServiceDescriptionUpdatedByTemplateUpdate" },
+      { type: "EServiceNameUpdatedByTemplateUpdate" },
       (msg) => ({
         event_version: msg.event_version,
         type: msg.type,
@@ -111,6 +160,7 @@ export function toOutboundEventV2(
       { type: "EServiceDescriptorSubmittedByDelegate" },
       { type: "EServiceDescriptorApprovedByDelegator" },
       { type: "EServiceDescriptorRejectedByDelegator" },
+      { type: "EServiceDescriptorQuotasUpdatedByTemplateUpdate" },
       (msg) => ({
         event_version: msg.event_version,
         type: msg.type,
@@ -132,6 +182,9 @@ export function toOutboundEventV2(
       { type: "EServiceDescriptorDocumentUpdated" },
       { type: "EServiceDescriptorInterfaceDeleted" },
       { type: "EServiceDescriptorDocumentDeleted" },
+      { type: "EServiceDescriptorDocumentAddedByTemplateUpdate" },
+      { type: "EServiceDescriptorDocumentUpdatedByTemplateUpdate" },
+      { type: "EServiceDescriptorDocumentDeletedByTemplateUpdate" },
       (msg) => ({
         event_version: msg.event_version,
         type: msg.type,
@@ -147,31 +200,28 @@ export function toOutboundEventV2(
         timestamp: new Date(),
       })
     )
-    .with({ type: "EServiceDescriptorAttributesUpdated" }, (msg) => ({
-      event_version: msg.event_version,
-      type: msg.type,
-      version: msg.version,
-      data: {
-        descriptorId: msg.data.descriptorId,
-        attributeIds: msg.data.attributeIds,
-        eservice: msg.data.eservice && toOutboundEServiceV2(msg.data.eservice),
-      },
-      stream_id: msg.stream_id,
-      streamVersion: msg.version,
-      timestamp: new Date(),
-    }))
+    .with(
+      { type: "EServiceDescriptorAttributesUpdated" },
+      { type: "EServiceDescriptorAttributesUpdatedByTemplateUpdate" },
+      (msg) => ({
+        event_version: msg.event_version,
+        type: msg.type,
+        version: msg.version,
+        data: {
+          descriptorId: msg.data.descriptorId,
+          attributeIds: msg.data.attributeIds,
+          eservice:
+            msg.data.eservice && toOutboundEServiceV2(msg.data.eservice),
+        },
+        stream_id: msg.stream_id,
+        streamVersion: msg.version,
+        timestamp: new Date(),
+      })
+    )
     .with(
       { type: "EServiceRiskAnalysisAdded" },
       { type: "EServiceRiskAnalysisDeleted" },
       { type: "EServiceRiskAnalysisUpdated" },
-      { type: "EServiceNameUpdatedByTemplateUpdate" },
-      { type: "EServiceDescriptionUpdatedByTemplateUpdate" },
-      { type: "EServiceDescriptorQuotasUpdatedByTemplateUpdate" },
-      { type: "EServiceDescriptorAttributesUpdatedByTemplateUpdate" },
-      { type: "EServiceDescriptorDocumentAddedByTemplateUpdate" },
-      { type: "EServiceDescriptorDocumentUpdatedByTemplateUpdate" },
-      { type: "EServiceDescriptorDocumentDeletedByTemplateUpdate" },
-
       () => undefined
     )
     .exhaustive();

--- a/packages/delegation-outbound-writer/package.json
+++ b/packages/delegation-outbound-writer/package.json
@@ -27,7 +27,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.4.2",
+    "@pagopa/interop-outbound-models": "1.5.4",
     "@protobuf-ts/runtime": "2.9.4",
     "connection-string": "4.4.0",
     "dotenv-flow": "4.1.0",

--- a/packages/eservice-template-outbound-writer/package.json
+++ b/packages/eservice-template-outbound-writer/package.json
@@ -27,7 +27,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.5.1",
+    "@pagopa/interop-outbound-models": "1.5.4",
     "@protobuf-ts/runtime": "2.9.4",
     "connection-string": "4.4.0",
     "dotenv-flow": "4.1.0",

--- a/packages/purpose-outbound-writer/package.json
+++ b/packages/purpose-outbound-writer/package.json
@@ -29,7 +29,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.4.2",
+    "@pagopa/interop-outbound-models": "1.5.4",
     "@protobuf-ts/runtime": "2.9.4",
     "connection-string": "4.4.0",
     "dotenv-flow": "4.1.0",

--- a/packages/tenant-outbound-writer/package.json
+++ b/packages/tenant-outbound-writer/package.json
@@ -29,7 +29,7 @@
     "vitest": "1.6.0"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.4.2",
+    "@pagopa/interop-outbound-models": "1.5.4",
     "@protobuf-ts/runtime": "2.9.4",
     "connection-string": "4.4.0",
     "dotenv-flow": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
   packages/agreement-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.4.2
-        version: 1.4.2
+        specifier: 1.5.4
+        version: 1.5.4
       '@protobuf-ts/runtime':
         specifier: 2.9.4
         version: 2.9.4
@@ -1072,8 +1072,8 @@ importers:
   packages/catalog-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.4.2
-        version: 1.4.2
+        specifier: 1.5.4
+        version: 1.5.4
       '@protobuf-ts/runtime':
         specifier: 2.9.4
         version: 2.9.4
@@ -1952,8 +1952,8 @@ importers:
   packages/delegation-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.4.2
-        version: 1.4.2
+        specifier: 1.5.4
+        version: 1.5.4
       '@protobuf-ts/runtime':
         specifier: 2.9.4
         version: 2.9.4
@@ -2312,8 +2312,8 @@ importers:
   packages/eservice-template-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.5.1
-        version: 1.5.1
+        specifier: 1.5.4
+        version: 1.5.4
       '@protobuf-ts/runtime':
         specifier: 2.9.4
         version: 2.9.4
@@ -3177,8 +3177,8 @@ importers:
   packages/purpose-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.4.2
-        version: 1.4.2
+        specifier: 1.5.4
+        version: 1.5.4
       '@protobuf-ts/runtime':
         specifier: 2.9.4
         version: 2.9.4
@@ -3586,8 +3586,8 @@ importers:
   packages/tenant-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.4.2
-        version: 1.4.2
+        specifier: 1.5.4
+        version: 1.5.4
       '@protobuf-ts/runtime':
         specifier: 2.9.4
         version: 2.9.4
@@ -5095,11 +5095,8 @@ packages:
   '@pagopa/eslint-config@3.0.0':
     resolution: {integrity: sha512-eYIPdiuYRbRPR5k0OuteRNqYb0Z2nfJ/lZohejB7ylfBeSDWwkaV8Z19AXP4RymE6oEesyPDZ6i0yNaE9tQrHw==}
 
-  '@pagopa/interop-outbound-models@1.4.2':
-    resolution: {integrity: sha512-dIPj4U798iwoL9KU8li+gfV852K/vsH3FyHrRlv/lOpWmxHJk5SCvqDYYcp88CQCm7Akm7WGXE2sKi5dFKrhpQ==}
-
-  '@pagopa/interop-outbound-models@1.5.1':
-    resolution: {integrity: sha512-qLrFrSAip8hGlU5RSMzJfY18wGPkUMUdalMiOuwx/4Ul1kgwCOhDGIiSe03ilxN8saUcGco8UOfvCjUktOS9Eg==}
+  '@pagopa/interop-outbound-models@1.5.4':
+    resolution: {integrity: sha512-d1OyacycQWA6B9hTumig5AH8eJbo9NRu5B3fdjt7RRl+dFGa28FVdaR97nEDDvSJX5SX5LoTALhbp8dcwtZqaw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -10835,13 +10832,7 @@ snapshots:
       - tsutils
       - typescript
 
-  '@pagopa/interop-outbound-models@1.4.2':
-    dependencies:
-      '@protobuf-ts/runtime': 2.9.4
-      ts-pattern: 5.2.0
-      zod: 3.23.8
-
-  '@pagopa/interop-outbound-models@1.5.1':
+  '@pagopa/interop-outbound-models@1.5.4':
     dependencies:
       '@protobuf-ts/runtime': 2.9.4
       ts-pattern: 5.2.0


### PR DESCRIPTION
This PR bump the outbound models version to `1.5.4` and adds support for template related events to `catalog-outbound-writer`