### PR TITLE
PIN-7185 - Fix risk analysis answers length by increasing the max length to 2000

### DIFF
--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -2680,7 +2680,7 @@ components:
             items:
               type: string
               minLength: 1
-              maxLength: 500
+              maxLength: 2000
       required:
         - version
         - answers

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -1466,7 +1466,7 @@ components:
             items:
               type: string
               minLength: 1
-              maxLength: 500
+              maxLength: 2000
       required:
         - version
         - answers

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -4927,7 +4927,7 @@ components:
             items:
               type: string
               minLength: 1
-              maxLength: 500
+              maxLength: 2000
       required:
         - version
         - answers

--- a/packages/api-clients/open-api/purposeApi.yml
+++ b/packages/api-clients/open-api/purposeApi.yml
@@ -1357,7 +1357,7 @@ components:
             items:
               type: string
               minLength: 1
-              maxLength: 500
+              maxLength: 2000
         riskAnalysisId:
           type: string
           format: uuid
@@ -1378,7 +1378,7 @@ components:
             items:
               type: string
               minLength: 1
-              maxLength: 500
+              maxLength: 2000
       required:
         - version
         - answers

--- a/packages/commons/src/risk-analysis/rules/PA/2.0.ts
+++ b/packages/commons/src/risk-analysis/rules/PA/2.0.ts
@@ -42,7 +42,7 @@ export const pa2 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -62,7 +62,7 @@ export const pa2 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -142,7 +142,7 @@ export const pa2 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -215,7 +215,7 @@ export const pa2 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -287,7 +287,7 @@ export const pa2 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -315,7 +315,7 @@ export const pa2 = {
         en: "TODO",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -343,7 +343,7 @@ export const pa2 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -500,7 +500,7 @@ export const pa2 = {
         en: "TODO",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,

--- a/packages/commons/src/risk-analysis/rules/PA/3.0.ts
+++ b/packages/commons/src/risk-analysis/rules/PA/3.0.ts
@@ -42,7 +42,7 @@ export const pa3 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -62,7 +62,7 @@ export const pa3 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -142,7 +142,7 @@ export const pa3 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -215,7 +215,7 @@ export const pa3 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -287,7 +287,7 @@ export const pa3 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -315,7 +315,7 @@ export const pa3 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -343,7 +343,7 @@ export const pa3 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -500,7 +500,7 @@ export const pa3 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,

--- a/packages/commons/src/risk-analysis/rules/PRIVATE/1.0.ts
+++ b/packages/commons/src/risk-analysis/rules/PRIVATE/1.0.ts
@@ -42,7 +42,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -62,7 +62,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -208,7 +208,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -297,7 +297,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -325,7 +325,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -405,7 +405,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -437,7 +437,7 @@ export const private1 = {
         en: "TODO",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -469,7 +469,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -672,7 +672,7 @@ export const private1 = {
         en: "TODO",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -733,7 +733,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -791,7 +791,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -938,7 +938,7 @@ export const private1 = {
         en: "",
       },
       validation: {
-        maxLength: 250,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,

--- a/packages/commons/src/risk-analysis/rules/PRIVATE/2.0.ts
+++ b/packages/commons/src/risk-analysis/rules/PRIVATE/2.0.ts
@@ -42,7 +42,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -62,7 +62,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -241,7 +241,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -330,7 +330,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -358,7 +358,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -438,7 +438,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -470,7 +470,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -502,7 +502,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -705,7 +705,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -766,7 +766,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -824,7 +824,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,
@@ -971,7 +971,7 @@ export const private2 = {
         en: "",
       },
       validation: {
-        maxLength: 500,
+        maxLength: 2000,
       },
       defaultValue: [],
       required: true,

--- a/packages/commons/src/risk-analysis/rules/riskAnalysisFormRules.ts
+++ b/packages/commons/src/risk-analysis/rules/riskAnalysisFormRules.ts
@@ -32,6 +32,7 @@ export type HideOptionConfig = z.infer<typeof HideOptionConfig>;
 const ValidationOption = z.object({
   maxLength: z.number().optional(),
 });
+export type ValidationOption = z.infer<typeof ValidationOption>;
 
 const LabeledValue = z.object({
   label: LocalizedText,

--- a/packages/purpose-process/src/model/domain/apiConverter.ts
+++ b/packages/purpose-process/src/model/domain/apiConverter.ts
@@ -18,6 +18,7 @@ import {
   LabeledValue,
   FormQuestionRules,
   RiskAnalysisFormRules,
+  ValidationOption,
 } from "pagopa-interop-commons";
 import { purposeApi } from "pagopa-interop-api-clients";
 
@@ -179,6 +180,12 @@ export const labeledValueToApiLabeledValue = (
   value: labeledValue.value,
 });
 
+export const validationToApiValidation = (
+  validation: ValidationOption
+): purposeApi.ValidationOptionResponse => ({
+  maxLength: validation.maxLength,
+});
+
 export const formConfigQuestionToApiFormConfigQuestion = (
   question: FormQuestionRules
 ): purposeApi.FormConfigQuestionResponse => {
@@ -195,6 +202,9 @@ export const formConfigQuestionToApiFormConfigQuestion = (
     defaultValue: question.defaultValue,
     hideOption: question.hideOption
       ? mapHideOptionToApiMapHideOption(question.hideOption)
+      : undefined,
+    validation: question.validation
+      ? validationToApiValidation(question.validation)
       : undefined,
   };
 


### PR DESCRIPTION
Related PR #1962 

This PR:
- increases the risk analysis answers max length to `2000`;
- adds the `validation` property to the `formConfigQuestionToApiFormConfigQuestion` function because it's needed by the FE.

Tested locally on the endpoint `/backend-for-frontend/purposes/riskAnalysis/latest?tenantKind={tenantKind}` which now also returns `validation` for the `"dataType": "FREETEXT"` questions.