### PR TITLE
PIN-7253 - APIV2 POST /eservices/{eServiceId}/descriptors

### DIFF
--- a/collections/m2m gateway/eservices/Create Descriptor.bru
+++ b/collections/m2m gateway/eservices/Create Descriptor.bru
@@ -1,0 +1,46 @@
+meta {
+  name: Create Descriptor
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{host-m2m-gw}}/eservices/:eserviceId/descriptors
+  body: json
+  auth: none
+}
+
+params:path {
+  eserviceId: {{eserviceId}}
+}
+
+headers {
+  Authorization: {{JWT-M2M-ADMIN}}
+  X-Correlation-Id: {{correlation-id}}
+}
+
+body:json {
+  {
+      "description": "testone testone",
+      "audience": [
+          "string"
+      ],
+      "voucherLifespan": 86400,
+      "dailyCallsPerConsumer": 100,
+      "dailyCallsTotal": 100,
+      "agreementApprovalPolicy": "AUTOMATIC",
+      "attributes": {
+          "certified": [
+          ],
+          "declared": [
+          ],
+          "verified": [
+          ]
+      },
+      "docs": []
+  }
+}
+
+vars:post-response {
+  descriptorId: res.body.id
+}

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -497,6 +497,9 @@ paths:
       responses:
         "200":
           description: EService Descriptor created.
+          headers:
+              X-Metadata-Version:
+                $ref: "#/components/headers/MetadataVersionHeader"
           content:
             application/json:
               schema:
@@ -2309,6 +2312,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/Problem"
 components:
+  headers:
+    MetadataVersionHeader:
+      description: The version number of the resource in the read model
+      schema:
+        type: integer
+        format: int32
   parameters:
     CorrelationIdHeader:
       in: header

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -3680,6 +3680,93 @@ paths:
               $ref: "#/components/headers/RateLimitRemainingHeader"
             X-Rate-Limit-Interval:
               $ref: "#/components/headers/RateLimitIntervalHeader"
+    post:
+      tags:
+        - eservices
+      summary: Adds a descriptor to the specified e-service
+      operationId: createDescriptor
+      description: Adds a descriptor to the specified e-service
+      parameters:
+        - name: eserviceId
+          in: path
+          description: The E-Service id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: An E-Service Descriptor seed
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EServiceDescriptorSeed"
+        required: true
+      responses:
+        "200":
+          description: EService Descriptor created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceDescriptor"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "400":
+          description: Invalid input
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
   /eservices/{eserviceId}/descriptors/{descriptorId}:
     parameters:
       - name: eserviceId
@@ -7166,6 +7253,142 @@ components:
         - SUSPENDED
         - ARCHIVED
         - WAITING_FOR_APPROVAL
