### PR TITLE
PIN-6489: Implement application‑audit-fallback

### DIFF
--- a/packages/application-audit-fallback/.env
+++ b/packages/application-audit-fallback/.env
@@ -1,0 +1,11 @@
+SERVICE_NAME="application-audit-fallback"
+LOG_LEVEL=info
+
+AWS_CONFIG_FILE=aws.config.local
+AWS_REGION="eu-south-1"
+CONSUMER_SQS_QUEUE_URL="http://localhost:9324/000000000000/sqsLocalQueue.fifo"
+
+APPLICATION_AUDIT_TOPIC="application-audit"
+PRODUCER_KAFKA_CLIENT_ID="application-audit-fallback"
+PRODUCER_KAFKA_BROKERS="localhost:9092"
+PRODUCER_KAFKA_DISABLE_AWS_IAM_AUTH="true"

--- a/packages/application-audit-fallback/Dockerfile
+++ b/packages/application-audit-fallback/Dockerfile
@@ -1,0 +1,49 @@
+#default value for compatibility
+ARG NODE_REGISTRY="docker.io"
+
+FROM ${NODE_REGISTRY}/node:20.14.0-slim@sha256:5e8ac65a0231d76a388683d07ca36a9769ab019a85d85169fe28e206f7a3208e as build 
+
+RUN npm install -g corepack@0.31.0 && corepack enable
+
+WORKDIR /app
+COPY package.json /app/
+COPY pnpm-lock.yaml /app/
+COPY pnpm-workspace.yaml /app/
+COPY .npmrc /app/
+
+COPY ./packages/application-audit-fallback/package.json /app/packages/application-audit-fallback/package.json
+COPY ./packages/commons/package.json /app/packages/commons/package.json
+COPY ./packages/models/package.json /app/packages/models/package.json
+COPY ./packages/kafka-iam-auth/package.json /app/packages/kafka-iam-auth/package.json
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+
+COPY tsconfig.json /app/
+COPY turbo.json /app/
+
+COPY ./packages/application-audit-fallback /app/packages/application-audit-fallback
+COPY ./packages/commons /app/packages/commons
+COPY ./packages/models /app/packages/models
+COPY ./packages/kafka-iam-auth /app/packages/kafka-iam-auth
+
+RUN pnpm build && \
+  rm -rf /app/node_modules/.modules.yaml && \
+  rm -rf /app/node_modules/.cache && \
+  mkdir /out && \
+  cp -a --parents -t /out \
+  node_modules packages/application-audit-fallback/node_modules \
+  package*.json packages/application-audit-fallback/package*.json \
+  packages/commons \
+  packages/models \
+  packages/kafka-iam-auth \
+  packages/application-audit-fallback/dist && \
+  find /out -exec touch -h --date=@0 {} \;
+
+FROM ${NODE_REGISTRY}/node:20.14.0-slim@sha256:5e8ac65a0231d76a388683d07ca36a9769ab019a85d85169fe28e206f7a3208e as final 
+
+COPY --from=build /out /app
+
+WORKDIR /app/packages/application-audit-fallback
+EXPOSE 3000
+
+CMD ["node", "."]

--- a/packages/application-audit-fallback/aws.config.local
+++ b/packages/application-audit-fallback/aws.config.local
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id=testawskey
+aws_secret_access_key=testawssecret
+region=eu-south-1

--- a/packages/application-audit-fallback/elasticmq.local.conf
+++ b/packages/application-audit-fallback/elasticmq.local.conf
@@ -1,0 +1,6 @@
+queues {
+  sqsLocalQueue {
+    fifo = true
+    contentBasedDeduplication = true
+  }
+}

--- a/packages/application-audit-fallback/package.json
+++ b/packages/application-audit-fallback/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "pagopa-interop-application-audit-fallback",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Pagopa Interop application audit fallback",
+  "main": "dist",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "test": "vitest",
+    "test:it": "vitest integration",
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:autofix": "eslint . --ext .ts,.tsx --fix",
+    "format:check": "prettier --check src",
+    "format:write": "prettier --write src",
+    "start": "tsx -r 'dotenv-flow/config' --watch ./src/index.ts",
+    "build": "tsc",
+    "check": "tsc --project tsconfig.check.json"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@pagopa/eslint-config": "3.0.0",
+    "@types/node": "20.14.6",
+    "prettier": "2.8.8",
+    "tsx": "4.19.1",
+    "typescript": "5.4.5",
+    "kafkajs": "2.2.4",
+    "pagopa-interop-commons-test": "workspace:*",
+    "testcontainers": "10.9.0",
+    "vitest": "1.6.0"
+  },
+  "dependencies": {
+    "@aws-sdk/client-sqs": "3.693.0",
+    "dotenv-flow": "4.1.0",
+    "kafka-iam-auth": "workspace:*",
+    "pagopa-interop-commons": "workspace:*",
+    "pagopa-interop-models": "workspace:*",
+    "ts-pattern": "5.2.0",
+    "zod": "3.23.8"
+  }
+}

