### PR TITLE
PIN-6850 - Updated EService Template name constraint

### DIFF
--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -633,10 +633,10 @@ export function eserviceTemplateServiceBuilder(
 
       if (name !== eserviceTemplate.data.name) {
         const eserviceTemplateWithSameName =
-          await readModelService.getEServiceTemplateByNameAndCreatorId({
+          await readModelService.getEServiceTemplateByName({
             name,
-            creatorId: eserviceTemplate.data.creatorId,
           });
+
         if (eserviceTemplateWithSameName !== undefined) {
           throw eserviceTemplateDuplicate(name);
         }
@@ -1179,10 +1179,10 @@ export function eserviceTemplateServiceBuilder(
       }
 
       const eserviceTemplateWithSameName =
-        await readModelService.getEServiceTemplateByNameAndCreatorId({
+        await readModelService.getEServiceTemplateByName({
           name: seed.name,
-          creatorId: authData.organizationId,
         });
+
       if (eserviceTemplateWithSameName) {
         throw eserviceTemplateDuplicate(seed.name);
       }
@@ -1255,9 +1255,8 @@ export function eserviceTemplateServiceBuilder(
 
       if (eserviceTemplateSeed.name !== eserviceTemplate.data.name) {
         const eserviceTemplateWithSameName =
-          await readModelService.getEServiceTemplateByNameAndCreatorId({
+          await readModelService.getEServiceTemplateByName({
             name: eserviceTemplateSeed.name,
-            creatorId: eserviceTemplate.data.creatorId,
           });
         if (eserviceTemplateWithSameName !== undefined) {
           throw eserviceTemplateDuplicate(eserviceTemplateSeed.name);

--- a/packages/eservice-template-process/src/services/readModelService.ts
+++ b/packages/eservice-template-process/src/services/readModelService.ts
@@ -101,19 +101,16 @@ export function readModelServiceBuilder({
       return getEServiceTemplate(eserviceTemplates, { "data.id": id });
     },
 
-    async getEServiceTemplateByNameAndCreatorId({
+    async getEServiceTemplateByName({
       name,
-      creatorId,
     }: {
       name: string;
-      creatorId: TenantId;
     }): Promise<WithMetadata<EServiceTemplate> | undefined> {
       return getEServiceTemplate(eserviceTemplates, {
         "data.name": {
           $regex: `^${ReadModelRepository.escapeRegExp(name)}$$`,
           $options: "i",
         },
-        "data.creatorId": creatorId,
       });
     },
 

--- a/packages/eservice-template-process/src/services/readModelServiceSQL.ts
+++ b/packages/eservice-template-process/src/services/readModelServiceSQL.ts
@@ -71,20 +71,15 @@ export function readModelServiceBuilderSQL({
         id
       );
     },
-    async getEServiceTemplateByNameAndCreatorId({
+    async getEServiceTemplateByName({
       name,
-      creatorId,
     }: {
       name: string;
-      creatorId: TenantId;
     }): Promise<WithMetadata<EServiceTemplate> | undefined> {
       return await eserviceTemplateReadModelServiceSQL.getEServiceTemplateByFilter(
-        and(
-          eq(eserviceTemplateInReadmodelEserviceTemplate.creatorId, creatorId),
-          ilike(
-            eserviceTemplateInReadmodelEserviceTemplate.name,
-            escapeRegExp(name)
-          )
+        ilike(
+          eserviceTemplateInReadmodelEserviceTemplate.name,
+          escapeRegExp(name)
         )
       );
     },

--- a/packages/eservice-template-process/test/integration/createEServiceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/createEServiceTemplate.test.ts
@@ -12,6 +12,7 @@ import {
   EServiceTemplate,
   toEServiceTemplateV2,
   EServiceTemplateAddedV2,
+  generateId,
 } from "pagopa-interop-models";
 import { expect, describe, it, beforeAll, vi, afterAll } from "vitest";
 import {
@@ -106,6 +107,23 @@ describe("create eservice template", () => {
 
   it("should throw eserviceTemplateDuplicate if an eservice template with the same name already exists, case insensitive", async () => {
     await addOneEServiceTemplate(mockEServiceTemplate);
+    await expect(
+      eserviceTemplateService.createEServiceTemplate(
+        eserviceTemplateToApiEServiceTemplateSeed(mockEServiceTemplate),
+        getMockContext({
+          authData: getMockAuthData(mockEServiceTemplate.creatorId),
+        })
+      )
+    ).rejects.toThrowError(
+      eserviceTemplateDuplicate(mockEServiceTemplate.name)
+    );
+  });
+
+  it("should throw eserviceTemplateDuplicate if an eservice template with the same name with different creator already exists, case insensitive", async () => {
+    await addOneEServiceTemplate({
+      ...mockEServiceTemplate,
+      creatorId: generateId(),
+    });
     await expect(
       eserviceTemplateService.createEServiceTemplate(
         eserviceTemplateToApiEServiceTemplateSeed(mockEServiceTemplate),

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplate.test.ts
@@ -298,6 +298,7 @@ describe("update EService template", () => {
     const eserviceTemplate2: EServiceTemplate = {
       ...mockEServiceTemplate,
       id: generateId(),
+      creatorId: generateId(),
       name: "eservice name already in use",
       versions: [],
     };

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplateName.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplateName.test.ts
@@ -181,6 +181,43 @@ describe("updateEServiceTemplateName", () => {
     ).rejects.toThrowError(eserviceTemplateDuplicate(duplicateName));
   });
 
+  it("should throw eserviceTemplateDuplicate is there is another eservice template with the same name by a different creator", async () => {
+    const creatorId = generateId<TenantId>();
+
+    const eserviceTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      interface: getMockDocument(),
+      state: eserviceTemplateVersionState.published,
+    };
+    const eserviceTemplate: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      creatorId,
+      versions: [eserviceTemplateVersion],
+    };
+
+    const duplicateName = "eservice duplciate name";
+
+    const eserviceTemplateWithSameName: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      creatorId: generateId<TenantId>(),
+      name: duplicateName,
+    };
+
+    await addOneEServiceTemplate(eserviceTemplate);
+    await addOneEServiceTemplate(eserviceTemplateWithSameName);
+
+    const updatedName = duplicateName;
+    expect(
+      eserviceTemplateService.updateEServiceTemplateName(
+        eserviceTemplate.id,
+        updatedName,
+        getMockContext({
+          authData: getMockAuthData(eserviceTemplate.creatorId),
+        })
+      )
+    ).rejects.toThrowError(eserviceTemplateDuplicate(duplicateName));
+  });
+
   it("should throw instanceNameConflict if the name is already used by a producer of a template instance", async () => {
     const eserviceTemplateVersion: EServiceTemplateVersion = {
       ...getMockEServiceTemplateVersion(),


### PR DESCRIPTION
Closes [PIN-6580](https://pagopa.atlassian.net/browse/PIN-6850)

This PR refactors the logic for validating unique e-service template names.
Previously, the uniqueness of an e-service template name was enforced only within the scope of its creator. With this change, the uniqueness constraint is now global, meaning an e-service template name must be unique across all templates within the system, regardless of the creator.