### PR TITLE
fix: Disable Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,6 @@
 {
   "extends": [
     "github>pagopa/eng-renovate",
-    ":automergeRequireAllStatusChecks",
-    ":automergeStableNonMajor",
-    ":automergeLinters",
-    ":automergeTesters",
-    ":automergeTypes",
-    ":automergeDigest",
     ":combinePatchMinorReleases",
     ":ignoreUnstable",
     ":rebaseStalePrs",


### PR DESCRIPTION
Renovate is having problems opening PRs due to automerge.
Temporarily disabling the feature