--- a/packages/application-audit-fallback/src/config/config.ts
+++ b/packages/application-audit-fallback/src/config/config.ts
@@ -1,0 +1,29 @@
+import {
+  ApplicationAuditTopicConfig,
+  KafkaProducerConfig,
+  LoggerConfig,
+  SQSConsumerConfig,
+} from "pagopa-interop-commons";
+import { z } from "zod";
+
+export const ApplicationAuditFallbackConfig = SQSConsumerConfig.and(
+  KafkaProducerConfig
+)
+  .and(ApplicationAuditTopicConfig)
+  .and(LoggerConfig)
+  .and(
+    z
+      .object({
+        SERVICE_NAME: z.string(),
+      })
+      .transform((c) => ({
+        serviceName: c.SERVICE_NAME,
+      }))
+  );
+
+export type ApplicationAuditFallbackConfig = z.infer<
+  typeof ApplicationAuditFallbackConfig
+>;
+
+export const config: ApplicationAuditFallbackConfig =
+  ApplicationAuditFallbackConfig.parse(process.env);

--- a/packages/application-audit-fallback/src/index.ts
+++ b/packages/application-audit-fallback/src/index.ts
@@ -1,0 +1,26 @@
+// index.ts
+import { initQueueManager, logger } from "pagopa-interop-commons";
+import { initProducer } from "kafka-iam-auth";
+import { config } from "./config/config.js";
+import { handleMessage } from "./handlers/handleMessage.js";
+
+const queueManager = initQueueManager({
+  messageGroupId: "message_group_all_notification",
+  logLevel: config.logLevel,
+});
+
+const processMessage = handleMessage(
+  await initProducer(config, config.applicationAuditTopic)
+);
+
+await queueManager.runConsumer(
+  processMessage,
+  logger({ serviceName: config.serviceName }),
+  {
+    queueUrl: config.consumerQueueUrl,
+    maxNumberOfMessages: config.maxNumberOfMessages,
+    waitTimeSeconds: config.waitTimeSeconds,
+    visibilityTimeout: config.visibilityTimeout,
+    serviceName: config.serviceName,
+  }
+);

--- a/packages/application-audit-fallback/src/models/application-audit.ts
+++ b/packages/application-audit-fallback/src/models/application-audit.ts
@@ -1,0 +1,18 @@
+import {
+  ApplicationAuditBeginRequest,
+  ApplicationAuditEndRequest,
+  ApplicationAuditEndRequestSessionTokenExchange,
+} from "pagopa-interop-models";
+import { z } from "zod";
+
+const EndRequestEvent = z.union([
+  ApplicationAuditEndRequestSessionTokenExchange,
+  ApplicationAuditEndRequest,
+]);
+
+export const ApplicationAuditEvent = z.union([
+  ApplicationAuditBeginRequest,
+  EndRequestEvent,
+]);
+
+export type ApplicationAuditEvent = z.infer<typeof ApplicationAuditEvent>;

--- a/packages/application-audit-fallback/src/models/kafka.ts
+++ b/packages/application-audit-fallback/src/models/kafka.ts
@@ -1,0 +1,5 @@
+export interface KafkaProducer {
+  send: (params: {
+    messages: Array<{ key: string; value: string }>;
+  }) => Promise<void>;
+}

