### PR TITLE
Add persistent volume for MongoDB in Docker Compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -74,6 +74,8 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: example
+    volumes:
+      - mongo-data:/data/db
 
   # Dynamo DB readmodel for token generation and privacy notices
   dynamodb-local:
@@ -247,3 +249,6 @@ services:
     image: "redis:7.2.5-alpine3.20"
     ports:
       - "6379:6379"
+
+volumes:
+  mongo-data:


### PR DESCRIPTION
**Jira Link**: https://pagopa.atlassian.net/browse/PIN-6536

Previously, our Docker Compose configuration was using "unknown" volumes for MongoDB, which is not a secure or reliable approach for persisting data. Using anonymous or unnamed volumes creates a risk of data loss, especially in case of Docker container restarts, crashes, or other issues that might occur with persistence.

In this PR, we have introduced a named volume (_mongo-data_) for MongoDB. This ensures that the data stored by MongoDB is safely persisted, even if the container is recreated or restarted. By defining a specific volume, we mitigate the risk of accidental data loss and improve the reliability of our local development environment.

This change ensures better persistence for MongoDB data, providing a more robust and stable setup for our local development and testing environments.