### PR TITLE
BFF handle forbidden error when get session token fail to read Tenant by selfcare Id

### DIFF
--- a/packages/backend-for-frontend/src/model/errors.ts
+++ b/packages/backend-for-frontend/src/model/errors.ts
@@ -61,6 +61,7 @@ export const errorCodes = {
   missingUserRolesInIdentityToken: "0054",
   noVersionInEServiceTemplate: "0055",
   templateInstanceNotAllowed: "0056",
+  tenantSelfcareNotFound: "0057",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -163,6 +164,16 @@ export function tenantNotFound(tenantId: string): ApiError<ErrorCodes> {
     detail: `Tenant ${tenantId} not found`,
     code: "tenantNotFound",
     title: "Tenant not found",
+  });
+}
+
+export function tenantSelfcareNotFound(
+  selfcareId: string
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Tenant with Selfcare ID ${selfcareId} forbidden`,
+    code: "tenantSelfcareNotFound",
+    title: "Tenant forbidden",
   });
 }
 

--- a/packages/backend-for-frontend/src/services/authorizationService.ts
+++ b/packages/backend-for-frontend/src/services/authorizationService.ts
@@ -1,3 +1,4 @@
+import { constants } from "http2";
 import { bffApi, tenantApi } from "pagopa-interop-api-clients";
 import {
   CustomClaims,
@@ -19,17 +20,20 @@ import {
   verifyJwtToken,
 } from "pagopa-interop-commons";
 import { TenantId, invalidClaim, unsafeBrandId } from "pagopa-interop-models";
+import { isAxiosError } from "axios";
 import { PagoPAInteropBeClients } from "../clients/clientsProvider.js";
 import { config } from "../config/config.js";
 import {
   missingSelfcareId,
   missingUserRolesInIdentityToken,
   tenantLoginNotAllowed,
+  tenantSelfcareNotFound,
 } from "../model/errors.js";
 import { BffAppContext } from "../utilities/context.js";
 import { validateSamlResponse } from "../utilities/samlValidator.js";
 
 const SUPPORT_USER_ID = "5119b1fa-825a-4297-8c9c-152e055cabca";
+const { HTTP_STATUS_NOT_FOUND } = constants;
 
 type GetSessionTokenReturnType =
   | {
@@ -167,10 +171,16 @@ export function authorizationServiceBuilder(
         Authorization: `Bearer ${serialized}`,
       };
 
-      const tenantBySelfcareId =
-        await tenantProcessClient.selfcare.getTenantBySelfcareId({
+      const tenantBySelfcareId = await tenantProcessClient.selfcare
+        .getTenantBySelfcareId({
           params: { selfcareId },
           headers: internalHeaders,
+        })
+        .catch((err) => {
+          throw isAxiosError(err) &&
+            err.response?.status === HTTP_STATUS_NOT_FOUND
+            ? tenantSelfcareNotFound(selfcareId)
+            : err;
         });
       const tenantId = unsafeBrandId<TenantId>(tenantBySelfcareId.id);
 

--- a/packages/backend-for-frontend/src/utilities/errorMappers.ts
+++ b/packages/backend-for-frontend/src/utilities/errorMappers.ts
@@ -78,7 +78,11 @@ export const getSelfcareUserErrorMapper = (
 export const sessionTokenErrorMapper = (error: ApiError<ErrorCodes>): number =>
   match(error.code)
     .with("tokenVerificationFailed", () => HTTP_STATUS_UNAUTHORIZED)
-    .with("tenantLoginNotAllowed", () => HTTP_STATUS_FORBIDDEN)
+    .with(
+      "tenantSelfcareNotFound",
+      "tenantLoginNotAllowed",
+      () => HTTP_STATUS_FORBIDDEN
+    )
     .with("tooManyRequestsError", () => HTTP_STATUS_TOO_MANY_REQUESTS)
     .with("missingUserRolesInIdentityToken", () => HTTP_STATUS_BAD_REQUEST)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
Partially close [PIN-5461](https://pagopa.atlassian.net/browse/PIN-5461)

# Description
This PR return error HTTP `404 - NOT FOUND` into `403 - FORBIDDEN` for security reason.

PIN-5461 - this issue wants fix internal server error HTTP 500 when doesn't exists tenant with provided selfcare ID, this behaviour could be 
 


# TEST 
✅  API return 403 if retrieve tenant by selfcare ID fails
<img width="1369" alt="Screenshot 2025-04-02 at 11 07 26" src="https://github.com/user-attachments/assets/4e8980fa-c589-40e2-86c9-64b67231fc36" />
