### PR TITLE
Removed paths-status rule off from .spectral.yaml

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -5,7 +5,6 @@ extends:
   ]
 rules:
   servers-use-https: off
-  paths-status: off # Enable this once authorization server migration is completed and we can remove the /authorization-server prefix
   paths-kebab-case: off # Disabled for compatibility with current endpoint naming
   cache-responses-indeterminate-behavior: off # Disabled to avoid warnings on cache management
   missing-ratelimit: off # Disabled to avoid warnings on rate limit headers

--- a/packages/api-clients/open-api/authorizationServerApi.yml
+++ b/packages/api-clients/open-api/authorizationServerApi.yml
@@ -25,7 +25,7 @@ tags:
       description: Find out more
       url: http://swagger.io
 paths:
-  "/authorization-server/token.oauth2":
+  "/token.oauth2":
     post:
       tags:
         - auth
@@ -104,7 +104,7 @@ paths:
                 type: integer
                 format: int32
               description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
-  /authorization-server/status:
+  /status:
     get:
       security: []
       summary: Returns the application status

--- a/packages/authorization-server/src/app.ts
+++ b/packages/authorization-server/src/app.ts
@@ -24,15 +24,16 @@ export async function createApp(service: TokenService) {
   // See https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_16
   app.disable("x-powered-by");
 
-  app.use(healthRouter);
-  app.use(contextMiddleware(serviceName, false));
-  app.use(await applicationAuditBeginMiddleware(serviceName, config));
   app.use(
-    await applicationAuditAuthorizationServerEndMiddleware(serviceName, config)
+    "/authorization-server",
+    healthRouter,
+    contextMiddleware(serviceName, false),
+    await applicationAuditBeginMiddleware(serviceName, config),
+    await applicationAuditAuthorizationServerEndMiddleware(serviceName, config),
+    express.urlencoded({ extended: true }),
+    loggerMiddleware(serviceName),
+    authorizationServerRouter(zodiosCtx, service)
   );
-  app.use(express.urlencoded({ extended: true }));
-  app.use(loggerMiddleware(serviceName));
-  app.use(authorizationServerRouter(zodiosCtx, service));
 
   return app;
 }

--- a/packages/authorization-server/src/routers/AuthorizationServerRouter.ts
+++ b/packages/authorization-server/src/routers/AuthorizationServerRouter.ts
@@ -31,101 +31,94 @@ const authorizationServerRouter = (
       validationErrorHandler: zodiosValidationErrorToApiProblem,
     }
   );
