### PR TITLE
PIN-6772 - M2M - GET certified attribute by ID

### DIFF
--- a/collections/attribute/Create certified attribute.bru
+++ b/collections/attribute/Create certified attribute.bru
@@ -23,6 +23,10 @@ body:json {
   }
 }
 
+vars:post-response {
+  attributeId: res.body.id
+}
+
 script:pre-request {
   const randomCode = Math.round(Math.random() * 10000)
   

--- a/collections/m2m gateway/certifiedAttributes/Get certified attribute.bru
+++ b/collections/m2m gateway/certifiedAttributes/Get certified attribute.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get certified attribute
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host-m2m-gw}}/certifiedAttributes/:attributeId
+  body: none
+  auth: none
+}
+
+params:path {
+  attributeId: {{attributeId}}
+}
+
+headers {
+  Authorization: {{JWT-M2M}}
+}

--- a/collections/m2m gateway/certifiedAttributes/folder.bru
+++ b/collections/m2m gateway/certifiedAttributes/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: certifiedAttributes
+}

--- a/packages/attribute-registry-process/src/routers/AttributeRouter.ts
+++ b/packages/attribute-registry-process/src/routers/AttributeRouter.ts
@@ -61,6 +61,7 @@ const attributeRouter = (
     SECURITY_ROLE,
     API_ROLE,
     M2M_ROLE,
+    M2M_ADMIN_ROLE,
     INTERNAL_ROLE,
     SUPPORT_ROLE,
   } = authRole;
@@ -181,6 +182,7 @@ const attributeRouter = (
             API_ROLE,
             SUPPORT_ROLE,
             SECURITY_ROLE,
+            M2M_ADMIN_ROLE,
             M2M_ROLE,
           ]);
 

