### PR TITLE
PIN-6944: Analytics - Agreement - Purpose - Eservice Template consumers (refactor edge cases)

### DIFF
--- a/docker/domains-analytics-db/domains-init.sql
+++ b/docker/domains-analytics-db/domains-init.sql
@@ -465,6 +465,47 @@ CREATE TABLE IF NOT EXISTS domains.client_key (
   PRIMARY KEY (client_id, kid)
 );
 
+CREATE TABLE IF NOT EXISTS domains.producer_keychain (
+  id VARCHAR(36),
+  metadata_version INTEGER NOT NULL,
+  producer_id VARCHAR(36) NOT NULL,
+  name VARCHAR(2048) NOT NULL,
+  description VARCHAR(2048) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  deleted BOOLEAN,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS domains.producer_keychain_user (
+  metadata_version INTEGER NOT NULL,
+  producer_keychain_id VARCHAR(36) NOT NULL REFERENCES domains.producer_keychain (id),
+  user_id VARCHAR(36) NOT NULL,
+  deleted BOOLEAN,
+  PRIMARY KEY (producer_keychain_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS domains.producer_keychain_eservice (
+  metadata_version INTEGER NOT NULL,
+  producer_keychain_id VARCHAR(36) NOT NULL REFERENCES domains.producer_keychain (id),
+  eservice_id VARCHAR(36) NOT NULL,
+  deleted BOOLEAN,
+  PRIMARY KEY (producer_keychain_id, eservice_id)
+);
+
+CREATE TABLE IF NOT EXISTS domains.producer_keychain_key (
+  metadata_version INTEGER NOT NULL,
+  producer_keychain_id VARCHAR(36) NOT NULL REFERENCES domains.producer_keychain (id),
+  user_id VARCHAR(36) NOT NULL,
+  kid VARCHAR(2048) NOT NULL,
+  name VARCHAR(2048) NOT NULL,
+  encoded_pem VARCHAR(8192) NOT NULL,
+  "algorithm" VARCHAR(2048) NOT NULL,
+  "use" VARCHAR(2048) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  deleted BOOLEAN,
+  PRIMARY KEY (producer_keychain_id, kid)
+);
+
 CREATE TABLE IF NOT EXISTS domains.eservice_template (
   id VARCHAR(36),
   metadata_version INTEGER NOT NULL,

--- a/docker/domains-analytics-db/domains-init.sql
+++ b/docker/domains-analytics-db/domains-init.sql
@@ -248,7 +248,7 @@ CREATE TABLE IF NOT EXISTS domains.purpose_risk_analysis_answer (
   id VARCHAR(36),
   purpose_id VARCHAR(36) NOT NULL REFERENCES domains.purpose(id),
   metadata_version INTEGER NOT NULL,
-  risk_analysis_form_id VARCHAR(36),
+  risk_analysis_form_id VARCHAR(36) NOT NULL,
   kind VARCHAR NOT NULL,
   key VARCHAR NOT NULL,
   value VARCHAR(65535),

--- a/packages/domains-analytics-writer/src/handlers/agreement/consumerServiceV1.ts
+++ b/packages/domains-analytics-writer/src/handlers/agreement/consumerServiceV1.ts
@@ -83,24 +83,22 @@ export async function handleAgreementMessageV1(
           );
         }
 
-        const doc = agreementDocumentToAgreementDocumentSQL(
+        const document = agreementDocumentToAgreementDocumentSQL(
           fromAgreementDocumentV1(msg.data.document),
           unsafeBrandId<AgreementId>(msg.data.agreementId),
           msg.version
         );
 
         upsertDocumentBatch.push(
-          AgreementConsumerDocumentSchema.parse({
-            ...doc,
-            deleted: false,
-          } satisfies z.input<typeof AgreementConsumerDocumentSchema>)
+          AgreementConsumerDocumentSchema.parse(
+            document satisfies z.input<typeof AgreementConsumerDocumentSchema>
+          )
         );
       })
       .with({ type: "AgreementConsumerDocumentRemoved" }, (msg) => {
         deleteDocumentBatch.push(
-          AgreementConsumerDocumentSchema.parse({
+          AgreementConsumerDocumentDeletingSchema.parse({
             id: msg.data.documentId,
-            deleted: true,
           } satisfies z.input<typeof AgreementConsumerDocumentDeletingSchema>)
         );
       })
@@ -118,10 +116,9 @@ export async function handleAgreementMessageV1(
         );
 
         upsertContractBatch.push(
-          AgreementContractSchema.parse({
-            ...contract,
-            deleted: false,
-          } satisfies z.input<typeof AgreementContractSchema>)
+          AgreementContractSchema.parse(
+            contract satisfies z.input<typeof AgreementContractSchema>
+          )
         );
       })
       .with({ type: "AgreementDeleted" }, (msg) => {

--- a/packages/domains-analytics-writer/src/handlers/authorization/consumerServiceV2.ts
+++ b/packages/domains-analytics-writer/src/handlers/authorization/consumerServiceV2.ts
@@ -2,10 +2,14 @@
 import {
   AuthorizationEventEnvelopeV2,
   fromClientV2,
+  fromProducerKeychainV2,
   genericInternalError,
 } from "pagopa-interop-models";
 import { match, P } from "ts-pattern";
-import { splitClientIntoObjectsSQL } from "pagopa-interop-readmodel";
+import {
+  splitClientIntoObjectsSQL,
+  splitProducerKeychainIntoObjectsSQL,
+} from "pagopa-interop-readmodel";
 import { z } from "zod";
 import { DBContext } from "../../db/db.js";
 import { authorizationServiceBuilder } from "../../service/authorizationService.js";
@@ -13,6 +17,10 @@ import {
   ClientItemsSchema,
   ClientDeletingSchema,
 } from "../../model/authorization/client.js";
+import {
+  ProducerKeychainDeletingSchema,
+  ProducerKeychainItemsSchema,
+} from "../../model/authorization/producerKeychain.js";
 
 export async function handleAuthorizationEventMessageV2(
   messages: AuthorizationEventEnvelopeV2[],
@@ -22,6 +30,8 @@ export async function handleAuthorizationEventMessageV2(
 
   const upsertClientBatch: ClientItemsSchema[] = [];
   const deleteClientBatch: ClientDeletingSchema[] = [];
+  const upsertProducerKeychainBatch: ProducerKeychainItemsSchema[] = [];
+  const deleteProducerKeychainBatch: ProducerKeychainDeletingSchema[] = [];
 
   for (const message of messages) {
     await match(message)
@@ -42,7 +52,6 @@ export async function handleAuthorizationEventMessageV2(
         },
         async (msg) => {
           const clientV2 = msg.data.client;
-
           if (!clientV2) {
             throw genericInternalError(
               "Client can't be missing in event message"
@@ -72,11 +81,18 @@ export async function handleAuthorizationEventMessageV2(
           } satisfies z.input<typeof ClientDeletingSchema>)
         );
       })
+      .with({ type: "ProducerKeychainDeleted" }, async (msg) => {
+        deleteProducerKeychainBatch.push(
+          ProducerKeychainDeletingSchema.parse({
+            id: msg.data.producerKeychainId,
+            deleted: true,
+          } satisfies z.input<typeof ProducerKeychainDeletingSchema>)
+        );
+      })
       .with(
         {
           type: P.union(
             "ProducerKeychainAdded",
-            "ProducerKeychainDeleted",
             "ProducerKeychainKeyAdded",
             "ProducerKeychainKeyDeleted",
             "ProducerKeychainUserAdded",
@@ -85,7 +101,28 @@ export async function handleAuthorizationEventMessageV2(
             "ProducerKeychainEServiceRemoved"
           ),
         },
-        () => Promise.resolve()
+        async (msg) => {
+          const producerKeychain = msg.data.producerKeychain;
+          if (!producerKeychain) {
+            throw genericInternalError(
+              "producerKeychain can't be missing in event message"
+            );
+          }
+
+          const splitResult = splitProducerKeychainIntoObjectsSQL(
+            fromProducerKeychainV2(producerKeychain),
+            message.version
+          );
+
+          upsertProducerKeychainBatch.push(
+            ProducerKeychainItemsSchema.parse({
+              producerKeychainSQL: splitResult.producerKeychainSQL,
+              usersSQL: splitResult.usersSQL,
+              eservicesSQL: splitResult.eservicesSQL,
+              keysSQL: splitResult.keysSQL,
+            } satisfies z.input<typeof ProducerKeychainItemsSchema>)
+          );
+        }
       )
       .exhaustive();
   }
@@ -96,5 +133,19 @@ export async function handleAuthorizationEventMessageV2(
 
   if (deleteClientBatch.length > 0) {
     await authorizationService.deleteClientBatch(dbContext, deleteClientBatch);
+  }
+
+  if (upsertProducerKeychainBatch.length > 0) {
+    await authorizationService.upsertProducerKeychainBatch(
+      dbContext,
+      upsertProducerKeychainBatch
+    );
+  }
+
+  if (deleteProducerKeychainBatch.length > 0) {
+    await authorizationService.deleteProducerKeychainBatch(
+      dbContext,
+      deleteProducerKeychainBatch
+    );
   }
 }

--- a/packages/domains-analytics-writer/src/handlers/eservice-template/consumerServiceV2.ts
+++ b/packages/domains-analytics-writer/src/handlers/eservice-template/consumerServiceV2.ts
@@ -15,10 +15,6 @@ import {
   EserviceTemplateDeletingSchema,
 } from "../../model/eserviceTemplate/eserviceTemplate.js";
 import { eserviceTemplateServiceBuilder } from "../../service/eserviceTemplateService.js";
-import { EserviceTemplateRiskAnalysisDeletingSchema } from "../../model/eserviceTemplate/eserviceTemplateRiskAnalysis.js";
-import { EserviceTemplateVersionDeletingSchema } from "../../model/eserviceTemplate/eserviceTemplateVersion.js";
-import { EserviceTemplateDocumentDeletingSchema } from "../../model/eserviceTemplate/eserviceTemplateVersionDocument.js";
-import { EserviceTemplateInterfaceDeletingSchema } from "../../model/eserviceTemplate/eserviceTemplateVersionInterface.js";
 
 export async function handleEserviceTemplateMessageV2(
   messages: EServiceTemplateEventEnvelope[],
@@ -28,14 +24,6 @@ export async function handleEserviceTemplateMessageV2(
 
   const upsertEserviceTemplateBatch: EserviceTemplateItemsSchema[] = [];
   const deleteEserviceTemplateBatch: EserviceTemplateDeletingSchema[] = [];
-  const deleteEserviceTemplateVersionBatch: EserviceTemplateVersionDeletingSchema[] =
-    [];
-  const deleteEserviceTemplateInterfaceBatch: EserviceTemplateInterfaceDeletingSchema[] =
-    [];
-  const deleteEserviceTemplateDocumentBatch: EserviceTemplateDocumentDeletingSchema[] =
-    [];
-  const deleteEserviceTemplateRiskAnalysisBatch: EserviceTemplateRiskAnalysisDeletingSchema[] =
-    [];
 
   for (const message of messages) {
     match(message)
@@ -59,7 +47,11 @@ export async function handleEserviceTemplateMessageV2(
             "EServiceTemplateVersionInterfaceUpdated",
             "EServiceTemplateRiskAnalysisAdded",
             "EServiceTemplateRiskAnalysisUpdated",
-            "EServiceTemplateVersionActivated"
+            "EServiceTemplateVersionActivated",
+            "EServiceTemplateDraftVersionDeleted",
+            "EServiceTemplateVersionInterfaceDeleted",
+            "EServiceTemplateVersionDocumentDeleted",
+            "EServiceTemplateRiskAnalysisDeleted"
           ),
         },
         (msg) => {
@@ -99,61 +91,6 @@ export async function handleEserviceTemplateMessageV2(
           } satisfies z.input<typeof EserviceTemplateDeletingSchema>)
         );
       })
-      .with({ type: "EServiceTemplateDraftVersionDeleted" }, (msg) => {
-        deleteEserviceTemplateVersionBatch.push(
-          EserviceTemplateVersionDeletingSchema.parse({
-            id: msg.data.eserviceTemplateVersionId,
-            deleted: true,
-          } satisfies z.input<typeof EserviceTemplateVersionDeletingSchema>)
-        );
-      })
-      .with({ type: "EServiceTemplateVersionInterfaceDeleted" }, (msg) => {
-        const { eserviceTemplate, eserviceTemplateVersionId } = msg.data;
-
-        if (!eserviceTemplate) {
-          throw genericInternalError(
-            "eserviceTemplate can't be missing in the event message"
-          );
-        }
-
-        const version = eserviceTemplate.versions.find(
-          (v) => v.id === eserviceTemplateVersionId
-        );
-        if (!version) {
-          throw genericInternalError(
-            `Version not found for versionId: ${eserviceTemplateVersionId}`
-          );
-        }
-
-        if (!version.interface) {
-          throw genericInternalError(
-            `Missing interface for the specified version id: ${version.id}`
-          );
-        }
-
-        deleteEserviceTemplateInterfaceBatch.push(
-          EserviceTemplateInterfaceDeletingSchema.parse({
-            id: version.interface.id,
-            deleted: true,
-          } satisfies z.input<typeof EserviceTemplateInterfaceDeletingSchema>)
-        );
-      })
-      .with({ type: "EServiceTemplateVersionDocumentDeleted" }, (msg) => {
-        deleteEserviceTemplateDocumentBatch.push(
-          EserviceTemplateDocumentDeletingSchema.parse({
-            id: msg.data.documentId,
-            deleted: true,
-          } satisfies z.input<typeof EserviceTemplateDocumentDeletingSchema>)
-        );
-      })
-      .with({ type: "EServiceTemplateRiskAnalysisDeleted" }, (msg) => {
-        deleteEserviceTemplateRiskAnalysisBatch.push(
-          EserviceTemplateRiskAnalysisDeletingSchema.parse({
-            id: msg.data.riskAnalysisId,
-            deleted: true,
-          } satisfies z.input<typeof EserviceTemplateRiskAnalysisDeletingSchema>)
-        );
-      })
       .exhaustive();
   }
 
@@ -167,30 +104,6 @@ export async function handleEserviceTemplateMessageV2(
     await templateService.deleteBatchEserviceTemplate(
       dbContext,
       deleteEserviceTemplateBatch
-    );
-  }
-  if (deleteEserviceTemplateVersionBatch.length > 0) {
-    await templateService.deleteBatchEserviceTemplateVersion(
-      dbContext,
-      deleteEserviceTemplateVersionBatch
-    );
-  }
-  if (deleteEserviceTemplateInterfaceBatch.length > 0) {
-    await templateService.deleteBatchEserviceTemplateInterface(
-      dbContext,
-      deleteEserviceTemplateInterfaceBatch
-    );
-  }
-  if (deleteEserviceTemplateDocumentBatch.length > 0) {
-    await templateService.deleteBatchEserviceTemplateDocument(
-      dbContext,
-      deleteEserviceTemplateDocumentBatch
-    );
-  }
-  if (deleteEserviceTemplateRiskAnalysisBatch.length > 0) {
-    await templateService.deleteBatchEserviceTemplateRiskAnalysis(
-      dbContext,
-      deleteEserviceTemplateRiskAnalysisBatch
     );
   }
 }

--- a/packages/domains-analytics-writer/src/handlers/purpose/consumerServiceV1.ts
+++ b/packages/domains-analytics-writer/src/handlers/purpose/consumerServiceV1.ts
@@ -105,7 +105,6 @@ export async function handlePurposeMessageV1(
         deleteVersionBatch.push(
           PurposeVersionDeletingSchema.parse({
             id: msg.data.versionId,
-            deleted: true,
           } satisfies z.input<typeof PurposeDeletingSchema>)
         );
       })

--- a/packages/domains-analytics-writer/src/index.ts
+++ b/packages/domains-analytics-writer/src/index.ts
@@ -22,6 +22,7 @@ import {
   TenantDbPartialTable,
   TenantDbTable,
   ClientDbTable,
+  ProducerKeychainDbTable,
 } from "./model/db/index.js";
 import { executeTopicHandler } from "./handlers/batchMessageHandler.js";
 import { EserviceTemplateDbTable } from "./model/db/eserviceTemplate.js";
@@ -73,6 +74,10 @@ await retryConnection(
       ClientDbTable.client_purpose,
       ClientDbTable.client_user,
       ClientDbTable.client_key,
+      ProducerKeychainDbTable.producer_keychain,
+      ProducerKeychainDbTable.producer_keychain_eservice,
+      ProducerKeychainDbTable.producer_keychain_user,
+      ProducerKeychainDbTable.producer_keychain_key,
       DelegationDbTable.delegation,
       DelegationDbTable.delegation_stamp,
       DelegationDbTable.delegation_contract_document,
@@ -125,6 +130,10 @@ await retryConnection(
       {
         name: DeletingDbTable.client_key_deleting_table,
         columns: ["clientId", "kid"],
+      },
+      {
+        name: DeletingDbTable.producer_keychain_deleting_table,
+        columns: ["id"],
       },
       {
         name: DeletingDbTable.eservice_template_deleting_table,

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychain.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychain.ts
@@ -1,0 +1,31 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { producerKeychainInReadmodelProducerKeychain } from "pagopa-interop-readmodel-models";
+import { ProducerKeychainEServiceSchema } from "./producerKeychainEService.js";
+import { ProducerKeychainKeySchema } from "./producerKeychainKey.js";
+import { ProducerKeychainUserSchema } from "./producerKeychainUser.js";
+
+export const ProducerKeychainSchema = createSelectSchema(
+  producerKeychainInReadmodelProducerKeychain
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ProducerKeychainSchema = z.infer<typeof ProducerKeychainSchema>;
+
+export const ProducerKeychainDeletingSchema = ProducerKeychainSchema.pick({
+  id: true,
+  deleted: true,
+});
+export type ProducerKeychainDeletingSchema = z.infer<
+  typeof ProducerKeychainDeletingSchema
+>;
+
+export const ProducerKeychainItemsSchema = z.object({
+  producerKeychainSQL: ProducerKeychainSchema,
+  usersSQL: z.array(ProducerKeychainUserSchema),
+  eservicesSQL: z.array(ProducerKeychainEServiceSchema),
+  keysSQL: z.array(ProducerKeychainKeySchema),
+});
+export type ProducerKeychainItemsSchema = z.infer<
+  typeof ProducerKeychainItemsSchema
+>;

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychainEService.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychainEService.ts
@@ -1,0 +1,12 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { producerKeychainEserviceInReadmodelProducerKeychain } from "pagopa-interop-readmodel-models";
+
+export const ProducerKeychainEServiceSchema = createSelectSchema(
+  producerKeychainEserviceInReadmodelProducerKeychain
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ProducerKeychainEServiceSchema = z.infer<
+  typeof ProducerKeychainEServiceSchema
+>;

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychainKey.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychainKey.ts
@@ -1,0 +1,12 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { producerKeychainKeyInReadmodelProducerKeychain } from "pagopa-interop-readmodel-models";
+
+export const ProducerKeychainKeySchema = createSelectSchema(
+  producerKeychainKeyInReadmodelProducerKeychain
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ProducerKeychainKeySchema = z.infer<
+  typeof ProducerKeychainKeySchema
+>;

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychainUser.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychainUser.ts
@@ -1,0 +1,12 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { producerKeychainUserInReadmodelProducerKeychain } from "pagopa-interop-readmodel-models";
+
+export const ProducerKeychainUserSchema = createSelectSchema(
+  producerKeychainUserInReadmodelProducerKeychain
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ProducerKeychainUserSchema = z.infer<
+  typeof ProducerKeychainUserSchema
+>;

--- a/packages/domains-analytics-writer/src/model/db/authorization.ts
+++ b/packages/domains-analytics-writer/src/model/db/authorization.ts
@@ -3,11 +3,19 @@ import {
   clientPurposeInReadmodelClient,
   clientUserInReadmodelClient,
   clientKeyInReadmodelClient,
+  producerKeychainEserviceInReadmodelProducerKeychain,
+  producerKeychainInReadmodelProducerKeychain,
+  producerKeychainKeyInReadmodelProducerKeychain,
+  producerKeychainUserInReadmodelProducerKeychain,
 } from "pagopa-interop-readmodel-models";
 import { ClientSchema } from "../authorization/client.js";
 import { ClientPurposeSchema } from "../authorization/clientPurpose.js";
 import { ClientUserSchema } from "../authorization/clientUser.js";
 import { ClientKeySchema } from "../authorization/clientKey.js";
+import { ProducerKeychainSchema } from "../authorization/producerKeychain.js";
+import { ProducerKeychainEServiceSchema } from "../authorization/producerKeychainEService.js";
+import { ProducerKeychainKeySchema } from "../authorization/producerKeychainKey.js";
+import { ProducerKeychainUserSchema } from "../authorization/producerKeychainUser.js";
 
 export const ClientDbTableConfig = {
   client: ClientSchema,
@@ -30,3 +38,29 @@ export type ClientDbTable = keyof typeof ClientDbTableConfig;
 export const ClientDbTable = Object.fromEntries(
   Object.keys(ClientDbTableConfig).map((k) => [k, k])
 ) as { [K in ClientDbTable]: K };
+
+export const ProducerKeychainDbTableConfig = {
+  producer_keychain: ProducerKeychainSchema,
+  producer_keychain_user: ProducerKeychainUserSchema,
+  producer_keychain_eservice: ProducerKeychainEServiceSchema,
+  producer_keychain_key: ProducerKeychainKeySchema,
+} as const;
+export type ProducerKeychainDbTableConfig =
+  typeof ProducerKeychainDbTableConfig;
+
+export const ProducerKeychainDbTableReadModel = {
+  producer_keychain: producerKeychainInReadmodelProducerKeychain,
+  producer_keychain_user: producerKeychainUserInReadmodelProducerKeychain,
+  producer_keychain_eservice:
+    producerKeychainEserviceInReadmodelProducerKeychain,
+  producer_keychain_key: producerKeychainKeyInReadmodelProducerKeychain,
+} as const;
+export type ProducerKeychainDbTableReadModel =
+  typeof ProducerKeychainDbTableReadModel;
+
+export type ProducerKeychainDbTable =
+  keyof typeof ProducerKeychainDbTableConfig;
+
+export const ProducerKeychainDbTable = Object.fromEntries(
+  Object.keys(ProducerKeychainDbTableConfig).map((k) => [k, k])
+) as { [K in ProducerKeychainDbTable]: K };

--- a/packages/domains-analytics-writer/src/model/db/deleting.ts
+++ b/packages/domains-analytics-writer/src/model/db/deleting.ts
@@ -12,6 +12,7 @@ import {
   clientUserInReadmodelClient,
   clientPurposeInReadmodelClient,
   clientKeyInReadmodelClient,
+  producerKeychainInReadmodelProducerKeychain,
 } from "pagopa-interop-readmodel-models";
 
 import { AttributeDeletingSchema } from "../attribute/attribute.js";
@@ -26,6 +27,7 @@ import { ClientPurposeDeletingSchema } from "../authorization/clientPurpose.js";
 import { ClientKeyDeletingSchema } from "../authorization/clientKey.js";
 import { PurposeDeletingSchema } from "../purpose/purpose.js";
 import { EserviceDescriptorDocumentOrInterfaceDeletingSchema } from "../catalog/eserviceDescriptorInterface.js";
+import { ProducerKeychainDeletingSchema } from "../authorization/producerKeychain.js";
 
 export const DeletingDbTableConfig = {
   attribute_deleting_table: AttributeDeletingSchema,
@@ -40,6 +42,7 @@ export const DeletingDbTableConfig = {
   client_user_deleting_table: ClientUserDeletingSchema,
   client_purpose_deleting_table: ClientPurposeDeletingSchema,
   client_key_deleting_table: ClientKeyDeletingSchema,
+  producer_keychain_deleting_table: ProducerKeychainDeletingSchema,
   eservice_template_deleting_table: EserviceTemplateDeletingSchema,
 } as const;
 export type DeletingDbTableConfig = typeof DeletingDbTableConfig;
@@ -57,6 +60,7 @@ export const DeletingDbTableReadModel = {
   client_user_deleting_table: clientUserInReadmodelClient,
   client_purpose_deleting_table: clientPurposeInReadmodelClient,
   client_key_deleting_table: clientKeyInReadmodelClient,
+  producer_keychain_deleting_table: producerKeychainInReadmodelProducerKeychain,
   eservice_template_deleting_table: eserviceTemplateInReadmodelEserviceTemplate,
 } as const;
 export type DeletingDbTableReadModel = typeof DeletingDbTableReadModel;

--- a/packages/domains-analytics-writer/src/model/db/index.ts
+++ b/packages/domains-analytics-writer/src/model/db/index.ts
@@ -15,6 +15,8 @@ import {
 import {
   ClientDbTableConfig,
   ClientDbTableReadModel,
+  ProducerKeychainDbTableConfig,
+  ProducerKeychainDbTableReadModel,
 } from "./authorization.js";
 import {
   DelegationDbTableConfig,
@@ -48,6 +50,7 @@ export const DomainDbTable = {
   ...DelegationDbTableConfig,
   ...TenantDbTableConfig,
   ...ClientDbTableConfig,
+  ...ProducerKeychainDbTableConfig,
   ...EserviceTemplateDbTableConfig,
 } as const;
 export type DomainDbTableSchemas = typeof DomainDbTable;
@@ -69,6 +72,7 @@ export const DomainDbTableReadModels = {
   ...PurposeDbTableReadModel,
   ...TenantDbTableReadModel,
   ...ClientDbTableReadModel,
+  ...ProducerKeychainDbTableReadModel,
   ...EserviceTemplateDbTableReadModel,
 } as const;
 export type DomainDbTableReadModels = typeof DomainDbTableReadModels;

--- a/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateRiskAnalysis.ts
+++ b/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateRiskAnalysis.ts
@@ -11,12 +11,3 @@ export const EserviceTemplateRiskAnalysisSchema = createSelectSchema(
 export type EserviceTemplateRiskAnalysisSchema = z.infer<
   typeof EserviceTemplateRiskAnalysisSchema
 >;
-
-export const EserviceTemplateRiskAnalysisDeletingSchema =
-  EserviceTemplateRiskAnalysisSchema.pick({
-    id: true,
-    deleted: true,
-  });
-export type EserviceTemplateRiskAnalysisDeletingSchema = z.infer<
-  typeof EserviceTemplateRiskAnalysisDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersion.ts
+++ b/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersion.ts
@@ -11,12 +11,3 @@ export const EserviceTemplateVersionSchema = createSelectSchema(
 export type EserviceTemplateVersionSchema = z.infer<
   typeof EserviceTemplateVersionSchema
 >;
-
-export const EserviceTemplateVersionDeletingSchema =
-  EserviceTemplateVersionSchema.pick({
-    id: true,
-    deleted: true,
-  });
-export type EserviceTemplateVersionDeletingSchema = z.infer<
-  typeof EserviceTemplateVersionDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersionDocument.ts
+++ b/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersionDocument.ts
@@ -11,12 +11,3 @@ export const EserviceTemplateVersionDocumentSchema = createSelectSchema(
 export type EserviceTemplateVersionDocumentSchema = z.infer<
   typeof EserviceTemplateVersionDocumentSchema
 >;
-
-export const EserviceTemplateDocumentDeletingSchema =
-  EserviceTemplateVersionDocumentSchema.pick({
-    id: true,
-    deleted: true,
-  });
-export type EserviceTemplateDocumentDeletingSchema = z.infer<
-  typeof EserviceTemplateDocumentDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersionInterface.ts
+++ b/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersionInterface.ts
@@ -11,12 +11,3 @@ export const EserviceTemplateVersionInterfaceSchema = createSelectSchema(
 export type EserviceTemplateVersionInterfaceSchema = z.infer<
   typeof EserviceTemplateVersionInterfaceSchema
 >;
-
-export const EserviceTemplateInterfaceDeletingSchema =
-  EserviceTemplateVersionInterfaceSchema.pick({
-    id: true,
-    deleted: true,
-  });
-export type EserviceTemplateInterfaceDeletingSchema = z.infer<
-  typeof EserviceTemplateInterfaceDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/repository/agreement/agreement.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/agreement/agreement.repository.ts
@@ -95,7 +95,9 @@ export function agreementRepo(conn: DBConnection) {
           schemaName,
           tableName,
           deletingTableName,
-          ["id"]
+          ["id"],
+          true,
+          false
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplate.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplate.repository.ts
@@ -95,7 +95,9 @@ export function eserviceTemplateRepository(conn: DBConnection) {
           schemaName,
           tableName,
           deletingTableName,
-          ["id"]
+          ["id"],
+          true,
+          false
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateRiskAnalysis.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateRiskAnalysis.repository.ts
@@ -5,26 +5,17 @@ import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
   generateMergeQuery,
-  generateMergeDeleteQuery,
   generateStagingDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
 
-import {
-  EserviceTemplateDbTable,
-  DeletingDbTable,
-} from "../../model/db/index.js";
-import {
-  EserviceTemplateRiskAnalysisDeletingSchema,
-  EserviceTemplateRiskAnalysisSchema,
-} from "../../model/eserviceTemplate/eserviceTemplateRiskAnalysis.js";
+import { EserviceTemplateDbTable } from "../../model/db/index.js";
+import { EserviceTemplateRiskAnalysisSchema } from "../../model/eserviceTemplate/eserviceTemplateRiskAnalysis.js";
 
 export function eserviceTemplateRiskAnalysisRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = EserviceTemplateDbTable.eservice_template_risk_analysis;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.eservice_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
     async insert(
@@ -69,53 +60,6 @@ export function eserviceTemplateRiskAnalysisRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateRiskAnalysisDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceTemplateRiskAnalysisDeletingSchema
-        );
-        await t.none(
-          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeDelQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeDelQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersion.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersion.repository.ts
@@ -5,26 +5,17 @@ import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
   generateMergeQuery,
-  generateMergeDeleteQuery,
   generateStagingDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
 
-import {
-  EserviceTemplateDbTable,
-  DeletingDbTable,
-} from "../../model/db/index.js";
-import {
-  EserviceTemplateVersionDeletingSchema,
-  EserviceTemplateVersionSchema,
-} from "../../model/eserviceTemplate/eserviceTemplateVersion.js";
+import { EserviceTemplateDbTable } from "../../model/db/index.js";
+import { EserviceTemplateVersionSchema } from "../../model/eserviceTemplate/eserviceTemplateVersion.js";
 
 export function eserviceTemplateVersionRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = EserviceTemplateDbTable.eservice_template_version;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.eservice_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
     async insert(
@@ -69,53 +60,6 @@ export function eserviceTemplateVersionRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateVersionDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceTemplateVersionDeletingSchema
-        );
-        await t.none(
-          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeDelQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeDelQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error truncating deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionDocument.repository.ts
@@ -5,25 +5,16 @@ import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
   generateMergeQuery,
-  generateMergeDeleteQuery,
   generateStagingDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
-import {
-  EserviceTemplateDbTable,
-  DeletingDbTable,
-} from "../../model/db/index.js";
-import {
-  EserviceTemplateDocumentDeletingSchema,
-  EserviceTemplateVersionDocumentSchema,
-} from "../../model/eserviceTemplate/eserviceTemplateVersionDocument.js";
+import { EserviceTemplateDbTable } from "../../model/db/index.js";
+import { EserviceTemplateVersionDocumentSchema } from "../../model/eserviceTemplate/eserviceTemplateVersionDocument.js";
 
 export function eserviceTemplateVersionDocumentRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = EserviceTemplateDbTable.eservice_template_version_document;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.eservice_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
     async insert(
@@ -68,53 +59,6 @@ export function eserviceTemplateVersionDocumentRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateDocumentDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceTemplateDocumentDeletingSchema
-        );
-        await t.none(
-          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeDelQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeDelQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionInterface.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionInterface.repository.ts
@@ -5,26 +5,17 @@ import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
   generateMergeQuery,
-  generateMergeDeleteQuery,
   generateStagingDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
 
-import {
-  EserviceTemplateDbTable,
-  DeletingDbTable,
-} from "../../model/db/index.js";
-import {
-  EserviceTemplateInterfaceDeletingSchema,
-  EserviceTemplateVersionInterfaceSchema,
-} from "../../model/eserviceTemplate/eserviceTemplateVersionInterface.js";
+import { EserviceTemplateDbTable } from "../../model/db/index.js";
+import { EserviceTemplateVersionInterfaceSchema } from "../../model/eserviceTemplate/eserviceTemplateVersionInterface.js";
 
 export function eserviceTemplateVersionInterfaceRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = EserviceTemplateDbTable.eservice_template_version_interface;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.eservice_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
     async insert(
@@ -69,53 +60,6 @@ export function eserviceTemplateVersionInterfaceRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateInterfaceDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceTemplateInterfaceDeletingSchema
-        );
-        await t.none(
-          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeDelQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeDelQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error truncating deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychain.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychain.repository.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+import {
+  DeletingDbTable,
+  ProducerKeychainDbTable,
+} from "../../model/db/index.js";
+import {
+  ProducerKeychainSchema,
+  ProducerKeychainDeletingSchema,
+} from "../../model/authorization/producerKeychain.js";
+
+export function producerKeychainRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ProducerKeychainDbTable.producer_keychain;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const deletingTableName = DeletingDbTable.producer_keychain_deleting_table;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ProducerKeychainSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ProducerKeychainSchema,
+          schemaName,
+          tableName,
+          ["id"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertDeleting(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainDeletingSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          deletingTableName,
+          ProducerKeychainDeletingSchema
+        );
+        await t.none(
+          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          ["id"],
+          false,
+          false
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainEService.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainEService.repository.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+
+import { ProducerKeychainDbTable } from "../../model/db/index.js";
+
+import { ProducerKeychainEServiceSchema } from "../../model/authorization/producerKeychainEService.js";
+
+export function producerKeychainEServiceRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ProducerKeychainDbTable.producer_keychain_eservice;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainEServiceSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          tableName,
+          ProducerKeychainEServiceSchema
+        );
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(
+          generateStagingDeleteQuery(tableName, [
+            "producerKeychainId",
+            "eserviceId",
+          ])
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ProducerKeychainEServiceSchema,
+          schemaName,
+          tableName,
+          ["producerKeychainId", "eserviceId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}
+
+export type ProducerKeychainEServiceRepository = ReturnType<
+  typeof producerKeychainEServiceRepository
+>;

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainKey.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainKey.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+
+import { ProducerKeychainDbTable } from "../../model/db/index.js";
+
+import { ProducerKeychainKeySchema } from "../../model/authorization/producerKeychainKey.js";
+
+export function producerKeychainKeyRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ProducerKeychainDbTable.producer_keychain_key;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainKeySchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ProducerKeychainKeySchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(
+          generateStagingDeleteQuery(tableName, ["producerKeychainId", "kid"])
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ProducerKeychainKeySchema,
+          schemaName,
+          tableName,
+          ["producerKeychainId", "kid"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}
+
+export type ProducerKeychainKeyRepository = ReturnType<
+  typeof producerKeychainKeyRepository
+>;

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainUser.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainUser.repository.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+
+import { ProducerKeychainDbTable } from "../../model/db/index.js";
+import { ProducerKeychainUserSchema } from "../../model/authorization/producerKeychainUser.js";
+
+export function producerKeychainUserRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ProducerKeychainDbTable.producer_keychain_user;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainUserSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ProducerKeychainUserSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(
+          generateStagingDeleteQuery(tableName, [
+            "producerKeychainId",
+            "userId",
+          ])
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ProducerKeychainUserSchema,
+          schemaName,
+          tableName,
+          ["producerKeychainId", "userId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}
+
+export type ProducerKeychainUserRepository = ReturnType<
+  typeof producerKeychainUserRepository
+>;

--- a/packages/domains-analytics-writer/src/repository/purpose/purpose.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purpose/purpose.repository.ts
@@ -94,7 +94,9 @@ export function purposeRepo(conn: DBConnection) {
           schemaName,
           tableName,
           deletingTableName,
-          ["id"]
+          ["id"],
+          true,
+          false
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {

--- a/packages/domains-analytics-writer/src/repository/purpose/purposeVersion.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purpose/purposeVersion.repository.ts
@@ -95,7 +95,9 @@ export function purposeVersionRepo(conn: DBConnection) {
           schemaName,
           tableName,
           deletingTableName,
-          ["id"]
+          ["id"],
+          true,
+          false
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {

--- a/packages/domains-analytics-writer/src/service/agreementService.ts
+++ b/packages/domains-analytics-writer/src/service/agreementService.ts
@@ -11,7 +11,10 @@ import { agreementAttributeRepo } from "../repository/agreement/agreementAttribu
 import { agreementConsumerDocumentRepo } from "../repository/agreement/agreementConsumerDocument.repository.js";
 import { agreementContractRepo } from "../repository/agreement/agreementContract.repository.js";
 import { agreementStampRepo } from "../repository/agreement/agreementStamp.repository.js";
-import { mergeDeletingCascadeById } from "../utils/sqlQueryHelper.js";
+import {
+  cleaningTargetTables,
+  mergeDeletingCascadeById,
+} from "../utils/sqlQueryHelper.js";
 import {
   AgreementDeletingSchema,
   AgreementItemsSchema,
@@ -89,6 +92,20 @@ export function agreementServiceBuilder(db: DBContext) {
         await attributeRepository.merge(t);
         await docRepository.merge(t);
         await contractRepository.merge(t);
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await cleaningTargetTables(
+          t,
+          "agreementId",
+          [
+            AgreementDbTable.agreement_stamp,
+            AgreementDbTable.agreement_attribute,
+            AgreementDbTable.agreement_consumer_document,
+            AgreementDbTable.agreement_contract,
+          ],
+          AgreementDbTable.agreement
+        );
       });
 
       genericLogger.info(

--- a/packages/domains-analytics-writer/src/service/authorizationService.ts
+++ b/packages/domains-analytics-writer/src/service/authorizationService.ts
@@ -27,18 +27,35 @@ import {
   ClientKeyDeletingSchema,
   ClientKeyUserMigrationSchema,
 } from "../model/authorization/clientKey.js";
-import { ClientDbTable } from "../model/db/authorization.js";
+import {
+  ClientDbTable,
+  ProducerKeychainDbTable,
+} from "../model/db/authorization.js";
 import { DeletingDbTable } from "../model/db/deleting.js";
 import { clientRepository } from "../repository/client/client.repository.js";
 import { clientKeyRepository } from "../repository/client/clientKey.repository.js";
 import { clientPurposeRepository } from "../repository/client/clientPurpose.repository.js";
 import { clientUserRepository } from "../repository/client/clientUser.repository.js";
+import {
+  ProducerKeychainDeletingSchema,
+  ProducerKeychainItemsSchema,
+} from "../model/authorization/producerKeychain.js";
+import { producerKeychainRepository } from "../repository/producerKeychain/producerKeychain.repository.js";
+import { producerKeychainEServiceRepository } from "../repository/producerKeychain/producerKeychainEService.repository.js";
+import { producerKeychainKeyRepository } from "../repository/producerKeychain/producerKeychainKey.js";
+import { producerKeychainUserRepository } from "../repository/producerKeychain/producerKeychainUser.repository.js";
 
 export function authorizationServiceBuilder(db: DBContext) {
   const clientRepo = clientRepository(db.conn);
   const clientUserRepo = clientUserRepository(db.conn);
   const clientPurposeRepo = clientPurposeRepository(db.conn);
   const clientKeyRepo = clientKeyRepository(db.conn);
+  const producerKeychainRepo = producerKeychainRepository(db.conn);
+  const producerKeychainUserRepo = producerKeychainUserRepository(db.conn);
+  const producerKeychainEServiceRepo = producerKeychainEServiceRepository(
+    db.conn
+  );
+  const producerKeychainKeyRepo = producerKeychainKeyRepository(db.conn);
 
   return {
     async upsertClientBatch(dbContext: DBContext, items: ClientItemsSchema[]) {
@@ -344,6 +361,126 @@ export function authorizationServiceBuilder(db: DBContext) {
       await clientKeyRepo.clean();
 
       genericLogger.info(`Staging table cleaned for ClientKeyUserMigration`);
+    },
+
+    async upsertProducerKeychainBatch(
+      dbContext: DBContext,
+      items: ProducerKeychainItemsSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        for (const batch of batchMessages(
+          items,
+          config.dbMessagesToInsertPerBatch
+        )) {
+          const batchItems = {
+            producerKeychainSQL: batch.map((i) => i.producerKeychainSQL),
+            usersSQL: batch.flatMap((i) => i.usersSQL),
+            eservicesSQL: batch.flatMap((i) => i.eservicesSQL),
+            keysSQL: batch.flatMap((i) => i.keysSQL),
+          };
+
+          if (batchItems.producerKeychainSQL.length) {
+            await producerKeychainRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.producerKeychainSQL
+            );
+          }
+          if (batchItems.usersSQL.length) {
+            await producerKeychainUserRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.usersSQL
+            );
+          }
+          if (batchItems.eservicesSQL.length) {
+            await producerKeychainEServiceRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.eservicesSQL
+            );
+          }
+          if (batchItems.keysSQL.length) {
+            await producerKeychainKeyRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.keysSQL
+            );
+          }
+
+          genericLogger.info(
+            `Staging data inserted for ProducerKeychain batch: ${batch
+              .map((i) => i.producerKeychainSQL.id)
+              .join(", ")}`
+          );
+        }
+
+        await producerKeychainRepo.merge(t);
+        await producerKeychainUserRepo.merge(t);
+        await producerKeychainEServiceRepo.merge(t);
+        await producerKeychainKeyRepo.merge(t);
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await cleaningTargetTables(
+          t,
+          "producerKeychainId",
+          [
+            ProducerKeychainDbTable.producer_keychain_user,
+            ProducerKeychainDbTable.producer_keychain_eservice,
+            ProducerKeychainDbTable.producer_keychain_key,
+          ],
+          ProducerKeychainDbTable.producer_keychain
+        );
+      });
+
+      genericLogger.info(
+        `Staging data merged into target tables for ProducerKeychain`
+      );
+
+      await producerKeychainRepo.clean();
+      await producerKeychainUserRepo.clean();
+      await producerKeychainEServiceRepo.clean();
+      await producerKeychainKeyRepo.clean();
+
+      genericLogger.info(`Staging data cleaned for ProducerKeychain`);
+    },
+
+    async deleteProducerKeychainBatch(
+      dbContext: DBContext,
+      items: ProducerKeychainDeletingSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        for (const batch of batchMessages(
+          items,
+          config.dbMessagesToInsertPerBatch
+        )) {
+          await producerKeychainRepo.insertDeleting(t, dbContext.pgp, batch);
+          genericLogger.info(
+            `Staging deletion inserted for ProducerKeychain ids: ${batch
+              .map((i) => i.id)
+              .join(", ")}`
+          );
+        }
+
+        await producerKeychainRepo.mergeDeleting(t);
+        await mergeDeletingCascadeById(
+          t,
+          "producerKeychainId",
+          [
+            ProducerKeychainDbTable.producer_keychain_user,
+            ProducerKeychainDbTable.producer_keychain_eservice,
+            ProducerKeychainDbTable.producer_keychain_key,
+          ],
+          DeletingDbTable.producer_keychain_deleting_table
+        );
+      });
+
+      genericLogger.info(`Staging deletion merged for ProducerKeychain`);
+
+      await producerKeychainRepo.cleanDeleting();
+
+      genericLogger.info(`ProducerKeychain deleting table cleaned`);
     },
   };
 }

--- a/packages/domains-analytics-writer/src/service/eserviceTemplateService.ts
+++ b/packages/domains-analytics-writer/src/service/eserviceTemplateService.ts
@@ -5,7 +5,10 @@ import { genericLogger } from "pagopa-interop-commons";
 import { DBContext } from "../db/db.js";
 import { EserviceTemplateDbTable, DeletingDbTable } from "../model/db/index.js";
 import { batchMessages } from "../utils/batchHelper.js";
-import { mergeDeletingCascadeById } from "../utils/sqlQueryHelper.js";
+import {
+  cleaningTargetTables,
+  mergeDeletingCascadeById,
+} from "../utils/sqlQueryHelper.js";
 import { config } from "../config/config.js";
 import {
   EserviceTemplateItemsSchema,
@@ -18,10 +21,6 @@ import { eserviceTemplateVersionInterfaceRepository } from "../repository/eservi
 import { eserviceTemplateRiskAnalysisRepository } from "../repository/eserviceTemplate/eserviceTemplateRiskAnalysis.repository.js";
 import { eserviceTemplateRiskAnalysisAnswerRepository } from "../repository/eserviceTemplate/eserviceTemplateRiskAnalysisAnswer.repository.js";
 import { eserviceTemplateVersionAttributeRepository } from "../repository/eserviceTemplate/eserviceTemplateVersionAttribute.repository.js";
-import { EserviceTemplateRiskAnalysisDeletingSchema } from "../model/eserviceTemplate/eserviceTemplateRiskAnalysis.js";
-import { EserviceTemplateDocumentDeletingSchema } from "../model/eserviceTemplate/eserviceTemplateVersionDocument.js";
-import { EserviceTemplateVersionDeletingSchema } from "../model/eserviceTemplate/eserviceTemplateVersion.js";
-import { EserviceTemplateInterfaceDeletingSchema } from "../model/eserviceTemplate/eserviceTemplateVersionInterface.js";
 
 export function eserviceTemplateServiceBuilder(db: DBContext) {
   const templateRepo = eserviceTemplateRepository(db.conn);
@@ -107,6 +106,22 @@ export function eserviceTemplateServiceBuilder(db: DBContext) {
         await riskAnswerRepo.merge(t);
       });
 
+      await dbContext.conn.tx(async (t) => {
+        await cleaningTargetTables(
+          t,
+          "eserviceTemplateId",
+          [
+            EserviceTemplateDbTable.eservice_template_risk_analysis_answer,
+            EserviceTemplateDbTable.eservice_template_risk_analysis,
+            EserviceTemplateDbTable.eservice_template_version_attribute,
+            EserviceTemplateDbTable.eservice_template_version_document,
+            EserviceTemplateDbTable.eservice_template_version_interface,
+            EserviceTemplateDbTable.eservice_template_version,
+          ],
+          EserviceTemplateDbTable.eservice_template
+        );
+      });
+
       genericLogger.info(`Merged all staged template data`);
 
       await templateRepo.clean();
@@ -155,114 +170,6 @@ export function eserviceTemplateServiceBuilder(db: DBContext) {
 
       await templateRepo.cleanDeleting();
       genericLogger.info(`Cleaned template deleting staging`);
-    },
-
-    async deleteBatchEserviceTemplateVersion(
-      dbContext: DBContext,
-      items: EserviceTemplateVersionDeletingSchema[]
-    ): Promise<void> {
-      await dbContext.conn.tx(async (t) => {
-        for (const batch of batchMessages(
-          items,
-          config.dbMessagesToInsertPerBatch
-        )) {
-          await versionRepo.insertDeleting(t, dbContext.pgp, batch);
-          genericLogger.info(
-            `Staged version deletions: ${batch.map((i) => i.id).join(", ")}`
-          );
-        }
-
-        await versionRepo.mergeDeleting(t);
-        await mergeDeletingCascadeById(
-          t,
-          "versionId",
-          [
-            EserviceTemplateDbTable.eservice_template_version_interface,
-            EserviceTemplateDbTable.eservice_template_version_document,
-            EserviceTemplateDbTable.eservice_template_version_attribute,
-          ],
-          DeletingDbTable.eservice_template_deleting_table
-        );
-      });
-
-      genericLogger.info(`Merged version deletions into target tables`);
-
-      await versionRepo.cleanDeleting();
-      genericLogger.info(`Cleaned version deleting staging`);
-    },
-
-    async deleteBatchEserviceTemplateInterface(
-      dbContext: DBContext,
-      items: EserviceTemplateInterfaceDeletingSchema[]
-    ): Promise<void> {
-      await dbContext.conn.tx(async (t) => {
-        for (const batch of batchMessages(
-          items,
-          config.dbMessagesToInsertPerBatch
-        )) {
-          await interfaceRepo.insertDeleting(t, dbContext.pgp, batch);
-          genericLogger.info(
-            `Staged interface deletions: ${batch.map((i) => i.id).join(", ")}`
-          );
-        }
-
-        await interfaceRepo.mergeDeleting(t);
-      });
-
-      genericLogger.info(`Merged interface deletions into target tables`);
-
-      await interfaceRepo.cleanDeleting();
-      genericLogger.info(`Cleaned interface deleting staging`);
-    },
-
-    async deleteBatchEserviceTemplateDocument(
-      dbContext: DBContext,
-      items: EserviceTemplateDocumentDeletingSchema[]
-    ): Promise<void> {
-      await dbContext.conn.tx(async (t) => {
-        for (const batch of batchMessages(
-          items,
-          config.dbMessagesToInsertPerBatch
-        )) {
-          await documentRepo.insertDeleting(t, dbContext.pgp, batch);
-          genericLogger.info(
-            `Staged document deletions: ${batch.map((i) => i.id).join(", ")}`
-          );
-        }
-
-        await documentRepo.mergeDeleting(t);
-      });
-
-      genericLogger.info(`Merged document deletions into target tables`);
-
-      await documentRepo.cleanDeleting();
-      genericLogger.info(`Cleaned document deleting staging`);
-    },
-
-    async deleteBatchEserviceTemplateRiskAnalysis(
-      dbContext: DBContext,
-      items: EserviceTemplateRiskAnalysisDeletingSchema[]
-    ): Promise<void> {
-      await dbContext.conn.tx(async (t) => {
-        for (const batch of batchMessages(
-          items,
-          config.dbMessagesToInsertPerBatch
-        )) {
-          await riskRepo.insertDeleting(t, dbContext.pgp, batch);
-          genericLogger.info(
-            `Staged risk-analysis deletions: ${batch
-              .map((i) => i.id)
-              .join(", ")}`
-          );
-        }
-
-        await riskRepo.mergeDeleting(t);
-      });
-
-      genericLogger.info(`Merged risk-analysis deletions into target tables`);
-
-      await riskRepo.cleanDeleting();
-      genericLogger.info(`Cleaned risk-analysis deleting staging`);
     },
   };
 }

--- a/packages/domains-analytics-writer/src/service/purposeService.ts
+++ b/packages/domains-analytics-writer/src/service/purposeService.ts
@@ -3,7 +3,10 @@
 import { genericLogger } from "pagopa-interop-commons";
 import { DBContext } from "../db/db.js";
 import { batchMessages } from "../utils/batchHelper.js";
-import { mergeDeletingCascadeById } from "../utils/sqlQueryHelper.js";
+import {
+  cleaningTargetTables,
+  mergeDeletingCascadeById,
+} from "../utils/sqlQueryHelper.js";
 import { config } from "../config/config.js";
 import { DeletingDbTable } from "../model/db/deleting.js";
 import { PurposeDbTable } from "../model/db/purpose.js";
@@ -99,6 +102,20 @@ export function purposeServiceBuilder(db: DBContext) {
         await answerRepository.merge(t);
       });
 
+      await dbContext.conn.tx(async (t) => {
+        await cleaningTargetTables(
+          t,
+          "purposeId",
+          [
+            PurposeDbTable.purpose_version_document,
+            PurposeDbTable.purpose_version,
+            PurposeDbTable.purpose_risk_analysis_answer,
+            PurposeDbTable.purpose_risk_analysis_form,
+          ],
+          PurposeDbTable.purpose
+        );
+      });
+
       genericLogger.info(
         `Staging data merged into target tables for all batches`
       );
@@ -149,6 +166,16 @@ export function purposeServiceBuilder(db: DBContext) {
         await versionRepository.merge(t);
         await versionDocumentRepository.merge(t);
       });
+
+      await dbContext.conn.tx(async (t) => {
+        await cleaningTargetTables(
+          t,
+          "purposeVersionId",
+          [PurposeDbTable.purpose_version_document],
+          PurposeDbTable.purpose_version
+        );
+      });
+
       genericLogger.info(
         `Staging data merged into target tables for all batches`
       );
@@ -211,13 +238,14 @@ export function purposeServiceBuilder(db: DBContext) {
           );
         }
 
-        await versionRepository.mergeDeleting(t);
         await mergeDeletingCascadeById(
           t,
           "purposeVersionId",
           [PurposeDbTable.purpose_version_document],
-          DeletingDbTable.purpose_deleting_table
+          DeletingDbTable.purpose_deleting_table,
+          true
         );
+        await versionRepository.mergeDeleting(t);
       });
       genericLogger.info(
         `Staging deletion merged into target tables for all purpose versions`

--- a/packages/domains-analytics-writer/test/agreementService.test.ts
+++ b/packages/domains-analytics-writer/test/agreementService.test.ts
@@ -65,7 +65,7 @@ describe("Agreement messages consumers - handleAgreementMessageV1", () => {
       { id: mock.id }
     );
     expect(storedAgreement).toBeDefined();
-    expect(storedAgreement.metadataVersion).toBe(1);
+    expect(storedAgreement?.metadataVersion).toBe(1);
 
     const storedStamps = await getManyFromDb(
       dbContext,
@@ -165,8 +165,8 @@ describe("Agreement messages consumers - handleAgreementMessageV1", () => {
     const stored = await getOneFromDb(dbContext, AgreementDbTable.agreement, {
       id: mock.id,
     });
-    expect(stored.metadataVersion).toBe(2);
-    expect(stored.state).toBe("Suspended");
+    expect(stored?.metadataVersion).toBe(2);
+    expect(stored?.state).toBe("Suspended");
   });
 
   it("AgreementDeleted: marks agreement and all subobjects deleted", async () => {
@@ -205,7 +205,7 @@ describe("Agreement messages consumers - handleAgreementMessageV1", () => {
       AgreementDbTable.agreement,
       { id: mock.id }
     );
-    expect(storedAgreement.deleted).toBe(true);
+    expect(storedAgreement?.deleted).toBe(true);
 
     const storedStamps = await getManyFromDb(
       dbContext,
@@ -315,7 +315,7 @@ describe("Agreement messages consumers - handleAgreementMessageV2", () => {
       { id: mock.id }
     );
     expect(storedAgreement).toBeDefined();
-    expect(storedAgreement.metadataVersion).toBe(1);
+    expect(storedAgreement?.metadataVersion).toBe(1);
 
     const storedStamps = await getManyFromDb(
       dbContext,
@@ -349,7 +349,7 @@ describe("Agreement messages consumers - handleAgreementMessageV2", () => {
     expect(storedContract[0].metadataVersion).toBe(1);
   });
 
-  it("AgreementConsumerDocumentRemoved: marks consumer document as deleted ", async () => {
+  it("AgreementConsumerDocumentRemoved: should delete consumer document", async () => {
     const doc = getMockAgreementDocument();
     const mock = { ...getMockAgreement(), consumerDocuments: [doc] };
 
@@ -369,7 +369,7 @@ describe("Agreement messages consumers - handleAgreementMessageV2", () => {
       event_version: 2,
       type: "AgreementConsumerDocumentRemoved",
       data: {
-        agreement: toAgreementV2(mock),
+        agreement: toAgreementV2({ ...mock, consumerDocuments: [] }),
         documentId: doc.id,
       } as AgreementConsumerDocumentRemovedV2,
       log_date: new Date(),
@@ -382,8 +382,7 @@ describe("Agreement messages consumers - handleAgreementMessageV2", () => {
       AgreementDbTable.agreement_consumer_document,
       { id: doc.id }
     );
-    expect(stored.length).toBe(1);
-    expect(stored[0].deleted).toBe(true);
+    expect(stored.length).toBe(0);
   });
 
   it("AgreementSuspendedByProducer: applies update", async () => {
@@ -415,8 +414,8 @@ describe("Agreement messages consumers - handleAgreementMessageV2", () => {
     const stored = await getOneFromDb(dbContext, AgreementDbTable.agreement, {
       id: mock.id,
     });
-    expect(stored.metadataVersion).toBe(2);
-    expect(stored.state).toBe("Suspended");
+    expect(stored?.metadataVersion).toBe(2);
+    expect(stored?.state).toBe("Suspended");
   });
 
   it("AgreementDeleted: marks agreement and all subobjects deleted (V2)", async () => {
@@ -455,7 +454,7 @@ describe("Agreement messages consumers - handleAgreementMessageV2", () => {
       AgreementDbTable.agreement,
       { id: mock.id }
     );
-    expect(storedAgreement.deleted).toBe(true);
+    expect(storedAgreement?.deleted).toBe(true);
 
     const storedStamps = await getManyFromDb(
       dbContext,

--- a/packages/domains-analytics-writer/test/eserviceTemplate.test.ts
+++ b/packages/domains-analytics-writer/test/eserviceTemplate.test.ts
@@ -8,10 +8,12 @@ import {
   toEServiceTemplateV2,
   generateId,
   EServiceTemplateRiskAnalysisDeletedV2,
-  EServiceTemplateVersionDocumentDeletedV2,
   EServiceTemplateVersionInterfaceDeletedV2,
   EServiceTemplateDraftVersionDeletedV2,
   EServiceTemplateDeletedV2,
+  eserviceTemplateVersionState,
+  EServiceTemplateVersion,
+  EServiceTemplate,
 } from "pagopa-interop-models";
 import {
   getMockEServiceTemplate,
@@ -76,7 +78,7 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
       { id: template.id }
     );
     expect(storedEserviceTemplate).toBeDefined();
-    expect(storedEserviceTemplate.metadataVersion).toBe(1);
+    expect(storedEserviceTemplate?.metadataVersion).toBe(1);
 
     const storedVersions = await getManyFromDb(
       dbContext,
@@ -165,8 +167,8 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
         id: mock.id,
       }
     );
-    expect(stored1.name).toBe("Template v1");
-    expect(stored1.metadataVersion).toBe(1);
+    expect(stored1?.name).toBe("Template v1");
+    expect(stored1?.metadataVersion).toBe(1);
 
     const templateV3 = toEServiceTemplateV2({ ...mock, name: "Template v3" });
     const msgV3 = {
@@ -183,8 +185,8 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
         id: mock.id,
       }
     );
-    expect(stored2.name).toBe("Template v3");
-    expect(stored2.metadataVersion).toBe(3);
+    expect(stored2?.name).toBe("Template v3");
+    expect(stored2?.metadataVersion).toBe(3);
 
     const templateV2 = toEServiceTemplateV2({ ...mock, name: "Template v2" });
     const msgV2 = {
@@ -201,8 +203,8 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
         id: mock.id,
       }
     );
-    expect(stored3.name).toBe("Template v3");
-    expect(stored3.metadataVersion).toBe(3);
+    expect(stored3?.name).toBe("Template v3");
+    expect(stored3?.metadataVersion).toBe(3);
   });
 
   it("EServiceTemplateAdded: should apply update when incoming metadata_version is greater", async () => {
@@ -227,8 +229,8 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
         id: mock.id,
       }
     );
-    expect(stored.name).toBe("Template v2");
-    expect(stored.metadataVersion).toBe(2);
+    expect(stored?.name).toBe("Template v2");
+    expect(stored?.metadataVersion).toBe(2);
   });
 
   it("EServiceTemplateDeleted: cascades delete to all nested tables", async () => {
@@ -281,7 +283,7 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
       EserviceTemplateDbTable.eservice_template,
       { id: template.id }
     );
-    expect(tpl.deleted).toBe(true);
+    expect(tpl?.deleted).toBe(true);
 
     (
       await getManyFromDb(
@@ -351,275 +353,265 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
   });
 
   it("EServiceTemplateDraftVersionDeleted: deletes version and its sub-objects", async () => {
-    const template = getMockEServiceTemplate();
-    const version = getMockEServiceTemplateVersion();
-    version.interface = {
-      id: generateId(),
-      name: "",
-      prettyName: "",
-      contentType: "",
-      path: "",
-      checksum: "",
-      uploadDate: new Date(),
+    const mockEServiceTemplate = getMockEServiceTemplate();
+    const document = getMockDocument();
+    const draftInterface = getMockDocument();
+    const attribute = getMockEServiceAttribute();
+    const draftEServiceTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      attributes: {
+        certified: [[attribute]],
+        declared: [],
+        verified: [],
+      },
+      docs: [document],
+      interface: draftInterface,
     };
-    const doc = getMockDocument();
-    version.docs = [doc];
-    const attr = getMockEServiceAttribute();
-    version.attributes = { certified: [[attr]], declared: [], verified: [] };
-    const risk = getMockValidRiskAnalysis("PA");
 
-    template.versions = [version];
-    template.riskAnalysis = [risk];
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      versions: [draftEServiceTemplateVersion],
+    };
+    const updatedEServiceTemplate: EServiceTemplate = {
+      ...eserviceTemplate,
+      versions: [],
+    };
+
+    const addPayload: EServiceTemplateAddedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+    };
+    const deletePayload: EServiceTemplateDraftVersionDeletedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+      eserviceTemplateVersionId: draftEServiceTemplateVersion.id,
+    };
 
     const addMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 1,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 1,
       type: "EServiceTemplateAdded",
       event_version: 2,
-      data: { eserviceTemplate: toEServiceTemplateV2(template) },
+      data: addPayload,
       log_date: new Date(),
     };
     const delMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 2,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 2,
       type: "EServiceTemplateDraftVersionDeleted",
       event_version: 2,
-      data: {
-        eserviceTemplateVersionId: version.id,
-      } as EServiceTemplateDraftVersionDeletedV2,
+      data: deletePayload,
       log_date: new Date(),
     };
 
     await handleEserviceTemplateMessageV2([addMsg, delMsg], dbContext);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version,
-        { id: version.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_interface,
-        { id: version.interface.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
+    const tablesToCheck: EserviceTemplateDbTable[] = [
+      EserviceTemplateDbTable.eservice_template_version,
+      EserviceTemplateDbTable.eservice_template_version_interface,
+      EserviceTemplateDbTable.eservice_template_version_document,
+      EserviceTemplateDbTable.eservice_template_version_attribute,
+    ];
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_document,
-        { versionId: version.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
-
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_attribute,
-        { attributeId: attr.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
-
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_risk_analysis,
-        { id: risk.id }
-      )
-    ).forEach((r) => expect(r.deleted).not.toBe(true));
+    for (const table of tablesToCheck) {
+      const rows = await getManyFromDb(dbContext, table, {
+        eserviceTemplateId: mockEServiceTemplate.id,
+      });
+      expect(rows).toHaveLength(0);
+    }
   });
 
   it("EServiceTemplateVersionInterfaceDeleted: deletes only interface", async () => {
-    const template = getMockEServiceTemplate();
-    const version = getMockEServiceTemplateVersion();
-    const ifaceId = generateId();
-    version.interface = {
-      id: ifaceId as any,
-      name: "",
-      prettyName: "",
-      contentType: "",
-      path: "",
-      checksum: "",
-      uploadDate: new Date(),
+    const mockEServiceTemplate = getMockEServiceTemplate();
+    const descriptorInterface = getMockDocument();
+    const draftEServiceTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      state: eserviceTemplateVersionState.draft,
+      interface: descriptorInterface,
     };
-    template.versions = [version];
+
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      versions: [draftEServiceTemplateVersion],
+    };
+
+    const updatedEServiceTemplate: EServiceTemplate = {
+      ...eserviceTemplate,
+      versions: [
+        {
+          ...draftEServiceTemplateVersion,
+          interface: undefined,
+        },
+      ],
+    };
+
+    const addPayload: EServiceTemplateAddedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+    };
+    const deletePayload: EServiceTemplateVersionInterfaceDeletedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+      eserviceTemplateVersionId: draftEServiceTemplateVersion.id,
+      documentId: descriptorInterface.id,
+    };
 
     const addMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 1,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 1,
       type: "EServiceTemplateAdded",
       event_version: 2,
-      data: { eserviceTemplate: toEServiceTemplateV2(template) },
+      data: addPayload,
       log_date: new Date(),
     };
     const delMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 2,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 2,
       type: "EServiceTemplateVersionInterfaceDeleted",
       event_version: 2,
-      data: {
-        eserviceTemplateVersionId: version.id as any,
-        eserviceTemplate: toEServiceTemplateV2(template),
-      } as EServiceTemplateVersionInterfaceDeletedV2,
+      data: deletePayload,
       log_date: new Date(),
     };
 
     await handleEserviceTemplateMessageV2([addMsg, delMsg], dbContext);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_interface,
-        { id: ifaceId }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
-
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version,
-        { id: version.id }
-      )
-    ).forEach((r) => expect(r.deleted).not.toBe(true));
-  });
-
-  it("EServiceTemplateVersionInterfaceDeleted: throws error when version is not found", async () => {
-    const template = getMockEServiceTemplate();
-
-    const msg = {
-      sequence_num: 1,
-      stream_id: template.id,
-      version: 1,
-      type: "EServiceTemplateVersionInterfaceDeleted",
-      event_version: 2,
-      data: {
-        eserviceTemplateVersionId: "non-existing-version-id",
-        eserviceTemplate: toEServiceTemplateV2(template),
-      },
-      log_date: new Date(),
-    } as any;
-
-    await expect(
-      handleEserviceTemplateMessageV2([msg], dbContext)
-    ).rejects.toThrowError(
-      "Version not found for versionId: non-existing-version-id"
+    const interfaces = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_version_interface,
+      { id: descriptorInterface.id }
     );
-  });
+    expect(interfaces).toHaveLength(0);
 
-  it("EServiceTemplateVersionInterfaceDeleted: throws error when interface is missing", async () => {
-    const template = getMockEServiceTemplate();
-    const version = getMockEServiceTemplateVersion();
-    version.interface = undefined;
-    template.versions = [version];
-
-    const msg = {
-      sequence_num: 1,
-      stream_id: template.id,
-      version: 1,
-      type: "EServiceTemplateVersionInterfaceDeleted",
-      event_version: 2,
-      data: {
-        eserviceTemplateVersionId: version.id,
-        eserviceTemplate: toEServiceTemplateV2(template),
-      },
-      log_date: new Date(),
-    } as any;
-
-    await expect(
-      handleEserviceTemplateMessageV2([msg], dbContext)
-    ).rejects.toThrowError(
-      `Missing interface for the specified version id: ${version.id}`
+    const versions = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_version,
+      { id: draftEServiceTemplateVersion.id }
     );
+    expect(versions).toHaveLength(1);
   });
 
   it("EServiceTemplateVersionDocumentDeleted: deletes only document", async () => {
-    const template = getMockEServiceTemplate();
-    const version = getMockEServiceTemplateVersion();
-    const doc = getMockDocument();
-    version.docs = [doc];
-    template.versions = [version];
+    const mockEServiceTemplate = getMockEServiceTemplate();
+    const document = getMockDocument();
+    const draftEServiceTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      state: eserviceTemplateVersionState.draft,
+      docs: [document],
+    };
+
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      versions: [draftEServiceTemplateVersion],
+    };
+    const updatedEServiceTemplate: EServiceTemplate = {
+      ...eserviceTemplate,
+      versions: [
+        {
+          ...draftEServiceTemplateVersion,
+          docs: [],
+        },
+      ],
+    };
+
+    const addPayload: EServiceTemplateAddedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+    };
+    const deletePayload: EServiceTemplateVersionInterfaceDeletedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+      eserviceTemplateVersionId: draftEServiceTemplateVersion.id,
+      documentId: document.id,
+    };
 
     const addMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 1,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 1,
       type: "EServiceTemplateAdded",
       event_version: 2,
-      data: { eserviceTemplate: toEServiceTemplateV2(template) },
+      data: addPayload,
       log_date: new Date(),
     };
     const delMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 2,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 2,
       type: "EServiceTemplateVersionDocumentDeleted",
       event_version: 2,
-      data: {
-        documentId: doc.id as any,
-      } as EServiceTemplateVersionDocumentDeletedV2,
+      data: deletePayload,
       log_date: new Date(),
     };
 
     await handleEserviceTemplateMessageV2([addMsg, delMsg], dbContext);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_document,
-        { id: doc.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
+    const documents = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_version_document,
+      { id: document.id }
+    );
+    expect(documents).toHaveLength(0);
+
+    const versions = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_version,
+      { id: draftEServiceTemplateVersion.id }
+    );
+    expect(versions).toHaveLength(1);
   });
 
   it("EServiceTemplateRiskAnalysisDeleted: deletes only riskAnalysis", async () => {
-    const template = getMockEServiceTemplate();
-    const risk = getMockValidRiskAnalysis("PA");
-    template.riskAnalysis = [risk];
+    const mockEServiceTemplate = getMockEServiceTemplate();
+    const riskAnalysis = getMockValidRiskAnalysis("PA");
+
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      riskAnalysis: [riskAnalysis],
+    };
+    const updatedEServiceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      riskAnalysis: [],
+    };
+
+    const addPayload: EServiceTemplateAddedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+    };
+    const deletePayload: EServiceTemplateRiskAnalysisDeletedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+      riskAnalysisId: riskAnalysis.id,
+    };
 
     const addMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 1,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 1,
       type: "EServiceTemplateAdded",
       event_version: 2,
-      data: { eserviceTemplate: toEServiceTemplateV2(template) },
+      data: addPayload,
       log_date: new Date(),
     };
     const delMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 2,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 2,
       type: "EServiceTemplateRiskAnalysisDeleted",
       event_version: 2,
-      data: {
-        riskAnalysisId: risk.id,
-      } as EServiceTemplateRiskAnalysisDeletedV2,
+      data: deletePayload,
       log_date: new Date(),
     };
 
     await handleEserviceTemplateMessageV2([addMsg, delMsg], dbContext);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_risk_analysis,
-        { id: risk.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
+    const retrievedRiskAnalysis = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_risk_analysis,
+      { id: riskAnalysis.id }
+    );
+    expect(retrievedRiskAnalysis).toHaveLength(0);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_risk_analysis_answer,
-        { riskAnalysisFormId: risk.riskAnalysisForm.id }
-      )
-    ).forEach((r) => expect(r.deleted).not.toBe(true));
+    const retrievedRiskAnalysisAnswers = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_risk_analysis_answer,
+      { riskAnalysisFormId: riskAnalysis.riskAnalysisForm.id }
+    );
+    expect(retrievedRiskAnalysisAnswers).toHaveLength(0);
   });
 });

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -22,6 +22,7 @@ import {
   TenantDbPartialTable,
   PurposeDbTable,
   TenantDbTable,
+  CatalogDbPartialTable,
   ClientDbTable,
 } from "../src/model/db/index.js";
 import { catalogServiceBuilder } from "../src/service/catalogService.js";
@@ -109,13 +110,16 @@ export const clientTables: ClientDbTable[] = [
   ClientDbTable.client_key,
 ];
 
-export const partialTables = [TenantDbPartialTable.tenant_self_care_id];
+export const partialTables = [
+  TenantDbPartialTable.tenant_self_care_id,
+  CatalogDbPartialTable.descriptor_server_urls,
+];
 
 export const deletingTables: DeletingDbTable[] = [
   DeletingDbTable.agreement_deleting_table,
   DeletingDbTable.attribute_deleting_table,
   DeletingDbTable.catalog_deleting_table,
-  DeletingDbTable.catalog_risk_deleting_table,
+  DeletingDbTable.catalog_descriptor_interface_deleting_table,
   DeletingDbTable.purpose_deleting_table,
   DeletingDbTable.tenant_deleting_table,
   DeletingDbTable.tenant_mail_deleting_table,
@@ -141,17 +145,11 @@ export const setupStagingDeletingTables: DeletingDbTableConfigMap[] = [
   { name: DeletingDbTable.attribute_deleting_table, columns: ["id"] },
   { name: DeletingDbTable.catalog_deleting_table, columns: ["id"] },
   {
-    name: DeletingDbTable.catalog_risk_deleting_table,
-    columns: ["id", "eserviceId"],
+    name: DeletingDbTable.catalog_descriptor_interface_deleting_table,
+    columns: ["id", "descriptorId", "metadataVersion"],
   },
-  {
-    name: DeletingDbTable.agreement_deleting_table,
-    columns: ["id"],
-  },
-  {
-    name: DeletingDbTable.purpose_deleting_table,
-    columns: ["id"],
-  },
+  { name: DeletingDbTable.agreement_deleting_table, columns: ["id"] },
+  { name: DeletingDbTable.purpose_deleting_table, columns: ["id"] },
   {
     name: DeletingDbTable.tenant_deleting_table,
     columns: ["id"],

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -24,6 +24,7 @@ import {
   TenantDbTable,
   CatalogDbPartialTable,
   ClientDbTable,
+  ProducerKeychainDbTable,
 } from "../src/model/db/index.js";
 import { catalogServiceBuilder } from "../src/service/catalogService.js";
 import { attributeServiceBuilder } from "../src/service/attributeService.js";
@@ -110,11 +111,17 @@ export const clientTables: ClientDbTable[] = [
   ClientDbTable.client_key,
 ];
 
+export const producerKeychainTables: ProducerKeychainDbTable[] = [
+  ProducerKeychainDbTable.producer_keychain,
+  ProducerKeychainDbTable.producer_keychain_eservice,
+  ProducerKeychainDbTable.producer_keychain_user,
+  ProducerKeychainDbTable.producer_keychain_key,
+];
+
 export const partialTables = [
   TenantDbPartialTable.tenant_self_care_id,
   CatalogDbPartialTable.descriptor_server_urls,
 ];
-
 export const deletingTables: DeletingDbTable[] = [
   DeletingDbTable.agreement_deleting_table,
   DeletingDbTable.attribute_deleting_table,
@@ -127,6 +134,7 @@ export const deletingTables: DeletingDbTable[] = [
   DeletingDbTable.client_purpose_deleting_table,
   DeletingDbTable.client_user_deleting_table,
   DeletingDbTable.client_key_deleting_table,
+  DeletingDbTable.producer_keychain_deleting_table,
   DeletingDbTable.eservice_template_deleting_table,
 ];
 
@@ -138,6 +146,7 @@ export const domainTables: DomainDbTable[] = [
   ...delegationTables,
   ...tenantTables,
   ...clientTables,
+  ...producerKeychainTables,
   ...eserviceTemplateTables,
 ];
 
@@ -170,6 +179,10 @@ export const setupStagingDeletingTables: DeletingDbTableConfigMap[] = [
   {
     name: DeletingDbTable.client_key_deleting_table,
     columns: ["clientId", "kid"],
+  },
+  {
+    name: DeletingDbTable.producer_keychain_deleting_table,
+    columns: ["id"],
   },
   {
     name: DeletingDbTable.eservice_template_deleting_table,


### PR DESCRIPTION
## Purpose

  - The `PurposeDeleted` and `DraftPurposeDeleted` and `WaitingForApprovalPurposeDeleted` and `PurposeDeletedByRevokedDelegation` event performs a **logical delete** on the main `purpose` table (sets the `deleted` flag, preserving history to the target tables).  
  - All other delete events execute **physical deletes**, removing rows outright from target tables.
  
  ## Eservice Template
  
-   The `EServiceTemplateDeleted` event performs a logical delete on the main `eservice_template` table (sets the deleted flag, preserving history to the target tables).
- All other delete events execute physical deletes, removing rows outright from target tables.

## Agreement

  - The `AgreementDeleted` and `AgreementDeletedByRevokedDelegation` events performs a **logical delete** on the main `agreement` table  and its subobjects (sets the `deleted` flag, preserving history to the target tables).  
  - All other delete events execute **physical deletes**, removing rows outright from target tables.

## Cleanup
**Pre-merge cleanup**  
  Before each upsert MERGE (excluding the V1 single-record path), we now run a set-based `MERGE … WHEN MATCHED THEN DELETE` on the target tables to purge any rows whose `metadata_version` is lower than the incoming staging version, ensuring outdated records will be cleaned.
