### PR TITLE
Added bff importEService test

### DIFF
--- a/packages/backend-for-frontend/.env.test
+++ b/packages/backend-for-frontend/.env.test
@@ -1,0 +1,1 @@
+IMPORT_ESERVICE_CONTAINER="interop-local-bucket"

--- a/packages/backend-for-frontend/test/addAgreementConsumerDocument.test.ts
+++ b/packages/backend-for-frontend/test/addAgreementConsumerDocument.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { bffApi } from "pagopa-interop-api-clients";
+import { getMockAuthData, getMockContext } from "pagopa-interop-commons-test";
+import { AuthData, FileManager, userRoles } from "pagopa-interop-commons";
+import { generateId } from "pagopa-interop-models";
+import { agreementServiceBuilder } from "../src/services/agreementService.js";
+import { PagoPAInteropBeClients } from "../src/clients/clientsProvider.js";
+import { config } from "../src/config/config.js";
+import { getBffMockContext } from "./utils.js";
+
+describe("addAgreementConsumerDocument", () => {
+  const agreementId = "test-agreement-id";
+  const mockStoragePath = `${config.consumerDocumentsPath}/${agreementId}/mocked-uuid-1234-12-34`;
+
+  const mockFile = new File(["test content"], "test.json", {
+    type: "application/json",
+  });
+
+  const authData: AuthData = {
+    ...getMockAuthData(),
+    organizationId: generateId(),
+    userRoles: [userRoles.ADMIN_ROLE],
+  };
+
+  it("should add agreement consumer document and store it", async () => {
+    const arrayBufferMock = vi.fn().mockResolvedValue(new ArrayBuffer(10));
+    const mockFileWithArrayBuffer = {
+      ...mockFile,
+      arrayBuffer: arrayBufferMock,
+      name: "test.json",
+      type: "application/json",
+    };
+
+    const enhancedMockDoc = {
+      doc: mockFileWithArrayBuffer,
+      name: "test.json",
+      prettyName: "test.json",
+    } as unknown as bffApi.addAgreementConsumerDocument_Body;
+
+    const mockAddAgreementConsumerDocument = vi.fn().mockResolvedValue({});
+    const mockStoreBytes = vi.fn().mockResolvedValue(mockStoragePath);
+
+    const mockFileManager = {
+      storeBytes: mockStoreBytes,
+    } as unknown as FileManager;
+
+    const mockClients = {
+      agreementProcessClient: {
+        addAgreementConsumerDocument: mockAddAgreementConsumerDocument,
+      },
+    } as unknown as PagoPAInteropBeClients;
+
+    const agreementService = agreementServiceBuilder(
+      mockClients,
+      mockFileManager
+    );
+
+    const bffMockContext = getBffMockContext(getMockContext({ authData }));
+    const result = await agreementService.addAgreementConsumerDocument(
+      agreementId,
+      enhancedMockDoc,
+      bffMockContext
+    );
+
+    expect(arrayBufferMock).toHaveBeenCalled();
+
+    expect(mockStoreBytes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bucket: config.consumerDocumentsContainer,
+        path: `${config.consumerDocumentsPath}/${agreementId}`,
+        resourceId: expect.any(String),
+        name: "test.json",
+        content: expect.any(Buffer),
+      }),
+      bffMockContext.logger
+    );
+
+    expect(result).toBeInstanceOf(Buffer);
+  });
+});