--- a/packages/attribute-registry-process/test/api/getAttributeById.test.ts
+++ b/packages/attribute-registry-process/test/api/getAttributeById.test.ts
@@ -33,6 +33,7 @@ describe("API /attributes/{attributeId} authorization test", () => {
     authRole.API_ROLE,
     authRole.SECURITY_ROLE,
     authRole.M2M_ROLE,
+    authRole.M2M_ADMIN_ROLE,
     authRole.SUPPORT_ROLE,
   ];
   it.each(authorizedRoles)(

--- a/packages/m2m-gateway/package.json
+++ b/packages/m2m-gateway/package.json
@@ -19,6 +19,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@anatine/zod-mock": "3.13.4",
     "@pagopa/eslint-config": "3.0.0",
     "@types/adm-zip": "0.5.5",
     "@types/express": "4.17.21",

--- a/packages/m2m-gateway/src/api/attributeApiConverter.ts
+++ b/packages/m2m-gateway/src/api/attributeApiConverter.ts
@@ -13,7 +13,7 @@ export function toM2MGatewayApiCertifiedAttribute(
   assertAttributeKindIs(
     attribute,
     attributeRegistryApi.AttributeKind.Values.CERTIFIED,
-    "certifiedAttributeNotFound"
+    "attributeNotFound"
   );
   assertAttributeOiginAndCodeAreDefined(attribute);
 

--- a/packages/m2m-gateway/src/api/attributeApiConverter.ts
+++ b/packages/m2m-gateway/src/api/attributeApiConverter.ts
@@ -4,7 +4,7 @@ import {
 } from "pagopa-interop-api-clients";
 import {
   assertAttributeKindIs,
-  assertAttributeOiginAndCodeAreDefined,
+  assertAttributeOriginAndCodeAreDefined,
 } from "../utils/validators/attributeValidators.js";
 
 export function toM2MGatewayApiCertifiedAttribute(
@@ -15,7 +15,7 @@ export function toM2MGatewayApiCertifiedAttribute(
     attributeRegistryApi.AttributeKind.Values.CERTIFIED,
     "attributeNotFound"
   );
-  assertAttributeOiginAndCodeAreDefined(attribute);
+  assertAttributeOriginAndCodeAreDefined(attribute);
 
   return {
     id: attribute.id,

--- a/packages/m2m-gateway/src/api/attributeApiConverter.ts
+++ b/packages/m2m-gateway/src/api/attributeApiConverter.ts
@@ -12,7 +12,8 @@ export function toM2MGatewayApiCertifiedAttribute(
 ): m2mGatewayApi.CertifiedAttribute {
   assertAttributeKindIs(
     attribute,
-    attributeRegistryApi.AttributeKind.Values.CERTIFIED
+    attributeRegistryApi.AttributeKind.Values.CERTIFIED,
+    "certifiedAttributeNotFound"
   );
   assertAttributeOiginAndCodeAreDefined(attribute);
 

--- a/packages/m2m-gateway/src/api/attributeApiConverter.ts
+++ b/packages/m2m-gateway/src/api/attributeApiConverter.ts
@@ -1,0 +1,27 @@
+import {
+  attributeRegistryApi,
+  m2mGatewayApi,
+} from "pagopa-interop-api-clients";
+import {
+  assertAttributeKindIs,
+  assertAttributeOiginAndCodeAreDefined,
+} from "../utils/validators/attributeValidators.js";
+
+export function toM2MGatewayApiCertifiedAttribute(
+  attribute: attributeRegistryApi.Attribute
+): m2mGatewayApi.CertifiedAttribute {
+  assertAttributeKindIs(
+    attribute,
+    attributeRegistryApi.AttributeKind.Values.CERTIFIED
+  );
+  assertAttributeOiginAndCodeAreDefined(attribute);
+
+  return {
+    id: attribute.id,
+    code: attribute.code,
+    description: attribute.description,
+    origin: attribute.origin,
+    name: attribute.name,
+    createdAt: attribute.creationTime,
+  };
+}

--- a/packages/m2m-gateway/src/model/errors.ts
+++ b/packages/m2m-gateway/src/model/errors.ts
@@ -10,6 +10,7 @@ export const errorCodes = {
   unexpectedDelegationKind: "0003",
   unexpectedAttributeKind: "0004",
   unexpectedUndefinedAttributeOriginOrCode: "0005",
+  certifiedAttributeNotFound: "0006",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -64,5 +65,15 @@ export function unexpectedUndefinedAttributeOriginOrCode(
     detail: `Attribute ${attribute.id} has undefined origin or code`,
     code: "unexpectedUndefinedAttributeOriginOrCode",
     title: "Unexpected Undefined Attribute Origin or Code",
+  });
+}
+
+export function certifiedAttributeNotFound(
+  attribute: attributeRegistryApi.Attribute
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Certified attribute ${attribute.id} not found`,
+    code: "certifiedAttributeNotFound",
+    title: "Certified Attribute Not Found",
   });
 }

--- a/packages/m2m-gateway/src/model/errors.ts
+++ b/packages/m2m-gateway/src/model/errors.ts
@@ -1,10 +1,15 @@
-import { delegationApi } from "pagopa-interop-api-clients";
+import {
+  attributeRegistryApi,
+  delegationApi,
+} from "pagopa-interop-api-clients";
 import { ApiError, makeApiProblemBuilder } from "pagopa-interop-models";
 
 export const errorCodes = {
   resourcePollingTimeout: "0001",
   missingMetadata: "0002",
   unexpectedDelegationKind: "0003",
+  unexpectedAttributeKind: "0004",
+  unexpectedUndefinedAttributeOriginOrCode: "0005",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -39,5 +44,25 @@ export function unexpectedDelegationKind(
     detail: `Unexpected delegation kind "${delegation.kind}" for delegation ${delegation.id}`,
     code: "unexpectedDelegationKind",
     title: "Unexpected Delegation Kind",
+  });
+}
+
+export function unexpectedAttributeKind(
+  attribute: attributeRegistryApi.Attribute
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Unexpected attribute kind "${attribute.kind}" for attribute ${attribute.id}`,
+    code: "unexpectedAttributeKind",
+    title: "Unexpected Attribute Kind",
+  });
+}
+
+export function unexpectedUndefinedAttributeOriginOrCode(
+  attribute: attributeRegistryApi.Attribute
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Attribute ${attribute.id} has undefined origin or code`,
+    code: "unexpectedUndefinedAttributeOriginOrCode",
+    title: "Unexpected Undefined Attribute Origin or Code",
   });
 }

--- a/packages/m2m-gateway/src/model/errors.ts
+++ b/packages/m2m-gateway/src/model/errors.ts
@@ -10,7 +10,7 @@ export const errorCodes = {
   unexpectedDelegationKind: "0003",
   unexpectedAttributeKind: "0004",
   unexpectedUndefinedAttributeOriginOrCode: "0005",
-  certifiedAttributeNotFound: "0006",
+  attributeNotFound: "0006",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -68,12 +68,12 @@ export function unexpectedUndefinedAttributeOriginOrCode(
   });
 }
 
-export function certifiedAttributeNotFound(
+export function attributeNotFound(
   attribute: attributeRegistryApi.Attribute
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `Certified attribute ${attribute.id} not found`,
-    code: "certifiedAttributeNotFound",
-    title: "Certified Attribute Not Found",
+    detail: `Attribute ${attribute.id} not found`,
+    code: "attributeNotFound",
+    title: "Attribute not found",
   });
 }

--- a/packages/m2m-gateway/src/model/errors.ts
+++ b/packages/m2m-gateway/src/model/errors.ts
@@ -26,7 +26,7 @@ export function resourcePollingTimeout(
   return new ApiError({
     detail: `Resource polling timed out after ${maxAttempts} attempts`,
     code: "resourcePollingTimeout",
-    title: "Resource Polling Timeout",
+    title: "Resource polling timeout",
   });
 }
 
@@ -34,7 +34,7 @@ export function missingMetadata(): ApiError<ErrorCodes> {
   return new ApiError({
     detail: "Resource metadata is missing",
     code: "missingMetadata",
-    title: "Missing Metadata",
+    title: "Missing metadata",
   });
 }
 
@@ -44,7 +44,7 @@ export function unexpectedDelegationKind(
   return new ApiError({
     detail: `Unexpected delegation kind "${delegation.kind}" for delegation ${delegation.id}`,
     code: "unexpectedDelegationKind",
-    title: "Unexpected Delegation Kind",
+    title: "Unexpected delegation kind",
   });
 }
 
@@ -54,7 +54,7 @@ export function unexpectedAttributeKind(
   return new ApiError({
     detail: `Unexpected attribute kind "${attribute.kind}" for attribute ${attribute.id}`,
     code: "unexpectedAttributeKind",
-    title: "Unexpected Attribute Kind",
+    title: "Unexpected attribute kind",
   });
 }
 
@@ -64,7 +64,7 @@ export function unexpectedUndefinedAttributeOriginOrCode(
   return new ApiError({
     detail: `Attribute ${attribute.id} has undefined origin or code`,
     code: "unexpectedUndefinedAttributeOriginOrCode",
-    title: "Unexpected Undefined Attribute Origin or Code",
+    title: "Unexpected undefined attribute origin or code",
   });
 }
 

--- a/packages/m2m-gateway/src/routers/attributeRouter.ts
+++ b/packages/m2m-gateway/src/routers/attributeRouter.ts
@@ -12,6 +12,7 @@ import { emptyErrorMapper } from "pagopa-interop-models";
 import { makeApiProblem } from "../model/errors.js";
 import { AttributeService } from "../services/attributeService.js";
 import { fromM2MGatewayAppContext } from "../utils/context.js";
+import { getCertifiedAttributeErrorMapper } from "../utils/errorMappers.js";
 
 const { M2M_ADMIN_ROLE, M2M_ROLE } = authRole;
 
@@ -41,7 +42,7 @@ const attributeRouter = (
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
-          emptyErrorMapper,
+          getCertifiedAttributeErrorMapper,
           ctx,
           `Error retrieving certified attribute with id ${req.params.attributeId}`
         );

--- a/packages/m2m-gateway/src/routers/attributeRouter.ts
+++ b/packages/m2m-gateway/src/routers/attributeRouter.ts
@@ -5,11 +5,15 @@ import {
   ZodiosContext,
   ExpressContext,
   zodiosValidationErrorToApiProblem,
+  authRole,
+  validateAuthorization,
 } from "pagopa-interop-commons";
 import { emptyErrorMapper } from "pagopa-interop-models";
 import { makeApiProblem } from "../model/errors.js";
 import { AttributeService } from "../services/attributeService.js";
 import { fromM2MGatewayAppContext } from "../utils/context.js";
+
+const { M2M_ADMIN_ROLE, M2M_ROLE } = authRole;
 
 const attributeRouter = (
   ctx: ZodiosContext,
@@ -19,14 +23,21 @@ const attributeRouter = (
     validationErrorHandler: zodiosValidationErrorToApiProblem,
   });
 
-  void attributeService;
-
   attributeRouter
     .get("/certifiedAttributes/:attributeId", async (req, res) => {
       const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
 
       try {
-        return res.status(501).send();
+        validateAuthorization(ctx, [M2M_ROLE, M2M_ADMIN_ROLE]);
+
+        const attribute = await attributeService.getCertifiedAttribute(
+          req.params.attributeId,
+          ctx
+        );
+
+        return res
+          .status(200)
+          .send(m2mGatewayApi.CertifiedAttribute.parse(attribute));
       } catch (error) {
         const errorRes = makeApiProblem(
           error,

--- a/packages/m2m-gateway/src/services/attributeService.ts
+++ b/packages/m2m-gateway/src/services/attributeService.ts
@@ -1,8 +1,26 @@
+import { WithLogger } from "pagopa-interop-commons";
+import { m2mGatewayApi } from "pagopa-interop-api-clients";
 import { PagoPAInteropBeClients } from "../clients/clientsProvider.js";
+import { M2MGatewayAppContext } from "../utils/context.js";
+import { toM2MGatewayApiCertifiedAttribute } from "../api/attributeApiConverter.js";
 
 export type AttributeService = ReturnType<typeof attributeServiceBuilder>;
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function attributeServiceBuilder(_clients: PagoPAInteropBeClients) {
-  return {};
+export function attributeServiceBuilder(clients: PagoPAInteropBeClients) {
+  return {
+    async getCertifiedAttribute(
+      attributeId: string,
+      { headers }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApi.CertifiedAttribute> {
+      const response = await clients.attributeProcessClient.getAttributeById({
+        params: {
+          attributeId,
+        },
+        headers,
+      });
+
+      return toM2MGatewayApiCertifiedAttribute(response.data);
+    },
+  };
 }

--- a/packages/m2m-gateway/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway/src/utils/errorMappers.ts
@@ -11,5 +11,5 @@ export const getCertifiedAttributeErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)
-    .with("certifiedAttributeNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("attributeNotFound", () => HTTP_STATUS_NOT_FOUND)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/m2m-gateway/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway/src/utils/errorMappers.ts
@@ -1,0 +1,15 @@
+import { constants } from "http2";
+import { ApiError, CommonErrorCodes } from "pagopa-interop-models";
+import { match } from "ts-pattern";
+import { ErrorCodes as M2MGatewayErrorCodes } from "../model/errors.js";
+
+type ErrorCodes = M2MGatewayErrorCodes | CommonErrorCodes;
+
+const { HTTP_STATUS_NOT_FOUND, HTTP_STATUS_INTERNAL_SERVER_ERROR } = constants;
+
+export const getCertifiedAttributeErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("certifiedAttributeNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/m2m-gateway/src/utils/validators/attributeValidators.ts
+++ b/packages/m2m-gateway/src/utils/validators/attributeValidators.ts
@@ -2,7 +2,7 @@ import { attributeRegistryApi } from "pagopa-interop-api-clients";
 import { match } from "ts-pattern";
 import {
   ErrorCodes,
-  certifiedAttributeNotFound,
+  attributeNotFound,
   unexpectedAttributeKind,
   unexpectedUndefinedAttributeOriginOrCode,
 } from "../../model/errors.js";
@@ -14,7 +14,7 @@ export function assertAttributeKindIs<
   expectedKind: K,
   error: Extract<
     ErrorCodes,
-    "unexpectedAttributeKind" | "certifiedAttributeNotFound"
+    "unexpectedAttributeKind" | "attributeNotFound"
   > = "unexpectedAttributeKind"
 ): asserts attribute is attributeRegistryApi.Attribute & { kind: K } {
   if (attribute.kind !== expectedKind) {
@@ -22,8 +22,8 @@ export function assertAttributeKindIs<
       .with("unexpectedAttributeKind", () => {
         throw unexpectedAttributeKind(attribute);
       })
-      .with("certifiedAttributeNotFound", () => {
-        throw certifiedAttributeNotFound(attribute);
+      .with("attributeNotFound", () => {
+        throw attributeNotFound(attribute);
       })
       .exhaustive();
   }

--- a/packages/m2m-gateway/src/utils/validators/attributeValidators.ts
+++ b/packages/m2m-gateway/src/utils/validators/attributeValidators.ts
@@ -1,0 +1,27 @@
+import { attributeRegistryApi } from "pagopa-interop-api-clients";
+import {
+  unexpectedAttributeKind,
+  unexpectedUndefinedAttributeOriginOrCode,
+} from "../../model/errors.js";
+
+export function assertAttributeKindIs<
+  K extends attributeRegistryApi.AttributeKind
+>(
+  attribute: attributeRegistryApi.Attribute,
+  expectedKind: K
+): asserts attribute is attributeRegistryApi.Attribute & { kind: K } {
+  if (attribute.kind !== expectedKind) {
+    throw unexpectedAttributeKind(attribute);
+  }
+}
+
+export function assertAttributeOiginAndCodeAreDefined(
+  attribute: attributeRegistryApi.Attribute
+): asserts attribute is attributeRegistryApi.Attribute & {
+  origin: string;
+  code: string;
+} {
+  if (attribute.origin === undefined || attribute.code === undefined) {
+    throw unexpectedUndefinedAttributeOriginOrCode(attribute);
+  }
+}

--- a/packages/m2m-gateway/src/utils/validators/attributeValidators.ts
+++ b/packages/m2m-gateway/src/utils/validators/attributeValidators.ts
@@ -1,5 +1,8 @@
 import { attributeRegistryApi } from "pagopa-interop-api-clients";
+import { match } from "ts-pattern";
 import {
+  ErrorCodes,
+  certifiedAttributeNotFound,
   unexpectedAttributeKind,
   unexpectedUndefinedAttributeOriginOrCode,
 } from "../../model/errors.js";
@@ -8,10 +11,21 @@ export function assertAttributeKindIs<
   K extends attributeRegistryApi.AttributeKind
 >(
   attribute: attributeRegistryApi.Attribute,
-  expectedKind: K
+  expectedKind: K,
+  error: Extract<
+    ErrorCodes,
+    "unexpectedAttributeKind" | "certifiedAttributeNotFound"
+  > = "unexpectedAttributeKind"
 ): asserts attribute is attributeRegistryApi.Attribute & { kind: K } {
   if (attribute.kind !== expectedKind) {
-    throw unexpectedAttributeKind(attribute);
+    match(error)
+      .with("unexpectedAttributeKind", () => {
+        throw unexpectedAttributeKind(attribute);
+      })
+      .with("certifiedAttributeNotFound", () => {
+        throw certifiedAttributeNotFound(attribute);
+      })
+      .exhaustive();
   }
 }
 

--- a/packages/m2m-gateway/src/utils/validators/attributeValidators.ts
+++ b/packages/m2m-gateway/src/utils/validators/attributeValidators.ts
@@ -29,7 +29,7 @@ export function assertAttributeKindIs<
   }
 }
 
-export function assertAttributeOiginAndCodeAreDefined(
+export function assertAttributeOriginAndCodeAreDefined(
   attribute: attributeRegistryApi.Attribute
 ): asserts attribute is attributeRegistryApi.Attribute & {
   origin: string;

--- a/packages/m2m-gateway/test/.eslintrc.json
+++ b/packages/m2m-gateway/test/.eslintrc.json
@@ -4,6 +4,7 @@
   ],
   "rules": {
     "functional/immutable-data": "off",
-    "functional/no-let": "off"
+    "functional/no-let": "off",
+    "@typescript-eslint/no-non-null-assertion": "off"
   }
 }

--- a/packages/m2m-gateway/test/api/certifiedAttributes/getCertifiedAttribute.test.ts
+++ b/packages/m2m-gateway/test/api/certifiedAttributes/getCertifiedAttribute.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import { generateToken } from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import {
+  attributeRegistryApi,
+  m2mGatewayApi,
+} from "pagopa-interop-api-clients";
+import { api, mockAttributeService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import {
+  attributeNotFound,
+  unexpectedUndefinedAttributeOriginOrCode,
+} from "../../../src/model/errors.js";
+import { getMockedApiAttribute } from "../../mockUtils.js";
+import { toM2MGatewayApiCertifiedAttribute } from "../../../src/api/attributeApiConverter.js";
+
+describe("GET /certifiedAttribute router test", () => {
+  const mockApiCertifiedAttribute = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED,
+  });
+  const mockM2MCertifiedAttributeResponse: m2mGatewayApi.CertifiedAttribute =
+    toM2MGatewayApiCertifiedAttribute(mockApiCertifiedAttribute.data);
+
+  const makeRequest = async (token: string, attributeId: string) =>
+    request(api)
+      .get(`${appBasePath}/certifiedAttributes/${attributeId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send();
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.M2M_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+  it.each(authorizedRoles)(
+    "Should return 200 and perform API clients calls for user with role %s",
+    async (role) => {
+      mockAttributeService.getCertifiedAttribute = vi
+        .fn()
+        .mockResolvedValue(mockM2MCertifiedAttributeResponse);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token, mockApiCertifiedAttribute.data.id);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockM2MCertifiedAttributeResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, mockApiCertifiedAttribute.data.id);
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 400 if passed an invalid attribute id", async () => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, "invalidId");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 404 in case of attributeNotFound error", async () => {
+    mockAttributeService.getCertifiedAttribute = vi
+      .fn()
+      .mockRejectedValue(attributeNotFound(mockApiCertifiedAttribute.data));
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, mockApiCertifiedAttribute.data.id);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("Should return 500 in case of unexpectedUndefinedAttributeOriginOrCode error", async () => {
+    mockAttributeService.getCertifiedAttribute = vi
+      .fn()
+      .mockRejectedValue(
+        unexpectedUndefinedAttributeOriginOrCode(mockApiCertifiedAttribute.data)
+      );
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, mockApiCertifiedAttribute.data.id);
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway/test/integration/certifiedAttributes/getCertifiedAttribute.test.ts
+++ b/packages/m2m-gateway/test/integration/certifiedAttributes/getCertifiedAttribute.test.ts
@@ -1,0 +1,110 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  attributeRegistryApi,
+  m2mGatewayApi,
+} from "pagopa-interop-api-clients";
+import {
+  attributeService,
+  expectApiClientGetToHaveBeenCalledWith,
+  mockInteropBeClients,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import {
+  attributeNotFound,
+  unexpectedUndefinedAttributeOriginOrCode,
+} from "../../../src/model/errors.js";
+import {
+  getMockM2MAdminAppContext,
+  getMockedApiAttribute,
+} from "../../mockUtils.js";
+
+describe("getCertifiedAttribute", () => {
+  const mockAttributeProcessResponse = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED,
+  });
+  const mockGetAttribute = vi
+    .fn()
+    .mockResolvedValue(mockAttributeProcessResponse);
+
+  mockInteropBeClients.attributeProcessClient = {
+    getAttributeById: mockGetAttribute,
+  } as unknown as PagoPAInteropBeClients["attributeProcessClient"];
+
+  beforeEach(() => {
+    // Clear mock counters and call information before each test
+    mockGetAttribute.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const m2mAttributeResponse: m2mGatewayApi.CertifiedAttribute = {
+      id: mockAttributeProcessResponse.data.id,
+      code: mockAttributeProcessResponse.data.code!,
+      description: mockAttributeProcessResponse.data.description,
+      origin: mockAttributeProcessResponse.data.origin!,
+      name: mockAttributeProcessResponse.data.name,
+      createdAt: mockAttributeProcessResponse.data.creationTime,
+    };
+
+    const result = await attributeService.getCertifiedAttribute(
+      mockAttributeProcessResponse.data.id,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toEqual(m2mAttributeResponse);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributeById,
+      params: { attributeId: mockAttributeProcessResponse.data.id },
+    });
+  });
+
+  it("Should throw attributeNotFound in case the returned attribute has an unexpected kind", async () => {
+    const mockResponse = {
+      ...mockAttributeProcessResponse,
+      data: {
+        ...mockAttributeProcessResponse.data,
+        kind: attributeRegistryApi.AttributeKind.Values.DECLARED,
+      },
+    };
+
+    mockInteropBeClients.attributeProcessClient.getAttributeById =
+      mockGetAttribute.mockResolvedValueOnce(mockResponse);
+
+    await expect(
+      attributeService.getCertifiedAttribute(
+        mockAttributeProcessResponse.data.id,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(attributeNotFound(mockResponse.data));
+  });
+
+  it.each([
+    { origin: undefined, code: "validCode" },
+    { origin: "validOrigin", code: undefined },
+    { origin: undefined, code: undefined },
+  ])(
+    "Should throw unexpectedUndefinedAttributeOriginOrCode in case the returned attribute has an undefined origin or code",
+    async ({ origin, code }) => {
+      const mockResponse = {
+        ...mockAttributeProcessResponse,
+        data: {
+          ...mockAttributeProcessResponse.data,
+          origin,
+          code,
+        },
+      };
+
+      mockInteropBeClients.attributeProcessClient.getAttributeById =
+        mockGetAttribute.mockResolvedValueOnce(mockResponse);
+
+      await expect(
+        attributeService.getCertifiedAttribute(
+          mockAttributeProcessResponse.data.id,
+          getMockM2MAdminAppContext()
+        )
+      ).rejects.toThrowError(
+        unexpectedUndefinedAttributeOriginOrCode(mockResponse.data)
+      );
+    }
+  );
+});

--- a/packages/m2m-gateway/test/integrationUtils.ts
+++ b/packages/m2m-gateway/test/integrationUtils.ts
@@ -4,6 +4,7 @@ import { expect } from "vitest";
 import { PagoPAInteropBeClients } from "../src/clients/clientsProvider.js";
 import { delegationServiceBuilder } from "../src/services/delegationService.js";
 import { WithMaybeMetadata } from "../src/clients/zodiosWithMetadataPatch.js";
+import { attributeServiceBuilder } from "../src/services/attributeService.js";
 import { m2mTestToken } from "./mockUtils.js";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -63,3 +64,4 @@ export function expectApiClientPostToHaveBeenCalledWith({
 
 export const mockInteropBeClients = {} as PagoPAInteropBeClients;
 export const delegationService = delegationServiceBuilder(mockInteropBeClients);
+export const attributeService = attributeServiceBuilder(mockInteropBeClients);

--- a/packages/m2m-gateway/test/mockUtils.ts
+++ b/packages/m2m-gateway/test/mockUtils.ts
@@ -1,4 +1,7 @@
-import { delegationApi } from "pagopa-interop-api-clients";
+import {
+  attributeRegistryApi,
+  delegationApi,
+} from "pagopa-interop-api-clients";
 import { WithLogger, systemRole, genericLogger } from "pagopa-interop-commons";
 import {
   CorrelationId,
@@ -6,6 +9,8 @@ import {
   WithMetadata,
   generateId,
 } from "pagopa-interop-models";
+import { generateMock } from "@anatine/zod-mock";
+import { z } from "zod";
 import { M2MGatewayAppContext } from "../src/utils/context.js";
 
 export function getMockedApiDelegation({
@@ -32,6 +37,27 @@ export function getMockedApiDelegation({
           when: new Date().toISOString(),
         },
       },
+    },
+    metadata: {
+      version: 0,
+    },
+  };
+}
+
+export function getMockedApiAttribute({
+  kind,
+}: {
+  kind?: attributeRegistryApi.AttributeKind;
+} = {}): WithMetadata<attributeRegistryApi.Attribute> {
+  return {
+    data: {
+      id: generateId(),
+      name: generateMock(z.string()),
+      description: generateMock(z.string()),
+      creationTime: new Date().toISOString(),
+      code: generateMock(z.string()),
+      origin: generateMock(z.string()),
+      kind: kind ?? attributeRegistryApi.AttributeKind.Values.CERTIFIED,
     },
     metadata: {
       version: 0,

--- a/packages/m2m-gateway/test/vitest.api.setup.ts
+++ b/packages/m2m-gateway/test/vitest.api.setup.ts
@@ -64,11 +64,12 @@ import { PurposeService } from "../src/services/purposeService.js";
 import { TenantService } from "../src/services/tenantService.js";
 
 export const mockDelegationService = {} as DelegationService;
+export const mockAttributeService = {} as AttributeService;
 
 export const api = await createApp(
   {
     agreementService: {} as AgreementService,
-    attributeService: {} as AttributeService,
+    attributeService: mockAttributeService,
     clientService: {} as ClientService,
     delegationService: mockDelegationService,
     eserviceService: {} as EserviceService,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3303,6 +3303,9 @@ importers:
         specifier: 3.23.8
         version: 3.23.8
     devDependencies:
+      '@anatine/zod-mock':
+        specifier: 3.13.4
+        version: 3.13.4(@faker-js/faker@8.4.1)(zod@3.23.8)
       '@pagopa/eslint-config':
         specifier: 3.0.0
         version: 3.0.0(tsutils@3.21.0(typescript@5.4.5))(typescript@5.4.5)


### PR DESCRIPTION
Closes [PIN-6772](https://pagopa.atlassian.net/browse/PIN-6772)

# Description
GET `/certifiedAttributes/:attributeId`

## Double-check errors
- [x] Check errors returned by the process API calls (messages should be meaningful, clean, in correct English, etc.)
- [x] Check spec errors: it should list all non-500 errors, also the ones that pass through from the process

# Testing
Checklist:
- [x] Bruno call added to collection
- [x] Smoke test Bruno (attach result screenshot)
- [x] Supertest /api tests
- [x] /integration tests for the logic in the service

## Bruno smoke test

<img width="920" alt="image" src="https://github.com/user-attachments/assets/22e7ddfc-54ae-40af-8082-15c5b9d8fb4c" />

### Trying to retrieve an attribute with a different kind

<img width="433" alt="image" src="https://github.com/user-attachments/assets/b6ef31f5-da1b-4cb9-add7-39114edf4538" />

<img width="915" alt="image" src="https://github.com/user-attachments/assets/fea651f1-63dc-4716-9b45-ae37b81d5f01" />


### Not found error passthrough from the process

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/741895b5-af49-495d-9ea2-a0ad6fdd9892" />

<img width="919" alt="image" src="https://github.com/user-attachments/assets/015962b7-da54-4b26-9de8-ab7d05b98147" />


[PIN-6772]: https://pagopa.atlassian.net/browse/PIN-6772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