### PR TITLE
PIN-6856 - Update `winston` to 3.16.0 and use `forceConsole`

### DIFF
--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -47,7 +47,7 @@
     "rate-limiter-flexible": "5.0.3",
     "redis": "4.6.15",
     "ts-pattern": "5.2.0",
-    "winston": "3.13.0",
+    "winston": "3.16.0",
     "yaml": "2.4.5",
     "zod": "3.23.8",
     "zod-validation-error": "3.3.0",

--- a/packages/commons/src/logging/index.ts
+++ b/packages/commons/src/logging/index.ts
@@ -90,6 +90,7 @@ const getLogger = () =>
     transports: [
       new winston.transports.Console({
         stderrLevels: ["error"],
+        forceConsole: true,
       }),
     ],
     format: winston.format.combine(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1948,8 +1948,8 @@ importers:
         specifier: 5.2.0
         version: 5.2.0
       winston:
-        specifier: 3.13.0
-        version: 3.13.0
+        specifier: 3.16.0
+        version: 3.16.0
       yaml:
         specifier: 2.4.5
         version: 2.4.5
@@ -9797,8 +9797,8 @@ packages:
     resolution: {integrity: sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==}
     engines: {node: '>= 12.0.0'}
 
-  winston@3.13.0:
-    resolution: {integrity: sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==}
+  winston@3.16.0:
+    resolution: {integrity: sha512-xz7+cyGN5M+4CmmD4Npq1/4T+UZaz7HaeTlAruFUTjk79CNMq+P6H30vlE4z0qfqJ01VHYQwd7OZo03nYm/+lg==}
     engines: {node: '>= 12.0.0'}
 
   word-wrap@1.2.5:
@@ -16201,7 +16201,7 @@ snapshots:
       readable-stream: 3.6.2
       triple-beam: 1.4.1
 
-  winston@3.13.0:
+  winston@3.16.0:
     dependencies:
       '@colors/colors': 1.6.0
       '@dabh/diagnostics': 2.0.3


### PR DESCRIPTION
Closes [PIN-6856](https://pagopa.atlassian.net/browse/PIN-6856)

This PR is to set winston's `forceConsole` to true. It should fix the problem we have on CloudWatch where multiline messages are separated on multiple logs.

I didn't update winston to v3.17.0 because it currently [gives type problems](https://github.com/winstonjs/logform/issues/336).

[PIN-6856]: https://pagopa.atlassian.net/browse/PIN-6856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