### PR TITLE
PIN-6745 - Fix get producer keychain keys 500

### DIFF
--- a/packages/api-clients/open-api/authorizationApi.yml
+++ b/packages/api-clients/open-api/authorizationApi.yml
@@ -1232,7 +1232,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Keys"
+                $ref: "#/components/schemas/Key"
         "400":
           description: Bad Request
           content:

--- a/packages/authorization-process/src/routers/AuthorizationRouter.ts
+++ b/packages/authorization-process/src/routers/AuthorizationRouter.ts
@@ -771,19 +771,16 @@ const authorizationRouter = (
       try {
         validateAuthorization(ctx, [ADMIN_ROLE, SECURITY_ROLE]);
 
-        const producerKeychain =
-          await authorizationService.createProducerKeychainKey(
-            {
-              producerKeychainId: unsafeBrandId(req.params.producerKeychainId),
-              keySeed: req.body,
-            },
-            ctx
-          );
-        return res.status(200).send(
-          authorizationApi.Keys.parse({
-            keys: producerKeychain.keys.map(keyToApiKey),
-          })
+        const key = await authorizationService.createProducerKeychainKey(
+          {
+            producerKeychainId: unsafeBrandId(req.params.producerKeychainId),
+            keySeed: req.body,
+          },
+          ctx
         );
+        return res
+          .status(200)
+          .send(authorizationApi.Key.parse(keyToApiKey(key)));
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -812,9 +809,12 @@ const authorizationRouter = (
           ctx
         );
 
-        return res
-          .status(200)
-          .send(authorizationApi.Keys.parse({ keys: keys.map(keyToApiKey) }));
+        return res.status(200).send(
+          authorizationApi.Keys.parse({
+            keys: keys.map(keyToApiKey),
+            totalCount: keys.length,
+          })
+        );
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/authorization-process/src/services/authorizationService.ts
+++ b/packages/authorization-process/src/services/authorizationService.ts
@@ -1040,7 +1040,7 @@ export function authorizationServiceBuilder(
         keySeed: authorizationApi.KeySeed;
       },
       { logger, correlationId, authData }: WithLogger<AppContext<UIAuthData>>
-    ): Promise<ProducerKeychain> {
+    ): Promise<Key> {
       logger.info(`Creating keys for producer keychain ${producerKeychainId}`);
       const producerKeychain = await retrieveProducerKeychain(
         producerKeychainId,
@@ -1095,7 +1095,7 @@ export function authorizationServiceBuilder(
         )
       );
 
-      return updatedProducerKeychain;
+      return newKey;
     },
     async removeProducerKeychainKeyById(
       {

--- a/packages/authorization-process/test/createProducerKeychainKey.test.ts
+++ b/packages/authorization-process/test/createProducerKeychainKey.test.ts
@@ -105,23 +105,22 @@ describe("createProducerKeychainKey", () => {
 
     await addOneProducerKeychain(mockProducerKeychain);
 
-    const producerKeychain =
-      await authorizationService.createProducerKeychainKey(
-        {
-          producerKeychainId: mockProducerKeychain.id,
-          keySeed,
-        },
-        getMockContext({ authData: mockAuthData })
-      );
+    await authorizationService.createProducerKeychainKey(
+      {
+        producerKeychainId: mockProducerKeychain.id,
+        keySeed,
+      },
+      getMockContext({ authData: mockAuthData })
+    );
 
     const writtenEvent = await readLastEventByStreamId(
-      producerKeychain.id,
+      mockProducerKeychain.id,
       '"authorization"',
       postgresDB
     );
 
     expect(writtenEvent).toMatchObject({
-      stream_id: producerKeychain.id,
+      stream_id: mockProducerKeychain.id,
       version: "1",
       type: "ProducerKeychainKeyAdded",
       event_version: 2,


### PR DESCRIPTION
This pull request addresses an issue introduced by this [PR](https://github.com/pagopa/interop-be-monorepo/pull/1682) that implemented pagination for getClientKeys. 

The API component used by `getClientKeys` is also utilized by `getProducerKeychainKeys`, which unexpectedly began expecting a `totalCount` parameter due to the pagination changes. 
This fix ensures that `getProducerKeychainKeys` functions correctly by providing the expected `totalCount`. 