### PR TITLE
PIN-6946: Analytics - Template consumer (refactor edge cases)

### DIFF
--- a/packages/domains-analytics-writer/src/handlers/eservice-template/consumerServiceV2.ts
+++ b/packages/domains-analytics-writer/src/handlers/eservice-template/consumerServiceV2.ts
@@ -15,10 +15,6 @@ import {
   EserviceTemplateDeletingSchema,
 } from "../../model/eserviceTemplate/eserviceTemplate.js";
 import { eserviceTemplateServiceBuilder } from "../../service/eserviceTemplateService.js";
-import { EserviceTemplateRiskAnalysisDeletingSchema } from "../../model/eserviceTemplate/eserviceTemplateRiskAnalysis.js";
-import { EserviceTemplateVersionDeletingSchema } from "../../model/eserviceTemplate/eserviceTemplateVersion.js";
-import { EserviceTemplateDocumentDeletingSchema } from "../../model/eserviceTemplate/eserviceTemplateVersionDocument.js";
-import { EserviceTemplateInterfaceDeletingSchema } from "../../model/eserviceTemplate/eserviceTemplateVersionInterface.js";
 
 export async function handleEserviceTemplateMessageV2(
   messages: EServiceTemplateEventEnvelope[],
@@ -28,14 +24,6 @@ export async function handleEserviceTemplateMessageV2(
 
   const upsertEserviceTemplateBatch: EserviceTemplateItemsSchema[] = [];
   const deleteEserviceTemplateBatch: EserviceTemplateDeletingSchema[] = [];
-  const deleteEserviceTemplateVersionBatch: EserviceTemplateVersionDeletingSchema[] =
-    [];
-  const deleteEserviceTemplateInterfaceBatch: EserviceTemplateInterfaceDeletingSchema[] =
-    [];
-  const deleteEserviceTemplateDocumentBatch: EserviceTemplateDocumentDeletingSchema[] =
-    [];
-  const deleteEserviceTemplateRiskAnalysisBatch: EserviceTemplateRiskAnalysisDeletingSchema[] =
-    [];
 
   for (const message of messages) {
     match(message)
@@ -59,7 +47,11 @@ export async function handleEserviceTemplateMessageV2(
             "EServiceTemplateVersionInterfaceUpdated",
             "EServiceTemplateRiskAnalysisAdded",
             "EServiceTemplateRiskAnalysisUpdated",
-            "EServiceTemplateVersionActivated"
+            "EServiceTemplateVersionActivated",
+            "EServiceTemplateDraftVersionDeleted",
+            "EServiceTemplateVersionInterfaceDeleted",
+            "EServiceTemplateVersionDocumentDeleted",
+            "EServiceTemplateRiskAnalysisDeleted"
           ),
         },
         (msg) => {
@@ -99,61 +91,6 @@ export async function handleEserviceTemplateMessageV2(
           } satisfies z.input<typeof EserviceTemplateDeletingSchema>)
         );
       })
-      .with({ type: "EServiceTemplateDraftVersionDeleted" }, (msg) => {
-        deleteEserviceTemplateVersionBatch.push(
-          EserviceTemplateVersionDeletingSchema.parse({
-            id: msg.data.eserviceTemplateVersionId,
-            deleted: true,
-          } satisfies z.input<typeof EserviceTemplateVersionDeletingSchema>)
-        );
-      })
-      .with({ type: "EServiceTemplateVersionInterfaceDeleted" }, (msg) => {
-        const { eserviceTemplate, eserviceTemplateVersionId } = msg.data;
-
-        if (!eserviceTemplate) {
-          throw genericInternalError(
-            "eserviceTemplate can't be missing in the event message"
-          );
-        }
-
-        const version = eserviceTemplate.versions.find(
-          (v) => v.id === eserviceTemplateVersionId
-        );
-        if (!version) {
-          throw genericInternalError(
-            `Version not found for versionId: ${eserviceTemplateVersionId}`
-          );
-        }
-
-        if (!version.interface) {
-          throw genericInternalError(
-            `Missing interface for the specified version id: ${version.id}`
-          );
-        }
-
-        deleteEserviceTemplateInterfaceBatch.push(
-          EserviceTemplateInterfaceDeletingSchema.parse({
-            id: version.interface.id,
-            deleted: true,
-          } satisfies z.input<typeof EserviceTemplateInterfaceDeletingSchema>)
-        );
-      })
-      .with({ type: "EServiceTemplateVersionDocumentDeleted" }, (msg) => {
-        deleteEserviceTemplateDocumentBatch.push(
-          EserviceTemplateDocumentDeletingSchema.parse({
-            id: msg.data.documentId,
-            deleted: true,
-          } satisfies z.input<typeof EserviceTemplateDocumentDeletingSchema>)
-        );
-      })
-      .with({ type: "EServiceTemplateRiskAnalysisDeleted" }, (msg) => {
-        deleteEserviceTemplateRiskAnalysisBatch.push(
-          EserviceTemplateRiskAnalysisDeletingSchema.parse({
-            id: msg.data.riskAnalysisId,
-            deleted: true,
-          } satisfies z.input<typeof EserviceTemplateRiskAnalysisDeletingSchema>)
-        );
-      })
       .exhaustive();
   }
 
