### PR TITLE
Enhance E-Service filtering capabilities by adding new query paramete…

### DIFF
--- a/collections/catalog/Get eservices.bru
+++ b/collections/catalog/Get eservices.bru
@@ -19,6 +19,11 @@ params:query {
   ~agreementStates: ["SUSPENDED"]
   ~eservicesIds: ["adb7d6fa-9b8e-4eed-87b0-2b2bf3d95f7a"]
   ~states: "PUBLISHED, HELLO"
+  ~technology: REST
+  ~mode: RECEIVE
+  ~isSignalHubEnabled: true
+  ~isConsumerDelegable: true
+  ~isClientAccessDelegable: true
 }
 
 headers {

--- a/collections/m2m gateway/eservices/List eservices.bru
+++ b/collections/m2m gateway/eservices/List eservices.bru
@@ -13,8 +13,14 @@ get {
 params:query {
   offset: 0
   limit: 10
-  ~producersIds: 
-  ~templatesIds: 
+  ~producerIds: 
+  ~templateIds: 
+  ~name: 
+  technology: REST
+  mode: RECEIVE
+  isSignalHubEnabled: true
+  isConsumerDelegable: true
+  isClientAccessDelegable: true
 }
 
 headers {

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -2909,6 +2909,36 @@ paths:
             default: []
           explode: false
         - in: query
+          name: name
+          description: Filter E-Services by name
+          schema:
+            type: string
+        - in: query
+          name: technology
+          description: Filter E-Services by technology
+          schema:
+            $ref: "#/components/schemas/EServiceTechnology"
+        - in: query
+          name: mode
+          description: Filter E-Services by mode
+          schema:
+            $ref: "#/components/schemas/EServiceMode"
+        - in: query
+          name: isSignalHubEnabled
+          description: Filter E-Services by Signal Hub enabled status
+          schema:
+            type: boolean
+        - in: query
+          name: isConsumerDelegable
+          description: Filter E-Services by consumer delegable status
+          schema:
+            type: boolean
+        - in: query
+          name: isClientAccessDelegable
+          description: Filter E-Services by client access delegable status
+          schema:
+            type: boolean
+        - in: query
           name: offset
           description: Pagination starting position
           required: true

--- a/packages/catalog-process/src/model/domain/models.ts
+++ b/packages/catalog-process/src/model/domain/models.ts
@@ -12,6 +12,7 @@ import {
   AttributeId,
   TenantId,
   EServiceTemplateId,
+  Technology,
 } from "pagopa-interop-models";
 
 export type ApiGetEServicesFilters = {
@@ -21,8 +22,11 @@ export type ApiGetEServicesFilters = {
   states: DescriptorState[];
   agreementStates: AgreementState[];
   name?: string;
+  technology?: Technology;
   mode?: EServiceMode;
+  isSignalHubEnabled?: boolean;
   isConsumerDelegable?: boolean;
+  isClientAccessDelegable?: boolean;
   delegated?: boolean;
   templatesIds: EServiceTemplateId[];
 };

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -737,7 +737,7 @@ export function catalogServiceBuilder(
       }: WithLogger<AppContext<UIAuthData | M2MAuthData | M2MAdminAuthData>>
     ): Promise<ListResult<EService>> {
       logger.info(
-        `Getting EServices with name = ${filters.name}, ids = ${filters.eservicesIds}, producers = ${filters.producersIds}, states = ${filters.states}, agreementStates = ${filters.agreementStates}, mode = ${filters.mode}, isConsumerDelegable = ${filters.isConsumerDelegable}, limit = ${limit}, offset = ${offset}`
+        `Getting EServices with name = ${filters.name}, ids = ${filters.eservicesIds}, producers = ${filters.producersIds}, states = ${filters.states}, agreementStates = ${filters.agreementStates}, technology = ${filters.technology}, mode = ${filters.mode}, isSignalHubEnabled = ${filters.isSignalHubEnabled}, isConsumerDelegable = ${filters.isConsumerDelegable}, isClientAccessDelegable = ${filters.isClientAccessDelegable}, limit = ${limit}, offset = ${offset}`
       );
       const eservicesList = await readModelService.getEServices(
         authData,

--- a/packages/catalog-process/src/services/readModelService.ts
+++ b/packages/catalog-process/src/services/readModelService.ts
@@ -151,8 +151,11 @@ export function readModelServiceBuilder(
         agreementStates,
         name,
         attributesIds,
+        technology,
         mode,
+        isSignalHubEnabled,
         isConsumerDelegable,
+        isClientAccessDelegable,
         delegated,
         templatesIds,
       } = filters;
@@ -313,6 +316,24 @@ export function readModelServiceBuilder(
         ? { "data.mode": { $eq: mode } }
         : {};
 
+      const technologyFilter: ReadModelFilter<EService> = technology
+        ? { "data.technology": { $eq: technology } }
+        : {};
+
+      const isSignalHubEnabledFilter: ReadModelFilter<EService> =
+        isSignalHubEnabled === true
+          ? { "data.isSignalHubEnabled": { $eq: true } }
+          : isSignalHubEnabled === false
+          ? { "data.isSignalHubEnabled": { $ne: true } }
+          : {};
+
+      const isClientAccessDelegableFilter: ReadModelFilter<EService> =
+        isClientAccessDelegable === true
+          ? { "data.isClientAccessDelegable": { $eq: true } }
+          : isClientAccessDelegable === false
+          ? { "data.isClientAccessDelegable": { $ne: true } }
+          : {};
+
       const isConsumerDelegableFilter: ReadModelFilter<EService> =
         isConsumerDelegable === true
           ? { "data.isConsumerDelegable": { $eq: true } }
@@ -360,7 +381,10 @@ export function readModelServiceBuilder(
         { $match: attributesFilter },
         { $match: visibilityFilter },
         { $match: modeFilter },
+        { $match: technologyFilter },
+        { $match: isSignalHubEnabledFilter },
         { $match: isConsumerDelegableFilter },
+        { $match: isClientAccessDelegableFilter },
         { $match: delegatedFilter },
         { $match: templatesIdsFilter },
         {

--- a/packages/catalog-process/src/services/readModelServiceSQL.ts
+++ b/packages/catalog-process/src/services/readModelServiceSQL.ts
@@ -126,8 +126,11 @@ export function readModelServiceBuilderSQL(
         agreementStates,
         name,
         attributesIds,
+        technology,
         mode,
+        isSignalHubEnabled,
         isConsumerDelegable,
+        isClientAccessDelegable,
         delegated,
         templatesIds,
       } = filters;
@@ -260,6 +263,36 @@ export function readModelServiceBuilderSQL(
               : existsValidDescriptor(readmodelDB),
             // mode filter
             mode ? eq(eserviceInReadmodelCatalog.mode, mode) : undefined,
+            // technology filter
+            technology
+              ? eq(eserviceInReadmodelCatalog.technology, technology)
+              : undefined,
+            // isSignalHubEnabled filter
+            match(isSignalHubEnabled)
+              .with(true, () =>
+                eq(eserviceInReadmodelCatalog.isSignalHubEnabled, true)
+              )
+              .with(false, () =>
+                or(
+                  isNull(eserviceInReadmodelCatalog.isSignalHubEnabled),
+                  eq(eserviceInReadmodelCatalog.isSignalHubEnabled, false)
+                )
+              )
+              .with(undefined, () => undefined)
+              .exhaustive(),
+            // isClientAccessDelegable filter
+            match(isClientAccessDelegable)
+              .with(true, () =>
+                eq(eserviceInReadmodelCatalog.isClientAccessDelegable, true)
+              )
+              .with(false, () =>
+                or(
+                  isNull(eserviceInReadmodelCatalog.isClientAccessDelegable),
+                  eq(eserviceInReadmodelCatalog.isClientAccessDelegable, false)
+                )
+              )
+              .with(undefined, () => undefined)
+              .exhaustive(),
             // isConsumerDelegable filter
             match(isConsumerDelegable)
               .with(true, () =>

--- a/packages/catalog-process/test/integration/getEservices.test.ts
+++ b/packages/catalog-process/test/integration/getEservices.test.ts
@@ -1788,4 +1788,131 @@ describe("get eservices", () => {
       );
     }
   );
+
+  it("should get the eServices if they exist (parameters: technology)", async () => {
+    const result = await catalogService.getEServices(
+      {
+        eservicesIds: [],
+        producersIds: [],
+        states: [],
+        agreementStates: [],
+        attributesIds: [],
+        templatesIds: [],
+        technology: "Rest",
+      },
+      0,
+      50,
+      getMockContext({})
+    );
+    expect(result.totalCount).toBe(6);
+    expect(sortEServices(result.results)).toEqual(
+      sortEServices([
+        eservice1,
+        eservice2,
+        eservice3,
+        eservice4,
+        eservice5,
+        eservice6,
+      ])
+    );
+  });
+
+  it("should get the eServices if they exist (parameters: isSignalHubEnabled)", async () => {
+    const result1 = await catalogService.getEServices(
+      {
+        eservicesIds: [],
+        producersIds: [],
+        states: [],
+        agreementStates: [],
+        attributesIds: [],
+        templatesIds: [],
+        isSignalHubEnabled: true,
+      },
+      0,
+      50,
+      getMockContext({})
+    );
+
+    expect(result1.totalCount).toBe(1);
+    expect(sortEServices(result1.results)).toEqual(sortEServices([eservice1]));
+
+    const result2 = await catalogService.getEServices(
+      {
+        eservicesIds: [],
+        producersIds: [],
+        states: [],
+        agreementStates: [],
+        attributesIds: [],
+        templatesIds: [],
+        isSignalHubEnabled: false,
+      },
+      0,
+      50,
+      getMockContext({})
+    );
+    expect(result2.totalCount).toBe(5);
+    expect(sortEServices(result2.results)).toEqual(
+      sortEServices([eservice2, eservice3, eservice4, eservice5, eservice6])
+    );
+  });
+
+  it("should get the eServices if they exist (parameters: isClientAccessDelegable)", async () => {
+    const result1 = await catalogService.getEServices(
+      {
+        eservicesIds: [],
+        producersIds: [],
+        states: [],
+        agreementStates: [],
+        attributesIds: [],
+        templatesIds: [],
+        isClientAccessDelegable: true,
+      },
+      0,
+      50,
+      getMockContext({})
+    );
+
+    expect(result1.totalCount).toBe(1);
+    expect(sortEServices(result1.results)).toEqual(sortEServices([eservice1]));
+
+    const result2 = await catalogService.getEServices(
+      {
+        eservicesIds: [],
+        producersIds: [],
+        states: [],
+        agreementStates: [],
+        attributesIds: [],
+        templatesIds: [],
+        isClientAccessDelegable: false,
+      },
+      0,
+      50,
+      getMockContext({})
+    );
+    expect(result2.totalCount).toBe(5);
+    expect(sortEServices(result2.results)).toEqual(
+      sortEServices([eservice2, eservice3, eservice4, eservice5, eservice6])
+    );
+  });
+
+  it("should get the eServices if they exist (parameters: producersIds, mode)", async () => {
+    const result = await catalogService.getEServices(
+      {
+        eservicesIds: [],
+        producersIds: [organizationId2],
+        states: [],
+        agreementStates: [],
+        attributesIds: [],
+        templatesIds: [],
+        mode: eserviceMode.deliver,
+      },
+      0,
+      50,
+      getMockContext({})
+    );
+    expect(result.totalCount).toBe(2);
+    expect(sortEServices(result.results)).toEqual(
+      sortEServices([eservice4, eservice5])
+    );
+  });
 });

--- a/packages/m2m-gateway/src/api/eserviceApiConverter.ts
+++ b/packages/m2m-gateway/src/api/eserviceApiConverter.ts
@@ -6,13 +6,16 @@ export function toGetEServicesQueryParams(
   return {
     producersIds: params.producerIds,
     templatesIds: params.templateIds,
-    name: undefined,
+    name: params.name,
+    // technology: params.technology, // TODO: Add
     eservicesIds: [],
     attributesIds: [],
     states: [],
     agreementStates: [],
-    mode: undefined,
-    isConsumerDelegable: undefined,
+    mode: params.mode,
+    // isSignalHubEnabled: params.isSignalHubEnabled, // TODO: Add
+    isConsumerDelegable: params.isConsumerDelegable,
+    // isClientAccessDelegable: params.isClientAccessDelegable, // TODO: Add
     delegated: undefined,
     offset: params.offset,
     limit: params.limit,


### PR DESCRIPTION
# Description
Implemented Eservices filtering [SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/1812562407/DRAFT+SRS+API+V2+Parte+2#%5BPIN-7113%5D-%E2%80%93-Listing-e-services-parametri-aggiuntivi-%E2%80%93-GET-%2Feservices)

## Implementation
- [x] Finalize SRS
- [x] JIRA task link in PR, with link to SRS [JIRA](https://pagopa.atlassian.net/browse/PIN-7113)
- [x] API spec of the route in `m2mGatewayApi.yml`
- [x] Documentation: description fields in the spec endpoint, response, errors, params, etc. 

## Double-check errors
- [x] Check errors returned by the process API calls (messages should be meaningful, clean, in correct English, etc.)
- [x] Check spec errors: it should list all non-500 errors, also the ones that pass through from the process

# Testing
Checklist:
- [x] Bruno call added to collection
- [ ] Smoke test Bruno (attach result screenshot)
- [x] Supertest /api tests
- [x] /integration tests for the logic in the service