### PR TITLE
Fix bff update e-service document 500 error

### DIFF
--- a/packages/backend-for-frontend/src/routers/catalogRouter.ts
+++ b/packages/backend-for-frontend/src/routers/catalogRouter.ts
@@ -16,7 +16,10 @@ import {
   unsafeBrandId,
   emptyErrorMapper,
 } from "pagopa-interop-models";
-import { toEserviceCatalogProcessQueryParams } from "../api/catalogApiConverter.js";
+import {
+  toBffCatalogApiDescriptorDoc,
+  toEserviceCatalogProcessQueryParams,
+} from "../api/catalogApiConverter.js";
 import { PagoPAInteropBeClients } from "../clients/clientsProvider.js";
 import { config } from "../config/config.js";
 import { makeApiProblem } from "../model/errors.js";
@@ -531,7 +534,9 @@ const catalogRouter = (
             ctx
           );
 
-          return res.status(200).send(bffApi.EServiceDoc.parse(doc));
+          return res
+            .status(200)
+            .send(bffApi.EServiceDoc.parse(toBffCatalogApiDescriptorDoc(doc)));
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -1324,7 +1324,7 @@ export function catalogServiceBuilder(
       documentId: EServiceDocumentId,
       updateEServiceDescriptorDocumentSeed: bffApi.UpdateEServiceDescriptorDocumentSeed,
       { logger, headers }: WithLogger<BffAppContext>
-    ): Promise<bffApi.EServiceDoc> => {
+    ): Promise<catalogApi.EServiceDoc> => {
       logger.info(
         `Updating document ${documentId} of descriptor ${descriptorId} of EService ${eServiceId}`
       );

--- a/packages/backend-for-frontend/src/utilities/errorMappers.ts
+++ b/packages/backend-for-frontend/src/utilities/errorMappers.ts
@@ -158,7 +158,7 @@ export const createEServiceDocumentErrorMapper = (
     .with("eserviceDescriptorNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with(
       "invalidInterfaceContentTypeDetected",
-      "invalidInterfaceFileDetected",
+      "invalidEserviceInterfaceFileDetected",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -170,7 +170,7 @@ export const createEServiceTemplateDocumentErrorMapper = (
     .with("eserviceTemplateVersionNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with(
       "invalidInterfaceContentTypeDetected",
-      "invalidInterfaceFileDetected",
+      "invalidEserviceInterfaceFileDetected",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -241,7 +241,7 @@ export const addEServiceInterfaceByTemplateErrorMapper = (
       "eserviceTemplateInterfaceNotFound",
       "eserviceTemplateInterfaceDataNotValid",
       "invalidInterfaceContentTypeDetected",
-      "invalidInterfaceFileDetected",
+      "invalidEserviceInterfaceFileDetected",
       "interfaceExtractingInfoError",
       "templateDataNotFound",
       () => HTTP_STATUS_BAD_REQUEST


### PR DESCRIPTION
This PR solves a zod parsing error for bff's `EServiceDoc` data in the update document call.