@@ -167,30 +104,6 @@ export async function handleEserviceTemplateMessageV2(
     await templateService.deleteBatchEserviceTemplate(
       dbContext,
       deleteEserviceTemplateBatch
-    );
-  }
-  if (deleteEserviceTemplateVersionBatch.length > 0) {
-    await templateService.deleteBatchEserviceTemplateVersion(
-      dbContext,
-      deleteEserviceTemplateVersionBatch
-    );
-  }
-  if (deleteEserviceTemplateInterfaceBatch.length > 0) {
-    await templateService.deleteBatchEserviceTemplateInterface(
-      dbContext,
-      deleteEserviceTemplateInterfaceBatch
-    );
-  }
-  if (deleteEserviceTemplateDocumentBatch.length > 0) {
-    await templateService.deleteBatchEserviceTemplateDocument(
-      dbContext,
-      deleteEserviceTemplateDocumentBatch
-    );
-  }
-  if (deleteEserviceTemplateRiskAnalysisBatch.length > 0) {
-    await templateService.deleteBatchEserviceTemplateRiskAnalysis(
-      dbContext,
-      deleteEserviceTemplateRiskAnalysisBatch
     );
   }
 }

--- a/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateRiskAnalysis.ts
+++ b/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateRiskAnalysis.ts
@@ -11,12 +11,3 @@ export const EserviceTemplateRiskAnalysisSchema = createSelectSchema(
 export type EserviceTemplateRiskAnalysisSchema = z.infer<
   typeof EserviceTemplateRiskAnalysisSchema
 >;
-
-export const EserviceTemplateRiskAnalysisDeletingSchema =
-  EserviceTemplateRiskAnalysisSchema.pick({
-    id: true,
-    deleted: true,
-  });
-export type EserviceTemplateRiskAnalysisDeletingSchema = z.infer<
-  typeof EserviceTemplateRiskAnalysisDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersion.ts
+++ b/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersion.ts
@@ -11,12 +11,3 @@ export const EserviceTemplateVersionSchema = createSelectSchema(
 export type EserviceTemplateVersionSchema = z.infer<
   typeof EserviceTemplateVersionSchema
 >;
-
-export const EserviceTemplateVersionDeletingSchema =
-  EserviceTemplateVersionSchema.pick({
-    id: true,
-    deleted: true,
-  });
-export type EserviceTemplateVersionDeletingSchema = z.infer<
-  typeof EserviceTemplateVersionDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersionDocument.ts
+++ b/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersionDocument.ts
@@ -11,12 +11,3 @@ export const EserviceTemplateVersionDocumentSchema = createSelectSchema(
 export type EserviceTemplateVersionDocumentSchema = z.infer<
   typeof EserviceTemplateVersionDocumentSchema
 >;
-
-export const EserviceTemplateDocumentDeletingSchema =
-  EserviceTemplateVersionDocumentSchema.pick({
-    id: true,
-    deleted: true,
-  });
-export type EserviceTemplateDocumentDeletingSchema = z.infer<
-  typeof EserviceTemplateDocumentDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersionInterface.ts
+++ b/packages/domains-analytics-writer/src/model/eserviceTemplate/eserviceTemplateVersionInterface.ts
@@ -11,12 +11,3 @@ export const EserviceTemplateVersionInterfaceSchema = createSelectSchema(
 export type EserviceTemplateVersionInterfaceSchema = z.infer<
   typeof EserviceTemplateVersionInterfaceSchema
 >;
-
-export const EserviceTemplateInterfaceDeletingSchema =
-  EserviceTemplateVersionInterfaceSchema.pick({
-    id: true,
-    deleted: true,
-  });
-export type EserviceTemplateInterfaceDeletingSchema = z.infer<
-  typeof EserviceTemplateInterfaceDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplate.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplate.repository.ts
@@ -99,7 +99,9 @@ export function eserviceTemplateRepository(conn: DBConnection) {
           schemaName,
           tableName,
           deletingTableName,
-          ["id"]
+          ["id"],
+          true,
+          false
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateRiskAnalysis.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateRiskAnalysis.repository.ts
@@ -5,25 +5,16 @@ import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
   generateMergeQuery,
-  generateMergeDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
 
-import {
-  EserviceTemplateDbTable,
-  DeletingDbTable,
-} from "../../model/db/index.js";
-import {
-  EserviceTemplateRiskAnalysisDeletingSchema,
-  EserviceTemplateRiskAnalysisSchema,
-} from "../../model/eserviceTemplate/eserviceTemplateRiskAnalysis.js";
+import { EserviceTemplateDbTable } from "../../model/db/index.js";
+import { EserviceTemplateRiskAnalysisSchema } from "../../model/eserviceTemplate/eserviceTemplateRiskAnalysis.js";
 
 export function eserviceTemplateRiskAnalysisRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = EserviceTemplateDbTable.eservice_template_risk_analysis;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.eservice_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
     async insert(
@@ -73,53 +64,6 @@ export function eserviceTemplateRiskAnalysisRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateRiskAnalysisDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceTemplateRiskAnalysisDeletingSchema
-        );
-        await t.none(
-          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeDelQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeDelQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersion.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersion.repository.ts
@@ -5,25 +5,16 @@ import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
   generateMergeQuery,
-  generateMergeDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
 
-import {
-  EserviceTemplateDbTable,
-  DeletingDbTable,
-} from "../../model/db/index.js";
-import {
-  EserviceTemplateVersionDeletingSchema,
-  EserviceTemplateVersionSchema,
-} from "../../model/eserviceTemplate/eserviceTemplateVersion.js";
+import { EserviceTemplateDbTable } from "../../model/db/index.js";
+import { EserviceTemplateVersionSchema } from "../../model/eserviceTemplate/eserviceTemplateVersion.js";
 
 export function eserviceTemplateVersionRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = EserviceTemplateDbTable.eservice_template_version;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.eservice_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
     async insert(
@@ -73,53 +64,6 @@ export function eserviceTemplateVersionRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateVersionDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceTemplateVersionDeletingSchema
-        );
-        await t.none(
-          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeDelQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeDelQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error truncating deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionDocument.repository.ts
@@ -5,24 +5,15 @@ import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
   generateMergeQuery,
-  generateMergeDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
-import {
-  EserviceTemplateDbTable,
-  DeletingDbTable,
-} from "../../model/db/index.js";
-import {
-  EserviceTemplateDocumentDeletingSchema,
-  EserviceTemplateVersionDocumentSchema,
-} from "../../model/eserviceTemplate/eserviceTemplateVersionDocument.js";
+import { EserviceTemplateDbTable } from "../../model/db/index.js";
+import { EserviceTemplateVersionDocumentSchema } from "../../model/eserviceTemplate/eserviceTemplateVersionDocument.js";
 
 export function eserviceTemplateVersionDocumentRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = EserviceTemplateDbTable.eservice_template_version_document;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.eservice_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
     async insert(
@@ -72,53 +63,6 @@ export function eserviceTemplateVersionDocumentRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateDocumentDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceTemplateDocumentDeletingSchema
-        );
-        await t.none(
-          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeDelQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeDelQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionInterface.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionInterface.repository.ts
@@ -5,25 +5,16 @@ import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
   generateMergeQuery,
-  generateMergeDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
 
-import {
-  EserviceTemplateDbTable,
-  DeletingDbTable,
-} from "../../model/db/index.js";
-import {
-  EserviceTemplateInterfaceDeletingSchema,
-  EserviceTemplateVersionInterfaceSchema,
-} from "../../model/eserviceTemplate/eserviceTemplateVersionInterface.js";
+import { EserviceTemplateDbTable } from "../../model/db/index.js";
+import { EserviceTemplateVersionInterfaceSchema } from "../../model/eserviceTemplate/eserviceTemplateVersionInterface.js";
 
 export function eserviceTemplateVersionInterfaceRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = EserviceTemplateDbTable.eservice_template_version_interface;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.eservice_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
     async insert(
@@ -73,53 +64,6 @@ export function eserviceTemplateVersionInterfaceRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateInterfaceDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceTemplateInterfaceDeletingSchema
-        );
-        await t.none(
-          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeDelQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeDelQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error truncating deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/service/eserviceTemplateService.ts
+++ b/packages/domains-analytics-writer/src/service/eserviceTemplateService.ts
@@ -5,7 +5,10 @@ import { genericLogger } from "pagopa-interop-commons";
 import { DBContext } from "../db/db.js";
 import { EserviceTemplateDbTable, DeletingDbTable } from "../model/db/index.js";
 import { batchMessages } from "../utils/batchHelper.js";
-import { mergeDeletingCascadeById } from "../utils/sqlQueryHelper.js";
+import {
+  cleaningTargetTables,
+  mergeDeletingCascadeById,
+} from "../utils/sqlQueryHelper.js";
 import { config } from "../config/config.js";
 import {
   EserviceTemplateItemsSchema,
@@ -18,10 +21,6 @@ import { eserviceTemplateVersionInterfaceRepository } from "../repository/eservi
 import { eserviceTemplateRiskAnalysisRepository } from "../repository/eserviceTemplate/eserviceTemplateRiskAnalysis.repository.js";
 import { eserviceTemplateRiskAnalysisAnswerRepository } from "../repository/eserviceTemplate/eserviceTemplateRiskAnalysisAnswer.repository.js";
 import { eserviceTemplateVersionAttributeRepository } from "../repository/eserviceTemplate/eserviceTemplateVersionAttribute.repository.js";
-import { EserviceTemplateRiskAnalysisDeletingSchema } from "../model/eserviceTemplate/eserviceTemplateRiskAnalysis.js";
-import { EserviceTemplateDocumentDeletingSchema } from "../model/eserviceTemplate/eserviceTemplateVersionDocument.js";
-import { EserviceTemplateVersionDeletingSchema } from "../model/eserviceTemplate/eserviceTemplateVersion.js";
-import { EserviceTemplateInterfaceDeletingSchema } from "../model/eserviceTemplate/eserviceTemplateVersionInterface.js";
 
 export function eserviceTemplateServiceBuilder(db: DBContext) {
   const templateRepo = eserviceTemplateRepository(db.conn);
@@ -107,6 +106,22 @@ export function eserviceTemplateServiceBuilder(db: DBContext) {
         await riskAnswerRepo.merge(t);
       });
 
+      await dbContext.conn.tx(async (t) => {
+        await cleaningTargetTables(
+          t,
+          "eserviceTemplateId",
+          [
+            EserviceTemplateDbTable.eservice_template_risk_analysis_answer,
+            EserviceTemplateDbTable.eservice_template_risk_analysis,
+            EserviceTemplateDbTable.eservice_template_version_attribute,
+            EserviceTemplateDbTable.eservice_template_version_document,
+            EserviceTemplateDbTable.eservice_template_version_interface,
+            EserviceTemplateDbTable.eservice_template_version,
+          ],
+          EserviceTemplateDbTable.eservice_template
+        );
+      });
+
       genericLogger.info(`Merged all staged template data`);
 
       await templateRepo.clean();
@@ -155,114 +170,6 @@ export function eserviceTemplateServiceBuilder(db: DBContext) {
 
       await templateRepo.cleanDeleting();
       genericLogger.info(`Cleaned template deleting staging`);
-    },
-
-    async deleteBatchEserviceTemplateVersion(
-      dbContext: DBContext,
-      items: EserviceTemplateVersionDeletingSchema[]
-    ): Promise<void> {
-      await dbContext.conn.tx(async (t) => {
-        for (const batch of batchMessages(
-          items,
-          config.dbMessagesToInsertPerBatch
-        )) {
-          await versionRepo.insertDeleting(t, dbContext.pgp, batch);
-          genericLogger.info(
-            `Staged version deletions: ${batch.map((i) => i.id).join(", ")}`
-          );
-        }
-
-        await versionRepo.mergeDeleting(t);
-        await mergeDeletingCascadeById(
-          t,
-          "versionId",
-          [
-            EserviceTemplateDbTable.eservice_template_version_interface,
-            EserviceTemplateDbTable.eservice_template_version_document,
-            EserviceTemplateDbTable.eservice_template_version_attribute,
-          ],
-          DeletingDbTable.eservice_template_deleting_table
-        );
-      });
-
-      genericLogger.info(`Merged version deletions into target tables`);
-
-      await versionRepo.cleanDeleting();
-      genericLogger.info(`Cleaned version deleting staging`);
-    },
-
-    async deleteBatchEserviceTemplateInterface(
-      dbContext: DBContext,
-      items: EserviceTemplateInterfaceDeletingSchema[]
-    ): Promise<void> {
-      await dbContext.conn.tx(async (t) => {
-        for (const batch of batchMessages(
-          items,
-          config.dbMessagesToInsertPerBatch
-        )) {
-          await interfaceRepo.insertDeleting(t, dbContext.pgp, batch);
-          genericLogger.info(
-            `Staged interface deletions: ${batch.map((i) => i.id).join(", ")}`
-          );
-        }
-
-        await interfaceRepo.mergeDeleting(t);
-      });
-
-      genericLogger.info(`Merged interface deletions into target tables`);
-
-      await interfaceRepo.cleanDeleting();
-      genericLogger.info(`Cleaned interface deleting staging`);
-    },
-
-    async deleteBatchEserviceTemplateDocument(
-      dbContext: DBContext,
-      items: EserviceTemplateDocumentDeletingSchema[]
-    ): Promise<void> {
-      await dbContext.conn.tx(async (t) => {
-        for (const batch of batchMessages(
-          items,
-          config.dbMessagesToInsertPerBatch
-        )) {
-          await documentRepo.insertDeleting(t, dbContext.pgp, batch);
-          genericLogger.info(
-            `Staged document deletions: ${batch.map((i) => i.id).join(", ")}`
-          );
-        }
-
-        await documentRepo.mergeDeleting(t);
-      });
-
-      genericLogger.info(`Merged document deletions into target tables`);
-
-      await documentRepo.cleanDeleting();
-      genericLogger.info(`Cleaned document deleting staging`);
-    },
-
-    async deleteBatchEserviceTemplateRiskAnalysis(
-      dbContext: DBContext,
-      items: EserviceTemplateRiskAnalysisDeletingSchema[]
-    ): Promise<void> {
-      await dbContext.conn.tx(async (t) => {
-        for (const batch of batchMessages(
-          items,
-          config.dbMessagesToInsertPerBatch
-        )) {
-          await riskRepo.insertDeleting(t, dbContext.pgp, batch);
-          genericLogger.info(
-            `Staged risk-analysis deletions: ${batch
-              .map((i) => i.id)
-              .join(", ")}`
-          );
-        }
-
-        await riskRepo.mergeDeleting(t);
-      });
-
-      genericLogger.info(`Merged risk-analysis deletions into target tables`);
-
-      await riskRepo.cleanDeleting();
-      genericLogger.info(`Cleaned risk-analysis deleting staging`);
     },
   };
 }

--- a/packages/domains-analytics-writer/test/eserviceTemplate.test.ts
+++ b/packages/domains-analytics-writer/test/eserviceTemplate.test.ts
@@ -8,10 +8,12 @@ import {
   toEServiceTemplateV2,
   generateId,
   EServiceTemplateRiskAnalysisDeletedV2,
-  EServiceTemplateVersionDocumentDeletedV2,
   EServiceTemplateVersionInterfaceDeletedV2,
   EServiceTemplateDraftVersionDeletedV2,
   EServiceTemplateDeletedV2,
+  eserviceTemplateVersionState,
+  EServiceTemplateVersion,
+  EServiceTemplate,
 } from "pagopa-interop-models";
 import {
   getMockEServiceTemplate,
@@ -76,7 +78,7 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
       { id: template.id }
     );
     expect(storedEserviceTemplate).toBeDefined();
-    expect(storedEserviceTemplate.metadataVersion).toBe(1);
+    expect(storedEserviceTemplate?.metadataVersion).toBe(1);
 
     const storedVersions = await getManyFromDb(
       dbContext,
@@ -165,8 +167,8 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
         id: mock.id,
       }
     );
-    expect(stored1.name).toBe("Template v1");
-    expect(stored1.metadataVersion).toBe(1);
+    expect(stored1?.name).toBe("Template v1");
+    expect(stored1?.metadataVersion).toBe(1);
 
     const templateV3 = toEServiceTemplateV2({ ...mock, name: "Template v3" });
     const msgV3 = {
@@ -183,8 +185,8 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
         id: mock.id,
       }
     );
-    expect(stored2.name).toBe("Template v3");
-    expect(stored2.metadataVersion).toBe(3);
+    expect(stored2?.name).toBe("Template v3");
+    expect(stored2?.metadataVersion).toBe(3);
 
     const templateV2 = toEServiceTemplateV2({ ...mock, name: "Template v2" });
     const msgV2 = {
@@ -201,8 +203,8 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
         id: mock.id,
       }
     );
-    expect(stored3.name).toBe("Template v3");
-    expect(stored3.metadataVersion).toBe(3);
+    expect(stored3?.name).toBe("Template v3");
+    expect(stored3?.metadataVersion).toBe(3);
   });
 
   it("EServiceTemplateAdded: should apply update when incoming metadata_version is greater", async () => {
@@ -227,8 +229,8 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
         id: mock.id,
       }
     );
-    expect(stored.name).toBe("Template v2");
-    expect(stored.metadataVersion).toBe(2);
+    expect(stored?.name).toBe("Template v2");
+    expect(stored?.metadataVersion).toBe(2);
   });
 
   it("EServiceTemplateDeleted: cascades delete to all nested tables", async () => {
@@ -281,7 +283,7 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
       EserviceTemplateDbTable.eservice_template,
       { id: template.id }
     );
-    expect(tpl.deleted).toBe(true);
+    expect(tpl?.deleted).toBe(true);
 
     (
       await getManyFromDb(
@@ -351,275 +353,265 @@ describe("Template messages consumers - handleEserviceTemplateMessageV2", () => 
   });
 
   it("EServiceTemplateDraftVersionDeleted: deletes version and its sub-objects", async () => {
-    const template = getMockEServiceTemplate();
-    const version = getMockEServiceTemplateVersion();
-    version.interface = {
-      id: generateId(),
-      name: "",
-      prettyName: "",
-      contentType: "",
-      path: "",
-      checksum: "",
-      uploadDate: new Date(),
+    const mockEServiceTemplate = getMockEServiceTemplate();
+    const document = getMockDocument();
+    const draftInterface = getMockDocument();
+    const attribute = getMockEServiceAttribute();
+    const draftEServiceTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      attributes: {
+        certified: [[attribute]],
+        declared: [],
+        verified: [],
+      },
+      docs: [document],
+      interface: draftInterface,
     };
-    const doc = getMockDocument();
-    version.docs = [doc];
-    const attr = getMockEServiceAttribute();
-    version.attributes = { certified: [[attr]], declared: [], verified: [] };
-    const risk = getMockValidRiskAnalysis("PA");
 
-    template.versions = [version];
-    template.riskAnalysis = [risk];
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      versions: [draftEServiceTemplateVersion],
+    };
+    const updatedEServiceTemplate: EServiceTemplate = {
+      ...eserviceTemplate,
+      versions: [],
+    };
+
+    const addPayload: EServiceTemplateAddedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+    };
+    const deletePayload: EServiceTemplateDraftVersionDeletedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+      eserviceTemplateVersionId: draftEServiceTemplateVersion.id,
+    };
 
     const addMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 1,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 1,
       type: "EServiceTemplateAdded",
       event_version: 2,
-      data: { eserviceTemplate: toEServiceTemplateV2(template) },
+      data: addPayload,
       log_date: new Date(),
     };
     const delMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 2,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 2,
       type: "EServiceTemplateDraftVersionDeleted",
       event_version: 2,
-      data: {
-        eserviceTemplateVersionId: version.id,
-      } as EServiceTemplateDraftVersionDeletedV2,
+      data: deletePayload,
       log_date: new Date(),
     };
 
     await handleEserviceTemplateMessageV2([addMsg, delMsg], dbContext);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version,