--- a/packages/backend-for-frontend/test/importEService.test.ts
+++ b/packages/backend-for-frontend/test/importEService.test.ts
@@ -1,0 +1,368 @@
+import path from "path";
+import fs from "fs";
+import { describe, expect, it, vi } from "vitest";
+import { AuthData } from "pagopa-interop-commons/";
+import {
+  getMockAuthData,
+  getMockContext,
+  getMockDocument,
+} from "pagopa-interop-commons-test";
+import {
+  DescriptorId,
+  EServiceId,
+  generateId,
+  TenantId,
+} from "pagopa-interop-models";
+import { bffApi } from "pagopa-interop-api-clients";
+import { genericLogger } from "pagopa-interop-commons";
+import AdmZip from "adm-zip";
+import { catalogApi } from "pagopa-interop-api-clients";
+import * as apiUtils from "pagopa-interop-commons";
+import {
+  AgreementProcessClient,
+  AttributeProcessClient,
+  CatalogProcessClient,
+  DelegationProcessClient,
+  EServiceTemplateProcessClient,
+  TenantProcessClient,
+} from "../src/clients/clientsProvider.js";
+import { catalogServiceBuilder } from "../src/services/catalogService.js";
+import { config } from "../src/config/config.js";
+import { invalidZipStructure } from "../src/model/errors.js";
+import { fileManager, getBffMockContext } from "./utils.js";
+
+describe("importEService", () => {
+  const tenantId: TenantId = generateId<TenantId>();
+  const baseEService: catalogApi.EService = {
+    id: generateId<EServiceId>(),
+    name: "mockEService",
+    producerId: tenantId,
+    description: "mockDescription",
+    technology: "REST",
+    descriptors: [
+      {
+        id: generateId<DescriptorId>(),
+        version: "3.0.0",
+        audience: [],
+        voucherLifespan: 1,
+        dailyCallsPerConsumer: 2,
+        dailyCallsTotal: 2,
+        docs: [],
+        state: "PUBLISHED",
+        agreementApprovalPolicy: "AUTOMATIC",
+        serverUrls: [],
+        interface: {
+          id: "interface-id",
+          name: "interface.yaml",
+          path: "path/to/interface.yaml",
+          contentType: "mockContentType",
+          prettyName: "mockPrettyName",
+          checksum: "mockChecksum",
+        },
+        attributes: {
+          certified: [],
+          verified: [],
+          declared: [],
+        },
+      },
+    ],
+    mode: "RECEIVE",
+    riskAnalysis: [],
+  };
+
+  const mockCatalogProcessClient = {
+    createEService: vi.fn().mockResolvedValue(baseEService),
+    getEServiceById: vi.fn().mockResolvedValue(baseEService),
+    createEServiceDocument: vi.fn().mockResolvedValue(getMockDocument()),
+  } as unknown as CatalogProcessClient;
+  const mockTenantProcessClient = {} as unknown as TenantProcessClient;
+  const mockAgreementProcessClient = {} as unknown as AgreementProcessClient;
+  const mockAttributeProcessClient = {} as unknown as AttributeProcessClient;
+  const mockDelegationProcessClient = {} as unknown as DelegationProcessClient;
+  const mockEServiceTemplateProcessClient =
+    {} as unknown as EServiceTemplateProcessClient;
+
+  const catalogService = catalogServiceBuilder(
+    mockCatalogProcessClient,
+    mockTenantProcessClient,
+    mockAgreementProcessClient,
+    mockAttributeProcessClient,
+    mockDelegationProcessClient,
+    mockEServiceTemplateProcessClient,
+    fileManager,
+    config
+  );
+
+  const authData: AuthData = {
+    ...getMockAuthData(),
+    organizationId: tenantId,
+  };
+  const bffMockContext = getBffMockContext(getMockContext({ authData }));
+
+  const fileResource: bffApi.FileResource = {
+    filename: "test.zip",
+    url: "/import/folder",
+  };
+
+  const zip = new AdmZip();
+  const jsonFilename = "configuration.json";
+
+  const configuration = {
+    name: "Test EService",
+    description: "Descrizione del test EService",
+    technology: "REST",
+    openapi: "3.0.0",
+    servers: [],
+    mode: "RECEIVE",
+    descriptor: {
+      description: "Descrizione del descriptor",
+      audience: ["public"],
+      voucherLifespan: 30,
+      dailyCallsPerConsumer: 1000,
+      dailyCallsTotal: 10000,
+      agreementApprovalPolicy: "AUTOMATIC",
+      docs: [],
+      interface: { ...getMockDocument(), path: jsonFilename },
+    },
+    riskAnalysis: [],
+    isSignalHubEnabled: false,
+    isConsumerDelegable: false,
+    isClientAccessDelegable: false,
+  };
+  zip.addFile(jsonFilename, Buffer.from(JSON.stringify(configuration)));
+
+  const zipPath = path.join(__dirname, "test.zip");
+  zip.writeZip(zipPath);
+
+  const zipContent = fs.readFileSync(zipPath);
+
+  const mockPollingFunction = vi.fn(() => Promise.resolve());
+  vi.spyOn(apiUtils, "createPollingByCondition").mockImplementation(
+    () => mockPollingFunction
+  );
+
+  describe("success case", () => {
+    it("should import eService from url", async () => {
+      const storedBytes = await fileManager.storeBytes(
+        {
+          bucket: config.importEserviceContainer,
+          path: `${config.importEservicePath}`,
+          resourceId: `${tenantId}`,
+          name: `${fileResource.filename}`,
+          content: zipContent,
+        },
+        genericLogger
+      );
+      expect(storedBytes).toBe(
+        `${config.importEservicePath}/${tenantId}/${fileResource.filename}`
+      );
+
+      const result = await catalogService.importEService(
+        fileResource,
+        bffMockContext
+      );
+
+      expect(result).toEqual({
+        id: baseEService.id,
+        descriptorId: baseEService.descriptors[0].id,
+      });
+      fs.unlinkSync(zipPath);
+    });
+  });
+  describe("error case", () => {
+    it("should throw invalidZipStructure error when file name is not configuration.json", async () => {
+      const zip = new AdmZip();
+      const jsonFilename = "invalid_file.json";
+      zip.addFile(jsonFilename, Buffer.from(JSON.stringify(configuration)));
+      const zipPath = path.join(__dirname, "test.zip");
+      zip.writeZip(zipPath);
+
+      const zipContent = fs.readFileSync(zipPath);
+
+      const storedBytes = await fileManager.storeBytes(
+        {
+          bucket: config.importEserviceContainer,
+          path: `${config.importEservicePath}`,
+          resourceId: `${tenantId}`,
+          name: `${fileResource.filename}`,
+          content: zipContent,
+        },
+        genericLogger
+      );
+      expect(storedBytes).toBe(
+        `${config.importEservicePath}/${tenantId}/${fileResource.filename}`
+      );
+
+      await expect(
+        catalogService.importEService(fileResource, bffMockContext)
+      ).rejects.toThrowError(
+        invalidZipStructure("Error reading configuration.json")
+      );
+      fs.unlinkSync(zipPath);
+    });
+    it("should throw invalidZipStructure when configuration.json is malformed", async () => {
+      const malformedConfiguration = JSON.stringify({
+        name: "Test EService",
+      });
+
+      const zip = new AdmZip();
+      zip.addFile("configuration.json", Buffer.from(malformedConfiguration));
+      const zipPath = path.join(__dirname, "test.zip");
+      zip.writeZip(zipPath);
+
+      const zipContent = fs.readFileSync(zipPath);
+
+      const storedBytes = await fileManager.storeBytes(
+        {
+          bucket: config.importEserviceContainer,
+          path: `${config.importEservicePath}`,
+          resourceId: `${tenantId}`,
+          name: `${fileResource.filename}`,
+          content: zipContent,
+        },
+        genericLogger
+      );
+      expect(storedBytes).toBe(
+        `${config.importEservicePath}/${tenantId}/${fileResource.filename}`
+      );
+
+      await expect(
+        catalogService.importEService(fileResource, bffMockContext)
+      ).rejects.toThrowError(
+        invalidZipStructure("Error decoding configuration.json")
+      );
+      fs.unlinkSync(zipPath);
+    });
+    it("should should throw invalidZipStructure when some docs are undefined", async () => {
+      const configuration = {
+        name: "Test EService",
+        description: "Descrizione del test EService",
+        technology: "REST",
+        openapi: "3.0.0",
+        servers: [],
+        mode: "RECEIVE",
+        descriptor: {
+          description: "Descrizione del descriptor",
+          audience: ["public"],
+          voucherLifespan: 30,
+          dailyCallsPerConsumer: 1000,
+          dailyCallsTotal: 10000,
+          agreementApprovalPolicy: "AUTOMATIC",
+          docs: [
+            { path: "invalid path", prettyName: "invalid path prettyName" },
+          ],
+          interface: { ...getMockDocument(), path: jsonFilename },
+        },
+        riskAnalysis: [],
+        isSignalHubEnabled: false,
+        isConsumerDelegable: false,
+        isClientAccessDelegable: false,
+      };
+      zip.addFile(jsonFilename, Buffer.from(JSON.stringify(configuration)));
+
+      const zipPath = path.join(__dirname, "test.zip");
+      zip.writeZip(zipPath);
+
+      const zipContent = fs.readFileSync(zipPath);
+      const storedBytes = await fileManager.storeBytes(
+        {
+          bucket: config.importEserviceContainer,
+          path: `${config.importEservicePath}`,
+          resourceId: `${tenantId}`,
+          name: `${fileResource.filename}`,
+          content: zipContent,
+        },
+        genericLogger
+      );
+      expect(storedBytes).toBe(
+        `${config.importEservicePath}/${tenantId}/${fileResource.filename}`
+      );
+
+      await expect(
+        catalogService.importEService(fileResource, bffMockContext)
+      ).rejects.toThrowError(invalidZipStructure("Error reading docs"));
+      fs.unlinkSync(zipPath);
+    });
+    it("should should throw invalidZipStructure when error during interface reading", async () => {
+      const configuration = {
+        name: "Test EService",
+        description: "Descrizione del test EService",
+        technology: "REST",
+        openapi: "3.0.0",
+        servers: [],
+        mode: "RECEIVE",
+        descriptor: {
+          description: "Descrizione del descriptor",
+          audience: ["public"],
+          voucherLifespan: 30,
+          dailyCallsPerConsumer: 1000,
+          dailyCallsTotal: 10000,
+          agreementApprovalPolicy: "AUTOMATIC",
+          docs: [],
+          interface: {
+            ...getMockDocument(),
+            path: "invalid interface path",
+          },
+        },
+        riskAnalysis: [],
+        isSignalHubEnabled: false,
+        isConsumerDelegable: false,
+        isClientAccessDelegable: false,
+      };
+      zip.addFile(jsonFilename, Buffer.from(JSON.stringify(configuration)));
+
+      const zipPath = path.join(__dirname, "test.zip");
+      zip.writeZip(zipPath);
+
+      const zipContent = fs.readFileSync(zipPath);
+      const storedBytes = await fileManager.storeBytes(
+        {
+          bucket: config.importEserviceContainer,
+          path: `${config.importEservicePath}`,
+          resourceId: `${tenantId}`,
+          name: `${fileResource.filename}`,
+          content: zipContent,
+        },
+        genericLogger
+      );
+      expect(storedBytes).toBe(
+        `${config.importEservicePath}/${tenantId}/${fileResource.filename}`
+      );
+
+      await expect(
+        catalogService.importEService(fileResource, bffMockContext)
+      ).rejects.toThrowError(invalidZipStructure("Error reading interface"));
+      fs.unlinkSync(zipPath);
+    });
+    it("should should throw invalidZipStructure when more than one file in zip is present", async () => {
+      const secondFilename = "second file name";
+      zip.addFile(jsonFilename, Buffer.from(JSON.stringify(configuration)));
+      zip.addFile(secondFilename, Buffer.from("Second file"));
+
+      const zipPath = path.join(__dirname, "test.zip");
+      zip.writeZip(zipPath);
+
+      const zipContent = fs.readFileSync(zipPath);
+      const storedBytes = await fileManager.storeBytes(
+        {
+          bucket: config.importEserviceContainer,
+          path: `${config.importEservicePath}`,
+          resourceId: `${tenantId}`,
+          name: `${fileResource.filename}`,
+          content: zipContent,
+        },
+        genericLogger
+      );
+      expect(storedBytes).toBe(
+        `${config.importEservicePath}/${tenantId}/${fileResource.filename}`
+      );
+
+      await expect(
+        catalogService.importEService(fileResource, bffMockContext)
+      ).rejects.toThrowError(
+        invalidZipStructure(`Not allowed files found: ${secondFilename}`)
+      );
+      fs.unlinkSync(zipPath);
+    });
+  });
+});

