### PR TITLE
Fix `catalog-platformstate-writer` and `purpose-platformstate-writer` reprocess

### DIFF
--- a/packages/catalog-platformstate-writer/src/consumerServiceV1.ts
+++ b/packages/catalog-platformstate-writer/src/consumerServiceV1.ts
@@ -21,7 +21,7 @@ import {
   updateDescriptorInfoInTokenGenerationStatesTable,
   updateDescriptorStateInPlatformStatesEntry,
   updateDescriptorStateInTokenGenerationStatesTable,
-  writeCatalogEntry,
+  upsertPlatformStatesCatalogEntry,
 } from "./utils.js";
 
 export async function handleMessageV1(
@@ -48,27 +48,19 @@ export async function handleMessageV1(
               dynamoDBClient
             );
 
-            if (existingCatalogEntry) {
-              if (existingCatalogEntry.version > msg.version) {
-                // Stops processing if the message is older than the catalog entry
-                logger.info(
-                  `Skipping processing of entry ${existingCatalogEntry.PK}. Reason: a more recent entry already exists`
-                );
-                return Promise.resolve();
-              } else {
-                // suspended -> published
-                // suspended -> deprecated
-
-                await updateDescriptorStateInPlatformStatesEntry(
-                  dynamoDBClient,
-                  eserviceDescriptorPK,
-                  descriptorStateToItemState(descriptor.state),
-                  msg.version,
-                  logger
-                );
-              }
+            if (
+              existingCatalogEntry &&
+              existingCatalogEntry.version > msg.version
+            ) {
+              // Stops processing if the message is older than the catalog entry
+              logger.info(
+                `Skipping processing of entry ${existingCatalogEntry.PK}. Reason: a more recent entry already exists`
+              );
+              return Promise.resolve();
             } else {
               // draft -> published
+              // suspended -> published
+              // suspended -> deprecated
 
               const catalogEntry: PlatformStatesCatalogEntry = {
                 PK: eserviceDescriptorPK,
@@ -79,7 +71,11 @@ export async function handleMessageV1(
                 updatedAt: new Date().toISOString(),
               };
 
-              await writeCatalogEntry(catalogEntry, dynamoDBClient, logger);
+              await upsertPlatformStatesCatalogEntry(
+                catalogEntry,
+                dynamoDBClient,
+                logger
+              );
             }
 
             // token-generation-states

--- a/packages/catalog-platformstate-writer/src/consumerServiceV2.ts
+++ b/packages/catalog-platformstate-writer/src/consumerServiceV2.ts
@@ -25,7 +25,6 @@ import {
   updateDescriptorVoucherLifespanInPlatformStateEntry,
   updateDescriptorVoucherLifespanInTokenGenerationStatesTable,
   upsertPlatformStatesCatalogEntry,
-  writeCatalogEntry,
 } from "./utils.js";
 
 export async function handleMessageV2(

--- a/packages/catalog-platformstate-writer/src/utils.ts
+++ b/packages/catalog-platformstate-writer/src/utils.ts
@@ -30,42 +30,6 @@ import { z } from "zod";
 import { Logger } from "pagopa-interop-commons";
 import { config } from "./config/config.js";
 
-export const writeCatalogEntry = async (
-  catalogEntry: PlatformStatesCatalogEntry,
-  dynamoDBClient: DynamoDBClient,
-  logger: Logger
-): Promise<void> => {
-  const input: PutItemInput = {
-    ConditionExpression: "attribute_not_exists(PK)",
-    Item: {
-      PK: {
-        S: catalogEntry.PK,
-      },
-      state: {
-        S: catalogEntry.state,
-      },
-      descriptorAudience: {
-        L: catalogEntry.descriptorAudience.map((item) => ({
-          S: item,
-        })),
-      },
-      descriptorVoucherLifespan: {
-        N: catalogEntry.descriptorVoucherLifespan.toString(),
-      },
-      version: {
-        N: catalogEntry.version.toString(),
-      },
-      updatedAt: {
-        S: catalogEntry.updatedAt,
-      },
-    },
-    TableName: config.tokenGenerationReadModelTableNamePlatform,
-  };
-  const command = new PutItemCommand(input);
-  await dynamoDBClient.send(command);
-  logger.info(`Platform-states. Written catalog entry ${catalogEntry.PK}`);
-};
-
 export const upsertPlatformStatesCatalogEntry = async (
   catalogEntry: PlatformStatesCatalogEntry,
   dynamoDBClient: DynamoDBClient,

--- a/packages/catalog-platformstate-writer/src/utils.ts
+++ b/packages/catalog-platformstate-writer/src/utils.ts
@@ -66,6 +66,41 @@ export const writeCatalogEntry = async (
   logger.info(`Platform-states. Written catalog entry ${catalogEntry.PK}`);
 };
 
+export const upsertPlatformStatesCatalogEntry = async (
+  catalogEntry: PlatformStatesCatalogEntry,
+  dynamoDBClient: DynamoDBClient,
+  logger: Logger
+): Promise<void> => {
+  const input: PutItemInput = {
+    Item: {
+      PK: {
+        S: catalogEntry.PK,
+      },
+      state: {
+        S: catalogEntry.state,
+      },
+      descriptorAudience: {
+        L: catalogEntry.descriptorAudience.map((item) => ({
+          S: item,
+        })),
+      },
+      descriptorVoucherLifespan: {
+        N: catalogEntry.descriptorVoucherLifespan.toString(),
+      },
+      version: {
+        N: catalogEntry.version.toString(),
+      },
+      updatedAt: {
+        S: catalogEntry.updatedAt,
+      },
+    },
+    TableName: config.tokenGenerationReadModelTableNamePlatform,
+  };
+  const command = new PutItemCommand(input);
+  await dynamoDBClient.send(command);
+  logger.info(`Platform-states. Upserted catalog entry ${catalogEntry.PK}`);
+};
+
 export const readCatalogEntry = async (
   primaryKey: PlatformStatesEServiceDescriptorPK,
   dynamoDBClient: DynamoDBClient

--- a/packages/catalog-platformstate-writer/test/consumerServiceV1.test.ts
+++ b/packages/catalog-platformstate-writer/test/consumerServiceV1.test.ts
@@ -31,11 +31,12 @@ import {
   buildDynamoDBTables,
   deleteDynamoDBTables,
   readAllTokenGenStatesItems,
+  writePlatformCatalogEntry,
 } from "pagopa-interop-commons-test";
 import { writeTokenGenStatesConsumerClient } from "pagopa-interop-commons-test";
 import { genericLogger } from "pagopa-interop-commons";
 import { handleMessageV1 } from "../src/consumerServiceV1.js";
-import { readCatalogEntry, writeCatalogEntry } from "../src/utils.js";
+import { readCatalogEntry } from "../src/utils.js";
 import { dynamoDBClient } from "./utils.js";
 
 describe("V1 events", async () => {
@@ -208,11 +209,7 @@ describe("V1 events", async () => {
             version: 1,
             updatedAt: new Date().toISOString(),
           };
-          await writeCatalogEntry(
-            previousStateEntry,
-            dynamoDBClient,
-            genericLogger
-          );
+          await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
           // token-generation-states
           const tokenGenStatesEntryPK1 =
@@ -331,10 +328,9 @@ describe("V1 events", async () => {
           version: 2,
           updatedAt: new Date().toISOString(),
         };
-        await writeCatalogEntry(
+        await writePlatformCatalogEntry(
           previousCatalogStateEntry,
-          dynamoDBClient,
-          genericLogger
+          dynamoDBClient
         );
 
         // token-generation-states
@@ -439,11 +435,7 @@ describe("V1 events", async () => {
             version: 1,
             updatedAt: new Date().toISOString(),
           };
-          await writeCatalogEntry(
-            previousStateEntry,
-            dynamoDBClient,
-            genericLogger
-          );
+          await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
           // token-generation-states
           const tokenGenStatesEntryPK1 =
@@ -561,11 +553,7 @@ describe("V1 events", async () => {
             updatedAt: new Date().toISOString(),
           };
 
-          await writeCatalogEntry(
-            previousStateEntry,
-            dynamoDBClient,
-            genericLogger
-          );
+          await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
           // token-generation-states
           const tokenGenStatesEntryPK1 =
@@ -710,11 +698,7 @@ describe("V1 events", async () => {
         version: 1,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       // token-generation-states
       const tokenGenStatesEntryPK1 =

--- a/packages/catalog-platformstate-writer/test/consumerServiceV2.test.ts
+++ b/packages/catalog-platformstate-writer/test/consumerServiceV2.test.ts
@@ -39,9 +39,10 @@ import {
   deleteDynamoDBTables,
   readAllTokenGenStatesItems,
   writeTokenGenStatesConsumerClient,
+  writePlatformCatalogEntry,
 } from "pagopa-interop-commons-test";
 import { genericLogger } from "pagopa-interop-commons";
-import { readCatalogEntry, writeCatalogEntry } from "../src/utils.js";
+import { readCatalogEntry } from "../src/utils.js";
 import { handleMessageV2 } from "../src/consumerServiceV2.js";
 import { dynamoDBClient } from "./utils.js";
 
@@ -99,11 +100,7 @@ describe("integration tests V2 events", async () => {
         version: 2,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       // token-generation-states
       const tokenGenStatesEntryPK1 =
@@ -207,11 +204,7 @@ describe("integration tests V2 events", async () => {
         version: 2,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       // token-generation-states
       const tokenGenStatesEntryPK1 =
@@ -432,11 +425,7 @@ describe("integration tests V2 events", async () => {
         version: 1,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       const eserviceId_descriptorId = makeGSIPKEServiceIdDescriptorId({
         eserviceId: eservice.id,
@@ -661,11 +650,7 @@ describe("integration tests V2 events", async () => {
           version: 2,
           updatedAt: new Date().toISOString(),
         };
-        await writeCatalogEntry(
-          previousStateEntry,
-          dynamoDBClient,
-          genericLogger
-        );
+        await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
         const tokenGenStatesEntryPK1 =
           makeTokenGenerationStatesClientKidPurposePK({
@@ -765,11 +750,7 @@ describe("integration tests V2 events", async () => {
           version: 2,
           updatedAt: new Date().toISOString(),
         };
-        await writeCatalogEntry(
-          previousStateEntry,
-          dynamoDBClient,
-          genericLogger
-        );
+        await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
         const eserviceId_descriptorId = makeGSIPKEServiceIdDescriptorId({
           eserviceId: eservice.id,
           descriptorId: publishedDescriptor.id,
@@ -994,11 +975,7 @@ describe("integration tests V2 events", async () => {
         version: 2,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       // token-generation-states
       const tokenGenStatesEntryPK1 =
@@ -1099,11 +1076,7 @@ describe("integration tests V2 events", async () => {
         version: 1,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       // token-generation-states
       const tokenGenStatesEntryPK1 =
@@ -1332,11 +1305,7 @@ describe("integration tests V2 events", async () => {
         version: 2,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       // token-generation-states
       const tokenGenStatesEntryPK1 =
@@ -1450,11 +1419,7 @@ describe("integration tests V2 events", async () => {
         version: 2,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       // token-generation-states
       const tokenGenStatesEntryPK1 =
@@ -1700,11 +1665,7 @@ describe("integration tests V2 events", async () => {
         version: 2,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       // token-generation-states
       const tokenGenStatesEntryPK1 =
@@ -1820,11 +1781,7 @@ describe("integration tests V2 events", async () => {
         version: 2,
         updatedAt: new Date().toISOString(),
       };
-      await writeCatalogEntry(
-        previousStateEntry,
-        dynamoDBClient,
-        genericLogger
-      );
+      await writePlatformCatalogEntry(previousStateEntry, dynamoDBClient);
 
       // token-generation-states
       const tokenGenStatesEntryPK1 =

--- a/packages/catalog-platformstate-writer/test/utils.test.ts
+++ b/packages/catalog-platformstate-writer/test/utils.test.ts
@@ -119,7 +119,7 @@ describe("utils tests", async () => {
   });
 
   describe("upsertPlatformStatesCatalogEntry", async () => {
-    it("should update the entry if previous entry exists", async () => {
+    it("should update the entry if the previous entry exists", async () => {
       const primaryKey = makePlatformStatesEServiceDescriptorPK({
         eserviceId: generateId(),
         descriptorId: generateId(),

--- a/packages/purpose-platformstate-writer/src/consumerServiceV1.ts
+++ b/packages/purpose-platformstate-writer/src/consumerServiceV1.ts
@@ -15,11 +15,11 @@ import {
   getPurposeStateFromPurposeVersions,
   readPlatformPurposeEntry,
   updatePurposeDataInPlatformStatesEntry,
-  writePlatformPurposeEntry,
   getLastSuspendedOrActivatedPurposeVersion,
   updatePurposeDataInTokenGenStatesEntries,
   updateTokenGenStatesEntriesWithPurposeAndPlatformStatesData,
   getLastArchivedPurposeVersion,
+  upsertPlatformStatesPurposeEntry,
 } from "./utils.js";
 
 export async function handleMessageV1(
@@ -40,34 +40,12 @@ export async function handleMessageV1(
         purpose.versions
       );
 
-      if (existingPurposeEntry) {
-        if (existingPurposeEntry.version > msg.version) {
-          // Stops processing if the message is older than the purpose entry
-          logger.info(
-            `Skipping processing of entry ${existingPurposeEntry.PK}. Reason: a more recent entry already exists`
-          );
-          return Promise.resolve();
-        } else {
-          // platform-states
-          await updatePurposeDataInPlatformStatesEntry({
-            dynamoDBClient,
-            primaryKey,
-            purposeState,
-            version: msg.version,
-            purposeVersionId: purposeVersion.id,
-            logger,
-          });
-
-          // token-generation-states
-          await updatePurposeDataInTokenGenStatesEntries({
-            dynamoDBClient,
-            purposeId: purpose.id,
-            purposeState,
-            purposeVersionId: purposeVersion.id,
-            purposeConsumerId: purpose.consumerId,
-            logger,
-          });
-        }
+      if (existingPurposeEntry && existingPurposeEntry.version > msg.version) {
+        // Stops processing if the message is older than the purpose entry
+        logger.info(
+          `Skipping processing of entry ${existingPurposeEntry.PK}. Reason: a more recent entry already exists`
+        );
+        return Promise.resolve();
       } else {
         // platform-states
         const purposeEntry: PlatformStatesPurposeEntry = {
@@ -79,7 +57,11 @@ export async function handleMessageV1(
           version: msg.version,
           updatedAt: new Date().toISOString(),
         };
-        await writePlatformPurposeEntry(dynamoDBClient, purposeEntry, logger);
+        await upsertPlatformStatesPurposeEntry(
+          dynamoDBClient,
+          purposeEntry,
+          logger
+        );
 
         // token-generation-states
         await updateTokenGenStatesEntriesWithPurposeAndPlatformStatesData(

--- a/packages/purpose-platformstate-writer/src/consumerServiceV2.ts
+++ b/packages/purpose-platformstate-writer/src/consumerServiceV2.ts
@@ -20,9 +20,9 @@ import {
   readPlatformPurposeEntry,
   updatePurposeDataInPlatformStatesEntry,
   updatePurposeDataInTokenGenStatesEntries,
-  writePlatformPurposeEntry,
   updateTokenGenStatesEntriesWithPurposeAndPlatformStatesData,
   getLastSuspendedOrActivatedPurposeVersion,
+  upsertPlatformStatesPurposeEntry,
 } from "./utils.js";
 
 export async function handleMessageV2(
@@ -46,24 +46,15 @@ export async function handleMessageV2(
           purpose.versions
         );
 
-        if (existingPurposeEntry) {
-          if (existingPurposeEntry.version > msg.version) {
-            // Stops processing if the message is older than the purpose entry
-            logger.info(
-              `Skipping processing of entry ${existingPurposeEntry.PK}. Reason: a more recent entry already exists`
-            );
-            return Promise.resolve();
-          } else {
-            // platform-states
-            await updatePurposeDataInPlatformStatesEntry({
-              dynamoDBClient,
-              primaryKey,
-              purposeState,
-              purposeVersionId: purposeVersion.id,
-              version: msg.version,
-              logger,
-            });
-          }
+        if (
+          existingPurposeEntry &&
+          existingPurposeEntry.version > msg.version
+        ) {
+          // Stops processing if the message is older than the purpose entry
+          logger.info(
+            `Skipping processing of entry ${existingPurposeEntry.PK}. Reason: a more recent entry already exists`
+          );
+          return Promise.resolve();
         } else {
           // platform-states
           const purposeEntry: PlatformStatesPurposeEntry = {
@@ -75,17 +66,21 @@ export async function handleMessageV2(
             version: msg.version,
             updatedAt: new Date().toISOString(),
           };
-          await writePlatformPurposeEntry(dynamoDBClient, purposeEntry, logger);
-        }
+          await upsertPlatformStatesPurposeEntry(
+            dynamoDBClient,
+            purposeEntry,
+            logger
+          );
 
-        // token-generation-states
-        await updateTokenGenStatesEntriesWithPurposeAndPlatformStatesData(
-          dynamoDBClient,
-          purpose,
-          purposeState,
-          purposeVersion.id,
-          logger
-        );
+          // token-generation-states
+          await updateTokenGenStatesEntriesWithPurposeAndPlatformStatesData(
+            dynamoDBClient,
+            purpose,
+            purposeState,
+            purposeVersion.id,
+            logger
+          );
+        }
       }
     )
     .with(

--- a/packages/purpose-platformstate-writer/src/utils.ts
+++ b/packages/purpose-platformstate-writer/src/utils.ts
@@ -51,13 +51,12 @@ export const getPurposeStateFromPurposeVersions = (
   }
 };
 
-export const writePlatformPurposeEntry = async (
+export const upsertPlatformStatesPurposeEntry = async (
   dynamoDBClient: DynamoDBClient,
   purposeEntry: PlatformStatesPurposeEntry,
   logger: Logger
 ): Promise<void> => {
   const input: PutItemInput = {
-    ConditionExpression: "attribute_not_exists(PK)",
     Item: {
       PK: {
         S: purposeEntry.PK,
@@ -85,7 +84,7 @@ export const writePlatformPurposeEntry = async (
   };
   const command = new PutItemCommand(input);
   await dynamoDBClient.send(command);
-  logger.info(`Platform-states. Written purpose entry ${purposeEntry.PK}`);
+  logger.info(`Platform-states. Upserted purpose entry ${purposeEntry.PK}`);
 };
 
 export const readPlatformPurposeEntry = async (

--- a/packages/purpose-platformstate-writer/test/consumerServiceV2.integration.test.ts
+++ b/packages/purpose-platformstate-writer/test/consumerServiceV2.integration.test.ts
@@ -18,6 +18,7 @@ import {
   readAllTokenGenStatesItems,
   writePlatformAgreementEntry,
   writePlatformCatalogEntry,
+  writePlatformPurposeEntry,
   writeTokenGenStatesConsumerClient,
 } from "pagopa-interop-commons-test";
 import {
@@ -54,7 +55,6 @@ import { handleMessageV2 } from "../src/consumerServiceV2.js";
 import {
   getPurposeStateFromPurposeVersions,
   readPlatformPurposeEntry,
-  writePlatformPurposeEntry,
 } from "../src/utils.js";
 import { dynamoDBClient } from "./utils.js";
 
@@ -284,9 +284,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -372,9 +371,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -665,9 +663,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -772,9 +769,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -1097,9 +1093,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -1186,9 +1181,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -1480,9 +1474,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -1586,9 +1579,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -1713,9 +1705,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -1846,9 +1837,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -1952,9 +1942,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -2079,9 +2068,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -2213,9 +2201,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -2321,9 +2308,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -2450,9 +2436,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -2584,9 +2569,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -2692,9 +2676,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -2821,9 +2804,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states
@@ -2954,9 +2936,8 @@ describe("integration tests for events V2", () => {
         updatedAt: mockDate.toISOString(),
       };
       await writePlatformPurposeEntry(
-        dynamoDBClient,
         previousPlatformPurposeEntry,
-        genericLogger
+        dynamoDBClient
       );
 
       // token-generation-states


### PR DESCRIPTION
The events that write an entry should overwrite it if it already exists in the `platform-states` table because this action is needed for the events reprocessing.