-        { id: version.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_interface,
-        { id: version.interface.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
+    const tablesToCheck: EserviceTemplateDbTable[] = [
+      EserviceTemplateDbTable.eservice_template_version,
+      EserviceTemplateDbTable.eservice_template_version_interface,
+      EserviceTemplateDbTable.eservice_template_version_document,
+      EserviceTemplateDbTable.eservice_template_version_attribute,
+    ];
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_document,
-        { versionId: version.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
-
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_attribute,
-        { attributeId: attr.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
-
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_risk_analysis,
-        { id: risk.id }
-      )
-    ).forEach((r) => expect(r.deleted).not.toBe(true));
+    for (const table of tablesToCheck) {
+      const rows = await getManyFromDb(dbContext, table, {
+        eserviceTemplateId: mockEServiceTemplate.id,
+      });
+      expect(rows).toHaveLength(0);
+    }
   });
 
   it("EServiceTemplateVersionInterfaceDeleted: deletes only interface", async () => {
-    const template = getMockEServiceTemplate();
-    const version = getMockEServiceTemplateVersion();
-    const ifaceId = generateId();
-    version.interface = {
-      id: ifaceId as any,
-      name: "",
-      prettyName: "",
-      contentType: "",
-      path: "",
-      checksum: "",
-      uploadDate: new Date(),
+    const mockEServiceTemplate = getMockEServiceTemplate();
+    const descriptorInterface = getMockDocument();
+    const draftEServiceTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      state: eserviceTemplateVersionState.draft,
+      interface: descriptorInterface,
     };
-    template.versions = [version];
+
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      versions: [draftEServiceTemplateVersion],
+    };
+
+    const updatedEServiceTemplate: EServiceTemplate = {
+      ...eserviceTemplate,
+      versions: [
+        {
+          ...draftEServiceTemplateVersion,
+          interface: undefined,
+        },
+      ],
+    };
+
+    const addPayload: EServiceTemplateAddedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+    };
+    const deletePayload: EServiceTemplateVersionInterfaceDeletedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+      eserviceTemplateVersionId: draftEServiceTemplateVersion.id,
+      documentId: descriptorInterface.id,
+    };
 
     const addMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 1,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 1,
       type: "EServiceTemplateAdded",
       event_version: 2,