--- a/packages/application-audit-fallback/src/models/queue.ts
+++ b/packages/application-audit-fallback/src/models/queue.ts
@@ -1,0 +1,31 @@
+import { Message, QueueMessage } from "pagopa-interop-commons";
+import { z } from "zod";
+import { decodeSQSMessageError } from "pagopa-interop-models";
+import { ApplicationAuditEvent } from "./application-audit.js";
+
+export const ApplicationAuditEventMessageSchema = z.object({
+  value: z.preprocess((v) => {
+    if (v != null) {
+      try {
+        const parsed = JSON.parse(v.toString());
+        const queueMessage = QueueMessage.parse(parsed);
+        return queueMessage.payload;
+      } catch (err) {
+        return null;
+      }
+    }
+    return null;
+  }, ApplicationAuditEvent),
+});
+
+export function decodeSQSMessage(message: Message): ApplicationAuditEvent {
+  const parsed = ApplicationAuditEventMessageSchema.safeParse({
+    value: message.Body,
+  });
+
+  if (!parsed.success) {
+    throw decodeSQSMessageError(message.MessageId, parsed.error);
+  }
+
+  return parsed.data.value;
+}

--- a/packages/application-audit-fallback/test/processMessage.integration.test.ts
+++ b/packages/application-audit-fallback/test/processMessage.integration.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, afterAll, beforeEach } from "vitest";
+import { InternalError } from "pagopa-interop-models";
+import { CommonErrorCodes, decodeSQSMessageError } from "pagopa-interop-models";
+import { Message, QueueMessage } from "pagopa-interop-commons";
+import { initProducer } from "kafka-iam-auth";
+import { handleMessage } from "../src/handlers/handleMessage.js";
+import { ApplicationAuditEventMessageSchema } from "../src/models/queue.js";
+import { getMockBeginRequestAudit } from "./utils.js";
+
+describe("Process message test", () => {
+  const sendMock = vi.fn();
+
+  const mockProducer = {
+    send: sendMock,
+  } as unknown as Awaited<ReturnType<typeof initProducer>>;
+
+  const processMessage = handleMessage(mockProducer);
+
+  beforeEach(() => {
+    sendMock.mockReset();
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("given valid message, method should call kafka producer send", async () => {
+    const mockBeginRequestAudit: QueueMessage = {
+      correlationId: getMockBeginRequestAudit.correlationId,
+      spanId: getMockBeginRequestAudit.spanId,
+      payload: getMockBeginRequestAudit,
+    };
+    const validMessage: Message = {
+      MessageId: "12345",
+      ReceiptHandle: "receipt_handle_id",
+      Body: JSON.stringify(mockBeginRequestAudit),
+    };
+
+    await expect(processMessage(validMessage)).resolves.not.toThrowError();
+
+    expect(sendMock).toHaveBeenCalledOnce();
+  });
+
+  it("given invalid message, should throw an error", async () => {
+    const invalidMessage = {};
+
+    try {
+      await processMessage(invalidMessage);
+    } catch (error) {
+      expect(error).toBeInstanceOf(InternalError);
+      expect((error as InternalError<CommonErrorCodes>).code).toBe(
+        "decodeSQSMessageError"
+      );
+    }
+  });
+
+  it("given invalid Body message, should throw an error", async () => {
+    const missingBodyMessage: Message = {
+      MessageId: "12345",
+      ReceiptHandle: "receipt_handle_id",
+      Body: undefined,
+    };
+
+    const parsed = ApplicationAuditEventMessageSchema.safeParse({
+      value: missingBodyMessage.Body,
+    });
+
+    await expect(processMessage(missingBodyMessage)).rejects.toThrowError(
+      decodeSQSMessageError(missingBodyMessage.MessageId, parsed.error)
+    );
+  });
+});

--- a/packages/application-audit-fallback/test/queueManager.integration.test.ts
+++ b/packages/application-audit-fallback/test/queueManager.integration.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable functional/no-let */
+import { describe, expect, it } from "vitest";
+import {
+  genericLogger,
+  queueManagerSendError,
+  queueManagerReceiveError,
+  QueueMessage,
+} from "pagopa-interop-commons";
+import {
+  nonExistingQueueUrl,
+  nonExistingQueueWriter,
+  queueWriter,
+  producerQueueUrl,
+  getMockBeginRequestAudit,
+} from "./utils.js";
+
+describe("Queue Manager tests", async () => {
+  describe("QueueWriter", () => {
+    it("should send a message to the queue and receive it back", async () => {
+      const mockBeginRequestAudit: QueueMessage = {
+        correlationId: getMockBeginRequestAudit.correlationId,
+        spanId: getMockBeginRequestAudit.spanId,
+        payload: getMockBeginRequestAudit,
+      };
+
+      await queueWriter.send(
+        producerQueueUrl,
+        {
+          correlationId: getMockBeginRequestAudit.correlationId,
+          spanId: getMockBeginRequestAudit.spanId,
+          payload: getMockBeginRequestAudit,
+        },
+        genericLogger
+      );
+
+      const lastMessage = (
+        await queueWriter.receiveLast(producerQueueUrl, genericLogger)
+      )[0];
+      expect(lastMessage).toMatchObject(mockBeginRequestAudit);
+    });
+
+    it("should fail to send a message to a non existing queue", async () => {
+      const mockBeginRequestAudit: QueueMessage = {
+        correlationId: getMockBeginRequestAudit.correlationId,
+        spanId: getMockBeginRequestAudit.spanId,
+        payload: getMockBeginRequestAudit,
+      };
+
+      await expect(
+        nonExistingQueueWriter.send(
+          nonExistingQueueUrl,
+          mockBeginRequestAudit,
+          genericLogger
+        )
+      ).rejects.toThrowError(
+        queueManagerSendError(
+          nonExistingQueueUrl,
+          new Error("The specified queue does not exist.")
+        )
+      );
+    });
+
+    it("should fail to receive a message from a non existing queue", async () => {
+      await expect(
+        nonExistingQueueWriter.receiveLast(nonExistingQueueUrl, genericLogger)
+      ).rejects.toThrowError(
+        queueManagerReceiveError(
+          nonExistingQueueUrl,
+          new Error("The specified queue does not exist.")
+        )
+      );
+    });
+  });
+});

--- a/packages/application-audit-fallback/test/tsconfig.json
+++ b/packages/application-audit-fallback/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+}

--- a/packages/application-audit-fallback/test/utils.ts
+++ b/packages/application-audit-fallback/test/utils.ts
@@ -1,0 +1,81 @@
+/* eslint-disable functional/no-let */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {
+  CorrelationId,
+  generateId,
+  SpanId,
+  ApplicationAuditPhase,
+} from "pagopa-interop-models";
+
+import { afterAll, beforeAll } from "vitest";
+import { GenericContainer, StartedTestContainer } from "testcontainers";
+import { QueueManager, initQueueManager } from "pagopa-interop-commons";
+import { ApplicationAuditEvent } from "../src/models/application-audit.js";
+
+export const getMockBeginRequestAudit: ApplicationAuditEvent = {
+  spanId: generateId<SpanId>(),
+  correlationId: generateId<CorrelationId>(),
+  service: "mockService",
+  serviceVersion: "1.0",
+  endpoint: "/mock-endpoint",
+  httpMethod: "GET",
+  requesterIpAddress: "192.168.1.100",
+  nodeIp: "127.0.0.1",
+  podName: "mock-pod",
+  uptimeSeconds: 100,
+  timestamp: Date.now(),
+  amazonTraceId: generateId(),
+  phase: ApplicationAuditPhase.BEGIN_REQUEST,
+};
+
+/* The ElasticMQ test container is setup here and not in the commons-test
+global setup because it is used only in this test suite and the queueManager
+is not a generic common component.
+In case an SQS queue manager is needed in other services, the queue manager
+and the ElasticMQ test container setup should be moved
+to commons and commons-test respectively.
+*/
+const TEST_ELASTIC_MQ_IMAGE = "softwaremill/elasticmq-native:1.5.7";
+const TEST_ELASTIC_MQ_PORT = 9324;
+
+const elasticMQContainer = (): GenericContainer =>
+  new GenericContainer(TEST_ELASTIC_MQ_IMAGE)
+    .withCopyFilesToContainer([
+      {
+        source: "elasticmq.local.conf",
+        target: "/opt/elasticmq.conf",
+      },
+    ])
+    .withExposedPorts(TEST_ELASTIC_MQ_PORT);
+
+let startedElasticMQContainer: StartedTestContainer;
+export let producerQueueUrl: string;
+export let nonExistingQueueUrl: string;
+export let queueWriter: QueueManager;
+export let nonExistingQueueWriter: QueueManager;
+
+beforeAll(async () => {
+  startedElasticMQContainer = await elasticMQContainer().start();
+
+  producerQueueUrl = `http://localhost:${startedElasticMQContainer.getMappedPort(
+    TEST_ELASTIC_MQ_PORT
+  )}/000000000000/sqsLocalQueue.fifo`;
+
+  queueWriter = initQueueManager({
+    messageGroupId: "test-message-group-id",
+    logLevel: "info",
+  });
+
+  nonExistingQueueUrl = `http://localhost:${startedElasticMQContainer.getMappedPort(
+    TEST_ELASTIC_MQ_PORT
+  )}/000000000000/nonExistingQueue`;
+
+  nonExistingQueueWriter = initQueueManager({
+    messageGroupId: "test-message-group-id",
+    logLevel: "info",
+  });
+});
+
+afterAll(async () => {
+  await startedElasticMQContainer.stop();
+});

--- a/packages/application-audit-fallback/test/vitestGlobalSetup.ts
+++ b/packages/application-audit-fallback/test/vitestGlobalSetup.ts
@@ -1,0 +1,3 @@
+import { setupTestContainersVitestGlobal } from "pagopa-interop-commons-test";
+
+export default setupTestContainersVitestGlobal();

--- a/packages/application-audit-fallback/tsconfig.check.json
+++ b/packages/application-audit-fallback/tsconfig.check.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+  },
+  "include": ["src", "test"]
+}

