### PR TITLE
Hotfix: add TooManyRequestsError skipping with AWS SES client

### DIFF
--- a/packages/commons/src/email-manager/emailManager.ts
+++ b/packages/commons/src/email-manager/emailManager.ts
@@ -8,10 +8,23 @@ import {
   SESv2Client,
   SendEmailCommand,
   SendEmailCommandInput,
+  TooManyRequestsException,
 } from "@aws-sdk/client-sesv2";
 import Mail from "nodemailer/lib/mailer/index.js";
 import { PecEmailManagerConfig } from "../index.js";
 import { AWSSesConfig } from "../config/awsSesConfig.js";
+
+/* 
+  Temporary Hotfix: https://pagopa.atlassian.net/browse/PIN-6514 
+  we want to not consider the TooManyRequestsException as error, 
+  it's thrown by SESv2Client when the rate limit is reached with current configuration.
+  For more information about the errors and best practices to handle see:
+    https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-ses/Class/SES/
+  
+  AllowedSESErrors is used to limit other packages to filter only specific error from SESv2Client, 
+  and also avoid dependency on AWS SDK in other packages.
+*/
+export declare class AllowedSESErrors extends TooManyRequestsException {}
 
 export type EmailManagerKind = "PEC" | "SES";
 


### PR DESCRIPTION
Close [PIN-6514](https://pagopa.atlassian.net/browse/PIN-6514)

# Description
This Hotfix skip `TooManyRequests` error when AWS SES reach limit of requests per seconds.

### ⚠️  Note 
this implementation allows losing notification if `TooManyRequests` error occurs, the consumer continuing with execution and messages on relative kafka topic will be committed and not handled anymore.
No Dead Letter Queue mechanism was provided in current implementation, those emails are notifications and them are not too relevant.