-      data: { eserviceTemplate: toEServiceTemplateV2(template) },
+      data: addPayload,
       log_date: new Date(),
     };
     const delMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 2,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 2,
       type: "EServiceTemplateVersionInterfaceDeleted",
       event_version: 2,
-      data: {
-        eserviceTemplateVersionId: version.id as any,
-        eserviceTemplate: toEServiceTemplateV2(template),
-      } as EServiceTemplateVersionInterfaceDeletedV2,
+      data: deletePayload,
       log_date: new Date(),
     };
 
     await handleEserviceTemplateMessageV2([addMsg, delMsg], dbContext);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_interface,
-        { id: ifaceId }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
-
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version,
-        { id: version.id }
-      )
-    ).forEach((r) => expect(r.deleted).not.toBe(true));
-  });
-
-  it("EServiceTemplateVersionInterfaceDeleted: throws error when version is not found", async () => {
-    const template = getMockEServiceTemplate();
-
-    const msg = {
-      sequence_num: 1,
-      stream_id: template.id,
-      version: 1,
-      type: "EServiceTemplateVersionInterfaceDeleted",
-      event_version: 2,
-      data: {
-        eserviceTemplateVersionId: "non-existing-version-id",
-        eserviceTemplate: toEServiceTemplateV2(template),
-      },
-      log_date: new Date(),
-    } as any;
-
-    await expect(
-      handleEserviceTemplateMessageV2([msg], dbContext)
-    ).rejects.toThrowError(
-      "Version not found for versionId: non-existing-version-id"
+    const interfaces = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_version_interface,
+      { id: descriptorInterface.id }
     );
-  });
+    expect(interfaces).toHaveLength(0);
 
