### PR TITLE
PIN-7195 - Renamed M2M Api download purpose document

### DIFF
--- a/collections/m2m gateway/purposes/Download Purpose version Risk Analysis document.bru
+++ b/collections/m2m gateway/purposes/Download Purpose version Risk Analysis document.bru
@@ -1,11 +1,11 @@
 meta {
-  name: Download Purpose version document
+  name: Download Purpose version Risk Analysis document
   type: http
   seq: 14
 }
 
 get {
-  url: {{host-m2m-gw}}/purposes/:purposeId/versions/:versionId/document
+  url: {{host-m2m-gw}}/purposes/:purposeId/versions/:versionId/riskAnalysisDocument
   body: none
   auth: none
 }

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -5607,7 +5607,7 @@ paths:
               $ref: "#/components/headers/RateLimitRemainingHeader"
             X-Rate-Limit-Interval:
               $ref: "#/components/headers/RateLimitIntervalHeader"
-  /purposes/{purposeId}/versions/{versionId}/document:
+  /purposes/{purposeId}/versions/{versionId}/riskAnalysisDocument:
     parameters:
       - name: purposeId
         in: path
@@ -5626,12 +5626,12 @@ paths:
     get:
       tags:
         - purposes
-      summary: Download a Purpose Document
-      description: Download the Document for the specified Purpose version
-      operationId: downloadPurposeVersionDocument
+      summary: Download a Purpose Risk Analysis Document
+      description: Download the Risk Analysis Document for the specified Purpose version
+      operationId: downloadPurposeVersionRiskAnalysisDocument
       responses:
         "200":
-          description: Purpose version document retrieved, a multipart containing the file and its metadata
+          description: Purpose version risk analysis document retrieved, a multipart containing the file and its metadata
           content:
             multipart/form-data:
               schema:

--- a/packages/m2m-gateway/src/routers/purposeRouter.ts
+++ b/packages/m2m-gateway/src/routers/purposeRouter.ts
@@ -19,7 +19,7 @@ import {
   approvePurposeErrorMapper,
   activatePurposeErrorMapper,
   unsuspendPurposeErrorMapper,
-  downloadPurposeVersionDocumentErrorMapper,
+  downloadPurposeVersionRiskAnalysisDocumentErrorMapper,
   getPurposeAgreementErrorMapper,
 } from "../utils/errorMappers.js";
 import { sendDownloadedDocumentAsFormData } from "../utils/fileDownload.js";
