### PR TITLE
Fix JWK in DPoP Proof header

### DIFF
--- a/packages/commons-test/src/testUtils.ts
+++ b/packages/commons-test/src/testUtils.ts
@@ -122,7 +122,6 @@ import {
   WithLogger,
   UIClaims,
   M2MAdminAuthData,
-  calculateKid,
   createJWK,
 } from "pagopa-interop-commons";
 import { z } from "zod";
@@ -737,22 +736,8 @@ export const getMockDPoPProof = async (
   });
 
   const jwk = match(alg)
-    .with(algorithm.ES256, () =>
-      JWKKeyES256.parse({
-        ...cryptoJWK,
-        kid: calculateKid(cryptoJWK),
-        use: "sig",
-        alg,
-      })
-    )
-    .with(algorithm.RS256, () =>
-      JWKKeyRS256.parse({
-        ...cryptoJWK,
-        kid: calculateKid(cryptoJWK),
-        use: "sig",
-        alg,
-      })
-    )
+    .with(algorithm.ES256, () => JWKKeyES256.parse(cryptoJWK))
+    .with(algorithm.RS256, () => JWKKeyRS256.parse(cryptoJWK))
     .exhaustive();
 
   const header: DPoPProofHeader = {

--- a/packages/dpop-validation/package.json
+++ b/packages/dpop-validation/package.json
@@ -25,7 +25,6 @@
     "pagopa-interop-commons-test": "workspace:*",
     "pagopa-interop-models": "workspace:*",
     "pagopa-interop-commons": "workspace:*",
-    "ts-pattern": "5.2.0",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/packages/dpop-validation/src/errors.ts
+++ b/packages/dpop-validation/src/errors.ts
@@ -18,11 +18,10 @@ export const errorCodes = {
   invalidDPoPJwt: "0015",
   dpopAlgorithmNotFound: "0016",
   dpopAlgorithmNotAllowed: "0017",
-  dpopAlgorithmsMismatch: "0018",
-  dpopProofInvalidClaims: "0019",
-  invalidDPoPSignature: "0020",
-  expiredDPoPProof: "0021",
-  multipleDPoPProofsError: "0022",
+  dpopProofInvalidClaims: "0018",
+  invalidDPoPSignature: "0019",
+  expiredDPoPProof: "0020",
+  multipleDPoPProofsError: "0021",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -168,17 +167,6 @@ export function dpopAlgorithmNotAllowed(
     detail: `Algorithm ${algorithm} is not allowed for the DPoP proof`,
     code: "dpopAlgorithmNotAllowed",
     title: "DPoP ALG not allowed",
-  });
-}
-
-export function dpopAlgorithmsMismatch(
-  alg: string,
-  jwkAlg: string
-): ApiError<ErrorCodes> {
-  return new ApiError({
-    detail: `DPoP algorithms mismatch. ALG: ${alg}. JWK.ALG: ${jwkAlg}`,
-    code: "dpopAlgorithmsMismatch",
-    title: "DPoP algorithms mismatch",
   });
 }
 