-  it("EServiceTemplateVersionInterfaceDeleted: throws error when interface is missing", async () => {
-    const template = getMockEServiceTemplate();
-    const version = getMockEServiceTemplateVersion();
-    version.interface = undefined;
-    template.versions = [version];
-
-    const msg = {
-      sequence_num: 1,
-      stream_id: template.id,
-      version: 1,
-      type: "EServiceTemplateVersionInterfaceDeleted",
-      event_version: 2,
-      data: {
-        eserviceTemplateVersionId: version.id,
-        eserviceTemplate: toEServiceTemplateV2(template),
-      },
-      log_date: new Date(),
-    } as any;
-
-    await expect(
-      handleEserviceTemplateMessageV2([msg], dbContext)
-    ).rejects.toThrowError(
-      `Missing interface for the specified version id: ${version.id}`
+    const versions = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_version,
+      { id: draftEServiceTemplateVersion.id }
     );
+    expect(versions).toHaveLength(1);
   });
 
   it("EServiceTemplateVersionDocumentDeleted: deletes only document", async () => {
-    const template = getMockEServiceTemplate();
-    const version = getMockEServiceTemplateVersion();
-    const doc = getMockDocument();
-    version.docs = [doc];
-    template.versions = [version];
+    const mockEServiceTemplate = getMockEServiceTemplate();
+    const document = getMockDocument();
+    const draftEServiceTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      state: eserviceTemplateVersionState.draft,
+      docs: [document],
+    };
+
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      versions: [draftEServiceTemplateVersion],
+    };
+    const updatedEServiceTemplate: EServiceTemplate = {
+      ...eserviceTemplate,
+      versions: [
+        {
+          ...draftEServiceTemplateVersion,
+          docs: [],
+        },
+      ],
+    };
+
+    const addPayload: EServiceTemplateAddedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+    };
+    const deletePayload: EServiceTemplateVersionInterfaceDeletedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+      eserviceTemplateVersionId: draftEServiceTemplateVersion.id,
+      documentId: document.id,
+    };
 
     const addMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 1,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 1,
       type: "EServiceTemplateAdded",
       event_version: 2,
