### PR TITLE
PIN-7155 - APIV2 `POST /reversePurposes`

### DIFF
--- a/collections/m2m gateway/purposes/Create Reverse Purpose.bru
+++ b/collections/m2m gateway/purposes/Create Reverse Purpose.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Create Reverse Purpose
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{host-m2m-gw}}/reversePurposes
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: {{JWT-M2M-ADMIN}}
+}
+
+body:json {
+  {
+      "eServiceId": "{{eserviceId}}",
+      "riskAnalysisId": "{{riskAnalysisId}}",
+      "consumerId": "{{tenantId}}",
+      "title": "{{randomName}}",
+      "description": "a purpose long description",
+      "isFreeOfCharge": true,
+      "dailyCalls": 100,
+      "freeOfChargeReason": "Free!"
+  }
+}
+
+vars:post-response {
+  reversePurposeId: res.body.id
+}
+
+script:pre-request {
+  const random = Math.round(Math.random() * 100)
+  
+  bru.setVar("randomName",`test name ${random}`)
+}

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -4092,6 +4092,111 @@ paths:
               $ref: "#/components/headers/RateLimitRemainingHeader"
             X-Rate-Limit-Interval:
               $ref: "#/components/headers/RateLimitIntervalHeader"
+  /reversePurposes:
+    post:
+      tags:
+        - purposes
+      summary: Create a new e-service Purpose
+      description: Create a new purpose for an e-service in receive mode
+      operationId: createReversePurpose
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EServicePurposeSeed"
+        required: true
+      responses:
+        "201":
+          description: EService Purpose created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Purpose"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "409":
+          description: Name Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
   /tenants:
     get:
       tags:
@@ -5362,6 +5467,42 @@ components:
       required:
         - eserviceId
         - title
+        - description
+        - isFreeOfCharge
+        - dailyCalls
+    EServicePurposeSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        eserviceId:
+          type: string
+          format: uuid
+        consumerId:
+          type: string
+          format: uuid
+        riskAnalysisId:
+          type: string
+          format: uuid
+        title:
+          type: string
+          minLength: 5
+          maxLength: 60
+        description:
+          type: string
+          minLength: 10
+          maxLength: 250
+        isFreeOfCharge:
+          type: boolean
+        freeOfChargeReason:
+          type: string
+        dailyCalls:
+          type: integer
+          format: int32
+      required:
+        - eserviceId
+        - consumerId
+        - title
+        - riskAnalysisId
         - description
         - isFreeOfCharge
         - dailyCalls

--- a/packages/api-clients/open-api/purposeApi.yml
+++ b/packages/api-clients/open-api/purposeApi.yml
@@ -261,6 +261,9 @@ paths:
       responses:
         "200":
           description: Purpose created
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
           content:
             application/json:
               schema:

--- a/packages/m2m-gateway/src/routers/purposeRouter.ts
+++ b/packages/m2m-gateway/src/routers/purposeRouter.ts
@@ -265,6 +265,27 @@ const purposeRouter = (
         );
         return res.status(errorRes.status).send(errorRes);
       }
+    })
+    .post("/reversePurposes", async (req, res) => {
+      const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+      try {
+        validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+        const purpose = await purposeService.createReversePurpose(
+          req.body,
+          ctx
+        );
+
+        return res.status(201).send(m2mGatewayApi.Purpose.parse(purpose));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx,
+          `Error creating e-service purpose`
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
     });
 
   return purposeRouter;

--- a/packages/m2m-gateway/src/services/purposeService.ts
+++ b/packages/m2m-gateway/src/services/purposeService.ts
@@ -363,5 +363,25 @@ export function purposeServiceBuilder(clients: PagoPAInteropBeClients) {
       const polledPurpose = await pollPurposeById(purposeId, metadata, headers);
       return toM2MGatewayApiPurpose(polledPurpose.data);
     },
+    async createReversePurpose(
+      purposeSeed: m2mGatewayApi.EServicePurposeSeed,
+      { logger, headers }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApi.Purpose> {
+      logger.info(
+        `Creating reverse purpose for e-service ${purposeSeed.eserviceId}`
+      );
+
+      const purposeResponse =
+        await clients.purposeProcessClient.createPurposeFromEService(
+          { ...purposeSeed, eServiceId: purposeSeed.eserviceId },
+          {
+            headers,
+          }
+        );
+
+      const polledResource = await pollPurpose(purposeResponse, headers);
+
+      return toM2MGatewayApiPurpose(polledResource.data);
+    },
   };
 }