@@ -270,23 +270,24 @@ const purposeRouter = (
       }
     })
     .get(
-      "/purposes/:purposeId/versions/:versionId/document",
+      "/purposes/:purposeId/versions/:versionId/riskAnalysisDocument",
       async (req, res) => {
         const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
         try {
           validateAuthorization(ctx, [M2M_ROLE, M2M_ADMIN_ROLE]);
 
-          const document = await purposeService.downloadPurposeVersionDocument(
-            unsafeBrandId(req.params.purposeId),
-            unsafeBrandId(req.params.versionId),
-            ctx
-          );
+          const document =
+            await purposeService.downloadPurposeVersionRiskAnalysisDocument(
+              unsafeBrandId(req.params.purposeId),
+              unsafeBrandId(req.params.versionId),
+              ctx
+            );
 
           return sendDownloadedDocumentAsFormData(document, res);
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
-            downloadPurposeVersionDocumentErrorMapper,
+            downloadPurposeVersionRiskAnalysisDocumentErrorMapper,
             ctx,
             `Error retrieving document for purpose ${req.params.purposeId} with version ${req.params.versionId}`
           );

--- a/packages/m2m-gateway/src/services/purposeService.ts
+++ b/packages/m2m-gateway/src/services/purposeService.ts
@@ -442,7 +442,7 @@ export function purposeServiceBuilder(
 
       return toM2MGatewayApiPurpose(polledResource.data);
     },
-    async downloadPurposeVersionDocument(
+    async downloadPurposeVersionRiskAnalysisDocument(
       purposeId: PurposeId,
       versionId: PurposeVersionId,
       { logger, headers }: WithLogger<M2MGatewayAppContext>

--- a/packages/m2m-gateway/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway/src/utils/errorMappers.ts
@@ -104,7 +104,7 @@ export const unsuspendPurposeErrorMapper = (
     .with("missingPurposeVersionWithState", () => HTTP_STATUS_CONFLICT)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
-export const downloadPurposeVersionDocumentErrorMapper = (
+export const downloadPurposeVersionRiskAnalysisDocumentErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)

--- a/packages/m2m-gateway/test/api/purposes/downloadPurposeVersionRiskAnalysisDocument.test.ts
+++ b/packages/m2m-gateway/test/api/purposes/downloadPurposeVersionRiskAnalysisDocument.test.ts
@@ -25,7 +25,7 @@ describe("GET /purposes/:purposeId/versions/:versionId/document router test", ()
   ) =>
     request(api)
       .get(
-        `${appBasePath}/purposes/${purposeId}/versions/${versionId}/document`
+        `${appBasePath}/purposes/${purposeId}/versions/${versionId}/riskAnalysisDocument`
       )
       .set("Authorization", `Bearer ${token}`)
       .buffer(true)
@@ -39,7 +39,7 @@ describe("GET /purposes/:purposeId/versions/:versionId/document router test", ()
   it.each(authorizedRoles)(
     "Should return 200 and perform service calls for user with role %s",
     async (role) => {
-      mockPurposeService.downloadPurposeVersionDocument = vi
+      mockPurposeService.downloadPurposeVersionRiskAnalysisDocument = vi
         .fn()
         .mockResolvedValue(mockDownloadedDocument);
 
@@ -77,7 +77,7 @@ describe("GET /purposes/:purposeId/versions/:versionId/document router test", ()
     purposeVersionNotFound(generateId(), generateId()),
     purposeVersionDocumentNotFound(generateId(), generateId()),
   ])("Should return 404 in case of $code error", async (error) => {
-    mockPurposeService.downloadPurposeVersionDocument = vi
+    mockPurposeService.downloadPurposeVersionRiskAnalysisDocument = vi
       .fn()
       .mockRejectedValue(error);
     const token = generateToken(authRole.M2M_ADMIN_ROLE);

--- a/packages/m2m-gateway/test/integration/purposes/downloadPurposeVersionRiskAnalysisDocument.test.ts
+++ b/packages/m2m-gateway/test/integration/purposes/downloadPurposeVersionRiskAnalysisDocument.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../../../src/model/errors.js";
 import { config } from "../../../src/config/config.js";
 
-describe("downloadPurposeVersionDocument", () => {
+describe("downloadPurposeVersionRiskAnalysisDocument", () => {
   const testFileContent = `This is a mock file content for testing purposes.
 It simulates the content of a Purpose version document file.
 On multiple lines.`;
@@ -80,11 +80,12 @@ On multiple lines.`;
       ).at(0)
     ).toEqual(mockPurposeVersionDocument.path);
 
-    const result = await purposeService.downloadPurposeVersionDocument(
-      unsafeBrandId(mockPurposeProcessResponse.data.id),
-      unsafeBrandId(mockApiPurposeVersion.id),
-      getMockM2MAdminAppContext()
-    );
+    const result =
+      await purposeService.downloadPurposeVersionRiskAnalysisDocument(
+        unsafeBrandId(mockPurposeProcessResponse.data.id),
+        unsafeBrandId(mockApiPurposeVersion.id),
+        getMockM2MAdminAppContext()
+      );
 
     const expectedServiceResponse = {
       id: mockRiskAnalysisId,
@@ -104,7 +105,7 @@ On multiple lines.`;
   it("Should throw purposeVersionNotFound in case the returned purpose has no version with the given id", async () => {
     const nonExistingVersionId = generateId<PurposeVersionId>();
     await expect(
-      purposeService.downloadPurposeVersionDocument(
+      purposeService.downloadPurposeVersionRiskAnalysisDocument(
         unsafeBrandId(mockPurposeProcessResponse.data.id),
         nonExistingVersionId,
         getMockM2MAdminAppContext()
@@ -131,7 +132,7 @@ On multiple lines.`;
       },
     });
     await expect(
-      purposeService.downloadPurposeVersionDocument(
+      purposeService.downloadPurposeVersionRiskAnalysisDocument(
         unsafeBrandId(mockPurposeProcessResponse.data.id),
         unsafeBrandId(mockApiPurposeVersion.id),
         getMockM2MAdminAppContext()


### PR DESCRIPTION
This PR renames the path of the service that downloads purpose risk analysis document

from: `/purposes/{purposeId}/versions/{versionId}/document`
to: `/purposes/{purposeId}/versions/{versionId}/riskAnalysisDocument`

Also renamed all the services/files related accordingly