-      data: { eserviceTemplate: toEServiceTemplateV2(template) },
+      data: addPayload,
       log_date: new Date(),
     };
     const delMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 2,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 2,
       type: "EServiceTemplateVersionDocumentDeleted",
       event_version: 2,
-      data: {
-        documentId: doc.id as any,
-      } as EServiceTemplateVersionDocumentDeletedV2,
+      data: deletePayload,
       log_date: new Date(),
     };
 
     await handleEserviceTemplateMessageV2([addMsg, delMsg], dbContext);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_version_document,
-        { id: doc.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
+    const documents = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_version_document,
+      { id: document.id }
+    );
+    expect(documents).toHaveLength(0);
+
+    const versions = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_version,
+      { id: draftEServiceTemplateVersion.id }
+    );
+    expect(versions).toHaveLength(1);
   });
 
   it("EServiceTemplateRiskAnalysisDeleted: deletes only riskAnalysis", async () => {
-    const template = getMockEServiceTemplate();
-    const risk = getMockValidRiskAnalysis("PA");
-    template.riskAnalysis = [risk];
+    const mockEServiceTemplate = getMockEServiceTemplate();
+    const riskAnalysis = getMockValidRiskAnalysis("PA");
+
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      riskAnalysis: [riskAnalysis],
+    };
+    const updatedEServiceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      riskAnalysis: [],
+    };
+
+    const addPayload: EServiceTemplateAddedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+    };
+    const deletePayload: EServiceTemplateRiskAnalysisDeletedV2 = {
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+      riskAnalysisId: riskAnalysis.id,
+    };
 
     const addMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 1,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 1,
       type: "EServiceTemplateAdded",
       event_version: 2,