--- a/packages/dpop-validation/src/utilities/utils.ts
+++ b/packages/dpop-validation/src/utilities/utils.ts
@@ -14,7 +14,6 @@ import {
   SuccessfulValidation,
 } from "../types.js";
 import {
-  dpopAlgorithmsMismatch,
   dpopAlgorithmNotAllowed,
   dpopAlgorithmNotFound,
   ErrorCodes,
@@ -49,18 +48,13 @@ export const validateTyp = (
 };
 
 export const validateAlgorithm = (
-  alg: string | undefined,
-  jwkAlg: string | undefined
+  alg: string | undefined
 ): ValidationResult<string> => {
-  if (!alg || !jwkAlg) {
+  if (!alg) {
     return failedValidation([dpopAlgorithmNotFound()]);
   }
 
-  if (alg !== jwkAlg) {
-    return failedValidation([dpopAlgorithmsMismatch(alg, jwkAlg)]);
-  }
-
-  if (ALLOWED_ALGORITHMS.includes(alg) && ALLOWED_ALGORITHMS.includes(jwkAlg)) {
+  if (ALLOWED_ALGORITHMS.includes(alg)) {
     return successfulValidation(alg);
   }
 

--- a/packages/dpop-validation/src/utilities/utils.ts
+++ b/packages/dpop-validation/src/utilities/utils.ts
@@ -1,5 +1,4 @@
 import {
-  algorithm,
   Algorithm,
   ApiError,
   JWKKeyRS256,
@@ -7,7 +6,6 @@ import {
 } from "pagopa-interop-models";
 import * as jose from "jose";
 import { dateToSeconds } from "pagopa-interop-commons";
-import { match } from "ts-pattern";
 import {
   FailedValidation,
   ValidationResult,
@@ -68,11 +66,7 @@ export const validateJWK = (
     return failedValidation([dpopJwkNotFound()]);
   }
 
-  return match(jwk.alg)
-    .with(algorithm.ES256, () => successfulValidation(JWKKeyES256.parse(jwk)))
-    .with(algorithm.RS256, () => successfulValidation(JWKKeyRS256.parse(jwk)))
-    .with(undefined, () => failedValidation([dpopAlgorithmNotFound()]))
-    .otherwise((alg) => failedValidation([dpopAlgorithmNotAllowed(alg)]));
+  return successfulValidation(JWKKeyRS256.or(JWKKeyES256).parse(jwk));
 };
 
 export const validateHtm = (

--- a/packages/dpop-validation/src/validation.ts
+++ b/packages/dpop-validation/src/validation.ts
@@ -90,17 +90,17 @@ export const verifyDPoPProof = ({
       !jtiErrors
     ) {
       const payloadParseResult = DPoPProofPayload.safeParse(decodedPayload);
-      if (!payloadParseResult.success) {
-        return failedValidation([
-          dpopProofInvalidClaims(payloadParseResult.error.message),
-        ]);
-      }
-
       const headerParseResult = DPoPProofHeader.safeParse(decodedHeader);
-      if (!headerParseResult.success) {
-        return failedValidation([
-          dpopProofInvalidClaims(headerParseResult.error.message),
-        ]);
+      const parsingErrors = [
+        !payloadParseResult.success
+          ? dpopProofInvalidClaims(payloadParseResult.error.message)
+          : undefined,
+        !headerParseResult.success
+          ? dpopProofInvalidClaims(headerParseResult.error.message)
+          : undefined,
+      ];
+      if (parsingErrors.some(Boolean)) {
+        return failedValidation(parsingErrors);
       }
 
       const result: DPoPProof = {

--- a/packages/dpop-validation/src/validation.ts
+++ b/packages/dpop-validation/src/validation.ts
@@ -62,8 +62,7 @@ export const verifyDPoPProof = ({
       decodedHeader.jwk
     );
     const { errors: algErrors, data: validatedAlg } = validateAlgorithm(
-      decodedHeader.alg,
-      validatedJwk?.alg
+      decodedHeader.alg
     );
 
     // JWT payload

--- a/packages/dpop-validation/src/validation.ts
+++ b/packages/dpop-validation/src/validation.ts
@@ -144,10 +144,8 @@ export const verifyDPoPProofSignature = async (
   jwk: JWKKeyRS256 | JWKKeyES256
 ): Promise<ValidationResult<jose.JWTPayload>> => {
   try {
-    const publicKey = await jose.importJWK(jwk, jwk.alg);
-    const result = await jose.jwtVerify(dpopProofJWS, publicKey, {
-      algorithms: [jwk.alg],
-    });
+    const publicKey = await jose.importJWK(jwk);
+    const result = await jose.jwtVerify(dpopProofJWS, publicKey);
 
     return successfulValidation(result.payload);
   } catch (error: unknown) {

--- a/packages/dpop-validation/test/validation.test.ts
+++ b/packages/dpop-validation/test/validation.test.ts
@@ -1,12 +1,9 @@
 import {
   buildDynamoDBTables,
   deleteDynamoDBTables,
-  generateKeySet,
   getMockDPoPProof,
-  signJWT,
 } from "pagopa-interop-commons-test";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { algorithm } from "pagopa-interop-models";
 import { dateToSeconds } from "pagopa-interop-commons";
 import {
   checkDPoPCache,
@@ -14,7 +11,6 @@ import {
   verifyDPoPProofSignature,
 } from "../src/validation.js";
 import {
-  dpopAlgorithmsMismatch,
   dpopHtmNotFound,
   dpopHtuNotFound,
   dpopIatNotFound,
@@ -162,37 +158,6 @@ describe("DPoP validation tests", async () => {
       expect(errors).toBeDefined();
       expect(errors).toHaveLength(1);
       expect(errors?.[0].code).toBe(invalidDPoPTyp(wrongTyp).code);
-    });
-
-    it("should add error if the DPoP proof ALG is different from JWK's ALG", async () => {
-      const { dpopProofJWT } = await getMockDPoPProof();
-
-      const { keySet: keySetRS256 } = generateKeySet(algorithm.RS256);
-      const dpopProofJWTWithWrongAlg = {
-        ...dpopProofJWT,
-        header: {
-          ...dpopProofJWT.header,
-          alg: algorithm.RS256,
-        },
-      };
-      const dpopProofJWSWithWrongAlg = await signJWT({
-        payload: dpopProofJWTWithWrongAlg.payload,
-        headers: dpopProofJWTWithWrongAlg.header,
-        keySet: keySetRS256,
-      });
-
-      const { errors } = verifyDPoPProof({
-        dpopProofJWS: dpopProofJWSWithWrongAlg,
-        expectedDPoPProofHtu: dpopProofJWT.payload.htu,
-      });
-      expect(errors).toBeDefined();
-      expect(errors).toHaveLength(1);
-      expect(errors?.[0].code).toBe(
-        dpopAlgorithmsMismatch(
-          dpopProofJWT.header.alg,
-          dpopProofJWT.header.jwk.alg
-        ).code
-      );
     });
 
     it("should add error if the DPoP proof HTM is not found", async () => {

--- a/packages/models/src/authorization/key.ts
+++ b/packages/models/src/authorization/key.ts
@@ -22,7 +22,7 @@ export const Key = z.object({
 });
 export type Key = z.infer<typeof Key>;
 
-export const JWKKeyRS256 = z.object({
+const JWKKey = z.object({
   alg: z.string(),
   e: z.string(),
   kid: z.string(),
@@ -30,25 +30,28 @@ export const JWKKeyRS256 = z.object({
   n: z.string(),
   use: z.string(),
 });
+
+export const JWKKeyRS256 = JWKKey.pick({
+  kty: true,
+  n: true,
+  e: true,
+});
 export type JWKKeyRS256 = z.infer<typeof JWKKeyRS256>;
 
 export const JWKKeyES256 = z.object({
-  alg: z.string(),
   crv: z.string(),
-  kid: z.string(),
   kty: z.string(),
-  use: z.string(),
   x: z.string(),
   y: z.string(),
 });
 export type JWKKeyES256 = z.infer<typeof JWKKeyES256>;
 
-export const ClientJWKKey = JWKKeyRS256.extend({
+export const ClientJWKKey = JWKKey.extend({
   clientId: ClientId,
 });
 export type ClientJWKKey = z.infer<typeof ClientJWKKey>;
 
-export const ProducerJWKKey = JWKKeyRS256.extend({
+export const ProducerJWKKey = JWKKey.extend({
   producerKeychainId: ProducerKeychainId,
 });
 export type ProducerJWKKey = z.infer<typeof ProducerJWKKey>;

--- a/packages/models/src/authorization/key.ts
+++ b/packages/models/src/authorization/key.ts
@@ -35,15 +35,17 @@ export const JWKKeyRS256 = JWKKey.pick({
   kty: true,
   n: true,
   e: true,
-});
+}).strict();
 export type JWKKeyRS256 = z.infer<typeof JWKKeyRS256>;
 
-export const JWKKeyES256 = z.object({
-  crv: z.string(),
-  kty: z.string(),
-  x: z.string(),
-  y: z.string(),
-});
+export const JWKKeyES256 = z
+  .object({
+    crv: z.string(),
+    kty: z.string(),
+    x: z.string(),
+    y: z.string(),
+  })
+  .strict();
 export type JWKKeyES256 = z.infer<typeof JWKKeyES256>;
 
 export const ClientJWKKey = JWKKey.extend({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2738,9 +2738,6 @@ importers:
       pagopa-interop-models:
         specifier: workspace:*
         version: link:../models
-      ts-pattern:
-        specifier: 5.2.0
-        version: 5.2.0
       zod:
         specifier: 3.23.8
         version: 3.23.8


### PR DESCRIPTION
This PR fixes the DPoP Proof header's JWK which is not supposed to have the claims `alg`, `use` and `kid`.