--- a/packages/backend-for-frontend/test/utils.ts
+++ b/packages/backend-for-frontend/test/utils.ts
@@ -1,6 +1,11 @@
 import { setupTestContainersVitest } from "pagopa-interop-commons-test";
 import { inject, afterEach } from "vitest";
-import { FileManager } from "pagopa-interop-commons";
+import {
+  AppContext,
+  FileManager,
+  genericLogger,
+  WithLogger,
+} from "pagopa-interop-commons";
 import { catalogApi, eserviceTemplateApi } from "pagopa-interop-api-clients";
 import {
   Descriptor,
@@ -17,6 +22,7 @@ import {
   EServiceTemplateProcessClient,
   TenantProcessClient,
 } from "../src/clients/clientsProvider.js";
+import { BffAppContext } from "../src/utilities/context.js";
 
 export const { cleanup, readModelRepository, postgresDB, fileManager } =
   await setupTestContainersVitest(
@@ -83,4 +89,16 @@ export const toEserviceCatalogProcessMock = (
       templateVersionRef: descriptor.templateVersionRef,
     },
   ],
+});
+
+export const getBffMockContext = (
+  ctx: AppContext
+): WithLogger<BffAppContext> => ({
+  ...ctx,
+  headers: {
+    "X-Correlation-Id": ctx.correlationId,
+    Authorization: "authorization",
+    "X-Forwarded-For": "x-forwarded-for",
+  },
+  logger: genericLogger,
 });


### PR DESCRIPTION
**Jira Link**: https://pagopa.atlassian.net/browse/PIN-6524

I implemented a set of tests (covering both success and error scenarios) to validate the business logic of the BFF service, mocking all external service calls.

**N.B**: The only point worth mentioning is that I added a _.env.test_ file to override the `IMPORT_ESERVICE_CONTAINER` variable, setting it to `interop-local-bucket` to ensure an existing bucket is available for the import test.