### PR TITLE
PIN-6835 - Update openapi-zod-client

### DIFF
--- a/packages/agreement-process/package.json
+++ b/packages/agreement-process/package.json
@@ -25,7 +25,6 @@
     "@types/node": "20.14.6",
     "cpx2": "7.0.1",
     "date-fns": "3.6.0",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-commons-test": "workspace:*",
     "pg-promise": "11.8.0",
     "prettier": "2.8.8",

--- a/packages/api-clients/package.json
+++ b/packages/api-clients/package.json
@@ -29,7 +29,7 @@
     "@types/qs": "6.9.15",
     "openapi-types": "12.1.3",
     "handlebars": "4.7.7",
-    "openapi-zod-client": "1.18.1",
+    "openapi-zod-client": "1.18.3",
     "openapi3-ts": "3.1.0",
     "prettier": "2.8.8",
     "tsx": "4.19.1",

--- a/packages/api-clients/template-bff.hbs
+++ b/packages/api-clients/template-bff.hbs
@@ -40,6 +40,8 @@ export const {{@key}}Endpoints = makeApi([
 				{{/if}}
 				{{#if (and (eq type "Query") (eq schema "z.array(z.string()).optional().default([])"))}}
 						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string()).optional().default([])), z.array(z.string()).optional().default([])]),
+				{{else if (and (eq type "Query") (eq schema "z.array(z.string().uuid()).optional().default([])"))}}
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string().uuid()).optional().default([])), z.array(z.string().uuid()).optional().default([])]),
 				{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind).default([])"))}}
 						schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind).default([])), z.array(AttributeKind).default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(AgreementState).optional().default([])"))}}

--- a/packages/api-clients/template.hbs
+++ b/packages/api-clients/template.hbs
@@ -40,6 +40,8 @@ export const {{@key}}Endpoints = makeApi([
 				{{/if}}
 				{{#if (and (eq type "Query") (eq schema "z.array(z.string()).optional().default([])"))}}
 						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string()).optional().default([])), z.array(z.string()).optional().default([])]),
+				{{else if (and (eq type "Query") (eq schema "z.array(z.string().uuid()).optional().default([])"))}}
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string().uuid()).optional().default([])), z.array(z.string().uuid()).optional().default([])]),
 				{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind)"))}}
 						schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)), z.array(AttributeKind)])
 				{{else if (and (eq type "Query") (eq schema "z.array(AgreementState).optional().default([])"))}}

--- a/packages/attribute-registry-process/package.json
+++ b/packages/attribute-registry-process/package.json
@@ -45,7 +45,6 @@
     "drizzle-orm": "0.39.3",
     "express": "4.20.0",
     "mongodb": "6.7.0",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-api-clients": "workspace:*",
     "pagopa-interop-application-audit": "workspace:*",
     "pagopa-interop-commons": "workspace:*",

--- a/packages/authorization-process/package.json
+++ b/packages/authorization-process/package.json
@@ -42,7 +42,6 @@
     "drizzle-orm": "0.39.3",
     "express": "4.20.0",
     "mongodb": "6.7.0",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-api-clients": "workspace:*",
     "pagopa-interop-application-audit": "workspace:*",
     "pagopa-interop-commons": "workspace:*",

--- a/packages/authorization-server/package.json
+++ b/packages/authorization-server/package.json
@@ -40,7 +40,6 @@
     "dotenv-flow": "4.1.0",
     "express": "4.20.0",
     "kafka-iam-auth": "workspace:*",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-api-clients": "workspace:*",
     "pagopa-interop-client-assertion-validation": "workspace:*",
     "pagopa-interop-commons": "workspace:*",

--- a/packages/authorization-updater/package.json
+++ b/packages/authorization-updater/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@pagopa/eslint-config": "3.0.0",
     "@types/node": "20.14.6",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-commons-test": "workspace:*",
     "prettier": "2.8.8",
     "tsx": "4.19.1",

--- a/packages/catalog-process/package.json
+++ b/packages/catalog-process/package.json
@@ -42,7 +42,6 @@
     "drizzle-orm": "0.39.3",
     "express": "4.20.0",
     "mongodb": "6.7.0",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-api-clients": "workspace:*",
     "pagopa-interop-application-audit": "workspace:*",
     "pagopa-interop-commons": "workspace:*",

--- a/packages/delegation-process/package.json
+++ b/packages/delegation-process/package.json
@@ -42,7 +42,6 @@
     "drizzle-orm": "0.39.3",
     "express": "4.20.0",
     "mongodb": "6.7.0",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-api-clients": "workspace:*",
     "pagopa-interop-application-audit": "workspace:*",
     "pagopa-interop-commons": "workspace:*",

--- a/packages/eservice-descriptors-archiver/package.json
+++ b/packages/eservice-descriptors-archiver/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@pagopa/eslint-config": "3.0.0",
     "@types/node": "20.14.6",
-    "openapi-zod-client": "1.18.1",
     "prettier": "2.8.8",
     "testcontainers": "10.9.0",
     "tsx": "4.19.1",

--- a/packages/eservice-template-process/package.json
+++ b/packages/eservice-template-process/package.json
@@ -40,7 +40,6 @@
     "drizzle-orm": "0.39.3",
     "express": "4.20.0",
     "mongodb": "6.7.0",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-application-audit": "workspace:*",
     "pagopa-interop-commons": "workspace:*",
     "pagopa-interop-models": "workspace:*",

--- a/packages/purpose-process/package.json
+++ b/packages/purpose-process/package.json
@@ -39,7 +39,6 @@
     "express": "4.20.0",
     "handlebars": "4.7.8",
     "mongodb": "6.7.0",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-api-clients": "workspace:*",
     "pagopa-interop-application-audit": "workspace:*",
     "pagopa-interop-commons": "workspace:*",

