### PR TITLE
Hotfix: Restrict e-service template in RECEIVE mode creation

### DIFF
--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -1145,9 +1145,6 @@ export function eserviceTemplateServiceBuilder(
     ): Promise<EServiceTemplate> {
       logger.info(`Creating EService template with name ${seed.name}`);
 
-      /**
-       * TEMP: Remove this check when e-service template RECEIVE mode will be available
-       */
       if (seed.mode === eserviceTemplateApi.EServiceMode.Values.RECEIVE) {
         throw badRequestError(
           "EService template in RECEIVE mode is not supported"


### PR DESCRIPTION
This pull request introduces a temporary restriction to the eservice template in RECEIVE creation.
If a seed with `mode` in `RECEIVE` is passed, a 400 status code will be sent.