### PR TITLE
PIN-7015: Analytics - Authorization producerKeychain (implementation) 

### DIFF
--- a/docker/domains-analytics-db/domains-init.sql
+++ b/docker/domains-analytics-db/domains-init.sql
@@ -465,6 +465,47 @@ CREATE TABLE IF NOT EXISTS domains.client_key (
   PRIMARY KEY (client_id, kid)
 );
 
+CREATE TABLE IF NOT EXISTS domains.producer_keychain (
+  id VARCHAR(36),
+  metadata_version INTEGER NOT NULL,
+  producer_id VARCHAR(36) NOT NULL,
+  name VARCHAR(2048) NOT NULL,
+  description VARCHAR(2048) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  deleted BOOLEAN,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS domains.producer_keychain_user (
+  metadata_version INTEGER NOT NULL,
+  producer_keychain_id VARCHAR(36) NOT NULL REFERENCES domains.producer_keychain (id),
+  user_id VARCHAR(36) NOT NULL,
+  deleted BOOLEAN,
+  PRIMARY KEY (producer_keychain_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS domains.producer_keychain_eservice (
+  metadata_version INTEGER NOT NULL,
+  producer_keychain_id VARCHAR(36) NOT NULL REFERENCES domains.producer_keychain (id),
+  eservice_id VARCHAR(36) NOT NULL,
+  deleted BOOLEAN,
+  PRIMARY KEY (producer_keychain_id, eservice_id)
+);
+
+CREATE TABLE IF NOT EXISTS domains.producer_keychain_key (
+  metadata_version INTEGER NOT NULL,
+  producer_keychain_id VARCHAR(36) NOT NULL REFERENCES domains.producer_keychain (id),
+  user_id VARCHAR(36) NOT NULL,
+  kid VARCHAR(2048) NOT NULL,
+  name VARCHAR(2048) NOT NULL,
+  encoded_pem VARCHAR(8192) NOT NULL,
+  "algorithm" VARCHAR(2048) NOT NULL,
+  "use" VARCHAR(2048) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  deleted BOOLEAN,
+  PRIMARY KEY (producer_keychain_id, kid)
+);
+
 CREATE TABLE IF NOT EXISTS domains.eservice_template (
   id VARCHAR(36),
   metadata_version INTEGER NOT NULL,

--- a/packages/domains-analytics-writer/src/handlers/authorization/consumerServiceV2.ts
+++ b/packages/domains-analytics-writer/src/handlers/authorization/consumerServiceV2.ts
@@ -2,10 +2,14 @@
 import {
   AuthorizationEventEnvelopeV2,
   fromClientV2,
+  fromProducerKeychainV2,
   genericInternalError,
 } from "pagopa-interop-models";
 import { match, P } from "ts-pattern";
-import { splitClientIntoObjectsSQL } from "pagopa-interop-readmodel";
+import {
+  splitClientIntoObjectsSQL,
+  splitProducerKeychainIntoObjectsSQL,
+} from "pagopa-interop-readmodel";
 import { z } from "zod";
 import { DBContext } from "../../db/db.js";
 import { authorizationServiceBuilder } from "../../service/authorizationService.js";
@@ -13,6 +17,10 @@ import {
   ClientItemsSchema,
   ClientDeletingSchema,
 } from "../../model/authorization/client.js";
+import {
+  ProducerKeychainDeletingSchema,
+  ProducerKeychainItemsSchema,
+} from "../../model/authorization/producerKeychain.js";
 
 export async function handleAuthorizationEventMessageV2(
   messages: AuthorizationEventEnvelopeV2[],
@@ -22,6 +30,8 @@ export async function handleAuthorizationEventMessageV2(
 
   const upsertClientBatch: ClientItemsSchema[] = [];
   const deleteClientBatch: ClientDeletingSchema[] = [];
+  const upsertProducerKeychainBatch: ProducerKeychainItemsSchema[] = [];
+  const deleteProducerKeychainBatch: ProducerKeychainDeletingSchema[] = [];
 
   for (const message of messages) {
     await match(message)
@@ -42,7 +52,6 @@ export async function handleAuthorizationEventMessageV2(
         },
         async (msg) => {
           const clientV2 = msg.data.client;
-
           if (!clientV2) {
             throw genericInternalError(
               "Client can't be missing in event message"
@@ -72,11 +81,18 @@ export async function handleAuthorizationEventMessageV2(
           } satisfies z.input<typeof ClientDeletingSchema>)
         );
       })
+      .with({ type: "ProducerKeychainDeleted" }, async (msg) => {
+        deleteProducerKeychainBatch.push(
+          ProducerKeychainDeletingSchema.parse({
+            id: msg.data.producerKeychainId,
+            deleted: true,
+          } satisfies z.input<typeof ProducerKeychainDeletingSchema>)
+        );
+      })
       .with(
         {
           type: P.union(
             "ProducerKeychainAdded",
-            "ProducerKeychainDeleted",
             "ProducerKeychainKeyAdded",
             "ProducerKeychainKeyDeleted",
             "ProducerKeychainUserAdded",
@@ -85,7 +101,28 @@ export async function handleAuthorizationEventMessageV2(
             "ProducerKeychainEServiceRemoved"
           ),
         },
-        () => Promise.resolve()
+        async (msg) => {
+          const producerKeychain = msg.data.producerKeychain;
+          if (!producerKeychain) {
+            throw genericInternalError(
+              "producerKeychain can't be missing in event message"
+            );
+          }
+
+          const splitResult = splitProducerKeychainIntoObjectsSQL(
+            fromProducerKeychainV2(producerKeychain),
+            message.version
+          );
+
+          upsertProducerKeychainBatch.push(
+            ProducerKeychainItemsSchema.parse({
+              producerKeychainSQL: splitResult.producerKeychainSQL,
+              usersSQL: splitResult.usersSQL,
+              eservicesSQL: splitResult.eservicesSQL,
+              keysSQL: splitResult.keysSQL,
+            } satisfies z.input<typeof ProducerKeychainItemsSchema>)
+          );
+        }
       )
       .exhaustive();
   }
@@ -96,5 +133,19 @@ export async function handleAuthorizationEventMessageV2(
 
   if (deleteClientBatch.length > 0) {
     await authorizationService.deleteClientBatch(dbContext, deleteClientBatch);
+  }
+
+  if (upsertProducerKeychainBatch.length > 0) {
+    await authorizationService.upsertProducerKeychainBatch(
+      dbContext,
+      upsertProducerKeychainBatch
+    );
+  }
+
+  if (deleteProducerKeychainBatch.length > 0) {
+    await authorizationService.deleteProducerKeychainBatch(
+      dbContext,
+      deleteProducerKeychainBatch
+    );
   }
 }

--- a/packages/domains-analytics-writer/src/index.ts
+++ b/packages/domains-analytics-writer/src/index.ts
@@ -136,18 +136,6 @@ await retryConnection(
         columns: ["id"],
       },
       {
-        name: DeletingDbTable.producer_keychain_user_deleting_table,
-        columns: ["producerKeychainId", "userId"],
-      },
-      {
-        name: DeletingDbTable.producer_keychain_eservice_deleting_table,
-        columns: ["producerKeychainId", "eserviceId"],
-      },
-      {
-        name: DeletingDbTable.producer_keychain_key_deleting_table,
-        columns: ["producerKeychainId", "kid"],
-      },
-      {
         name: DeletingDbTable.eservice_template_deleting_table,
         columns: ["id"],
       },

--- a/packages/domains-analytics-writer/src/index.ts
+++ b/packages/domains-analytics-writer/src/index.ts
@@ -22,6 +22,7 @@ import {
   TenantDbPartialTable,
   TenantDbTable,
   ClientDbTable,
+  ProducerKeychainDbTable,
 } from "./model/db/index.js";
 import { executeTopicHandler } from "./handlers/batchMessageHandler.js";
 import { EserviceTemplateDbTable } from "./model/db/eserviceTemplate.js";
@@ -73,6 +74,10 @@ await retryConnection(
       ClientDbTable.client_purpose,
       ClientDbTable.client_user,
       ClientDbTable.client_key,
+      ProducerKeychainDbTable.producer_keychain,
+      ProducerKeychainDbTable.producer_keychain_eservice,
+      ProducerKeychainDbTable.producer_keychain_user,
+      ProducerKeychainDbTable.producer_keychain_key,
       DelegationDbTable.delegation,
       DelegationDbTable.delegation_stamp,
       DelegationDbTable.delegation_contract_document,
@@ -125,6 +130,22 @@ await retryConnection(
       {
         name: DeletingDbTable.client_key_deleting_table,
         columns: ["clientId", "kid"],
+      },
+      {
+        name: DeletingDbTable.producer_keychain_deleting_table,
+        columns: ["id"],
+      },
+      {
+        name: DeletingDbTable.producer_keychain_user_deleting_table,
+        columns: ["producerKeychainId", "userId"],
+      },
+      {
+        name: DeletingDbTable.producer_keychain_eservice_deleting_table,
+        columns: ["producerKeychainId", "eserviceId"],
+      },
+      {
+        name: DeletingDbTable.producer_keychain_key_deleting_table,
+        columns: ["producerKeychainId", "kid"],
       },
       {
         name: DeletingDbTable.eservice_template_deleting_table,

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychain.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychain.ts
@@ -1,0 +1,31 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { producerKeychainInReadmodelProducerKeychain } from "pagopa-interop-readmodel-models";
+import { ProducerKeychainEServiceSchema } from "./producerKeychainEService.js";
+import { ProducerKeychainKeySchema } from "./producerKeychainKey.js";
+import { ProducerKeychainUserSchema } from "./producerKeychainUser.js";
+
+export const ProducerKeychainSchema = createSelectSchema(
+  producerKeychainInReadmodelProducerKeychain
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ProducerKeychainSchema = z.infer<typeof ProducerKeychainSchema>;
+
+export const ProducerKeychainDeletingSchema = ProducerKeychainSchema.pick({
+  id: true,
+  deleted: true,
+});
+export type ProducerKeychainDeletingSchema = z.infer<
+  typeof ProducerKeychainDeletingSchema
+>;
+
+export const ProducerKeychainItemsSchema = z.object({
+  producerKeychainSQL: ProducerKeychainSchema,
+  usersSQL: z.array(ProducerKeychainUserSchema),
+  eservicesSQL: z.array(ProducerKeychainEServiceSchema),
+  keysSQL: z.array(ProducerKeychainKeySchema),
+});
+export type ProducerKeychainItemsSchema = z.infer<
+  typeof ProducerKeychainItemsSchema
+>;

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychainEService.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychainEService.ts
@@ -10,13 +10,3 @@ export const ProducerKeychainEServiceSchema = createSelectSchema(
 export type ProducerKeychainEServiceSchema = z.infer<
   typeof ProducerKeychainEServiceSchema
 >;
-
-export const ProducerKeychainEServiceDeletingSchema =
-  ProducerKeychainEServiceSchema.pick({
-    producerKeychainId: true,
-    eserviceId: true,
-    deleted: true,
-  });
-export type ProducerKeychainEServiceDeletingSchema = z.infer<
-  typeof ProducerKeychainEServiceDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychainEService.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychainEService.ts
@@ -1,0 +1,22 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { producerKeychainEserviceInReadmodelProducerKeychain } from "pagopa-interop-readmodel-models";
+
+export const ProducerKeychainEServiceSchema = createSelectSchema(
+  producerKeychainEserviceInReadmodelProducerKeychain
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ProducerKeychainEServiceSchema = z.infer<
+  typeof ProducerKeychainEServiceSchema
+>;
+
+export const ProducerKeychainEServiceDeletingSchema =
+  ProducerKeychainEServiceSchema.pick({
+    producerKeychainId: true,
+    eserviceId: true,
+    deleted: true,
+  });
+export type ProducerKeychainEServiceDeletingSchema = z.infer<
+  typeof ProducerKeychainEServiceDeletingSchema
+>;

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychainKey.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychainKey.ts
@@ -1,0 +1,23 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { producerKeychainKeyInReadmodelProducerKeychain } from "pagopa-interop-readmodel-models";
+
+export const ProducerKeychainKeySchema = createSelectSchema(
+  producerKeychainKeyInReadmodelProducerKeychain
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ProducerKeychainKeySchema = z.infer<
+  typeof ProducerKeychainKeySchema
+>;
+
+export const ProducerKeychainKeyDeletingSchema = ProducerKeychainKeySchema.pick(
+  {
+    producerKeychainId: true,
+    kid: true,
+    deleted: true,
+  }
+);
+export type ProducerKeychainKeyDeletingSchema = z.infer<
+  typeof ProducerKeychainKeyDeletingSchema
+>;

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychainKey.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychainKey.ts
@@ -10,14 +10,3 @@ export const ProducerKeychainKeySchema = createSelectSchema(
 export type ProducerKeychainKeySchema = z.infer<
   typeof ProducerKeychainKeySchema
 >;
-
-export const ProducerKeychainKeyDeletingSchema = ProducerKeychainKeySchema.pick(
-  {
-    producerKeychainId: true,
-    kid: true,
-    deleted: true,
-  }
-);
-export type ProducerKeychainKeyDeletingSchema = z.infer<
-  typeof ProducerKeychainKeyDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychainUser.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychainUser.ts
@@ -1,0 +1,22 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { producerKeychainUserInReadmodelProducerKeychain } from "pagopa-interop-readmodel-models";
+
+export const ProducerKeychainUserSchema = createSelectSchema(
+  producerKeychainUserInReadmodelProducerKeychain
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type ProducerKeychainUserSchema = z.infer<
+  typeof ProducerKeychainUserSchema
+>;
+
+export const ProducerKeychainUserDeletingSchema =
+  ProducerKeychainUserSchema.pick({
+    producerKeychainId: true,
+    userId: true,
+    deleted: true,
+  });
+export type ProducerKeychainUserDeletingSchema = z.infer<
+  typeof ProducerKeychainUserDeletingSchema
+>;

--- a/packages/domains-analytics-writer/src/model/authorization/producerKeychainUser.ts
+++ b/packages/domains-analytics-writer/src/model/authorization/producerKeychainUser.ts
@@ -10,13 +10,3 @@ export const ProducerKeychainUserSchema = createSelectSchema(
 export type ProducerKeychainUserSchema = z.infer<
   typeof ProducerKeychainUserSchema
 >;
-
-export const ProducerKeychainUserDeletingSchema =
-  ProducerKeychainUserSchema.pick({
-    producerKeychainId: true,
-    userId: true,
-    deleted: true,
-  });
-export type ProducerKeychainUserDeletingSchema = z.infer<
-  typeof ProducerKeychainUserDeletingSchema
->;

--- a/packages/domains-analytics-writer/src/model/db/authorization.ts
+++ b/packages/domains-analytics-writer/src/model/db/authorization.ts
@@ -3,11 +3,19 @@ import {
   clientPurposeInReadmodelClient,
   clientUserInReadmodelClient,
   clientKeyInReadmodelClient,
+  producerKeychainEserviceInReadmodelProducerKeychain,
+  producerKeychainInReadmodelProducerKeychain,
+  producerKeychainKeyInReadmodelProducerKeychain,
+  producerKeychainUserInReadmodelProducerKeychain,
 } from "pagopa-interop-readmodel-models";
 import { ClientSchema } from "../authorization/client.js";
 import { ClientPurposeSchema } from "../authorization/clientPurpose.js";
 import { ClientUserSchema } from "../authorization/clientUser.js";
 import { ClientKeySchema } from "../authorization/clientKey.js";
+import { ProducerKeychainSchema } from "../authorization/producerKeychain.js";
+import { ProducerKeychainEServiceSchema } from "../authorization/producerKeychainEService.js";
+import { ProducerKeychainKeySchema } from "../authorization/producerKeychainKey.js";
+import { ProducerKeychainUserSchema } from "../authorization/producerKeychainUser.js";
 
 export const ClientDbTableConfig = {
   client: ClientSchema,
@@ -30,3 +38,29 @@ export type ClientDbTable = keyof typeof ClientDbTableConfig;
 export const ClientDbTable = Object.fromEntries(
   Object.keys(ClientDbTableConfig).map((k) => [k, k])
 ) as { [K in ClientDbTable]: K };
+
+export const ProducerKeychainDbTableConfig = {
+  producer_keychain: ProducerKeychainSchema,
+  producer_keychain_user: ProducerKeychainUserSchema,
+  producer_keychain_eservice: ProducerKeychainEServiceSchema,
+  producer_keychain_key: ProducerKeychainKeySchema,
+} as const;
+export type ProducerKeychainDbTableConfig =
+  typeof ProducerKeychainDbTableConfig;
+
+export const ProducerKeychainDbTableReadModel = {
+  producer_keychain: producerKeychainInReadmodelProducerKeychain,
+  producer_keychain_user: producerKeychainUserInReadmodelProducerKeychain,
+  producer_keychain_eservice:
+    producerKeychainEserviceInReadmodelProducerKeychain,
+  producer_keychain_key: producerKeychainKeyInReadmodelProducerKeychain,
+} as const;
+export type ProducerKeychainDbTableReadModel =
+  typeof ProducerKeychainDbTableReadModel;
+
+export type ProducerKeychainDbTable =
+  keyof typeof ProducerKeychainDbTableConfig;
+
+export const ProducerKeychainDbTable = Object.fromEntries(
+  Object.keys(ProducerKeychainDbTableConfig).map((k) => [k, k])
+) as { [K in ProducerKeychainDbTable]: K };

--- a/packages/domains-analytics-writer/src/model/db/deleting.ts
+++ b/packages/domains-analytics-writer/src/model/db/deleting.ts
@@ -13,9 +13,6 @@ import {
   clientPurposeInReadmodelClient,
   clientKeyInReadmodelClient,
   producerKeychainInReadmodelProducerKeychain,
-  producerKeychainUserInReadmodelProducerKeychain,
-  producerKeychainEserviceInReadmodelProducerKeychain,
-  producerKeychainKeyInReadmodelProducerKeychain,
 } from "pagopa-interop-readmodel-models";
 
 import { AttributeDeletingSchema } from "../attribute/attribute.js";
@@ -31,9 +28,6 @@ import { ClientKeyDeletingSchema } from "../authorization/clientKey.js";
 import { PurposeDeletingSchema } from "../purpose/purpose.js";
 import { EserviceDescriptorDocumentOrInterfaceDeletingSchema } from "../catalog/eserviceDescriptorInterface.js";
 import { ProducerKeychainDeletingSchema } from "../authorization/producerKeychain.js";
-import { ProducerKeychainUserDeletingSchema } from "../authorization/producerKeychainUser.js";
-import { ProducerKeychainEServiceDeletingSchema } from "../authorization/producerKeychainEService.js";
-import { ProducerKeychainKeyDeletingSchema } from "../authorization/producerKeychainKey.js";
 
 export const DeletingDbTableConfig = {
   attribute_deleting_table: AttributeDeletingSchema,
@@ -49,10 +43,6 @@ export const DeletingDbTableConfig = {
   client_purpose_deleting_table: ClientPurposeDeletingSchema,
   client_key_deleting_table: ClientKeyDeletingSchema,
   producer_keychain_deleting_table: ProducerKeychainDeletingSchema,
-  producer_keychain_user_deleting_table: ProducerKeychainUserDeletingSchema,
-  producer_keychain_eservice_deleting_table:
-    ProducerKeychainEServiceDeletingSchema,
-  producer_keychain_key_deleting_table: ProducerKeychainKeyDeletingSchema,
   eservice_template_deleting_table: EserviceTemplateDeletingSchema,
 } as const;
 export type DeletingDbTableConfig = typeof DeletingDbTableConfig;
@@ -71,12 +61,6 @@ export const DeletingDbTableReadModel = {
   client_purpose_deleting_table: clientPurposeInReadmodelClient,
   client_key_deleting_table: clientKeyInReadmodelClient,
   producer_keychain_deleting_table: producerKeychainInReadmodelProducerKeychain,
-  producer_keychain_user_deleting_table:
-    producerKeychainUserInReadmodelProducerKeychain,
-  producer_keychain_eservice_deleting_table:
-    producerKeychainEserviceInReadmodelProducerKeychain,
-  producer_keychain_key_deleting_table:
-    producerKeychainKeyInReadmodelProducerKeychain,
   eservice_template_deleting_table: eserviceTemplateInReadmodelEserviceTemplate,
 } as const;
 export type DeletingDbTableReadModel = typeof DeletingDbTableReadModel;

--- a/packages/domains-analytics-writer/src/model/db/deleting.ts
+++ b/packages/domains-analytics-writer/src/model/db/deleting.ts
@@ -12,6 +12,10 @@ import {
   clientUserInReadmodelClient,
   clientPurposeInReadmodelClient,
   clientKeyInReadmodelClient,
+  producerKeychainInReadmodelProducerKeychain,
+  producerKeychainUserInReadmodelProducerKeychain,
+  producerKeychainEserviceInReadmodelProducerKeychain,
+  producerKeychainKeyInReadmodelProducerKeychain,
 } from "pagopa-interop-readmodel-models";
 
 import { AttributeDeletingSchema } from "../attribute/attribute.js";
@@ -26,6 +30,10 @@ import { ClientPurposeDeletingSchema } from "../authorization/clientPurpose.js";
 import { ClientKeyDeletingSchema } from "../authorization/clientKey.js";
 import { PurposeDeletingSchema } from "../purpose/purpose.js";
 import { EserviceDescriptorDocumentOrInterfaceDeletingSchema } from "../catalog/eserviceDescriptorInterface.js";
+import { ProducerKeychainDeletingSchema } from "../authorization/producerKeychain.js";
+import { ProducerKeychainUserDeletingSchema } from "../authorization/producerKeychainUser.js";
+import { ProducerKeychainEServiceDeletingSchema } from "../authorization/producerKeychainEService.js";
+import { ProducerKeychainKeyDeletingSchema } from "../authorization/producerKeychainKey.js";
 
 export const DeletingDbTableConfig = {
   attribute_deleting_table: AttributeDeletingSchema,
@@ -40,6 +48,11 @@ export const DeletingDbTableConfig = {
   client_user_deleting_table: ClientUserDeletingSchema,
   client_purpose_deleting_table: ClientPurposeDeletingSchema,
   client_key_deleting_table: ClientKeyDeletingSchema,
+  producer_keychain_deleting_table: ProducerKeychainDeletingSchema,
+  producer_keychain_user_deleting_table: ProducerKeychainUserDeletingSchema,
+  producer_keychain_eservice_deleting_table:
+    ProducerKeychainEServiceDeletingSchema,
+  producer_keychain_key_deleting_table: ProducerKeychainKeyDeletingSchema,
   eservice_template_deleting_table: EserviceTemplateDeletingSchema,
 } as const;
 export type DeletingDbTableConfig = typeof DeletingDbTableConfig;
@@ -57,6 +70,13 @@ export const DeletingDbTableReadModel = {
   client_user_deleting_table: clientUserInReadmodelClient,
   client_purpose_deleting_table: clientPurposeInReadmodelClient,
   client_key_deleting_table: clientKeyInReadmodelClient,
+  producer_keychain_deleting_table: producerKeychainInReadmodelProducerKeychain,
+  producer_keychain_user_deleting_table:
+    producerKeychainUserInReadmodelProducerKeychain,
+  producer_keychain_eservice_deleting_table:
+    producerKeychainEserviceInReadmodelProducerKeychain,
+  producer_keychain_key_deleting_table:
+    producerKeychainKeyInReadmodelProducerKeychain,
   eservice_template_deleting_table: eserviceTemplateInReadmodelEserviceTemplate,
 } as const;
 export type DeletingDbTableReadModel = typeof DeletingDbTableReadModel;

--- a/packages/domains-analytics-writer/src/model/db/index.ts
+++ b/packages/domains-analytics-writer/src/model/db/index.ts
@@ -15,6 +15,8 @@ import {
 import {
   ClientDbTableConfig,
   ClientDbTableReadModel,
+  ProducerKeychainDbTableConfig,
+  ProducerKeychainDbTableReadModel,
 } from "./authorization.js";
 import {
   DelegationDbTableConfig,
@@ -48,6 +50,7 @@ export const DomainDbTable = {
   ...DelegationDbTableConfig,
   ...TenantDbTableConfig,
   ...ClientDbTableConfig,
+  ...ProducerKeychainDbTableConfig,
   ...EserviceTemplateDbTableConfig,
 } as const;
 export type DomainDbTableSchemas = typeof DomainDbTable;
@@ -69,6 +72,7 @@ export const DomainDbTableReadModels = {
   ...PurposeDbTableReadModel,
   ...TenantDbTableReadModel,
   ...ClientDbTableReadModel,
+  ...ProducerKeychainDbTableReadModel,
   ...EserviceTemplateDbTableReadModel,
 } as const;
 export type DomainDbTableReadModels = typeof DomainDbTableReadModels;

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychain.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychain.repository.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+import {
+  DeletingDbTable,
+  ProducerKeychainDbTable,
+} from "../../model/db/index.js";
+import {
+  ProducerKeychainSchema,
+  ProducerKeychainDeletingSchema,
+} from "../../model/authorization/producerKeychain.js";
+
+export function producerKeychainRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ProducerKeychainDbTable.producer_keychain;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const deletingTableName = DeletingDbTable.producer_keychain_deleting_table;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ProducerKeychainSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ProducerKeychainSchema,
+          schemaName,
+          tableName,
+          ["id"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertDeleting(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainDeletingSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          deletingTableName,
+          ProducerKeychainDeletingSchema
+        );
+        await t.none(
+          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          ["id"],
+          false,
+          false
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainEService.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainEService.repository.ts
@@ -5,28 +5,18 @@ import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
-  generateMergeDeleteQuery,
   generateMergeQuery,
   generateStagingDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
 
-import {
-  DeletingDbTable,
-  ProducerKeychainDbTable,
-} from "../../model/db/index.js";
+import { ProducerKeychainDbTable } from "../../model/db/index.js";
 
-import {
-  ProducerKeychainEServiceSchema,
-  ProducerKeychainEServiceDeletingSchema,
-} from "../../model/authorization/producerKeychainEService.js";
+import { ProducerKeychainEServiceSchema } from "../../model/authorization/producerKeychainEService.js";
 
 export function producerKeychainEServiceRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = ProducerKeychainDbTable.producer_keychain_eservice;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName =
-    DeletingDbTable.producer_keychain_eservice_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
     async insert(
@@ -76,55 +66,6 @@ export function producerKeychainEServiceRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ProducerKeychainEServiceDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          ProducerKeychainEServiceDeletingSchema
-        );
-        await t.none(
-          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["producerKeychainId", "eserviceId"],
-          false,
-          true
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainEService.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainEService.repository.ts
@@ -1,0 +1,136 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+
+import {
+  DeletingDbTable,
+  ProducerKeychainDbTable,
+} from "../../model/db/index.js";
+
+import {
+  ProducerKeychainEServiceSchema,
+  ProducerKeychainEServiceDeletingSchema,
+} from "../../model/authorization/producerKeychainEService.js";
+
+export function producerKeychainEServiceRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ProducerKeychainDbTable.producer_keychain_eservice;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const deletingTableName =
+    DeletingDbTable.producer_keychain_eservice_deleting_table;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainEServiceSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          tableName,
+          ProducerKeychainEServiceSchema
+        );
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(
+          generateStagingDeleteQuery(tableName, [
+            "producerKeychainId",
+            "eserviceId",
+          ])
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ProducerKeychainEServiceSchema,
+          schemaName,
+          tableName,
+          ["producerKeychainId", "eserviceId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertDeleting(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainEServiceDeletingSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          deletingTableName,
+          ProducerKeychainEServiceDeletingSchema
+        );
+        await t.none(
+          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          ["producerKeychainId", "eserviceId"],
+          false,
+          true
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}
+
+export type ProducerKeychainEServiceRepository = ReturnType<
+  typeof producerKeychainEServiceRepository
+>;

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainKey.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainKey.ts
@@ -1,0 +1,129 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+
+import {
+  DeletingDbTable,
+  ProducerKeychainDbTable,
+} from "../../model/db/index.js";
+
+import {
+  ProducerKeychainKeySchema,
+  ProducerKeychainKeyDeletingSchema,
+} from "../../model/authorization/producerKeychainKey.js";
+
+export function producerKeychainKeyRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ProducerKeychainDbTable.producer_keychain_key;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const deletingTableName =
+    DeletingDbTable.producer_keychain_key_deleting_table;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainKeySchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ProducerKeychainKeySchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(
+          generateStagingDeleteQuery(tableName, ["producerKeychainId", "kid"])
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ProducerKeychainKeySchema,
+          schemaName,
+          tableName,
+          ["producerKeychainId", "kid"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertDeleting(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainKeyDeletingSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          deletingTableName,
+          ProducerKeychainKeyDeletingSchema
+        );
+        await t.none(
+          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          ["producerKeychainId", "kid"],
+          false,
+          true
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}
+
+export type ProducerKeychainKeyRepository = ReturnType<
+  typeof producerKeychainKeyRepository
+>;

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainUser.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainUser.repository.ts
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { ITask, IMain } from "pg-promise";
+import { config } from "../../config/config.js";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+
+import {
+  DeletingDbTable,
+  ProducerKeychainDbTable,
+} from "../../model/db/index.js";
+import {
+  ProducerKeychainUserSchema,
+  ProducerKeychainUserDeletingSchema,
+} from "../../model/authorization/producerKeychainUser.js";
+
+export function producerKeychainUserRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = ProducerKeychainDbTable.producer_keychain_user;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const deletingTableName =
+    DeletingDbTable.producer_keychain_user_deleting_table;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainUserSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, ProducerKeychainUserSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(
+          generateStagingDeleteQuery(tableName, [
+            "producerKeychainId",
+            "userId",
+          ])
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          ProducerKeychainUserSchema,
+          schemaName,
+          tableName,
+          ["producerKeychainId", "userId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async insertDeleting(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: ProducerKeychainUserDeletingSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          deletingTableName,
+          ProducerKeychainUserDeletingSchema
+        );
+        await t.none(
+          pgp.helpers.insert(records, cs) + " ON CONFLICT DO NOTHING"
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          ["producerKeychainId", "userId"],
+          false,
+          true
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}
+
+export type ProducerKeychainUserRepository = ReturnType<
+  typeof producerKeychainUserRepository
+>;

--- a/packages/domains-analytics-writer/src/service/authorizationService.ts
+++ b/packages/domains-analytics-writer/src/service/authorizationService.ts
@@ -27,18 +27,35 @@ import {
   ClientKeyDeletingSchema,
   ClientKeyUserMigrationSchema,
 } from "../model/authorization/clientKey.js";
-import { ClientDbTable } from "../model/db/authorization.js";
+import {
+  ClientDbTable,
+  ProducerKeychainDbTable,
+} from "../model/db/authorization.js";
 import { DeletingDbTable } from "../model/db/deleting.js";
 import { clientRepository } from "../repository/client/client.repository.js";
 import { clientKeyRepository } from "../repository/client/clientKey.repository.js";
 import { clientPurposeRepository } from "../repository/client/clientPurpose.repository.js";
 import { clientUserRepository } from "../repository/client/clientUser.repository.js";
+import {
+  ProducerKeychainDeletingSchema,
+  ProducerKeychainItemsSchema,
+} from "../model/authorization/producerKeychain.js";
+import { producerKeychainRepository } from "../repository/producerKeychain/producerKeychain.repository.js";
+import { producerKeychainEServiceRepository } from "../repository/producerKeychain/producerKeychainEService.repository.js";
+import { producerKeychainKeyRepository } from "../repository/producerKeychain/producerKeychainKey.js";
+import { producerKeychainUserRepository } from "../repository/producerKeychain/producerKeychainUser.repository.js";
 
 export function authorizationServiceBuilder(db: DBContext) {
   const clientRepo = clientRepository(db.conn);
   const clientUserRepo = clientUserRepository(db.conn);
   const clientPurposeRepo = clientPurposeRepository(db.conn);
   const clientKeyRepo = clientKeyRepository(db.conn);
+  const producerKeychainRepo = producerKeychainRepository(db.conn);
+  const producerKeychainUserRepo = producerKeychainUserRepository(db.conn);
+  const producerKeychainEServiceRepo = producerKeychainEServiceRepository(
+    db.conn
+  );
+  const producerKeychainKeyRepo = producerKeychainKeyRepository(db.conn);
 
   return {
     async upsertClientBatch(dbContext: DBContext, items: ClientItemsSchema[]) {
@@ -344,6 +361,126 @@ export function authorizationServiceBuilder(db: DBContext) {
       await clientKeyRepo.clean();
 
       genericLogger.info(`Staging table cleaned for ClientKeyUserMigration`);
+    },
+
+    async upsertProducerKeychainBatch(
+      dbContext: DBContext,
+      items: ProducerKeychainItemsSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        for (const batch of batchMessages(
+          items,
+          config.dbMessagesToInsertPerBatch
+        )) {
+          const batchItems = {
+            producerKeychainSQL: batch.map((i) => i.producerKeychainSQL),
+            usersSQL: batch.flatMap((i) => i.usersSQL),
+            eservicesSQL: batch.flatMap((i) => i.eservicesSQL),
+            keysSQL: batch.flatMap((i) => i.keysSQL),
+          };
+
+          if (batchItems.producerKeychainSQL.length) {
+            await producerKeychainRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.producerKeychainSQL
+            );
+          }
+          if (batchItems.usersSQL.length) {
+            await producerKeychainUserRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.usersSQL
+            );
+          }
+          if (batchItems.eservicesSQL.length) {
+            await producerKeychainEServiceRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.eservicesSQL
+            );
+          }
+          if (batchItems.keysSQL.length) {
+            await producerKeychainKeyRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.keysSQL
+            );
+          }
+
+          genericLogger.info(
+            `Staging data inserted for ProducerKeychain batch: ${batch
+              .map((i) => i.producerKeychainSQL.id)
+              .join(", ")}`
+          );
+        }
+
+        await producerKeychainRepo.merge(t);
+        await producerKeychainUserRepo.merge(t);
+        await producerKeychainEServiceRepo.merge(t);
+        await producerKeychainKeyRepo.merge(t);
+      });
+
+      await dbContext.conn.tx(async (t) => {
+        await cleaningTargetTables(
+          t,
+          "producerKeychainId",
+          [
+            ProducerKeychainDbTable.producer_keychain_user,
+            ProducerKeychainDbTable.producer_keychain_eservice,
+            ProducerKeychainDbTable.producer_keychain_key,
+          ],
+          ProducerKeychainDbTable.producer_keychain
+        );
+      });
+
+      genericLogger.info(
+        `Staging data merged into target tables for ProducerKeychain`
+      );
+
+      await producerKeychainRepo.clean();
+      await producerKeychainUserRepo.clean();
+      await producerKeychainEServiceRepo.clean();
+      await producerKeychainKeyRepo.clean();
+
+      genericLogger.info(`Staging data cleaned for ProducerKeychain`);
+    },
+
+    async deleteProducerKeychainBatch(
+      dbContext: DBContext,
+      items: ProducerKeychainDeletingSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        for (const batch of batchMessages(
+          items,
+          config.dbMessagesToInsertPerBatch
+        )) {
+          await producerKeychainRepo.insertDeleting(t, dbContext.pgp, batch);
+          genericLogger.info(
+            `Staging deletion inserted for ProducerKeychain ids: ${batch
+              .map((i) => i.id)
+              .join(", ")}`
+          );
+        }
+
+        await producerKeychainRepo.mergeDeleting(t);
+        await mergeDeletingCascadeById(
+          t,
+          "producerKeychainId",
+          [
+            ProducerKeychainDbTable.producer_keychain_user,
+            ProducerKeychainDbTable.producer_keychain_eservice,
+            ProducerKeychainDbTable.producer_keychain_key,
+          ],
+          DeletingDbTable.producer_keychain_deleting_table
+        );
+      });
+
+      genericLogger.info(`Staging deletion merged for ProducerKeychain`);
+
+      await producerKeychainRepo.cleanDeleting();
+
+      genericLogger.info(`ProducerKeychain deleting table cleaned`);
     },
   };
 }

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -135,9 +135,6 @@ export const deletingTables: DeletingDbTable[] = [
   DeletingDbTable.client_user_deleting_table,
   DeletingDbTable.client_key_deleting_table,
   DeletingDbTable.producer_keychain_deleting_table,
-  DeletingDbTable.producer_keychain_user_deleting_table,
-  DeletingDbTable.producer_keychain_eservice_deleting_table,
-  DeletingDbTable.producer_keychain_key_deleting_table,
   DeletingDbTable.eservice_template_deleting_table,
 ];
 
@@ -186,18 +183,6 @@ export const setupStagingDeletingTables: DeletingDbTableConfigMap[] = [
   {
     name: DeletingDbTable.producer_keychain_deleting_table,
     columns: ["id"],
-  },
-  {
-    name: DeletingDbTable.producer_keychain_user_deleting_table,
-    columns: ["producerKeychainId", "userId"],
-  },
-  {
-    name: DeletingDbTable.producer_keychain_eservice_deleting_table,
-    columns: ["producerKeychainId", "eserviceId"],
-  },
-  {
-    name: DeletingDbTable.producer_keychain_key_deleting_table,
-    columns: ["producerKeychainId", "kid"],
   },
   {
     name: DeletingDbTable.eservice_template_deleting_table,

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -24,6 +24,7 @@ import {
   TenantDbTable,
   CatalogDbPartialTable,
   ClientDbTable,
+  ProducerKeychainDbTable,
 } from "../src/model/db/index.js";
 import { catalogServiceBuilder } from "../src/service/catalogService.js";
 import { attributeServiceBuilder } from "../src/service/attributeService.js";
@@ -110,11 +111,17 @@ export const clientTables: ClientDbTable[] = [
   ClientDbTable.client_key,
 ];
 
+export const producerKeychainTables: ProducerKeychainDbTable[] = [
+  ProducerKeychainDbTable.producer_keychain,
+  ProducerKeychainDbTable.producer_keychain_eservice,
+  ProducerKeychainDbTable.producer_keychain_user,
+  ProducerKeychainDbTable.producer_keychain_key,
+];
+
 export const partialTables = [
   TenantDbPartialTable.tenant_self_care_id,
   CatalogDbPartialTable.descriptor_server_urls,
 ];
-
 export const deletingTables: DeletingDbTable[] = [
   DeletingDbTable.agreement_deleting_table,
   DeletingDbTable.attribute_deleting_table,
@@ -127,6 +134,10 @@ export const deletingTables: DeletingDbTable[] = [
   DeletingDbTable.client_purpose_deleting_table,
   DeletingDbTable.client_user_deleting_table,
   DeletingDbTable.client_key_deleting_table,
+  DeletingDbTable.producer_keychain_deleting_table,
+  DeletingDbTable.producer_keychain_user_deleting_table,
+  DeletingDbTable.producer_keychain_eservice_deleting_table,
+  DeletingDbTable.producer_keychain_key_deleting_table,
   DeletingDbTable.eservice_template_deleting_table,
 ];
 
@@ -138,6 +149,7 @@ export const domainTables: DomainDbTable[] = [
   ...delegationTables,
   ...tenantTables,
   ...clientTables,
+  ...producerKeychainTables,
   ...eserviceTemplateTables,
 ];
 
@@ -170,6 +182,22 @@ export const setupStagingDeletingTables: DeletingDbTableConfigMap[] = [
   {
     name: DeletingDbTable.client_key_deleting_table,
     columns: ["clientId", "kid"],
+  },
+  {
+    name: DeletingDbTable.producer_keychain_deleting_table,
+    columns: ["id"],
+  },
+  {
+    name: DeletingDbTable.producer_keychain_user_deleting_table,
+    columns: ["producerKeychainId", "userId"],
+  },
+  {
+    name: DeletingDbTable.producer_keychain_eservice_deleting_table,
+    columns: ["producerKeychainId", "eserviceId"],
+  },
+  {
+    name: DeletingDbTable.producer_keychain_key_deleting_table,
+    columns: ["producerKeychainId", "kid"],
   },
   {
     name: DeletingDbTable.eservice_template_deleting_table,


### PR DESCRIPTION
## Summary
This PR introduces:
-  `handleAuthorizationMessageV2` functions to handle `ProducerKeychain events `from the `authorization` topic

**Hybrid delete strategy**  
  - The `ProducerKeychainDeleted` events performs a **logical delete** on the main `producer_keychain` table  and its subobjects (sets the `deleted` flag, preserving history to the target tables).  
  - All other delete events execute **physical deletes**, removing rows outright from target tables.
  
**Pre-merge cleanup**  
  Before each upsert MERGE, we now run a set-based `MERGE … WHEN MATCHED THEN DELETE` on the target tables to purge any rows whose `metadata_version` is lower than the incoming staging version, ensuring outdated records will be cleaned.