### PR TITLE
PIN-6048: Analytics - Authorization consumer

### DIFF
--- a/docker/domains-analytics-db/domains-init.sql
+++ b/docker/domains-analytics-db/domains-init.sql
@@ -149,3 +149,42 @@ CREATE TABLE domains.eservice_risk_analysis_answer (
   FOREIGN KEY (eservice_id) REFERENCES domains.eservice (id),
   FOREIGN KEY (risk_analysis_form_id, eservice_id) REFERENCES domains.eservice_risk_analysis (risk_analysis_form_id, eservice_id)
 );
+
+CREATE TABLE IF NOT EXISTS domains.client (
+  id VARCHAR(36),
+  metadata_version INTEGER NOT NULL,
+  consumer_id VARCHAR(36) NOT NULL,
+  admin_id VARCHAR(36),
+  name VARCHAR NOT NULL,
+  description VARCHAR,
+  kind VARCHAR NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS domains.client_user (
+  metadata_version INTEGER NOT NULL,
+  client_id VARCHAR(36) NOT NULL REFERENCES domains.client (id),
+  user_id VARCHAR(36) NOT NULL,
+  PRIMARY KEY (client_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS domains.client_purpose (
+  metadata_version INTEGER NOT NULL,
+  client_id VARCHAR(36) NOT NULL REFERENCES domains.client (id),
+  purpose_id VARCHAR(36) NOT NULL,
+  PRIMARY KEY (client_id, purpose_id)
+);
+
+CREATE TABLE IF NOT EXISTS domains.client_key (
+  metadata_version INTEGER NOT NULL,
+  client_id VARCHAR(36) NOT NULL REFERENCES domains.client (id),
+  user_id VARCHAR(36),
+  kid VARCHAR NOT NULL,
+  name VARCHAR NOT NULL,
+  encoded_pem VARCHAR NOT NULL,
+  "algorithm" VARCHAR NOT NULL,
+  "use" VARCHAR NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  PRIMARY KEY (client_id, kid)
+);

--- a/packages/domains-analytics-writer/src/handlers/authorization/consumerServiceV1.ts
+++ b/packages/domains-analytics-writer/src/handlers/authorization/consumerServiceV1.ts
@@ -1,31 +1,239 @@
-import { AuthorizationEventEnvelopeV1 } from "pagopa-interop-models";
-import { match, P } from "ts-pattern";
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable functional/immutable-data */
+/* eslint-disable sonarjs/cognitive-complexity */
+
+import {
+  AuthorizationEventEnvelopeV1,
+  dateToString,
+  fromClientV1,
+  fromKeyV1,
+  genericInternalError,
+  Key,
+} from "pagopa-interop-models";
+import { match } from "ts-pattern";
+import { createJWK } from "pagopa-interop-commons";
+import { splitClientIntoObjectsSQL } from "pagopa-interop-readmodel";
+import { z } from "zod";
 import { DBContext } from "../../db/db.js";
+import { authorizationServiceBuilder } from "../../service/authorizationService.js";
+import {
+  ClientKeyDeletingSchema,
+  ClientKeySchema,
+  ClientKeyUserMigrationSchema,
+} from "../../model/authorization/clientKey.js";
+import {
+  ClientItemsSchema,
+  ClientDeletingSchema,
+} from "../../model/authorization/client.js";
+import {
+  ClientPurposeDeletingSchema,
+  ClientPurposeSchema,
+} from "../../model/authorization/clientPurpose.js";
+import {
+  ClientUserDeletingSchema,
+  ClientUserSchema,
+} from "../../model/authorization/clientUser.js";
 
 export async function handleAuthorizationMessageV1(
   messages: AuthorizationEventEnvelopeV1[],
-  _dbContext: DBContext
+  dbContext: DBContext
 ): Promise<void> {
+  const authorizationService = authorizationServiceBuilder(dbContext);
+
+  const upsertClientBatch: ClientItemsSchema[] = [];
+  const deleteClientBatch: ClientDeletingSchema[] = [];
+  const upsertClientUserBatch: ClientUserSchema[] = [];
+  const removeUserBatch: ClientUserDeletingSchema[] = [];
+  const upsertClientPurposeBatch: ClientPurposeSchema[] = [];
+  const removePurposeBatch: ClientPurposeDeletingSchema[] = [];
+  const upsertKeyBatch: ClientKeySchema[] = [];
+  const deleteKeyBatch: ClientKeyDeletingSchema[] = [];
+  const migrateKeyUserRelationshipBatch: ClientKeyUserMigrationSchema[] = [];
+
   for (const message of messages) {
     await match(message)
+      .with({ type: "ClientAdded" }, async (msg) => {
+        const client = msg.data.client;
+        if (!client) {
+          throw genericInternalError(
+            "Client can't be missing in event message"
+          );
+        }
+
+        const splitResult = splitClientIntoObjectsSQL(
+          fromClientV1(client),
+          msg.version
+        );
+
+        upsertClientBatch.push(
+          ClientItemsSchema.parse({
+            clientSQL: splitResult.clientSQL,
+            usersSQL: splitResult.usersSQL,
+            purposesSQL: splitResult.purposesSQL,
+            keysSQL: splitResult.keysSQL,
+          } satisfies z.input<typeof ClientItemsSchema>)
+        );
+      })
+      .with({ type: "ClientDeleted" }, async (msg) => {
+        deleteClientBatch.push(
+          ClientDeletingSchema.parse({
+            id: msg.data.clientId,
+            deleted: true,
+          } satisfies z.input<typeof ClientDeletingSchema>)
+        );
+      })
+      .with({ type: "UserAdded" }, async (msg) => {
+        const client = msg.data.client;
+        if (!client) {
+          throw genericInternalError(
+            "Client can't be missing in event message"
+          );
+        }
+
+        upsertClientUserBatch.push(
+          ClientUserSchema.parse({
+            clientId: client.id,
+            userId: msg.data.userId,
+            metadataVersion: msg.version,
+          } satisfies z.input<typeof ClientUserSchema>)
+        );
+      })
+      .with({ type: "UserRemoved" }, async (msg) => {
+        const client = msg.data.client;
+        if (!client) {
+          throw genericInternalError(
+            "Client can't be missing in event message"
+          );
+        }
+
+        removeUserBatch.push(
+          ClientUserDeletingSchema.parse({
+            clientId: client.id,
+            userId: msg.data.userId,
+            deleted: true,
+          } satisfies z.input<typeof ClientUserDeletingSchema>)
+        );
+      })
+      .with({ type: "ClientPurposeAdded" }, async (msg) => {
+        const purposeId = msg.data.statesChain?.purpose?.purposeId;
+        if (!purposeId) {
+          throw genericInternalError(
+            "purposeId can't be missing in event message"
+          );
+        }
+
+        upsertClientPurposeBatch.push(
+          ClientPurposeSchema.parse({
+            clientId: msg.data.clientId,
+            purposeId,
+            metadataVersion: msg.version,
+          } satisfies z.input<typeof ClientPurposeSchema>)
+        );
+      })
+      .with({ type: "ClientPurposeRemoved" }, async (msg) => {
+        removePurposeBatch.push(
+          ClientPurposeDeletingSchema.parse({
+            clientId: msg.data.clientId,
+            purposeId: msg.data.purposeId,
+            deleted: true,
+          } satisfies z.input<typeof ClientPurposeDeletingSchema>)
+        );
+      })
+      .with({ type: "KeysAdded" }, async (msg) => {
+        const keysSQL = msg.data.keys
+          .map((keyV1) => (keyV1.value ? fromKeyV1(keyV1.value) : undefined))
+          .filter((k): k is Key => !!k)
+          .filter((k) => {
+            const jwk = createJWK({
+              pemKeyBase64: k.encodedPem,
+              strictCheck: false,
+            });
+            return jwk.kty !== "EC";
+          })
+          .map((key) =>
+            ClientKeySchema.parse({
+              ...key,
+              metadataVersion: msg.version,
+              clientId: msg.data.clientId,
+              userId: key.userId !== "" ? key.userId : null,
+              createdAt: dateToString(key.createdAt),
+            } satisfies z.input<typeof ClientKeySchema>)
+          );
+
+        upsertKeyBatch.push(...keysSQL);
+      })
+      .with({ type: "KeyDeleted" }, async (msg) => {
+        deleteKeyBatch.push(
+          ClientKeyDeletingSchema.parse({
+            clientId: msg.data.clientId,
+            kid: msg.data.keyId,
+            deleted: true,
+          } satisfies z.input<typeof ClientKeyDeletingSchema>)
+        );
+      })
+      .with({ type: "KeyRelationshipToUserMigrated" }, async (msg) => {
+        migrateKeyUserRelationshipBatch.push(
+          ClientKeyUserMigrationSchema.parse({
+            clientId: msg.data.clientId,
+            kid: msg.data.keyId,
+            userId: msg.data.userId,
+            metadataVersion: msg.version,
+          } satisfies z.input<typeof ClientKeyUserMigrationSchema>)
+        );
+      })
       .with(
-        {
-          type: P.union(
-            "KeysAdded",
-            "KeyDeleted",
-            "KeyRelationshipToUserMigrated",
-            "ClientAdded",
-            "ClientDeleted",
-            "RelationshipAdded",
-            "RelationshipRemoved",
-            "UserAdded",
-            "UserRemoved",
-            "ClientPurposeAdded",
-            "ClientPurposeRemoved"
-          ),
-        },
-        async () => Promise.resolve()
+        { type: "RelationshipAdded" },
+        { type: "RelationshipRemoved" },
+        () => Promise.resolve()
       )
       .exhaustive();
+  }
+
+  if (upsertClientBatch.length > 0) {
+    await authorizationService.upsertClientBatch(dbContext, upsertClientBatch);
+  }
+
+  if (deleteClientBatch.length > 0) {
+    await authorizationService.deleteClientBatch(dbContext, deleteClientBatch);
+  }
+
+  if (upsertClientUserBatch.length > 0) {
+    await authorizationService.upsertClientUserBatch(
+      dbContext,
+      upsertClientUserBatch
+    );
+  }
+
+  if (removeUserBatch.length > 0) {
+    await authorizationService.removeUserBatch(dbContext, removeUserBatch);
+  }
+
+  if (upsertClientPurposeBatch.length > 0) {
+    await authorizationService.upsertClientPurposeBatch(
+      dbContext,
+      upsertClientPurposeBatch
+    );
+  }
+
+  if (removePurposeBatch.length > 0) {
+    await authorizationService.removePurposeBatch(
+      dbContext,
+      removePurposeBatch
+    );
+  }
+
+  if (deleteKeyBatch.length > 0) {
+    await authorizationService.deleteKeyBatch(dbContext, deleteKeyBatch);
+  }
+
+  if (upsertKeyBatch.length > 0) {
+    await authorizationService.upsertKeyBatch(dbContext, upsertKeyBatch);
+  }
+
+  if (migrateKeyUserRelationshipBatch.length > 0) {
+    await authorizationService.upsertMigrateKeyUserRelationshipBatch(
+      dbContext,
+      migrateKeyUserRelationshipBatch
+    );
   }
 }

--- a/packages/domains-analytics-writer/src/index.ts
+++ b/packages/domains-analytics-writer/src/index.ts
@@ -14,6 +14,7 @@ import { retryConnection } from "./db/buildColumnSet.js";
 import {
   AttributeDbTable,
   CatalogDbTable,
+  ClientDbTable,
   DeletingDbTable,
 } from "./model/db/index.js";
 import { executeTopicHandler } from "./handlers/batchMessageHandler.js";
@@ -51,6 +52,10 @@ await retryConnection(
       CatalogDbTable.eservice_descriptor_attribute,
       CatalogDbTable.eservice_risk_analysis,
       CatalogDbTable.eservice_risk_analysis_answer,
+      ClientDbTable.client,
+      ClientDbTable.client_purpose,
+      ClientDbTable.client_user,
+      ClientDbTable.client_key,
     ]);
     await setupDbService.setupStagingDeletingTables([
       { name: DeletingDbTable.attribute_deleting_table, columns: ["id"] },
@@ -58,6 +63,19 @@ await retryConnection(
       {
         name: DeletingDbTable.catalog_risk_deleting_table,
         columns: ["id", "eserviceId"],
+      },
+      { name: DeletingDbTable.client_deleting_table, columns: ["id"] },
+      {
+        name: DeletingDbTable.client_user_deleting_table,
+        columns: ["clientId", "userId"],
+      },
+      {
+        name: DeletingDbTable.client_purpose_deleting_table,
+        columns: ["clientId", "purposeId"],
+      },
+      {
+        name: DeletingDbTable.client_key_deleting_table,
+        columns: ["clientId", "kid"],
       },
     ]);
   },

--- a/packages/domains-analytics-writer/src/model/authorization/client.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/client.ts
@@ -1,0 +1,25 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { clientInReadmodelClient } from "pagopa-interop-readmodel-models";
+import { ClientKeySchema } from "./clientKey.js";
+import { ClientPurposeSchema } from "./clientPurpose.js";
+import { ClientUserSchema } from "./clientUser.js";
+
+export const ClientSchema = createSelectSchema(clientInReadmodelClient).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ClientSchema = z.infer<typeof ClientSchema>;
+
+export const ClientDeletingSchema = ClientSchema.pick({
+  id: true,
+  deleted: true,
+});
+export type ClientDeletingSchema = z.infer<typeof ClientDeletingSchema>;
+
+export const ClientItemsSchema = z.object({
+  clientSQL: ClientSchema,
+  usersSQL: z.array(ClientUserSchema),
+  purposesSQL: z.array(ClientPurposeSchema),
+  keysSQL: z.array(ClientKeySchema),
+});
+export type ClientItemsSchema = z.infer<typeof ClientItemsSchema>;

--- a/packages/domains-analytics-writer/src/model/authorization/clientKey.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/clientKey.ts
@@ -1,0 +1,27 @@
+import { createSelectSchema } from "drizzle-zod";
+import { clientKeyInReadmodelClient } from "pagopa-interop-readmodel-models";
+import { z } from "zod";
+
+export const ClientKeySchema = createSelectSchema(
+  clientKeyInReadmodelClient
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ClientKeySchema = z.infer<typeof ClientKeySchema>;
+
+export const ClientKeyDeletingSchema = ClientKeySchema.pick({
+  clientId: true,
+  kid: true,
+  deleted: true,
+});
+export type ClientKeyDeletingSchema = z.infer<typeof ClientKeyDeletingSchema>;
+
+export const ClientKeyUserMigrationSchema = ClientKeySchema.pick({
+  clientId: true,
+  kid: true,
+  userId: true,
+  metadataVersion: true,
+});
+export type ClientKeyUserMigrationSchema = z.infer<
+  typeof ClientKeyUserMigrationSchema
+>;

--- a/packages/domains-analytics-writer/src/model/authorization/clientPurpose.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/clientPurpose.ts
@@ -1,0 +1,19 @@
+import { createSelectSchema } from "drizzle-zod";
+import { clientPurposeInReadmodelClient } from "pagopa-interop-readmodel-models";
+import { z } from "zod";
+
+export const ClientPurposeSchema = createSelectSchema(
+  clientPurposeInReadmodelClient
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ClientPurposeSchema = z.infer<typeof ClientPurposeSchema>;
+
+export const ClientPurposeDeletingSchema = ClientPurposeSchema.pick({
+  clientId: true,
+  purposeId: true,
+  deleted: true,
+});
+export type ClientPurposeDeletingSchema = z.infer<
+  typeof ClientPurposeDeletingSchema
+>;

--- a/packages/domains-analytics-writer/src/model/authorization/clientUser.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/clientUser.ts
@@ -1,0 +1,17 @@
+import { createSelectSchema } from "drizzle-zod";
+import { clientUserInReadmodelClient } from "pagopa-interop-readmodel-models";
+import { z } from "zod";
+
+export const ClientUserSchema = createSelectSchema(
+  clientUserInReadmodelClient
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ClientUserSchema = z.infer<typeof ClientUserSchema>;
+
+export const ClientUserDeletingSchema = ClientUserSchema.pick({
+  clientId: true,
+  userId: true,
+  deleted: true,
+});
+export type ClientUserDeletingSchema = z.infer<typeof ClientUserDeletingSchema>;

--- a/packages/domains-analytics-writer/src/model/db/authorization.ts
+++ b/packages/domains-analytics-writer/src/model/db/authorization.ts
@@ -1,0 +1,32 @@
+import {
+  clientInReadmodelClient,
+  clientPurposeInReadmodelClient,
+  clientUserInReadmodelClient,
+  clientKeyInReadmodelClient,
+} from "pagopa-interop-readmodel-models";
+import { ClientSchema } from "../authorization/client.js";
+import { ClientPurposeSchema } from "../authorization/clientPurpose.js";
+import { ClientUserSchema } from "../authorization/clientUser.js";
+import { ClientKeySchema } from "../authorization/clientKey.js";
+
+export const ClientDbTableConfig = {
+  client: ClientSchema,
+  client_purpose: ClientPurposeSchema,
+  client_user: ClientUserSchema,
+  client_key: ClientKeySchema,
+} as const;
+export type ClientDbTableConfig = typeof ClientDbTableConfig;
+
+export const ClientDbTableReadModel = {
+  client: clientInReadmodelClient,
+  client_purpose: clientPurposeInReadmodelClient,
+  client_user: clientUserInReadmodelClient,
+  client_key: clientKeyInReadmodelClient,
+} as const;
+export type ClientDbTableReadModel = typeof ClientDbTableReadModel;
+
+export type ClientDbTable = keyof typeof ClientDbTableConfig;
+
+export const ClientDbTable = Object.fromEntries(
+  Object.keys(ClientDbTableConfig).map((k) => [k, k])
+) as { [K in ClientDbTable]: K };

--- a/packages/domains-analytics-writer/src/model/db/deleting.ts
+++ b/packages/domains-analytics-writer/src/model/db/deleting.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import {
   attributeInReadmodelAttribute,
+  clientInReadmodelClient,
+  clientUserInReadmodelClient,
+  clientPurposeInReadmodelClient,
+  clientKeyInReadmodelClient,
   eserviceInReadmodelCatalog,
   eserviceRiskAnalysisInReadmodelCatalog,
 } from "pagopa-interop-readmodel-models";
@@ -8,11 +12,19 @@ import {
 import { AttributeDeletingSchema } from "../attribute/attribute.js";
 import { EserviceDeletingSchema } from "../catalog/eservice.js";
 import { EserviceRiskAnalysisDeletingSchema } from "../catalog/eserviceRiskAnalysis.js";
+import { ClientDeletingSchema } from "../authorization/client.js";
+import { ClientUserDeletingSchema } from "../authorization/clientUser.js";
+import { ClientPurposeDeletingSchema } from "../authorization/clientPurpose.js";
+import { ClientKeyDeletingSchema } from "../authorization/clientKey.js";
 
 export const DeletingDbTableConfig = {
   attribute_deleting_table: AttributeDeletingSchema,
   catalog_deleting_table: EserviceDeletingSchema,
   catalog_risk_deleting_table: EserviceRiskAnalysisDeletingSchema,
+  client_deleting_table: ClientDeletingSchema,
+  client_user_deleting_table: ClientUserDeletingSchema,
+  client_purpose_deleting_table: ClientPurposeDeletingSchema,
+  client_key_deleting_table: ClientKeyDeletingSchema,
 } as const;
 export type DeletingDbTableConfig = typeof DeletingDbTableConfig;
 
@@ -20,6 +32,10 @@ export const DeletingDbTableReadModel = {
   attribute_deleting_table: attributeInReadmodelAttribute,
   catalog_deleting_table: eserviceInReadmodelCatalog,
   catalog_risk_deleting_table: eserviceRiskAnalysisInReadmodelCatalog,
+  client_deleting_table: clientInReadmodelClient,
+  client_user_deleting_table: clientUserInReadmodelClient,
+  client_purpose_deleting_table: clientPurposeInReadmodelClient,
+  client_key_deleting_table: clientKeyInReadmodelClient,
 } as const;
 export type DeletingDbTableReadModel = typeof DeletingDbTableReadModel;
 

--- a/packages/domains-analytics-writer/src/model/db/index.ts
+++ b/packages/domains-analytics-writer/src/model/db/index.ts
@@ -2,12 +2,17 @@ import {
   AttributeDbTableConfig,
   AttributeDbTableReadModel,
 } from "./attribute.js";
+import {
+  ClientDbTableConfig,
+  ClientDbTableReadModel,
+} from "./authorization.js";
 import { CatalogDbTableConfig, CatalogDbTableReadModel } from "./catalog.js";
 import { DeletingDbTableConfig, DeletingDbTableReadModel } from "./deleting.js";
 
 export const DomainDbTable = {
   ...AttributeDbTableConfig,
   ...CatalogDbTableConfig,
+  ...ClientDbTableConfig,
 } as const;
 export type DomainDbTableSchemas = typeof DomainDbTable;
 export type DomainDbTable = keyof DomainDbTableSchemas;
@@ -22,6 +27,7 @@ export type DbTable = keyof DbTableSchemas;
 export const DomainDbTableReadModels = {
   ...AttributeDbTableReadModel,
   ...CatalogDbTableReadModel,
+  ...ClientDbTableReadModel,
 } as const;
 export type DomainDbTableReadModels = typeof DomainDbTableReadModels;
 
@@ -33,4 +39,5 @@ export type DbTableReadModels = typeof DbTableReadModels;
 
 export * from "./attribute.js";
 export * from "./catalog.js";
+export * from "./authorization.js";
 export * from "./deleting.js";

--- a/packages/domains-analytics-writer/src/repository/client/client.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/client.repository.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+} from "../../utils/sqlQueryHelper.js";
+import { DeletingDbTable, ClientDbTable } from "../../model/db/index.js";
+import {
+  ClientDeletingSchema,
+  ClientSchema,
+} from "../../model/authorization/client.js";
+
+export function clientRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ClientDbTable.client;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const deletingTableName = DeletingDbTable.client_deleting_table;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ClientSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ClientSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(`
+            DELETE FROM ${stagingTableName} a
+            USING ${stagingTableName} b
+            WHERE a.id = b.id
+            AND a.metadata_version < b.metadata_version;
+          `);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ClientSchema,
+          schemaName,
+          tableName,
+          ["id"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertDeleting(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ClientDeletingSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, deletingTableName, ClientDeletingSchema);
+        await t.none(
+          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          ["id"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}

--- a/packages/domains-analytics-writer/src/repository/client/clientKey.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/clientKey.repository.ts
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+} from "../../utils/sqlQueryHelper.js";
+import { DeletingDbTable, ClientDbTable } from "../../model/db/index.js";
+import {
+  ClientKeySchema,
+  ClientKeyDeletingSchema,
+  ClientKeyUserMigrationSchema,
+} from "../../model/authorization/clientKey.js";
+
+export function clientKeyRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ClientDbTable.client_key;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const deletingTableName = DeletingDbTable.client_deleting_table;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ClientKeySchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ClientKeySchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(`
+          DELETE FROM ${stagingTableName} a
+          USING ${stagingTableName} b
+          WHERE a.client_id = b.client_id
+            AND a.kid = b.kid
+            AND a.metadata_version < b.metadata_version;
+        `);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ClientKeySchema,
+          schemaName,
+          tableName,
+          ["clientId", "kid"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertDeleting(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ClientKeyDeletingSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          deletingTableName,
+          ClientKeyDeletingSchema
+        );
+        await t.none(
+          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          ["clientId", "kid"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertKeyUserMigration(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ClientKeyUserMigrationSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ClientKeyUserMigrationSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(`
+          DELETE FROM ${stagingTableName} a
+          USING ${stagingTableName} b
+          WHERE a.client_id = b.client_id
+            AND a.kid = b.kid
+            AND a.metadata_version < b.metadata_version;
+        `);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeKeyUserMigration(): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ClientKeyUserMigrationSchema,
+          schemaName,
+          tableName,
+          ["clientId", "kid"]
+        );
+        await conn.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+  };
+}
+
+export type ClientKeyRepository = ReturnType<typeof clientKeyRepository>;

--- a/packages/domains-analytics-writer/src/repository/client/clientPurpose.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/clientPurpose.repository.ts
@@ -1,0 +1,124 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+} from "../../utils/sqlQueryHelper.js";
+import { DeletingDbTable, ClientDbTable } from "../../model/db/index.js";
+import {
+  ClientPurposeSchema,
+  ClientPurposeDeletingSchema,
+} from "../../model/authorization/clientPurpose.js";
+
+export function clientPurposeRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ClientDbTable.client_purpose;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const deletingTableName = DeletingDbTable.client_deleting_table;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ClientPurposeSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ClientPurposeSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(`
+          DELETE FROM ${stagingTableName} a
+          USING ${stagingTableName} b
+          WHERE a.client_id = b.client_id
+          AND a.purpose_id = b.purpose_id
+          AND a.metadata_version < b.metadata_version;
+        `);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ClientPurposeSchema,
+          schemaName,
+          tableName,
+          ["clientId", "purposeId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertDeleting(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ClientPurposeDeletingSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          deletingTableName,
+          ClientPurposeDeletingSchema
+        );
+        await t.none(
+          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          ["clientId", "purposeId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}
+
+export type ClientPurposeRepository = ReturnType<
+  typeof clientPurposeRepository
+>;

--- a/packages/domains-analytics-writer/src/repository/client/clientUser.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/clientUser.repository.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+} from "../../utils/sqlQueryHelper.js";
+import { DeletingDbTable, ClientDbTable } from "../../model/db/index.js";
+import {
+  ClientUserSchema,
+  ClientUserDeletingSchema,
+} from "../../model/authorization/clientUser.js";
+
+export function clientUserRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ClientDbTable.client_user;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const deletingTableName = DeletingDbTable.client_deleting_table;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ClientUserSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ClientUserSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(`
+          DELETE FROM ${stagingTableName} a
+          USING ${stagingTableName} b
+          WHERE a.client_id = b.client_id
+          AND a.user_id = b.user_id
+          AND a.metadata_version < b.metadata_version;
+        `);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ClientUserSchema,
+          schemaName,
+          tableName,
+          ["clientId", "userId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertDeleting(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ClientUserDeletingSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          deletingTableName,
+          ClientUserDeletingSchema
+        );
+        await t.none(
+          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          ["clientId", "userId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}

--- a/packages/domains-analytics-writer/src/service/authorizationService.ts
+++ b/packages/domains-analytics-writer/src/service/authorizationService.ts
@@ -1,0 +1,303 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable functional/immutable-data */
+/* eslint-disable sonarjs/cognitive-complexity */
+
+import { genericLogger } from "pagopa-interop-commons";
+import { DBContext } from "../db/db.js";
+import { batchMessages } from "../utils/batchHelper.js";
+import { mergeDeletingCascadeById } from "../utils/sqlQueryHelper.js";
+import { config } from "../config/config.js";
+import {
+  ClientItemsSchema,
+  ClientDeletingSchema,
+} from "../model/authorization/client.js";
+import {
+  ClientUserSchema,
+  ClientUserDeletingSchema,
+} from "../model/authorization/clientUser.js";
+import {
+  ClientPurposeSchema,
+  ClientPurposeDeletingSchema,
+} from "../model/authorization/clientPurpose.js";
+import {
+  ClientKeySchema,
+  ClientKeyDeletingSchema,
+  ClientKeyUserMigrationSchema,
+} from "../model/authorization/clientKey.js";
+import { ClientDbTable } from "../model/db/authorization.js";
+import { DeletingDbTable } from "../model/db/deleting.js";
+import { clientRepository } from "../repository/client/client.repository.js";
+import { clientKeyRepository } from "../repository/client/clientKey.repository.js";
+import { clientPurposeRepository } from "../repository/client/clientPurpose.repository.js";
+import { clientUserRepository } from "../repository/client/clientUser.repository.js";
+
+export function authorizationServiceBuilder(db: DBContext) {
+  const clientRepo = clientRepository(db.conn);
+  const clientUserRepo = clientUserRepository(db.conn);
+  const clientPurposeRepo = clientPurposeRepository(db.conn);
+  const clientKeyRepo = clientKeyRepository(db.conn);
+
+  return {
+    async upsertClientBatch(dbContext: DBContext, items: ClientItemsSchema[]) {
+      for (const batch of batchMessages(
+        items,
+        config.dbMessagesToInsertPerBatch
+      )) {
+        const batchItems = {
+          clientSQL: batch.map((i) => i.clientSQL),
+          usersSQL: batch.flatMap((i) => i.usersSQL),
+          purposesSQL: batch.flatMap((i) => i.purposesSQL),
+          keysSQL: batch.flatMap((i) => i.keysSQL),
+        };
+
+        await dbContext.conn.tx(async (t) => {
+          if (batchItems.clientSQL.length) {
+            await clientRepo.insert(t, dbContext.pgp, batchItems.clientSQL);
+          }
+          if (batchItems.usersSQL.length) {
+            await clientUserRepo.insert(t, dbContext.pgp, batchItems.usersSQL);
+          }
+          if (batchItems.purposesSQL.length) {
+            await clientPurposeRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.purposesSQL
+            );
+          }
+          if (batchItems.keysSQL.length) {
+            await clientKeyRepo.insert(t, dbContext.pgp, batchItems.keysSQL);
+          }
+        });
+
+        genericLogger.info(
+          `Staging data inserted for Client batch: ${batch
+            .map((i) => i.clientSQL.id)
+            .join(", ")}`
+        );
+      }
+
+      await dbContext.conn.tx(async (t) => {
+        await clientRepo.merge(t);
+        await clientUserRepo.merge(t);
+        await clientPurposeRepo.merge(t);
+        await clientKeyRepo.merge(t);
+      });
+
+      genericLogger.info(
+        `Staging data merged into target tables for all Client batches`
+      );
+
+      await clientRepo.clean();
+      await clientUserRepo.clean();
+      await clientPurposeRepo.clean();
+      await clientKeyRepo.clean();
+
+      genericLogger.info(`Staging data cleaned for Client`);
+    },
+
+    async deleteClientBatch(
+      dbContext: DBContext,
+      items: ClientDeletingSchema[]
+    ) {
+      for (const batch of batchMessages(
+        items,
+        config.dbMessagesToInsertPerBatch
+      )) {
+        await dbContext.conn.tx(async (t) => {
+          await clientRepo.insertDeleting(t, dbContext.pgp, batch);
+          genericLogger.info(
+            `Staging deletion inserted for Client ids: ${batch
+              .map((i) => i.id)
+              .join(", ")}`
+          );
+        });
+      }
+
+      await dbContext.conn.tx(async (t) => {
+        await clientRepo.mergeDeleting(t);
+        await mergeDeletingCascadeById(
+          t,
+          "clientId",
+          [
+            ClientDbTable.client_user,
+            ClientDbTable.client_purpose,
+            ClientDbTable.client_key,
+          ],
+          DeletingDbTable.client_deleting_table
+        );
+      });
+
+      genericLogger.info(
+        `Staging deletion merged into target tables for Client`
+      );
+      await clientRepo.cleanDeleting();
+      genericLogger.info(`Client deleting table cleaned`);
+    },
+
+    async upsertClientUserBatch(
+      dbContext: DBContext,
+      items: ClientUserSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        await clientUserRepo.insert(t, dbContext.pgp, items);
+        genericLogger.info(
+          `Staging data inserted for ClientUser batch: ${items
+            .map((i) => `${i.clientId}/${i.userId}`)
+            .join(", ")}`
+        );
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await clientUserRepo.merge(t);
+      });
+      genericLogger.info(
+        `Staging data merged into target tables for ClientUser`
+      );
+      await clientUserRepo.clean();
+      genericLogger.info(`Staging data cleaned for ClientUser`);
+    },
+
+    async removeUserBatch(
+      dbContext: DBContext,
+      items: ClientUserDeletingSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        await clientUserRepo.insertDeleting(t, dbContext.pgp, items);
+        genericLogger.info(
+          `Staging deletion inserted for ClientUser: ${items
+            .map((i) => `${i.clientId}/${i.userId}`)
+            .join(", ")}`
+        );
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await clientUserRepo.mergeDeleting(t);
+      });
+      genericLogger.info(
+        `Staging deletion merged into target tables for ClientUser`
+      );
+      await clientUserRepo.cleanDeleting();
+      genericLogger.info(`ClientUser deleting table cleaned`);
+    },
+
+    async upsertClientPurposeBatch(
+      dbContext: DBContext,
+      items: ClientPurposeSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        await clientPurposeRepo.insert(t, dbContext.pgp, items);
+        genericLogger.info(
+          `Staging data inserted for ClientPurpose batch: ${items
+            .map((i) => `${i.clientId}/${i.purposeId}`)
+            .join(", ")}`
+        );
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await clientPurposeRepo.merge(t);
+      });
+      genericLogger.info(
+        `Staging data merged into target tables for ClientPurpose`
+      );
+      await clientPurposeRepo.clean();
+      genericLogger.info(`Staging data cleaned for ClientPurpose`);
+    },
+
+    async removePurposeBatch(
+      dbContext: DBContext,
+      items: ClientPurposeDeletingSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        await clientPurposeRepo.insertDeleting(t, dbContext.pgp, items);
+        genericLogger.info(
+          `Staging deletion inserted for ClientPurpose: ${items
+            .map((i) => `${i.clientId}/${i.purposeId}`)
+            .join(", ")}`
+        );
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await clientPurposeRepo.mergeDeleting(t);
+      });
+      genericLogger.info(
+        `Staging deletion merged into target tables for ClientPurpose`
+      );
+      await clientPurposeRepo.cleanDeleting();
+      genericLogger.info(`ClientPurpose deleting table cleaned`);
+    },
+
+    async upsertKeyBatch(dbContext: DBContext, items: ClientKeySchema[]) {
+      await dbContext.conn.tx(async (t) => {
+        await clientKeyRepo.insert(t, dbContext.pgp, items);
+        genericLogger.info(
+          `Staging data inserted for ClientKey batch: ${items
+            .map((i) => `${i.clientId}/${i.kid}`)
+            .join(", ")}`
+        );
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await clientKeyRepo.merge(t);
+      });
+      genericLogger.info(
+        `Staging data merged into target tables for ClientKey`
+      );
+      await clientKeyRepo.clean();
+      genericLogger.info(`Staging data cleaned for ClientKey`);
+    },
+
+    async deleteKeyBatch(
+      dbContext: DBContext,
+      items: ClientKeyDeletingSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        await clientKeyRepo.insertDeleting(t, dbContext.pgp, items);
+        genericLogger.info(
+          `Staging deletion inserted for ClientKey: ${items
+            .map((i) => `${i.clientId}/${i.kid}`)
+            .join(", ")}`
+        );
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await clientKeyRepo.mergeDeleting(t);
+      });
+      genericLogger.info(
+        `Staging deletion merged into target tables for ClientKey`
+      );
+      await clientKeyRepo.cleanDeleting();
+      genericLogger.info(`ClientKey deleting table cleaned`);
+    },
+
+    async upsertMigrateKeyUserRelationshipBatch(
+      dbContext: DBContext,
+      items: ClientKeyUserMigrationSchema[]
+    ): Promise<void> {
+      await dbContext.conn.tx(async (t) => {
+        for (const batch of batchMessages(
+          items,
+          config.dbMessagesToInsertPerBatch
+        )) {
+          await clientKeyRepo.insertKeyUserMigration(t, dbContext.pgp, batch);
+          genericLogger.info(
+            `Staging data inserted for ClientKeyUserMigration batch: ${batch
+              .map((item) => `${item.clientId}/${item.kid}`)
+              .join(", ")}`
+          );
+        }
+      });
+
+      await clientKeyRepo.mergeKeyUserMigration();
+      genericLogger.info(
+        `Staging data merged into target tables for ClientKeyUserMigration`
+      );
+
+      await clientKeyRepo.clean();
+      genericLogger.info(`Staging table cleaned for ClientKeyUserMigration`);
+    },
+  };
+}
+
+export type AuthorizationService = ReturnType<
+  typeof authorizationServiceBuilder
+>;

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -12,6 +12,7 @@ import { setupDbServiceBuilder } from "../src/service/setupDbService.js";
 import {
   AttributeDbTable,
   CatalogDbTable,
+  ClientDbTable,
   DeletingDbTable,
   DeletingDbTableConfigMap,
   DomainDbTable,
@@ -52,6 +53,13 @@ export const catalogTables: CatalogDbTable[] = [
   CatalogDbTable.eservice_risk_analysis_answer,
 ];
 
+export const clientTables: ClientDbTable[] = [
+  ClientDbTable.client,
+  ClientDbTable.client_purpose,
+  ClientDbTable.client_user,
+  ClientDbTable.client_key,
+];
+
 export const deletingTables: DeletingDbTable[] = [
   DeletingDbTable.attribute_deleting_table,
   DeletingDbTable.catalog_deleting_table,
@@ -61,6 +69,7 @@ export const deletingTables: DeletingDbTable[] = [
 export const domainTables: DomainDbTable[] = [
   ...attributeTables,
   ...catalogTables,
+  ...clientTables,
 ];
 
 export const setupStagingDeletingTables: DeletingDbTableConfigMap[] = [


### PR DESCRIPTION
## Summary
This PR introduces:
-  `handleAuthorizationMessageV2` functions to handle messages from the `authorization` topic

## Key Points
- Added client tables and its deleting table
- Using splitter functions like `splitClientIntoObjectsSQL` to transform client data into `ClientItemsSQL` and its sub-objects.  

- Sub-objects are inserted and deleted in cascade across all tables

- Deletions cascade through related tables based on foreign key `client_id`

- The ingestion logic follows the following strategy for Redshift:  
  - All incoming messages are inserted into temporary staging tables.  
  - A **single MERGE per topic** is executed after staging, to ensure efficient batch ingestion.  
  - Deletions are handled logically by adding a `deleted` field to the tables  
  - Logical deletions are handled via a deleted flag on each table

- Unit tests added  

## Infra

- Updated `domains-init.sql` to include `client` tables  