--- a/packages/tenant-process/package.json
+++ b/packages/tenant-process/package.json
@@ -37,7 +37,6 @@
     "drizzle-orm": "0.39.3",
     "express": "4.20.0",
     "mongodb": "6.7.0",
-    "openapi-zod-client": "1.18.1",
     "pagopa-interop-api-clients": "workspace:*",
     "pagopa-interop-application-audit": "workspace:*",
     "pagopa-interop-commons": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,9 +234,6 @@ importers:
       date-fns:
         specifier: 3.6.0
         version: 3.6.0
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-commons-test:
         specifier: workspace:*
         version: link:../commons-test
@@ -500,8 +497,8 @@ importers:
         specifier: 12.1.3
         version: 12.1.3
       openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
+        specifier: 1.18.3
+        version: 1.18.3
       openapi3-ts:
         specifier: 3.1.0
         version: 3.1.0
@@ -645,9 +642,6 @@ importers:
       mongodb:
         specifier: 6.7.0
         version: 6.7.0(@aws-sdk/credential-providers@3.609.0)(socks@2.8.3)
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-api-clients:
         specifier: workspace:*
         version: link:../api-clients
@@ -922,9 +916,6 @@ importers:
       mongodb:
         specifier: 6.7.0
         version: 6.7.0(@aws-sdk/credential-providers@3.609.0)(socks@2.8.3)
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-api-clients:
         specifier: workspace:*
         version: link:../api-clients
@@ -1025,9 +1016,6 @@ importers:
       kafka-iam-auth:
         specifier: workspace:*
         version: link:../kafka-iam-auth
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-api-clients:
         specifier: workspace:*
         version: link:../api-clients
@@ -1123,9 +1111,6 @@ importers:
       '@types/node':
         specifier: 20.14.6
         version: 20.14.6
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-commons-test:
         specifier: workspace:*
         version: link:../commons-test
@@ -1405,9 +1390,6 @@ importers:
       mongodb:
         specifier: 6.7.0
         version: 6.7.0(@aws-sdk/credential-providers@3.609.0)(socks@2.8.3)
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-api-clients:
         specifier: workspace:*
         version: link:../api-clients
@@ -2352,9 +2334,6 @@ importers:
       mongodb:
         specifier: 6.7.0
         version: 6.7.0(@aws-sdk/credential-providers@3.609.0)(socks@2.8.3)
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-api-clients:
         specifier: workspace:*
         version: link:../api-clients
@@ -2703,9 +2682,6 @@ importers:
       '@types/node':
         specifier: 20.14.6
         version: 20.14.6
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       prettier:
         specifier: 2.8.8
         version: 2.8.8
@@ -2858,9 +2834,6 @@ importers:
       mongodb:
         specifier: 6.7.0
         version: 6.7.0(@aws-sdk/credential-providers@3.609.0)(socks@2.8.3)
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-api-clients:
         specifier: workspace:*
         version: link:../api-clients
@@ -4149,9 +4122,6 @@ importers:
       mongodb:
         specifier: 6.7.0
         version: 6.7.0(@aws-sdk/credential-providers@3.609.0)(socks@2.8.3)
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-api-clients:
         specifier: workspace:*
         version: link:../api-clients
@@ -4634,9 +4604,6 @@ importers:
       mongodb:
         specifier: 6.7.0
         version: 6.7.0(@aws-sdk/credential-providers@3.609.0)(socks@2.8.3)
-      openapi-zod-client:
-        specifier: 1.18.1
-        version: 1.18.1
       pagopa-interop-api-clients:
         specifier: workspace:*
         version: link:../api-clients
@@ -8765,8 +8732,8 @@ packages:
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
-  openapi-zod-client@1.18.1:
-    resolution: {integrity: sha512-L0GzU/7Sx9ugbWWoQwOJdKtyxr8ZnjxIK2RJP63//OkmKws2w7c5HSgS2bdNxPVCIp/eJuYk+CtaKfvCoJ08Yw==}
+  openapi-zod-client@1.18.3:
+    resolution: {integrity: sha512-10vYK7xo1yyZfcoRvYNGIsDeej1CG9k63u8dkjbGBlr+NHZMy2Iy2h9s11UWNKdj6XMDWbNOPp5gIy8YdpgPtQ==}
     hasBin: true
 
   openapi3-ts@3.1.0:
@@ -14944,7 +14911,7 @@ snapshots:
 
   openapi-types@12.1.3: {}
 
-  openapi-zod-client@1.18.1:
+  openapi-zod-client@1.18.3:
     dependencies:
       '@apidevtools/swagger-parser': 10.1.0(openapi-types@12.1.3)
       '@liuli-util/fs-extra': 0.1.0


### PR DESCRIPTION
Updates openapi-zod-client from 1.18.1 to 1.18.3 to fix this issue: https://github.com/astahmer/openapi-zod-client/issues/238

As a consequence of this PR, string arrays with format constraints (like `format: uuid` or `format: url`) in the OpenAPI specs (in query params or bodies) are now converted to Zod codecs with the same constraints.

For example:
<img width="1216" alt="Screenshot 2025-05-14 at 15 36 19" src="https://github.com/user-attachments/assets/b5f83182-93a8-414e-be95-da49ee389283" />

Full diff of the generated APIs before and after this is attached here (since generated files are not committed): 
[diff.txt](https://github.com/user-attachments/files/20208549/diff.txt)

Note: the only other change in 1.18.3 is https://github.com/astahmer/openapi-zod-client/pull/322 which shouldn't apply for our specs, so I don't think there's any other impact.