### PR TITLE
Fix bff router

### DIFF
--- a/packages/backend-for-frontend/src/app.ts
+++ b/packages/backend-for-frontend/src/app.ts
@@ -198,13 +198,13 @@ export async function createApp(
       serviceName,
       config
     ),
+    authorizationRouter(zodiosCtx, services.authorizationService),
     authenticationMiddleware(config),
     uiAuthDataValidationMiddleware(),
     // Authenticated routes (rate limiter & authorization middlewares rely on auth data to work)
     rateLimiterMiddleware,
     agreementRouter(zodiosCtx, services.agreementService),
     attributeRouter(zodiosCtx, services.attributeService),
-    authorizationRouter(zodiosCtx, services.authorizationService),
     catalogRouter(zodiosCtx, services.catalogService),
     clientRouter(zodiosCtx, services.clientService),
     consumerDelegationRouter(zodiosCtx, services.delegationService),


### PR DESCRIPTION
This PR fixes the position of the `authorization router`, which should not be placed after the token validation