### PR TITLE
Fix dtd export request error

### DIFF
--- a/packages/dtd-catalog-exporter/src/services/dtdCatalogExporterService.ts
+++ b/packages/dtd-catalog-exporter/src/services/dtdCatalogExporterService.ts
@@ -155,7 +155,6 @@ export function dtdCatalogExporterServiceBuilder({
         `data/${config.dtdCatalogCsvFilename}`
       );
 
-      // Tenants
       loggerInstance.info("\nUploading Tenants JSON result to GitHub repo...");
       const tenantsJsonContent = JSON.stringify(tenants);
       await githubClient.createOrUpdateRepoFile(

--- a/packages/dtd-catalog-exporter/src/services/dtdCatalogExporterService.ts
+++ b/packages/dtd-catalog-exporter/src/services/dtdCatalogExporterService.ts
@@ -155,6 +155,7 @@ export function dtdCatalogExporterServiceBuilder({
         `data/${config.dtdCatalogCsvFilename}`
       );
 
+      // Tenants
       loggerInstance.info("\nUploading Tenants JSON result to GitHub repo...");
       const tenantsJsonContent = JSON.stringify(tenants);
       await githubClient.createOrUpdateRepoFile(

--- a/packages/dtd-catalog-exporter/src/services/github-client.services.ts
+++ b/packages/dtd-catalog-exporter/src/services/github-client.services.ts
@@ -1,4 +1,4 @@
-import { Octokit, RequestError } from "octokit";
+import { Octokit } from "octokit";
 
 export class GithubClient {
   private octokit: Octokit;
@@ -41,13 +41,22 @@ export class GithubClient {
           filePath,
         }
       );
+
       return response.data.sha;
     } catch (error) {
-      if (error instanceof RequestError && error.status === 404) {
+      if (this.isNotFoundError(error)) {
         return undefined;
       } else {
         throw error;
       }
     }
+  }
+
+  private isNotFoundError(error: unknown): boolean {
+    if (!error || typeof error !== "object") {
+      return false;
+    }
+
+    return "status" in error && (error as { status: number }).status === 404;
   }
 }

--- a/packages/dtd-catalog-exporter/src/services/github-client.services.ts
+++ b/packages/dtd-catalog-exporter/src/services/github-client.services.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Octokit } from "octokit";
 
 export class GithubClient {
@@ -43,56 +44,16 @@ export class GithubClient {
       );
 
       return response.data.sha;
-    } catch (error) {
-      if (this.isNotFoundError(error)) {
+    } catch (error: any) {
+      if (
+        error.status === 404 ||
+        error.response?.status === 404 ||
+        error.data?.status === 404
+      ) {
         return undefined;
       } else {
         throw error;
       }
     }
-  }
-
-  private isNotFoundError(error: unknown): boolean {
-    if (!error || typeof error !== "object") {
-      return false;
-    }
-
-    // Check for status directly on error
-    if (
-      "status" in error &&
-      typeof (error as { status: unknown }).status === "number"
-    ) {
-      return (error as { status: number }).status === 404;
-    }
-
-    // Check for status in error.response
-    if ("response" in error) {
-      const errorWithResponse = error as { response: unknown };
-      if (
-        errorWithResponse.response &&
-        typeof errorWithResponse.response === "object" &&
-        "status" in errorWithResponse.response &&
-        typeof (errorWithResponse.response as { status: unknown }).status ===
-          "number"
-      ) {
-        return (
-          (errorWithResponse.response as { status: number }).status === 404
-        );
-      }
-    }
-
-    // Check for status in error.response.data
-    if ("response" in error) {
-      const response = (error as { response: unknown }).response;
-      if (response && typeof response === "object" && "data" in response) {
-        const data = (response as { data: unknown }).data;
-        if (data && typeof data === "object" && "status" in data) {
-          const status = (data as { status: unknown }).status;
-          return status === "404" || status === 404;
-        }
-      }
-    }
-
-    return false;
   }
 }


### PR DESCRIPTION
This PR should fix the error thrown by Octokit not being recognized as a `RequestError` and, as such, not returning undefined for non existing files.
The error object has a different structure, so this should now be caught correctly.

Here's an example of the error:
```
{
    "response": {
      "url": "https://api.github.com/repos/italia/pdnd-opendata/contents/data%2Fcatalogo_eservice.json",
      "status": 404,
      "headers": {
        "access-control-allow-origin": "*",
        "access-control-expose-headers": "ETag,Link,Location,Retry-After,X-GitHub-OTP,X-RateLimit-Limit,X-RateLimit-Remaining,X-RateLimit-Used,X-RateLimit-Resource,X-RateLimit-Reset,X-OAuth-Scopes,X-Accepted-OAuth-Scopes,X-Poll-Interval,X-GitHub-Media-Typ",
        "content-encoding": "gzip",
        "content-security-policy": "default-src'none'",
        "content-type": "application/json;charset=utf-8",
        "date": "Thu,27Mar202514:21:26GMT",
        "referrer-policy": "origin-when-cross-origin,strict-origin-when-cross-origin",
        "server": "github.com",
        "strict-transport-security": "max-age=31536000;includeSubdomains;preload",
        "transfer-encoding": "chunked",
        "vary": "Accept-Encoding,Accept,X-Requested-With",
        "x-accepted-oauth-scopes": "",
        "x-content-type-options": "nosniff",
        "x-frame-options": "deny",
        "x-github-api-version-selected": "2022-11-28",
        "x-github-media-type": "github.v3;format=json",
        "x-github-request-id": "123B:45F45:2440468:25427D2:67E55EE5",
        "x-oauth-scopes": "repo",
        "x-ratelimit-limit": "5000",
        "x-ratelimit-remaining": "4998",
        "x-ratelimit-reset": "1743088884",
        "x-ratelimit-resource": "core",
        "x-ratelimit-used": "2",
        "x-xss-protection": "0"
      },
      "data": {
        "message": "NotFound",
        "documentation_url": "https://docs.github.com/rest/repos/contents#create-or-update-file-contents",
        "status": "404"
      }
    }
  }
```