--- a/packages/m2m-gateway/test/api/purposes/createReversePurpose.test.ts
+++ b/packages/m2m-gateway/test/api/purposes/createReversePurpose.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  generateToken,
+  getMockedApiPurpose,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import { m2mGatewayApi, purposeApi } from "pagopa-interop-api-clients";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { api, mockPurposeService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { toM2MGatewayApiPurpose } from "../../../src/api/purposeApiConverter.js";
+
+describe("POST /reversePurposes router test", () => {
+  const mockPurpose: purposeApi.Purpose = getMockedApiPurpose();
+
+  const mockEServicePurposeSeed: m2mGatewayApi.EServicePurposeSeed = {
+    eserviceId: mockPurpose.eserviceId,
+    consumerId: mockPurpose.consumerId,
+    riskAnalysisId: generateId(),
+    description: mockPurpose.description,
+    dailyCalls: mockPurpose.versions[0].dailyCalls,
+    isFreeOfCharge: mockPurpose.isFreeOfCharge,
+    title: mockPurpose.title,
+  };
+
+  const mockM2MPurpose: m2mGatewayApi.Purpose =
+    toM2MGatewayApiPurpose(mockPurpose);
+
+  const makeRequest = async (
+    token: string,
+    body: m2mGatewayApi.EServicePurposeSeed
+  ) =>
+    request(api)
+      .post(`${appBasePath}/reversePurposes`)
+      .set("Authorization", `Bearer ${token}`)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 201 and perform service calls for user with role %s",
+    async (role) => {
+      mockPurposeService.createReversePurpose = vi
+        .fn()
+        .mockResolvedValue(mockM2MPurpose);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token, mockEServicePurposeSeed);
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual(mockM2MPurpose);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, mockEServicePurposeSeed);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { invalidParam: "invalidValue" },
+    { ...mockEServicePurposeSeed, extraParam: -1 },
+    { ...mockEServicePurposeSeed, description: "short" },
+  ])("Should return 400 if passed invalid delegation seed", async (body) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      body as m2mGatewayApi.EServicePurposeSeed
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it.each([missingMetadata(), pollingMaxRetriesExceeded(3, 10)])(
+    "Should return 500 in case of $code error",
+    async (error) => {
+      mockPurposeService.createReversePurpose = vi
+        .fn()
+        .mockRejectedValue(error);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token, mockEServicePurposeSeed);
+
+      expect(res.status).toBe(500);
+    }
+  );
+
+  it.each([
+    { ...mockM2MPurpose, createdAt: undefined },
+    { ...mockM2MPurpose, eserviceId: "invalidId" },
+    { ...mockM2MPurpose, extraParam: "extraValue" },
+    {},
+  ])(
+    "Should return 500 when API model parsing fails for response",
+    async (resp) => {
+      mockPurposeService.createReversePurpose = vi.fn().mockResolvedValue(resp);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token, mockEServicePurposeSeed);
+
+      expect(res.status).toBe(500);
+    }
+  );
+});

