### PR TITLE
PIN-6945: Analytics - Delegation consumer (refactor edge cases) 

### DIFF
--- a/packages/domains-analytics-writer/src/service/delegationService.ts
+++ b/packages/domains-analytics-writer/src/service/delegationService.ts
@@ -7,6 +7,8 @@ import { DelegationItemsSchema } from "../model/delegation/delegation.js";
 import { delegationRepository } from "../repository/delegation/delegation.repository.js";
 import { delegationStampRepository } from "../repository/delegation/delegationStamp.repository.js";
 import { delegationContractDocumentRepository } from "../repository/delegation/delegationContractDocument.repository.js";
+import { cleaningTargetTables } from "../utils/sqlQueryHelper.js";
+import { DelegationDbTable } from "../model/db/delegation.js";
 
 export function delegationServiceBuilder(dbContext: DBContext) {
   const delegationRepo = delegationRepository(dbContext.conn);
@@ -61,6 +63,18 @@ export function delegationServiceBuilder(dbContext: DBContext) {
         await delegationRepo.merge(t);
         await stampRepo.merge(t);
         await contractDocumentRepo.merge(t);
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await cleaningTargetTables(
+          t,
+          "delegationId",
+          [
+            DelegationDbTable.delegation_contract_document,
+            DelegationDbTable.delegation_stamp,
+          ],
+          DelegationDbTable.delegation
+        );
       });
 
       genericLogger.info(


### PR DESCRIPTION
## Changes

**Pre-merge cleanup**  
  Before each upsert MERGE, we now run a set-based `MERGE … WHEN MATCHED THEN DELETE` on the target tables to purge any rows whose `metadata_version` is lower than the incoming staging version, ensuring outdated records will be cleaned.
