### PR TITLE
PIN-6974: fix for notification-email-sender purpose mails (Including a small improvement on a query)

### DIFF
--- a/packages/authorization-process/src/services/readModelServiceSQL.ts
+++ b/packages/authorization-process/src/services/readModelServiceSQL.ts
@@ -195,7 +195,13 @@ export function readModelServiceBuilderSQL({
         .from(clientInReadmodelClient)
         .innerJoin(
           clientPurposeInReadmodelClient,
-          eq(clientPurposeInReadmodelClient.purposeId, purposeId)
+          and(
+            eq(
+              clientInReadmodelClient.id,
+              clientPurposeInReadmodelClient.clientId
+            ),
+            eq(clientPurposeInReadmodelClient.purposeId, purposeId)
+          )
         )
         .groupBy(clientInReadmodelClient.id)
         .as("subquery");

--- a/packages/notification-email-sender/src/services/notificationEmailSenderService.ts
+++ b/packages/notification-email-sender/src/services/notificationEmailSenderService.ts
@@ -346,22 +346,26 @@ export function notificationEmailSenderServiceBuilder(
     ) => {
       const purpose = fromPurposeV2(purposeV2Msg);
 
-      const [htmlTemplate, eservice, consumer] = await Promise.all([
+      const [htmlTemplate, eservice] = await Promise.all([
         retrieveHTMLTemplate(
           eventMailTemplateType.newPurposeVersionWaitingForApprovalMailTemplate
         ),
         retrieveEService(purpose.eserviceId, readModelService),
-        retrieveTenant(purpose.consumerId, readModelService),
       ]);
 
-      const consumerEmail = getLatestTenantMailOfKind(
-        consumer.mails,
+      const producer = await retrieveTenant(
+        eservice.producerId,
+        readModelService
+      );
+
+      const producerEmail = getLatestTenantMailOfKind(
+        producer.mails,
         tenantMailKind.ContactEmail
       );
 
-      if (!consumerEmail) {
+      if (!producerEmail) {
         logger.warn(
-          `Consumer email not found for purpose ${purpose.id}, skipping email`
+          `Producer email not found for purpose ${purpose.id}, skipping email`
         );
         return;
       }
@@ -369,7 +373,7 @@ export function notificationEmailSenderServiceBuilder(
       const mailOptions: Mail.Options = {
         from: { name: sesSenderData.label, address: sesSenderData.mail },
         subject: `Richiesta di variazione della stima di carico per ${eservice.name}`,
-        to: [consumerEmail.address],
+        to: [producerEmail.address],
         html: templateService.compileHtml(htmlTemplate, {
           interopFeUrl: `https://${interopFeBaseUrl}/ui/it/erogazione/finalita/${purpose.id}`,
           purposeName: purpose.title,
@@ -398,22 +402,26 @@ export function notificationEmailSenderServiceBuilder(
     ) => {
       const purpose = fromPurposeV2(purposeV2Msg);
 
-      const [htmlTemplate, eservice, consumer] = await Promise.all([
+      const [htmlTemplate, eservice] = await Promise.all([
         retrieveHTMLTemplate(
           eventMailTemplateType.purposeWaitingForApprovalMailTemplate
         ),
         retrieveEService(purpose.eserviceId, readModelService),
-        retrieveTenant(purpose.consumerId, readModelService),
       ]);
 
-      const consumerEmail = getLatestTenantMailOfKind(
-        consumer.mails,
+      const producer = await retrieveTenant(
+        eservice.producerId,
+        readModelService
+      );
+
+      const producerEmail = getLatestTenantMailOfKind(
+        producer.mails,
         tenantMailKind.ContactEmail
       );
 
-      if (!consumerEmail) {
+      if (!producerEmail) {
         logger.warn(
-          `Consumer email not found for purpose ${purpose.id}, skipping email`
+          `Producer email not found for purpose ${purpose.id}, skipping email`
         );
         return;
       }
@@ -421,7 +429,7 @@ export function notificationEmailSenderServiceBuilder(
       const mailOptions: Mail.Options = {
         from: { name: sesSenderData.label, address: sesSenderData.mail },
         subject: `Richiesta di attivazione della stima di carico sopra soglia per ${eservice.name}`,
-        to: [consumerEmail.address],
+        to: [producerEmail.address],
         html: templateService.compileHtml(htmlTemplate, {
           interopFeUrl: `https://${interopFeBaseUrl}/ui/it/erogazione/finalita/${purpose.id}`,
           eserviceName: eservice.name,

--- a/packages/notification-email-sender/test/sendNewPurposeVersionWaitingForApprovalEmail.integration.test.ts
+++ b/packages/notification-email-sender/test/sendNewPurposeVersionWaitingForApprovalEmail.integration.test.ts
@@ -12,6 +12,8 @@ import {
 } from "pagopa-interop-commons-test";
 import {
   EService,
+  EServiceId,
+  generateId,
   Purpose,
   Tenant,
   tenantMailKind,
@@ -34,29 +36,29 @@ import {
 } from "./utils.js";
 
 describe("sendNewPurposeVersionWaitingForApprovalEmail", () => {
-  it("should send an email to Consumer to contact email addresses", async () => {
+  it("should send an email to Producer to contact email addresses", async () => {
     vi.spyOn(sesEmailManager, "send");
-    const consumerEmail = getMockTenantMail(tenantMailKind.ContactEmail);
-    const consumer: Tenant = {
+    const producerEmail = getMockTenantMail(tenantMailKind.ContactEmail);
+    const producer: Tenant = {
       ...getMockTenant(),
       name: "Jane Doe",
-      mails: [consumerEmail],
+      mails: [producerEmail],
     };
 
-    await addOneTenant(consumer);
+    await addOneTenant(producer);
 
     const descriptor = getMockDescriptor();
-    const eservice: EService = {
-      ...getMockEService(),
-      name: "EService",
-      descriptors: [descriptor],
-    };
+    const eservice: EService = getMockEService(
+      generateId<EServiceId>(),
+      producer.id,
+      [descriptor]
+    );
     await addOneEService(eservice);
 
     const purpose: Purpose = {
       ...getMockPurpose(),
       eserviceId: eservice.id,
-      consumerId: consumer.id,
+      consumerId: producer.id,
     };
     await addOnePurpose(purpose);
 
@@ -78,7 +80,7 @@ describe("sendNewPurposeVersionWaitingForApprovalEmail", () => {
         address: sesEmailSenderData.mail,
       },
       subject: `Richiesta di variazione della stima di carico per ${eservice.name}`,
-      to: [consumerEmail.address],
+      to: [producerEmail.address],
       html: templateService.compileHtml(aboveTheThresholdEmailTemplate, {
         interopFeUrl: `https://${interopFeBaseUrl}/ui/it/erogazione/finalita/${purpose.id}`,
         purposeName: purpose.title,

--- a/packages/notification-email-sender/test/sendPurposeWaitingForApprovalEmail.integration.test.ts
+++ b/packages/notification-email-sender/test/sendPurposeWaitingForApprovalEmail.integration.test.ts
@@ -12,6 +12,7 @@ import {
 } from "pagopa-interop-commons-test";
 import {
   EService,
+  EServiceId,
   generateId,
   Purpose,
   PurposeId,
@@ -36,30 +37,30 @@ import {
 } from "./utils.js";
 
 describe("sendPurposeWaitingForApprovalEmail", () => {
-  it("should send an email to Consumer to contact email addresses", async () => {
+  it("should send an email to Producer to contact email addresses", async () => {
     vi.spyOn(sesEmailManager, "send");
-    const consumerEmail = getMockTenantMail(tenantMailKind.ContactEmail);
-    const consumer: Tenant = {
+    const producerEmail = getMockTenantMail(tenantMailKind.ContactEmail);
+    const producer: Tenant = {
       ...getMockTenant(),
       name: "Jane Doe",
-      mails: [consumerEmail],
+      mails: [producerEmail],
     };
 
-    await addOneTenant(consumer);
+    await addOneTenant(producer);
 
     const descriptor = getMockDescriptor();
-    const eservice: EService = {
-      ...getMockEService(),
-      name: "EService",
-      descriptors: [descriptor],
-    };
+    const eservice: EService = getMockEService(
+      generateId<EServiceId>(),
+      producer.id,
+      [descriptor]
+    );
     await addOneEService(eservice);
 
     const purpose: Purpose = {
       ...getMockPurpose(),
       id: generateId<PurposeId>(),
       eserviceId: eservice.id,
-      consumerId: consumer.id,
+      consumerId: producer.id,
     };
     await addOnePurpose(purpose);
 
@@ -81,7 +82,7 @@ describe("sendPurposeWaitingForApprovalEmail", () => {
         address: sesEmailSenderData.mail,
       },
       subject: `Richiesta di attivazione della stima di carico sopra soglia per ${eservice.name}`,
-      to: [consumerEmail.address],
+      to: [producerEmail.address],
       html: templateService.compileHtml(aboveTheThresholdEmailTemplate, {
         interopFeUrl: `https://${interopFeBaseUrl}/ui/it/erogazione/finalita/${purpose.id}`,
         eserviceName: eservice.name,


### PR DESCRIPTION
Update the email sender service to utilize the producer's email instead of the consumer's email on purpose events, ensuring that notifications are sent to the correct recipient. Adjust related tests to reflect this change.