### PR TITLE
replace RelationshipStatus enum with string in UsersEventPayload

### DIFF
--- a/packages/selfcare-client-users-updater/src/model/UsersEventPayload.ts
+++ b/packages/selfcare-client-users-updater/src/model/UsersEventPayload.ts
@@ -16,6 +16,7 @@ export const relationshipStatus = {
   active: "ACTIVE",
   suspended: "SUSPENDED",
   deleted: "DELETED",
+  rejected: "REJECTED",
 } as const;
 export const RelationshipStatus = z.enum([
   Object.values(relationshipStatus)[0],
@@ -30,7 +31,7 @@ const SCUser = z.object({
   email: z.string(),
   role: z.string(),
   productRole: UserRole,
-  relationshipStatus: RelationshipStatus,
+  relationshipStatus: z.string(),
   mobilePhone: z.string().nullish(),
 });
 

--- a/packages/selfcare-client-users-updater/test/selfcareClientUsersUpdaterProcessor.test.ts
+++ b/packages/selfcare-client-users-updater/test/selfcareClientUsersUpdaterProcessor.test.ts
@@ -66,7 +66,11 @@ describe("selfcareClientUsersUpdaterProcessor", () => {
     vi.clearAllMocks();
   });
 
-  it.each([relationshipStatus.suspended, relationshipStatus.deleted])(
+  it.each(
+    Object.values(relationshipStatus).filter(
+      (status) => status !== relationshipStatus.active
+    )
+  )(
     "should remove admin when event has productRole admin and relationshipStatus %s",
     async (status) => {
       const tenantMock: Tenant = {


### PR DESCRIPTION
Since we received a new event with relationshipStatus `REJECTED`, which wasn't supported by the model and we actually only check for `ACTIVE`, the relationshipStatus enum is replaced by `z.string()` while keeping the enum for comparison purposes