### PR TITLE
PIN-6700: Add organizationNotAllowedOnClient in getClient

### DIFF
--- a/packages/authorization-process/src/utilities/errorMappers.ts
+++ b/packages/authorization-process/src/utilities/errorMappers.ts
@@ -17,6 +17,7 @@ const {
 export const getClientErrorMapper = (error: ApiError<ErrorCodes>): number =>
   match(error.code)
     .with("clientNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("organizationNotAllowedOnClient", () => HTTP_STATUS_FORBIDDEN)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
 export const createConsumerClientErrorMapper = (


### PR DESCRIPTION
Introduce a new mapping for the "organizationNotAllowedOnClient" error to return a forbidden status code.