+    EServiceDescriptorSeed:
+      required:
+        - audience
+        - voucherLifespan
+        - dailyCallsPerConsumer
+        - dailyCallsTotal
+        - agreementApprovalPolicy
+        - attributes
+        - docs
+      type: object
+      additionalProperties: false
+      properties:
+        description:
+          type: string
+          minLength: 10
+          maxLength: 250
+        audience:
+          type: array
+          items:
+            type: string
+            minLength: 0
+            maxLength: 250
+        voucherLifespan:
+          type: integer
+          format: int32
+          minimum: 60
+          maximum: 86400
+        dailyCallsPerConsumer:
+          description: "maximum number of daily calls that this descriptor can afford."
+          type: integer
+          format: int32
+          minimum: 1
+        dailyCallsTotal:
+          description: "total daily calls available for this e-service."
+          type: integer
+          format: int32
+          minimum: 1
+        agreementApprovalPolicy:
+          $ref: "#/components/schemas/AgreementApprovalPolicy"
+        attributes:
+          $ref: "#/components/schemas/AttributesSeed"
+        docs:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateEServiceDescriptorDocumentSeed"
+    AttributesSeed:
+      properties:
+        certified:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/AttributeSeed"
+        declared:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/AttributeSeed"
+        verified:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/AttributeSeed"
+      required:
+        - certified
+        - declared
+        - verified
+    AttributeSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        explicitAttributeVerification:
+          type: boolean
+      required:
+        - id
+        - explicitAttributeVerification
+    CreateEServiceDescriptorDocumentSeed:
+      required:
+        - documentId
+        - kind
+        - prettyName
+        - filePath
+        - fileName
+        - contentType
+        - checksum
+        - serverUrls
+      type: object
+      additionalProperties: false
+      properties:
+        documentId:
+          type: string
+          format: uuid
+        kind:
+          $ref: "#/components/schemas/EServiceDocumentKind"
+        prettyName:
+          type: string
+        filePath:
+          type: string
+        fileName:
+          type: string
+        contentType:
+          type: string
+        checksum:
+          type: string
+        serverUrls:
+          type: array
+          items:
+            type: string
+        interfaceTemplateMetadata:
+          $ref: "#/components/schemas/TemplateInstanceInterfaceMetadata"
+    TemplateInstanceInterfaceMetadata:
+      type: object
+      additionalProperties: false
+      properties:
+        contactName:
+          type: string
+        contactEmail:
+          type: string
+          format: email
+        contactUrl:
+          type: string
+          format: uri
+        termsAndConditionsUrl:
+          type: string
+          format: uri
+    EServiceDocumentKind:
+      type: string
+      description: EService Document Kind
+      enum:
+        - INTERFACE
+        - DOCUMENT
     EServiceMode:
       type: string
       description: Indicates if the E-Service is intended for receiving or delivering data

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -5,6 +5,7 @@ import {
   authRole,
   ExpressContext,
   fromAppContext,
+  setMetadataVersionHeader,
   validateAuthorization,
   ZodiosContext,
   zodiosValidationErrorToApiProblem,
@@ -446,13 +447,15 @@ const eservicesRouter = (
       const ctx = fromAppContext(req.ctx);
 
       try {
-        validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE]);
+        validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
 
-        const descriptor = await catalogService.createDescriptor(
-          unsafeBrandId(req.params.eServiceId),
-          req.body,
-          ctx
-        );
+        const { data: descriptor, metadata } =
+          await catalogService.createDescriptor(
+            unsafeBrandId(req.params.eServiceId),
+            req.body,
+            ctx
+          );
+        setMetadataVersionHeader(res, metadata);
         return res
           .status(200)
           .send(

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1238,8 +1238,12 @@ export function catalogServiceBuilder(
     async createDescriptor(
       eserviceId: EServiceId,
       eserviceDescriptorSeed: catalogApi.EServiceDescriptorSeed,
-      { authData, correlationId, logger }: WithLogger<AppContext<UIAuthData>>
-    ): Promise<Descriptor> {
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
+    ): Promise<WithMetadata<Descriptor>> {
       logger.info(`Creating Descriptor for EService ${eserviceId}`);
 
       const eservice = await retrieveEService(eserviceId, readModelService);
@@ -1334,7 +1338,10 @@ export function catalogServiceBuilder(
       );
 
       await repository.createEvents(events);
-      return descriptorWithDocs;
+      return {
+        data: descriptorWithDocs,
+        metadata: { version: events[events.length - 1].version ?? 0 },
+      };
     },
 
     async deleteDraftDescriptor(

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -115,7 +115,7 @@ function isDescriptorUpdatableAfterPublish(descriptor: Descriptor): boolean {
 export async function assertRequesterIsDelegateProducerOrProducer(
   producerId: TenantId,
   eserviceId: EServiceId,
-  authData: UIAuthData | M2MAuthData,
+  authData: UIAuthData | M2MAuthData | M2MAdminAuthData,
   readModelService: ReadModelService
 ): Promise<void> {
   // Search for active producer delegation
@@ -141,7 +141,7 @@ export async function assertRequesterIsDelegateProducerOrProducer(
 
 export function assertRequesterIsProducer(
   producerId: TenantId,
-  authData: UIAuthData | M2MAuthData
+  authData: UIAuthData | M2MAuthData | M2MAdminAuthData
 ): void {
   if (producerId !== authData.organizationId) {
     throw operationForbidden;

--- a/packages/catalog-process/test/integration/createDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/createDescriptor.test.ts
@@ -85,7 +85,7 @@ describe("create descriptor", async () => {
       descriptorSeed,
       getMockContext({ authData: getMockAuthData(eservice.producerId) })
     );
-    const newDescriptorId = returnedDescriptor.id;
+    const newDescriptorId = returnedDescriptor.data.id;
     const writtenEvent = await readLastEserviceEvent(eservice.id);
     expect(writtenEvent).toMatchObject({
       stream_id: eservice.id,
@@ -128,7 +128,7 @@ describe("create descriptor", async () => {
       descriptorId: newDescriptorId,
       eservice: toEServiceV2({
         ...eservice,
-        descriptors: [returnedDescriptor],
+        descriptors: [returnedDescriptor.data],
       }),
     });
   });
@@ -173,7 +173,7 @@ describe("create descriptor", async () => {
       descriptorSeed,
       getMockContext({ authData: getMockAuthData(eservice.producerId) })
     );
-    const newDescriptorId = returnedDescriptor.id;
+    const newDescriptorId = returnedDescriptor.data.id;
     const descriptorCreationEvent = await readEventByStreamIdAndVersion(
       eservice.id,
       1,
@@ -293,7 +293,7 @@ describe("create descriptor", async () => {
       descriptorSeed,
       getMockContext({ authData: getMockAuthData(delegation.delegateId) })
     );
-    const newDescriptorId = returnedDescriptor.id;
+    const newDescriptorId = returnedDescriptor.data.id;
     const descriptorCreationEvent = await readEventByStreamIdAndVersion(
       eservice.id,
       1,

--- a/packages/m2m-gateway/src/routers/eserviceRouter.ts
+++ b/packages/m2m-gateway/src/routers/eserviceRouter.ts
@@ -95,6 +95,31 @@ const eserviceRouter = (
         return res.status(errorRes.status).send(errorRes);
       }
     })
+    .post("/eservices/:eserviceId/descriptors", async (req, res) => {
+      const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+      try {
+        validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+        const descriptor = await eserviceService.createDescriptor(
+          unsafeBrandId(req.params.eserviceId),
+          req.body,
+          ctx
+        );
+
+        return res
+          .status(200)
+          .send(m2mGatewayApi.EServiceDescriptor.parse(descriptor));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx,
+          `Error creating descriptor`
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
     .get(
       "/eservices/:eserviceId/descriptors/:descriptorId",
       async (req, res) => {

--- a/packages/m2m-gateway/test/api/eservices/createDescriptor.test.ts
+++ b/packages/m2m-gateway/test/api/eservices/createDescriptor.test.ts
@@ -1,0 +1,171 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import {
+  Attribute,
+  generateId,
+  pollingMaxRetriesExceeded,
+} from "pagopa-interop-models";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { catalogApi, m2mGatewayApi } from "pagopa-interop-api-clients";
+import {
+  generateToken,
+  getMockedApiEservice,
+} from "pagopa-interop-commons-test";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { toM2MGatewayApiEServiceDescriptor } from "../../../src/api/eserviceApiConverter.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("API /eservices/{eServiceId}/descriptors authorization test", () => {
+  const attribute: Attribute = {
+    name: "Attribute name",
+    id: generateId(),
+    kind: "Declared",
+    description: "Attribute Description",
+    creationTime: new Date(),
+  };
+
+  const descriptorSeed: catalogApi.EServiceDescriptorSeed = {
+    attributes: {
+      certified: [],
+      declared: [[{ id: attribute.id, explicitAttributeVerification: false }]],
+      verified: [],
+    },
+    audience: ["http/test.test"],
+    voucherLifespan: 100,
+    dailyCallsPerConsumer: 10,
+    dailyCallsTotal: 10,
+    docs: [
+      {
+        prettyName: "prettyName",
+        contentType: "",
+        documentId: generateId(),
+        kind: "INTERFACE",
+        serverUrls: [],
+        checksum: "",
+        fileName: "testName",
+        filePath: "/test/test",
+      },
+    ],
+    agreementApprovalPolicy: "AUTOMATIC",
+  };
+
+  const mockApiDescriptor: catalogApi.EServiceDescriptor = {
+    version: "1",
+    id: generateId(),
+    serverUrls: [],
+    attributes: {
+      certified: [],
+      declared: [[{ id: attribute.id, explicitAttributeVerification: false }]],
+      verified: [],
+    },
+    state: "DRAFT",
+    audience: descriptorSeed.audience,
+    voucherLifespan: descriptorSeed.voucherLifespan,
+    dailyCallsPerConsumer: descriptorSeed.dailyCallsPerConsumer,
+    dailyCallsTotal: descriptorSeed.dailyCallsTotal,
+    docs: descriptorSeed.docs.map((doc) => ({
+      path: doc.filePath,
+      id: doc.documentId,
+      name: doc.fileName,
+      prettyName: doc.prettyName,
+      contentType: doc.contentType,
+      checksum: doc.checksum,
+    })),
+    agreementApprovalPolicy: descriptorSeed.agreementApprovalPolicy,
+  };
+
+  const mockApiEservice = getMockedApiEservice({
+    descriptors: [mockApiDescriptor],
+  });
+
+  const mockM2MEserviceDescriptorResponse: m2mGatewayApi.EServiceDescriptor =
+    toM2MGatewayApiEServiceDescriptor(mockApiDescriptor);
+
+  mockEserviceService.createDescriptor = vi
+    .fn()
+    .mockResolvedValue(mockM2MEserviceDescriptorResponse);
+
+  const makeRequest = async (
+    token: string,
+    eserviceId: string,
+    body: catalogApi.EServiceDescriptorSeed = descriptorSeed
+  ) =>
+    request(api)
+      .post(`${appBasePath}/eservices/${eserviceId}/descriptors`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token, mockApiEservice.id);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockM2MEserviceDescriptorResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, mockApiEservice.id);
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { ...descriptorSeed, audience: undefined },
+    { ...descriptorSeed, voucherLifespan: undefined },
+    { ...descriptorSeed, dailyCallsPerConsumer: undefined },
+    { ...descriptorSeed, dailyCallsTotal: undefined },
+    { ...descriptorSeed, agreementApprovalPolicy: "INVALID_POLICY" },
+    {
+      ...descriptorSeed,
+      docs: [
+        {
+          ...descriptorSeed.docs[0],
+          kind: "INVALID_KIND",
+        },
+      ],
+    },
+    {
+      ...descriptorSeed,
+      attributes: {
+        ...descriptorSeed.attributes,
+        declared: undefined,
+      },
+    },
+    {
+      ...descriptorSeed,
+      docs: undefined,
+    },
+  ])(
+    "Should return 400 if passed an invalid Descriptor seed: %s",
+    async (body) => {
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        mockApiEservice.id,
+        body as catalogApi.EServiceDescriptorSeed
+      );
+
+      expect(res.status).toBe(400);
+    }
+  );
+
+  it.each([missingMetadata(), pollingMaxRetriesExceeded(3, 10)])(
+    "Should return 500 in case of $code error",
+    async (error) => {
+      mockEserviceService.createDescriptor = vi.fn().mockRejectedValue(error);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token, mockApiEservice.id);
+
+      expect(res.status).toBe(500);
+    }
+  );
+});

--- a/packages/m2m-gateway/test/integration/eservices/createDescriptor.test.ts
+++ b/packages/m2m-gateway/test/integration/eservices/createDescriptor.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { catalogApi, m2mGatewayApi } from "pagopa-interop-api-clients";
+import {
+  Attribute,
+  EServiceId,
+  generateId,
+  pollingMaxRetriesExceeded,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceService,
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("createDescriptor", () => {
+  const attribute: Attribute = {
+    name: "Attribute name",
+    id: generateId(),
+    kind: "Declared",
+    description: "Attribute Description",
+    creationTime: new Date(),
+  };
+
+  const descriptorSeed: catalogApi.EServiceDescriptorSeed = {
+    attributes: {
+      certified: [],
+      declared: [[{ id: attribute.id, explicitAttributeVerification: false }]],
+      verified: [],
+    },
+    audience: ["http/test.test"],
+    voucherLifespan: 100,
+    dailyCallsPerConsumer: 10,
+    dailyCallsTotal: 10,
+    docs: [
+      {
+        prettyName: "prettyName",
+        contentType: "",
+        documentId: generateId(),
+        kind: "INTERFACE",
+        serverUrls: [],
+        checksum: "",
+        fileName: "testName",
+        filePath: "/test/test",
+      },
+    ],
+    agreementApprovalPolicy: "AUTOMATIC",
+  };
+
+  const mockApiDescriptor: catalogApi.EServiceDescriptor = {
+    version: "1",
+    id: generateId(),
+    serverUrls: [],
+    attributes: {
+      certified: [],
+      declared: [[{ id: attribute.id, explicitAttributeVerification: false }]],
+      verified: [],
+    },
+    state: "DRAFT",
+    audience: descriptorSeed.audience,
+    voucherLifespan: descriptorSeed.voucherLifespan,
+    dailyCallsPerConsumer: descriptorSeed.dailyCallsPerConsumer,
+    dailyCallsTotal: descriptorSeed.dailyCallsTotal,
+    docs: descriptorSeed.docs.map((doc) => ({
+      path: doc.filePath,
+      id: doc.documentId,
+      name: doc.fileName,
+      prettyName: doc.prettyName,
+      contentType: doc.contentType,
+      checksum: doc.checksum,
+    })),
+    agreementApprovalPolicy: descriptorSeed.agreementApprovalPolicy,
+  };
+
+  const mockApiEservice = getMockedApiEservice({
+    descriptors: [mockApiDescriptor],
+  });
+
+  const mockEserviceDescriptorProcessResponse =
+    getMockWithMetadata(mockApiDescriptor);
+
+  const mockEserviceProcessResponse = getMockWithMetadata(mockApiEservice);
+
+  const mockcreateDescriptor = vi
+    .fn()
+    .mockResolvedValue(mockEserviceDescriptorProcessResponse);
+
+  const mockGetEservice = vi.fn(
+    mockPollingResponse(mockEserviceProcessResponse, 2)
+  );
+
+  mockInteropBeClients.catalogProcessClient = {
+    createDescriptor: mockcreateDescriptor,
+    getEServiceById: mockGetEservice,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    // Clear mock counters and call information before each test
+    mockcreateDescriptor.mockClear();
+    mockGetEservice.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const m2mEserviceDescriptorResponse: m2mGatewayApi.EServiceDescriptor = {
+      id: mockApiDescriptor.id,
+      state: mockApiDescriptor.state,
+      version: mockApiDescriptor.version,
+      serverUrls: mockApiDescriptor.serverUrls,
+      audience: mockApiDescriptor.audience,
+      voucherLifespan: mockApiDescriptor.voucherLifespan,
+      dailyCallsPerConsumer: mockApiDescriptor.dailyCallsPerConsumer,
+      dailyCallsTotal: mockApiDescriptor.dailyCallsTotal,
+      agreementApprovalPolicy: mockApiDescriptor.agreementApprovalPolicy,
+    };
+
+    const result = await eserviceService.createDescriptor(
+      mockApiEservice.id as EServiceId,
+      descriptorSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toEqual(m2mEserviceDescriptorResponse);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost: mockInteropBeClients.catalogProcessClient.createDescriptor,
+      params: { eServiceId: mockEserviceProcessResponse.data.id },
+      body: descriptorSeed,
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockEserviceProcessResponse.data.id },
+    });
+    expect(
+      mockInteropBeClients.catalogProcessClient.getEServiceById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw missingMetadata in case the attribute returned by the creation POST call has no metadata", async () => {
+    mockcreateDescriptor.mockResolvedValueOnce({
+      ...mockEserviceDescriptorProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.createDescriptor(
+        mockApiEservice.id as EServiceId,
+        descriptorSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the attribute returned by the polling GET call has no metadata", async () => {
+    mockGetEservice.mockResolvedValueOnce({
+      ...mockEserviceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.createDescriptor(
+        mockApiEservice.id as EServiceId,
+        descriptorSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEservice.mockImplementation(
+      mockPollingResponse(
+        mockEserviceProcessResponse,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      eserviceService.createDescriptor(
+        mockApiEservice.id as EServiceId,
+        descriptorSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEservice).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});


### PR DESCRIPTION
Closes [PIN-7253](https://pagopa.atlassian.net/browse/PIN-7253)
[SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/edit-v2/1812562407)

# Description
Implemented `POST /eservices/{eServiceId}/descriptors` route in m2m gateway

## Implementation
- [x] Finalize SRS
- [x] JIRA task link in PR, with link to SRS
- [x] API spec of the route in `m2mGatewayApi.yml`
- [x] Documentation: description fields in the spec endpoint, response, errors, params, etc. 

## Double-check errors
- [x] Check errors returned by the process API calls (messages should be meaningful, clean, in correct English, etc.)
- [x] Check spec errors: it should list all non-500 errors, also the ones that pass through from the process

# Testing
Checklist:
- [x] Bruno call added to collection
- [x] Smoke test Bruno (attach result screenshot)
- [] Supertest /api tests
- [x] /integration tests for the logic in the service
