### PR TITLE
PIN-7139 remove feature flag admin client

### DIFF
--- a/packages/authorization-process/src/config/config.ts
+++ b/packages/authorization-process/src/config/config.ts
@@ -4,7 +4,6 @@ import {
   EventStoreConfig,
   SelfCareClientConfig,
   ApplicationAuditProducerConfig,
-  FeatureFlagAdminClientConfig,
   FeatureFlagSQLConfig,
   ReadModelSQLDbConfig,
 } from "pagopa-interop-commons";
@@ -25,7 +24,6 @@ const AuthorizationConfig = CommonHTTPServiceConfig.and(ReadModelDbConfig)
       }))
   )
   .and(ApplicationAuditProducerConfig)
-  .and(FeatureFlagAdminClientConfig)
   .and(FeatureFlagSQLConfig)
   .and(ReadModelSQLDbConfig);
 

--- a/packages/authorization-process/src/services/authorizationService.ts
+++ b/packages/authorization-process/src/services/authorizationService.ts
@@ -24,7 +24,6 @@ import {
 } from "pagopa-interop-models";
 import {
   AppContext,
-  assertFeatureFlagEnabled,
   calculateKid,
   createJWK,
   DB,
@@ -97,7 +96,6 @@ import {
   clientToApiClient,
   producerJWKToApiProducerJWK,
 } from "../model/domain/apiConverter.js";
-import { config } from "../config/config.js";
 import {
   GetClientsFilters,
   GetProducerKeychainsFilters,
@@ -594,8 +592,6 @@ export function authorizationServiceBuilder(
       },
       { authData, correlationId, logger }: WithLogger<AppContext<UIAuthData>>
     ): Promise<{ client: Client; showUsers: boolean }> {
-      assertFeatureFlagEnabled(config, "featureFlagAdminClient");
-
       logger.info(`Set user ${adminId} in client ${clientId} as admin`);
 
       await assertUserSelfcareSecurityPrivileges({
@@ -1439,7 +1435,6 @@ export function authorizationServiceBuilder(
       { clientId, adminId }: { clientId: ClientId; adminId: UserId },
       { correlationId, logger, authData }: WithLogger<AppContext<UIAuthData>>
     ): Promise<void> {
-      assertFeatureFlagEnabled(config, "featureFlagAdminClient");
       logger.info(`Removing client admin ${adminId} from client ${clientId}`);
       const client = await retrieveClient(clientId, readModelService);
 

--- a/packages/commons/src/config/featureFlagsConfig.ts
+++ b/packages/commons/src/config/featureFlagsConfig.ts
@@ -51,21 +51,6 @@ export type FeatureFlagAgreementApprovalPolicyUpdateConfig = z.infer<
   typeof FeatureFlagAgreementApprovalPolicyUpdateConfig
 >;
 
-export const FeatureFlagAdminClientConfig = z
-  .object({
-    FEATURE_FLAG_ADMIN_CLIENT: z
-      .enum(["true", "false"])
-      .default("false")
-      .transform((value) => value === "true")
-      .optional(),
-  })
-  .transform((c) => ({
-    featureFlagAdminClient: c.FEATURE_FLAG_ADMIN_CLIENT ?? false,
-  }));
-export type FeatureFlagAdminClientConfig = z.infer<
-  typeof FeatureFlagAdminClientConfig
->;
-
 export const FeatureFlagApplicationAuditStrictConfig = z
   .object({
     FEATURE_FLAG_APPLICATION_AUDIT_STRICT_STRICT: z
@@ -115,7 +100,6 @@ export type FeatureFlagClientAssertionStrictClaimsValidationConfig = z.infer<
 type FeatureFlags = FeatureFlagSignalhubWhitelistConfig &
   FeatureFlagAgreementApprovalPolicyUpdateConfig &
   FeatureFlagSQLConfig &
-  FeatureFlagAdminClientConfig &
   FeatureFlagApplicationAuditStrictConfig &
   FeatureFlagImprovedProducerVerificationClaimsConfig &
   FeatureFlagClientAssertionStrictClaimsValidationConfig;


### PR DESCRIPTION
Close [PIN-7139](https://pagopa.atlassian.net/browse/PIN-7139) 

# Description
This PR remove feature flag `FEATURE_FLAG_ADMIN_CLIENT`, no assertions required for feature flag enablish.
Assertion affects two API endpoints of `AuthorizationProcess`
 
- set admin to client  ( POST `/clients/:clientId/admin` )
- remove admin from client ( DELETE `/clients/:clientId/admin/:adminId`)