-  authorizationServerRouter.post(
-    "/authorization-server/token.oauth2",
-    async (req, res) => {
-      /* generateToken needs to mutate the context to set the clientId and organizationId,
+  authorizationServerRouter.post("/token.oauth2", async (req, res) => {
+    /* generateToken needs to mutate the context to set the clientId and organizationId,
       so that they can be used in further middlewares (e.g., the application audit).
       We create two dedicated mutation functions so that we can pass down a read-only context
       and the mutation function, and avoid mutating it directly.
       */
-      const setCtxClientId = (clientId: ClientId): void => {
-        // eslint-disable-next-line functional/immutable-data
-        req.ctx.clientId = clientId;
-      };
+    const setCtxClientId = (clientId: ClientId): void => {
+      // eslint-disable-next-line functional/immutable-data
+      req.ctx.clientId = clientId;
+    };
 
-      const setCtxOrganizationId = (organizationId: TenantId): void => {
-        // eslint-disable-next-line functional/immutable-data
-        req.ctx.organizationId = organizationId;
-      };
+    const setCtxOrganizationId = (organizationId: TenantId): void => {
+      // eslint-disable-next-line functional/immutable-data
+      req.ctx.organizationId = organizationId;
+    };
 
-      const ctx: WithLogger<AuthServerAppContext> = {
-        ...req.ctx,
-        logger: logger({ ...req.ctx }),
-      };
+    const ctx: WithLogger<AuthServerAppContext> = {
+      ...req.ctx,
+      logger: logger({ ...req.ctx }),
+    };
 
-      try {
-        const tokenResult = await tokenService.generateToken(
-          req.headers,
-          req.body,
-          ctx,
-          setCtxClientId,
-          setCtxOrganizationId
-        );
+    try {
+      const tokenResult = await tokenService.generateToken(
+        req.headers,
+        req.body,
+        ctx,
+        setCtxClientId,
+        setCtxOrganizationId
+      );
 
-        const headers = rateLimiterHeadersFromStatus(
-          tokenResult.rateLimiterStatus
-        );
-        res.set(headers);
+      const headers = rateLimiterHeadersFromStatus(
+        tokenResult.rateLimiterStatus
+      );
+      res.set(headers);
 
-        if (tokenResult.limitReached) {
-          const errorRes = makeApiProblem(
-            tooManyRequestsError(tokenResult.rateLimitedTenantId),
-            authorizationServerErrorMapper,
-            ctx
-          );
-
-          return res.status(errorRes.status).send(errorRes);
-        }
-
-        return res.status(200).send({
-          access_token: tokenResult.token.serialized,
-          token_type: tokenResult.isDPoP ? "DPoP" : "Bearer",
-          expires_in:
-            tokenResult.token.payload.exp - tokenResult.token.payload.iat,
-        });
-      } catch (err) {
+      if (tokenResult.limitReached) {
         const errorRes = makeApiProblem(
-          err,
+          tooManyRequestsError(tokenResult.rateLimitedTenantId),
           authorizationServerErrorMapper,
           ctx
         );
-        if (errorRes.status === constants.HTTP_STATUS_BAD_REQUEST) {
-          const cleanedError: Problem = {
-            title: "The request contains bad syntax or cannot be fulfilled.",
-            type: "about:blank",
-            status: constants.HTTP_STATUS_BAD_REQUEST,
-            detail: "Bad request",
-            errors: [
-              {
-                code: "015-0008",
-                detail: "Unable to generate a token for the given request",
-              },
-            ],
-            correlationId: ctx.correlationId,
-          };
 
-          return res.status(cleanedError.status).send(cleanedError);
-        } else {
-          const cleanedError: Problem = {
-            title: "The request couldn't be fulfilled due to an internal error",
-            type: "internalServerError",
-            status: constants.HTTP_STATUS_INTERNAL_SERVER_ERROR,
-            detail: "Internal server error",
-            errors: [
-              {
-                code: "015-0000",
-                detail:
-                  "Unable to generate a token for the given request due to an internal error",
-              },
-            ],
-            correlationId: ctx.correlationId,
-          };
-          return res.status(cleanedError.status).send(cleanedError);
-        }
+        return res.status(errorRes.status).send(errorRes);
+      }
+
+      return res.status(200).send({
+        access_token: tokenResult.token.serialized,
+        token_type: tokenResult.isDPoP ? "DPoP" : "Bearer",
+        expires_in:
+          tokenResult.token.payload.exp - tokenResult.token.payload.iat,
+      });
+    } catch (err) {
+      const errorRes = makeApiProblem(err, authorizationServerErrorMapper, ctx);
+      if (errorRes.status === constants.HTTP_STATUS_BAD_REQUEST) {
+        const cleanedError: Problem = {
+          title: "The request contains bad syntax or cannot be fulfilled.",
+          type: "about:blank",
+          status: constants.HTTP_STATUS_BAD_REQUEST,
+          detail: "Bad request",
+          errors: [
+            {
+              code: "015-0008",
+              detail: "Unable to generate a token for the given request",
+            },
+          ],
+          correlationId: ctx.correlationId,
+        };
+
+        return res.status(cleanedError.status).send(cleanedError);
+      } else {
+        const cleanedError: Problem = {
+          title: "The request couldn't be fulfilled due to an internal error",
+          type: "internalServerError",
+          status: constants.HTTP_STATUS_INTERNAL_SERVER_ERROR,
+          detail: "Internal server error",
+          errors: [
+            {
+              code: "015-0000",
+              detail:
+                "Unable to generate a token for the given request due to an internal error",
+            },
+          ],
+          correlationId: ctx.correlationId,
+        };
+        return res.status(cleanedError.status).send(cleanedError);
       }
     }
-  );
+  });
   return authorizationServerRouter;
 };
 

--- a/packages/authorization-server/src/routers/HealthRouter.ts
+++ b/packages/authorization-server/src/routers/HealthRouter.ts
@@ -3,8 +3,6 @@ import { authorizationServerApi } from "pagopa-interop-api-clients";
 
 const healthRouter = zodiosRouter(authorizationServerApi.healthApi.api);
 
-healthRouter.get("/authorization-server/status", async (_, res) =>
-  res.status(200).send()
-);
+healthRouter.get("/status", async (_, res) => res.status(200).send());
 
 export default healthRouter;


### PR DESCRIPTION
**Jira Link**: https://pagopa.atlassian.net/browse/PIN-6991

## Removed `paths-status: off` from `.spectral.yaml`

Removed the `paths-status: off` rule from `.spectral.yaml`.
This rule was originally added because the _authorization-server_ package defined the base path inside `authorizationServerApi.yml`.
A refactoring has been carried out to align it with others project structures, moving the base path definition into `app.ts` instead.