--- a/packages/application-audit-fallback/tsconfig.json
+++ b/packages/application-audit-fallback/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/application-audit-fallback/vitest.config.ts
+++ b/packages/application-audit-fallback/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globalSetup: ["./test/vitestGlobalSetup.ts"],
+    testTimeout: 60000,
+    hookTimeout: 60000,
+    fileParallelism: false,
+    pool: "forks",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,6 +592,58 @@ importers:
         specifier: 5.4.5
         version: 5.4.5
 
+  packages/application-audit-fallback:
+    dependencies:
+      '@aws-sdk/client-sqs':
+        specifier: 3.693.0
+        version: 3.693.0
+      dotenv-flow:
+        specifier: 4.1.0
+        version: 4.1.0
+      kafka-iam-auth:
+        specifier: workspace:*
+        version: link:../kafka-iam-auth
+      pagopa-interop-commons:
+        specifier: workspace:*
+        version: link:../commons
+      pagopa-interop-models:
+        specifier: workspace:*
+        version: link:../models
+      ts-pattern:
+        specifier: 5.2.0
+        version: 5.2.0
+      zod:
+        specifier: 3.23.8
+        version: 3.23.8
+    devDependencies:
+      '@pagopa/eslint-config':
+        specifier: 3.0.0
+        version: 3.0.0(tsutils@3.21.0(typescript@5.4.5))(typescript@5.4.5)
+      '@types/node':
+        specifier: 20.14.6
+        version: 20.14.6
+      kafkajs:
+        specifier: 2.2.4
+        version: 2.2.4
+      pagopa-interop-commons-test:
+        specifier: workspace:*
+        version: link:../commons-test
+      prettier:
+        specifier: 2.8.8
+        version: 2.8.8
+      testcontainers:
+        specifier: 10.9.0
+        version: 10.9.0
+      tsx:
+        specifier: 4.19.1
+        version: 4.19.1
+      typescript:
+        specifier: 5.4.5
+        version: 5.4.5
+      vitest:
+        specifier: 1.6.0
+        version: 1.6.0(@types/node@20.14.6)
+
   packages/attribute-registry-process:
     dependencies:
       '@zodios/core':
@@ -12786,7 +12838,7 @@ snapshots:
       get-func-name: 2.0.2
       loupe: 2.3.7
       pathval: 1.1.1
-      type-detect: 4.0.8
+      type-detect: 4.1.0
 
   chalk@2.4.2:
     dependencies:
@@ -13011,7 +13063,7 @@ snapshots:
 
   deep-eql@4.1.4:
     dependencies:
-      type-detect: 4.0.8
+      type-detect: 4.1.0
 
   deep-is@0.1.4: {}
 


### PR DESCRIPTION
## Description

Introduce `application‑audit‑fallback` package, a consumer that polls the SQS "audit‑fallback‑queue" (where the producer enqueued messages on Kafka failure) and retries publishing those audit events to the application‑audit Kafka topic.

Under transient Kafka outages, the primary producer writes failed audit events to SQS to prevent data loss. An automated way to drain that queue and replay events back into Kafka so that no audit record is ever lost.

## Changes Made
- Updated `application‑audit‑fallback` package.