--- a/packages/m2m-gateway/test/integration/purposes/createReversePurpose.test.ts
+++ b/packages/m2m-gateway/test/integration/purposes/createReversePurpose.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { m2mGatewayApi } from "pagopa-interop-api-clients";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import {
+  getMockedApiPurpose,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientGetToHaveBeenNthCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+  purposeService,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("createReversePurpose", () => {
+  const mockPurposeProcessGetResponse = getMockWithMetadata(
+    getMockedApiPurpose()
+  );
+
+  const mockEServicePurposeSeed: m2mGatewayApi.EServicePurposeSeed = {
+    dailyCalls: mockPurposeProcessGetResponse.data.versions[0].dailyCalls,
+    description: mockPurposeProcessGetResponse.data.description,
+    eserviceId: mockPurposeProcessGetResponse.data.eserviceId,
+    consumerId: mockPurposeProcessGetResponse.data.consumerId,
+    riskAnalysisId: generateId(),
+    isFreeOfCharge: mockPurposeProcessGetResponse.data.isFreeOfCharge,
+    title: mockPurposeProcessGetResponse.data.title,
+  };
+
+  const mockCreatePurposeFromEService = vi
+    .fn()
+    .mockResolvedValue(mockPurposeProcessGetResponse);
+  const mockGetPurpose = vi.fn(
+    mockPollingResponse(mockPurposeProcessGetResponse, 2)
+  );
+
+  mockInteropBeClients.purposeProcessClient = {
+    getPurpose: mockGetPurpose,
+    createPurposeFromEService: mockCreatePurposeFromEService,
+  } as unknown as PagoPAInteropBeClients["purposeProcessClient"];
+
+  beforeEach(() => {
+    mockCreatePurposeFromEService.mockClear();
+    mockGetPurpose.mockClear();
+  });
+
+  it("Should succeed and perform service calls", async () => {
+    const expectedM2MPurpose: m2mGatewayApi.Purpose = {
+      consumerId: mockPurposeProcessGetResponse.data.consumerId,
+      createdAt: mockPurposeProcessGetResponse.data.createdAt,
+      description: mockPurposeProcessGetResponse.data.description,
+      eserviceId: mockPurposeProcessGetResponse.data.eserviceId,
+      id: mockPurposeProcessGetResponse.data.id,
+      isFreeOfCharge: mockPurposeProcessGetResponse.data.isFreeOfCharge,
+      isRiskAnalysisValid:
+        mockPurposeProcessGetResponse.data.isRiskAnalysisValid,
+      title: mockPurposeProcessGetResponse.data.title,
+      currentVersion: mockPurposeProcessGetResponse.data.versions.at(0),
+      delegationId: mockPurposeProcessGetResponse.data.delegationId,
+      freeOfChargeReason: mockPurposeProcessGetResponse.data.freeOfChargeReason,
+      rejectedVersion: undefined,
+      suspendedByConsumer: undefined,
+      suspendedByProducer: undefined,
+      updatedAt: mockPurposeProcessGetResponse.data.updatedAt,
+      waitingForApprovalVersion: undefined,
+    };
+
+    const mockAppContext = getMockM2MAdminAppContext();
+
+    const result = await purposeService.createReversePurpose(
+      mockEServicePurposeSeed,
+      mockAppContext
+    );
+
+    expect(result).toEqual(expectedM2MPurpose);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.purposeProcessClient.createPurposeFromEService,
+      body: {
+        ...mockEServicePurposeSeed,
+        eServiceId: mockEServicePurposeSeed.eserviceId,
+      },
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.purposeProcessClient.getPurpose,
+      params: { id: expectedM2MPurpose.id },
+    });
+    expectApiClientGetToHaveBeenNthCalledWith({
+      nthCall: 2,
+      mockGet: mockInteropBeClients.purposeProcessClient.getPurpose,
+      params: { id: expectedM2MPurpose.id },
+    });
+    expect(
+      mockInteropBeClients.purposeProcessClient.getPurpose
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw missingMetadata in case the purpose returned by the creation POST call has no metadata", async () => {
+    mockCreatePurposeFromEService.mockResolvedValueOnce({
+      ...mockPurposeProcessGetResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      purposeService.createReversePurpose(
+        mockEServicePurposeSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the purpose returned by the polling GET call has no metadata", async () => {
+    mockGetPurpose.mockResolvedValueOnce({
+      ...mockPurposeProcessGetResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      purposeService.createReversePurpose(
+        mockEServicePurposeSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetPurpose.mockImplementation(
+      mockPollingResponse(
+        mockPurposeProcessGetResponse,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      purposeService.createReversePurpose(
+        mockEServicePurposeSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetPurpose).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});

--- a/packages/purpose-process/src/routers/PurposeRouter.ts
+++ b/packages/purpose-process/src/routers/PurposeRouter.ts
@@ -134,10 +134,15 @@ const purposeRouter = (
       const ctx = fromAppContext(req.ctx);
 
       try {
-        validateAuthorization(ctx, [ADMIN_ROLE]);
+        validateAuthorization(ctx, [ADMIN_ROLE, M2M_ADMIN_ROLE]);
 
-        const { purpose, isRiskAnalysisValid } =
-          await purposeService.createReversePurpose(req.body, ctx);
+        const {
+          data: { purpose, isRiskAnalysisValid },
+          metadata,
+        } = await purposeService.createReversePurpose(req.body, ctx);
+
+        setMetadataVersionHeader(res, metadata);
+
         return res
           .status(200)
           .send(

--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -1215,8 +1215,14 @@ export function purposeServiceBuilder(
     },
     async createReversePurpose(
       seed: purposeApi.EServicePurposeSeed,
-      { authData, correlationId, logger }: WithLogger<AppContext<UIAuthData>>
-    ): Promise<{ purpose: Purpose; isRiskAnalysisValid: boolean }> {
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
+    ): Promise<
+      WithMetadata<{ purpose: Purpose; isRiskAnalysisValid: boolean }>
+    > {
       logger.info(
         `Creating Purpose for EService ${seed.eServiceId}, Consumer ${seed.consumerId}`
       );
@@ -1287,12 +1293,16 @@ export function purposeServiceBuilder(
         },
       };
 
-      await repository.createEvent(
+      const event = await repository.createEvent(
         toCreateEventPurposeAdded(purpose, correlationId)
       );
+
       return {
-        purpose,
-        isRiskAnalysisValid: true,
+        data: {
+          purpose,
+          isRiskAnalysisValid: true,
+        },
+        metadata: { version: event.newVersion },
       };
     },
     async clonePurpose({

--- a/packages/purpose-process/test/api/createReversePurpose.test.ts
+++ b/packages/purpose-process/test/api/createReversePurpose.test.ts
@@ -10,8 +10,9 @@ import {
   generateToken,
   getMockEService,
   getMockPurpose,
+  getMockWithMetadata,
 } from "pagopa-interop-commons-test";
-import { authRole } from "pagopa-interop-commons";
+import { AuthRole, authRole } from "pagopa-interop-commons";
 import request from "supertest";
 import { purposeApi } from "pagopa-interop-api-clients";
 import { api, purposeService } from "../vitest.api.setup.js";
@@ -38,15 +39,17 @@ describe("API POST /reverse/purposes test", () => {
   );
   const mockPurpose: Purpose = getMockPurpose();
   const isRiskAnalysisValid = true;
+  const serviceResponse = getMockWithMetadata({
+    purpose: mockPurpose,
+    isRiskAnalysisValid,
+  });
 
-  const apiResponse = purposeApi.Purpose.parse(
-    purposeToApiPurpose(mockPurpose, isRiskAnalysisValid)
-  );
+  const apiResponse = purposeToApiPurpose(mockPurpose, isRiskAnalysisValid);
 
   beforeEach(() => {
     purposeService.createReversePurpose = vi
       .fn()
-      .mockResolvedValue({ purpose: mockPurpose, isRiskAnalysisValid });
+      .mockResolvedValue(serviceResponse);
   });
 
   const makeRequest = async (
@@ -59,15 +62,26 @@ describe("API POST /reverse/purposes test", () => {
       .set("X-Correlation-Id", generateId())
       .send(body);
 
-  it("Should return 200 for user with role Admin", async () => {
-    const token = generateToken(authRole.ADMIN_ROLE);
-    const res = await makeRequest(token);
-    expect(res.body).toEqual(apiResponse);
-    expect(res.status).toBe(200);
-  });
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.body).toEqual(apiResponse);
+      expect(res.status).toBe(200);
+      expect(res.headers["x-metadata-version"]).toBe(
+        serviceResponse.metadata.version.toString()
+      );
+    }
+  );
 
   it.each(
-    Object.values(authRole).filter((role) => role !== authRole.ADMIN_ROLE)
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
   )("Should return 403 for user with role %s", async (role) => {
     const token = generateToken(role);
     const res = await makeRequest(token);

--- a/packages/purpose-process/test/integration/createReversePurpose.test.ts
+++ b/packages/purpose-process/test/integration/createReversePurpose.test.ts
@@ -100,11 +100,15 @@ describe("createReversePurpose", () => {
     await addOneTenant(consumer);
     await addOneAgreement(mockAgreement);
 
-    const { purpose, isRiskAnalysisValid } =
+    const createReversePurposeResponse =
       await purposeService.createReversePurpose(
         reversePurposeSeed,
         getMockContext({ authData: getMockAuthData(consumer.id) })
       );
+
+    const purpose = createReversePurposeResponse.data.purpose;
+    const isRiskAnalysisValid =
+      createReversePurposeResponse.data.isRiskAnalysisValid;
 
     const writtenEvent = await readLastPurposeEvent(purpose.id);
 
@@ -209,11 +213,15 @@ describe("createReversePurpose", () => {
     await addOneTenant(consumer);
     await addOneAgreement(mockAgreement);
 
-    const { purpose, isRiskAnalysisValid } =
+    const createReversePurposeResponse =
       await purposeService.createReversePurpose(
         reversePurposeSeed,
         getMockContext({ authData: getMockAuthData(delegateTenant.id) })
       );
+
+    const purpose = createReversePurposeResponse.data.purpose;
+    const isRiskAnalysisValid =
+      createReversePurposeResponse.data.isRiskAnalysisValid;
 
     const writtenEvent = await readLastPurposeEvent(purpose.id);
 
@@ -348,11 +356,15 @@ describe("createReversePurpose", () => {
     await addOneTenant(producerDelegate);
     await addOneAgreement(mockAgreement);
 
-    const { purpose, isRiskAnalysisValid } =
+    const createReversePurposeResponse =
       await purposeService.createReversePurpose(
         reversePurposeSeed,
         getMockContext({ authData: getMockAuthData(consumerDelegate.id) })
       );
+
+    const purpose = createReversePurposeResponse.data.purpose;
+    const isRiskAnalysisValid =
+      createReversePurposeResponse.data.isRiskAnalysisValid;
 
     const writtenEvent = await readLastPurposeEvent(purpose.id);
 


### PR DESCRIPTION
Closes [PIN-7155](https://pagopa.atlassian.net/browse/PIN-7155)
[SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/1812562407/DRAFT+SRS+API+V2+Parte+2#%5BPIN-7155%5D-Creazione-purpose-per-e-service-in-modalit%C3%A0-RECEIVE-%E2%80%93-POST-%2FreversePurposes)

# Description
Implemented `POST /reversePurposes` route in m2m gateway

## Implementation
- [x] Finalize SRS
- [x] JIRA task link in PR, with link to SRS
- [x] API spec of the route in `m2mGatewayApi.yml`
- [x] Documentation: description fields in the spec endpoint, response, errors, params, etc. 

## Double-check errors
- [x] Check errors returned by the process API calls (messages should be meaningful, clean, in correct English, etc.)
- [x] Check spec errors: it should list all non-500 errors, also the ones that pass through from the process

# Testing
Checklist:
- [x] Bruno call added to collection
- [ ] Smoke test Bruno (attach result screenshot)
- [x] Supertest /api tests
- [x] /integration tests for the logic in the service