-      data: { eserviceTemplate: toEServiceTemplateV2(template) },
+      data: addPayload,
       log_date: new Date(),
     };
     const delMsg: EServiceTemplateEventEnvelope = {
       sequence_num: 2,
-      stream_id: template.id,
+      stream_id: mockEServiceTemplate.id,
       version: 2,
       type: "EServiceTemplateRiskAnalysisDeleted",
       event_version: 2,
-      data: {
-        riskAnalysisId: risk.id,
-      } as EServiceTemplateRiskAnalysisDeletedV2,
+      data: deletePayload,
       log_date: new Date(),
     };
 
     await handleEserviceTemplateMessageV2([addMsg, delMsg], dbContext);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_risk_analysis,
-        { id: risk.id }
-      )
-    ).forEach((r) => expect(r.deleted).toBe(true));
+    const retrievedRiskAnalysis = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_risk_analysis,
+      { id: riskAnalysis.id }
+    );
+    expect(retrievedRiskAnalysis).toHaveLength(0);
 
-    (
-      await getManyFromDb(
-        dbContext,
-        EserviceTemplateDbTable.eservice_template_risk_analysis_answer,
-        { riskAnalysisFormId: risk.riskAnalysisForm.id }
-      )
-    ).forEach((r) => expect(r.deleted).not.toBe(true));
+    const retrievedRiskAnalysisAnswers = await getManyFromDb(
+      dbContext,
+      EserviceTemplateDbTable.eservice_template_risk_analysis_answer,
+      { riskAnalysisFormId: riskAnalysis.riskAnalysisForm.id }
+    );
+    expect(retrievedRiskAnalysisAnswers).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Changes

**Hybrid delete strategy**  
  - The `EServiceTemplateDeleted` event performs a **logical delete** on the main `eservice_template` table (sets the `deleted` flag, preserving history to the target tables).  
  - All other delete events execute **physical deletes**, removing rows outright from target tables.

**Pre-merge cleanup**  
  Before each upsert MERGE, we now run a set-based `MERGE … WHEN MATCHED THEN DELETE` on the target tables to purge any rows whose `metadata_version` is lower than the incoming staging version, ensuring outdated records will be cleaned.
