### PR TITLE
PIN-7354 fixing delegated purpose creation in API V2

### DIFF
--- a/collections/agreement/Create Agreement.bru
+++ b/collections/agreement/Create Agreement.bru
@@ -18,7 +18,8 @@ headers {
 body:json {
   {
       "eserviceId":"{{eserviceId}}",
-      "descriptorId":"{{descriptorId}}"
+      "descriptorId":"{{descriptorId}}",
+      "delegationId": "{{delegationId}}"
   }
 }
 

--- a/collections/catalog/Create Eservice.bru
+++ b/collections/catalog/Create Eservice.bru
@@ -27,7 +27,8 @@ body:json {
           "dailyCallsPerConsumer": 100,
           "dailyCallsTotal": 100,
           "agreementApprovalPolicy": "MANUAL"
-      }
+      },
+      "isConsumerDelegable": true
   }
 }
 
@@ -38,6 +39,6 @@ vars:post-response {
 
 script:pre-request {
   const random = Math.round(Math.random() * 100)
-  
+
   bru.setVar("randomName",`test name ${random}`)
 }

--- a/collections/environments/PagoPA local.bru
+++ b/collections/environments/PagoPA local.bru
@@ -3,7 +3,7 @@ vars {
   JWT: Bearer {{process.env.JWT}}
   host-catalog: http://localhost:3000
   correlation-id: 79eb4963-3866-422f-8ef0-87871e5f9a71
-  JWT-Invalid: 
+  JWT-Invalid:
   host-bff: http://localhost:3600/backend-for-frontend/0.0
   host-attribute: http://localhost:3200
   host-tenant: http://localhost:3500
@@ -19,5 +19,6 @@ vars {
   host-notification-config: http://localhost:4100
   JWT-API-SEC: Bearer {{process.env.JWT-API-SEC}}
   JWT-M2M-ADMIN: Bearer {{process.env.JWT-M2M-ADMIN}}
+  JWT2-M2M-ADMIN: Bearer {{process.env.JWT2-M2M-ADMIN}}
   host-in-app-notification: http://localhost:4200
 }

--- a/collections/m2m gateway/purposes/Create Reverse Purpose.bru
+++ b/collections/m2m gateway/purposes/Create Reverse Purpose.bru
@@ -18,7 +18,7 @@ body:json {
   {
       "eserviceId": "{{eserviceId}}",
       "riskAnalysisId": "{{riskAnalysisId}}",
-      "consumerId": "{{tenantId}}",
+      "delegationId": "{{delegationId}}",
       "title": "{{randomName}}",
       "description": "a purpose long description",
       "isFreeOfCharge": true,
@@ -33,6 +33,6 @@ vars:post-response {
 
 script:pre-request {
   const random = Math.round(Math.random() * 100)
-  
+
   bru.setVar("randomName",`test name ${random}`)
 }

--- a/collections/m2m gateway/purposes/Create purpose.bru
+++ b/collections/m2m gateway/purposes/Create purpose.bru
@@ -17,7 +17,7 @@ headers {
 body:json {
   {
     "eserviceId": "{{eserviceId}}",
-    "consumerId": "{{tenantId}}",
+    "delegationId": "{{delegationId}}",
     "title": "{{randomLoremWord}} test",
     "description": "{{randomLoremWords}}",
     "isFreeOfCharge": {{randomBoolean}},

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -7931,7 +7931,11 @@ components:
         eserviceId:
           type: string
           format: uuid
-        delegationId:
+        consumerId:
+          description: |
+            The ID of the tenant that will consume the e-service. It can be:
+            - the ID of your tenant
+            - the ID of a tenant for which you are the consumer delegate
           type: string
           format: uuid
         riskAnalysisForm:
@@ -7954,6 +7958,7 @@ components:
           minimum: 0
       required:
         - eserviceId
+        - consumerId
         - title
         - description
         - isFreeOfCharge
@@ -7961,11 +7966,16 @@ components:
     EServicePurposeSeed:
       type: object
       additionalProperties: false
+      description: contains the expected payload for reverse purpose creation
       properties:
         eserviceId:
           type: string
           format: uuid
         consumerId:
+          description: |
+            The ID of the tenant that will consume the e-service. It can be:
+            - the ID of your tenant
+            - the ID of a tenant for which you are the consumer delegate
           type: string
           format: uuid
         riskAnalysisId:

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -7931,11 +7931,10 @@ components:
         eserviceId:
           type: string
           format: uuid
-        consumerId:
+        delegationId:
           description: |
-            The ID of the tenant that will consume the e-service. It can be:
-            - the ID of your tenant
-            - the ID of a tenant for which you are the consumer delegate
+            Set it to create the Purpose for a Tenant for which you are the e-service consumer delegate.
+            If not set, the Purpose will be created for your Tenant.
           type: string
           format: uuid
         riskAnalysisForm:
@@ -7958,7 +7957,6 @@ components:
           minimum: 0
       required:
         - eserviceId
-        - consumerId
         - title
         - description
         - isFreeOfCharge
@@ -7971,11 +7969,10 @@ components:
         eserviceId:
           type: string
           format: uuid
-        consumerId:
+        delegationId:
           description: |
-            The ID of the tenant that will consume the e-service. It can be:
-            - the ID of your tenant
-            - the ID of a tenant for which you are the consumer delegate
+            Set it to create the Purpose for a Tenant for which you are the e-service consumer delegate.
+            If not set, the Purpose will be created for your Tenant.
           type: string
           format: uuid
         riskAnalysisId:
@@ -7998,7 +7995,6 @@ components:
           format: int32
       required:
         - eserviceId
-        - consumerId
         - title
         - riskAnalysisId
         - description

--- a/packages/api-clients/open-api/purposeApi.yml
+++ b/packages/api-clients/open-api/purposeApi.yml
@@ -1275,6 +1275,10 @@ components:
           type: string
           format: uuid
         consumerId:
+          description: |
+            The ID of the tenant that will consume the e-service. It can be:
+            - the ID of your tenant
+            - the ID of a tenant for which you are the consumer delegate
           type: string
           format: uuid
         riskAnalysisId:
@@ -1312,6 +1316,10 @@ components:
           type: string
           format: uuid
         consumerId:
+          description: |
+            The ID of the tenant that will consume the e-service. It can be:
+            - the ID of your tenant
+            - the ID of a tenant for which you are the consumer delegate
           type: string
           format: uuid
         riskAnalysisForm:

--- a/packages/m2m-gateway/src/model/errors.ts
+++ b/packages/m2m-gateway/src/model/errors.ts
@@ -12,6 +12,7 @@ import {
   makeApiProblemBuilder,
   PurposeId,
   PurposeVersionId,
+  TenantId,
 } from "pagopa-interop-models";
 
 export const errorCodes = {
@@ -37,6 +38,7 @@ export const errorCodes = {
   unexpectedClientKind: "0021",
   purposeAgreementNotFound: "0022",
   agreementContractNotFound: "0023",
+  notAnActiveConsumerDelegation: "0024",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -245,5 +247,17 @@ export function agreementContractNotFound(
     detail: `Contract not found for agreement ${agreementId}`,
     code: "agreementContractNotFound",
     title: "Agreement contract not found",
+  });
+}
+
+export function notAnActiveConsumerDelegation(
+  requesterTenantId: TenantId,
+  eserviceId: string,
+  delegation: delegationApi.Delegation
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Delegation ${delegation.id} is not an active consumer delegation for e-service ${eserviceId} and delegate ${requesterTenantId}`,
+    code: "notAnActiveConsumerDelegation",
+    title: "Not an active consumer delegation",
   });
 }

--- a/packages/m2m-gateway/src/routers/purposeRouter.ts
+++ b/packages/m2m-gateway/src/routers/purposeRouter.ts
@@ -21,6 +21,7 @@ import {
   unsuspendPurposeErrorMapper,
   downloadPurposeVersionRiskAnalysisDocumentErrorMapper,
   getPurposeAgreementErrorMapper,
+  createPurposeErrorMapper,
 } from "../utils/errorMappers.js";
 import { sendDownloadedDocumentAsFormData } from "../utils/fileDownload.js";
 
@@ -133,7 +134,7 @@ const purposeRouter = (
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
-          emptyErrorMapper,
+          createPurposeErrorMapper,
           ctx,
           `Error creating purpose`
         );
@@ -309,7 +310,7 @@ const purposeRouter = (
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
-          emptyErrorMapper,
+          createPurposeErrorMapper,
           ctx,
           `Error creating reverse purpose`
         );

--- a/packages/m2m-gateway/src/services/purposeService.ts
+++ b/packages/m2m-gateway/src/services/purposeService.ts
@@ -168,8 +168,14 @@ export function purposeServiceBuilder(
 
       const purposeResponse = await clients.purposeProcessClient.createPurpose(
         {
-          ...purposeSeed,
-          consumerId: authData.organizationId,
+          consumerId: purposeSeed.consumerId,
+          eserviceId: purposeSeed.eserviceId,
+          dailyCalls: purposeSeed.dailyCalls,
+          description: purposeSeed.description,
+          isFreeOfCharge: purposeSeed.isFreeOfCharge,
+          riskAnalysisForm: purposeSeed.riskAnalysisForm,
+          title: purposeSeed.title,
+          freeOfChargeReason: purposeSeed.freeOfChargeReason,
         },
         { headers }
       );

--- a/packages/m2m-gateway/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway/src/utils/errorMappers.ts
@@ -11,6 +11,7 @@ const {
   HTTP_STATUS_BAD_REQUEST,
   HTTP_STATUS_NOT_FOUND,
   HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_FORBIDDEN,
 } = constants;
 
 export const approveAgreementErrorMapper = (
@@ -129,3 +130,8 @@ export function downloadAgreementConsumerContractErrorMapper(
     .with("agreementContractNotFound", () => HTTP_STATUS_NOT_FOUND)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 }
+
+export const createPurposeErrorMapper = (error: ApiError<ErrorCodes>): number =>
+  match(error.code)
+    .with("notAnActiveConsumerDelegation", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/m2m-gateway/src/utils/validators/validators.ts
+++ b/packages/m2m-gateway/src/utils/validators/validators.ts
@@ -1,5 +1,9 @@
-import { WithMetadata, unauthorizedError } from "pagopa-interop-models";
-import { authorizationApi } from "pagopa-interop-api-clients";
+import {
+  TenantId,
+  WithMetadata,
+  unauthorizedError,
+} from "pagopa-interop-models";
+import { authorizationApi, delegationApi } from "pagopa-interop-api-clients";
 import { WithMaybeMetadata } from "../../clients/zodiosWithMetadataPatch.js";
 import { missingMetadata } from "../../model/errors.js";
 
@@ -27,6 +31,24 @@ export function assertClientVisibilityIsFull(
   if (client.visibility !== authorizationApi.Visibility.Values.FULL) {
     throw unauthorizedError(
       `Tenant is not the owner of the client with id ${client.id}`
+    );
+  }
+}
+
+export function assertActiveConsumerDelegateForEservice(
+  requesterTenantId: TenantId,
+  eserviceId: string,
+  delegation: delegationApi.Delegation
+): void {
+  if (
+    delegation.kind !==
+      delegationApi.DelegationKind.Values.DELEGATED_CONSUMER ||
+    delegation.state !== delegationApi.DelegationState.Values.ACTIVE ||
+    delegation.delegateId !== requesterTenantId ||
+    delegation.eserviceId !== eserviceId
+  ) {
+    throw unauthorizedError(
+      `Delegation ${delegation.id} is not an active consumer delegation for e-service ${eserviceId} and delegate ${requesterTenantId}`
     );
   }
 }

--- a/packages/m2m-gateway/src/utils/validators/validators.ts
+++ b/packages/m2m-gateway/src/utils/validators/validators.ts
@@ -5,7 +5,10 @@ import {
 } from "pagopa-interop-models";
 import { authorizationApi, delegationApi } from "pagopa-interop-api-clients";
 import { WithMaybeMetadata } from "../../clients/zodiosWithMetadataPatch.js";
-import { missingMetadata } from "../../model/errors.js";
+import {
+  missingMetadata,
+  notAnActiveConsumerDelegation,
+} from "../../model/errors.js";
 
 export function assertMetadataExists<T>(
   resource: WithMaybeMetadata<T>
@@ -47,8 +50,10 @@ export function assertActiveConsumerDelegateForEservice(
     delegation.delegateId !== requesterTenantId ||
     delegation.eserviceId !== eserviceId
   ) {
-    throw unauthorizedError(
-      `Delegation ${delegation.id} is not an active consumer delegation for e-service ${eserviceId} and delegate ${requesterTenantId}`
+    throw notAnActiveConsumerDelegation(
+      requesterTenantId,
+      eserviceId,
+      delegation
     );
   }
 }

--- a/packages/m2m-gateway/test/api/purposes/createPurpose.test.ts
+++ b/packages/m2m-gateway/test/api/purposes/createPurpose.test.ts
@@ -6,7 +6,8 @@ import {
 import { AuthRole, authRole } from "pagopa-interop-commons";
 import request from "supertest";
 import { m2mGatewayApi, purposeApi } from "pagopa-interop-api-clients";
-import { pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { generateMock } from "@anatine/zod-mock";
 import { api, mockPurposeService } from "../../vitest.api.setup.js";
 import { appBasePath } from "../../../src/config/appBasePath.js";
 import { missingMetadata } from "../../../src/model/errors.js";
@@ -21,6 +22,8 @@ describe("POST /purposes router test", () => {
     eserviceId: mockPurpose.eserviceId,
     isFreeOfCharge: mockPurpose.isFreeOfCharge,
     title: mockPurpose.title,
+    delegationId: generateId(),
+    riskAnalysisForm: generateMock(m2mGatewayApi.RiskAnalysisFormSeed),
   };
 
   const mockM2MPurpose: m2mGatewayApi.Purpose =
@@ -60,7 +63,7 @@ describe("POST /purposes router test", () => {
     { invalidParam: "invalidValue" },
     { ...mockPurposeSeed, extraParam: -1 },
     { ...mockPurposeSeed, description: "short" },
-  ])("Should return 400 if passed invalid delegation seed", async (body) => {
+  ])("Should return 400 if passed invalid purpose seed", async (body) => {
     const token = generateToken(authRole.M2M_ADMIN_ROLE);
     const res = await makeRequest(token, body as m2mGatewayApi.PurposeSeed);
 

--- a/packages/m2m-gateway/test/api/purposes/createReversePurpose.test.ts
+++ b/packages/m2m-gateway/test/api/purposes/createReversePurpose.test.ts
@@ -17,7 +17,7 @@ describe("POST /reversePurposes router test", () => {
 
   const mockEServicePurposeSeed: m2mGatewayApi.EServicePurposeSeed = {
     eserviceId: mockPurpose.eserviceId,
-    consumerId: mockPurpose.consumerId,
+    delegationId: generateId(),
     riskAnalysisId: generateId(),
     description: mockPurpose.description,
     dailyCalls: mockPurpose.versions[0].dailyCalls,
@@ -65,7 +65,7 @@ describe("POST /reversePurposes router test", () => {
     { invalidParam: "invalidValue" },
     { ...mockEServicePurposeSeed, extraParam: -1 },
     { ...mockEServicePurposeSeed, description: "short" },
-  ])("Should return 400 if passed invalid delegation seed", async (body) => {
+  ])("Should return 400 if passed invalid purpose seed", async (body) => {
     const token = generateToken(authRole.M2M_ADMIN_ROLE);
     const res = await makeRequest(
       token,

--- a/packages/m2m-gateway/test/api/purposes/createReversePurpose.test.ts
+++ b/packages/m2m-gateway/test/api/purposes/createReversePurpose.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   generateToken,
+  getMockedApiDelegation,
   getMockedApiPurpose,
 } from "pagopa-interop-commons-test";
 import { AuthRole, authRole } from "pagopa-interop-commons";
@@ -9,7 +10,10 @@ import { m2mGatewayApi, purposeApi } from "pagopa-interop-api-clients";
 import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
 import { api, mockPurposeService } from "../../vitest.api.setup.js";
 import { appBasePath } from "../../../src/config/appBasePath.js";
-import { missingMetadata } from "../../../src/model/errors.js";
+import {
+  missingMetadata,
+  notAnActiveConsumerDelegation,
+} from "../../../src/model/errors.js";
 import { toM2MGatewayApiPurpose } from "../../../src/api/purposeApiConverter.js";
 
 describe("POST /reversePurposes router test", () => {
@@ -73,6 +77,22 @@ describe("POST /reversePurposes router test", () => {
     );
 
     expect(res.status).toBe(400);
+  });
+
+  it("Should return 403 in case of notAnActiveConsumerDelegation error", async () => {
+    mockPurposeService.createReversePurpose = vi
+      .fn()
+      .mockRejectedValue(
+        notAnActiveConsumerDelegation(
+          generateId(),
+          generateId(),
+          getMockedApiDelegation()
+        )
+      );
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, mockEServicePurposeSeed);
+
+    expect(res.status).toBe(403);
   });
 
   it.each([missingMetadata(), pollingMaxRetriesExceeded(3, 10)])(

--- a/packages/m2m-gateway/test/integration/purposes/createPurpose.test.ts
+++ b/packages/m2m-gateway/test/integration/purposes/createPurpose.test.ts
@@ -5,6 +5,7 @@ import {
   getMockedApiPurpose,
   getMockWithMetadata,
 } from "pagopa-interop-commons-test";
+import { generateMock } from "@anatine/zod-mock";
 import {
   expectApiClientGetToHaveBeenCalledWith,
   expectApiClientGetToHaveBeenNthCalledWith,
@@ -29,6 +30,8 @@ describe("createPurpose", () => {
     eserviceId: mockPurposeProcessGetResponse.data.eserviceId,
     isFreeOfCharge: mockPurposeProcessGetResponse.data.isFreeOfCharge,
     title: mockPurposeProcessGetResponse.data.title,
+    riskAnalysisForm: generateMock(m2mGatewayApi.RiskAnalysisFormSeed),
+    // TODO test delegation and test that purpose process is called with the right consumerId
   };
 
   const mockCreatePurpose = vi

--- a/packages/m2m-gateway/test/integration/purposes/createPurpose.test.ts
+++ b/packages/m2m-gateway/test/integration/purposes/createPurpose.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { m2mGatewayApi } from "pagopa-interop-api-clients";
-import { pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { delegationApi, m2mGatewayApi } from "pagopa-interop-api-clients";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
 import {
+  getMockedApiDelegation,
   getMockedApiPurpose,
   getMockWithMetadata,
 } from "pagopa-interop-commons-test";
@@ -16,7 +17,10 @@ import {
 } from "../../integrationUtils.js";
 import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
 import { config } from "../../../src/config/config.js";
-import { missingMetadata } from "../../../src/model/errors.js";
+import {
+  missingMetadata,
+  notAnActiveConsumerDelegation,
+} from "../../../src/model/errors.js";
 import { getMockM2MAdminAppContext } from "../../mockUtils.js";
 
 describe("createPurpose", () => {
@@ -38,9 +42,7 @@ describe("createPurpose", () => {
   const mockCreatePurpose = vi
     .fn()
     .mockResolvedValue(mockPurposeProcessGetResponse);
-  const mockGetPurpose = vi.fn(
-    mockPollingResponse(mockPurposeProcessGetResponse, 2)
-  );
+  const mockGetPurpose = vi.fn();
   const mockGetDelegation = vi.fn();
 
   mockInteropBeClients.purposeProcessClient = {
@@ -55,29 +57,41 @@ describe("createPurpose", () => {
   beforeEach(() => {
     mockCreatePurpose.mockClear();
     mockGetPurpose.mockClear();
+    mockGetDelegation.mockClear();
   });
 
+  const expectedM2MPurpose: m2mGatewayApi.Purpose = {
+    consumerId: mockPurposeProcessGetResponse.data.consumerId,
+    createdAt: mockPurposeProcessGetResponse.data.createdAt,
+    description: mockPurposeProcessGetResponse.data.description,
+    eserviceId: mockPurposeProcessGetResponse.data.eserviceId,
+    id: mockPurposeProcessGetResponse.data.id,
+    isFreeOfCharge: mockPurposeProcessGetResponse.data.isFreeOfCharge,
+    isRiskAnalysisValid: mockPurposeProcessGetResponse.data.isRiskAnalysisValid,
+    title: mockPurposeProcessGetResponse.data.title,
+    currentVersion: mockPurposeProcessGetResponse.data.versions.at(0),
+    delegationId: mockPurposeProcessGetResponse.data.delegationId,
+    freeOfChargeReason: mockPurposeProcessGetResponse.data.freeOfChargeReason,
+    rejectedVersion: undefined,
+    suspendedByConsumer: undefined,
+    suspendedByProducer: undefined,
+    updatedAt: mockPurposeProcessGetResponse.data.updatedAt,
+    waitingForApprovalVersion: undefined,
+  };
+
+  const mockAppContext = getMockM2MAdminAppContext();
+  const mockConsumerDelegation: delegationApi.Delegation =
+    getMockedApiDelegation({
+      kind: delegationApi.DelegationKind.Values.DELEGATED_CONSUMER,
+      eserviceId: mockPurposeSeed.eserviceId,
+      state: delegationApi.DelegationState.Values.ACTIVE,
+      delegateId: mockAppContext.authData.organizationId,
+    });
+
   it("Should succeed and perform service calls without delegationId", async () => {
-    const expectedM2MPurpose: m2mGatewayApi.Purpose = {
-      consumerId: mockPurposeProcessGetResponse.data.consumerId,
-      createdAt: mockPurposeProcessGetResponse.data.createdAt,
-      description: mockPurposeProcessGetResponse.data.description,
-      eserviceId: mockPurposeProcessGetResponse.data.eserviceId,
-      id: mockPurposeProcessGetResponse.data.id,
-      isFreeOfCharge: mockPurposeProcessGetResponse.data.isFreeOfCharge,
-      isRiskAnalysisValid:
-        mockPurposeProcessGetResponse.data.isRiskAnalysisValid,
-      title: mockPurposeProcessGetResponse.data.title,
-      currentVersion: mockPurposeProcessGetResponse.data.versions.at(0),
-      delegationId: mockPurposeProcessGetResponse.data.delegationId,
-      freeOfChargeReason: mockPurposeProcessGetResponse.data.freeOfChargeReason,
-      rejectedVersion: undefined,
-      suspendedByConsumer: undefined,
-      suspendedByProducer: undefined,
-      updatedAt: mockPurposeProcessGetResponse.data.updatedAt,
-      waitingForApprovalVersion: undefined,
-    };
-    const mockAppContext = getMockM2MAdminAppContext();
+    mockGetPurpose.mockImplementation(
+      mockPollingResponse(mockPurposeProcessGetResponse, 2)
+    );
 
     const result = await purposeService.createPurpose(
       mockPurposeSeed,
@@ -90,8 +104,8 @@ describe("createPurpose", () => {
       body: {
         dailyCalls: mockPurposeSeed.dailyCalls,
         description: mockPurposeSeed.description,
-        eServiceId: mockPurposeSeed.eserviceId,
-        RiskAnalysisForm: mockPurposeSeed.riskAnalysisForm,
+        eserviceId: mockPurposeSeed.eserviceId,
+        riskAnalysisForm: mockPurposeSeed.riskAnalysisForm,
         isFreeOfCharge: mockPurposeSeed.isFreeOfCharge,
         freeOfChargeReason: mockPurposeSeed.freeOfChargeReason,
         title: mockPurposeSeed.title,
@@ -115,7 +129,107 @@ describe("createPurpose", () => {
     ).toHaveBeenCalledTimes(0);
   });
 
-  // TODO test delegation and test that purpose process is called with the right consumerId
+  it("Should succeed and perform service calls with delegationId", async () => {
+    mockGetPurpose.mockImplementation(
+      mockPollingResponse(mockPurposeProcessGetResponse, 2)
+    );
+
+    mockGetDelegation.mockResolvedValue(
+      getMockWithMetadata(mockConsumerDelegation)
+    );
+
+    const mockPurposeSeedWithDelegation: m2mGatewayApi.PurposeSeed = {
+      ...mockPurposeSeed,
+      delegationId: mockConsumerDelegation.id,
+    };
+
+    const result = await purposeService.createPurpose(
+      mockPurposeSeedWithDelegation,
+      mockAppContext
+    );
+
+    expect(result).toEqual(expectedM2MPurpose);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost: mockInteropBeClients.purposeProcessClient.createPurpose,
+      body: {
+        dailyCalls: mockPurposeSeed.dailyCalls,
+        description: mockPurposeSeed.description,
+        eserviceId: mockPurposeSeed.eserviceId,
+        riskAnalysisForm: mockPurposeSeed.riskAnalysisForm,
+        isFreeOfCharge: mockPurposeSeed.isFreeOfCharge,
+        freeOfChargeReason: mockPurposeSeed.freeOfChargeReason,
+        title: mockPurposeSeed.title,
+        consumerId: mockConsumerDelegation.delegatorId,
+      },
+    });
+
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.purposeProcessClient.getPurpose,
+      params: { id: expectedM2MPurpose.id },
+    });
+    expect(
+      mockInteropBeClients.purposeProcessClient.getPurpose
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      mockInteropBeClients.delegationProcessClient.delegation.getDelegation
+    ).toHaveBeenCalledTimes(1);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet:
+        mockInteropBeClients.delegationProcessClient.delegation.getDelegation,
+      params: { delegationId: mockConsumerDelegation.id },
+    });
+  });
+
+  it.each([
+    {
+      ...mockConsumerDelegation,
+      state: delegationApi.DelegationState.Values.REJECTED,
+    },
+    {
+      ...mockConsumerDelegation,
+      state: delegationApi.DelegationState.Values.REVOKED,
+    },
+    {
+      ...mockConsumerDelegation,
+      state: delegationApi.DelegationState.Values.WAITING_FOR_APPROVAL,
+    },
+    {
+      ...mockConsumerDelegation,
+      kind: delegationApi.DelegationKind.Values.DELEGATED_PRODUCER,
+    },
+    {
+      ...mockConsumerDelegation,
+      eserviceId: generateId(),
+    },
+    {
+      ...mockConsumerDelegation,
+      delegateId: generateId(),
+    },
+  ] satisfies delegationApi.Delegation[])(
+    `Should throw notAnActiveConsumerDelegation if the specified delegation
+    is not an active consumer delegation for requester tenant and e-service`,
+    async (mockDelegation) => {
+      mockGetDelegation.mockResolvedValue(getMockWithMetadata(mockDelegation));
+
+      const mockPurposeSeedWithDelegation: m2mGatewayApi.PurposeSeed = {
+        ...mockPurposeSeed,
+        delegationId: mockDelegation.id,
+      };
+
+      await expect(
+        purposeService.createPurpose(
+          mockPurposeSeedWithDelegation,
+          mockAppContext
+        )
+      ).rejects.toThrowError(
+        notAnActiveConsumerDelegation(
+          mockAppContext.authData.organizationId,
+          mockPurposeSeed.eserviceId,
+          mockDelegation
+        )
+      );
+    }
+  );
 
   it("Should throw missingMetadata in case the purpose returned by the creation POST call has no metadata", async () => {
     mockCreatePurpose.mockResolvedValueOnce({

--- a/packages/m2m-gateway/test/integration/purposes/createReversePurpose.test.ts
+++ b/packages/m2m-gateway/test/integration/purposes/createReversePurpose.test.ts
@@ -27,10 +27,10 @@ describe("createReversePurpose", () => {
     dailyCalls: mockPurposeProcessGetResponse.data.versions[0].dailyCalls,
     description: mockPurposeProcessGetResponse.data.description,
     eserviceId: mockPurposeProcessGetResponse.data.eserviceId,
-    consumerId: mockPurposeProcessGetResponse.data.consumerId,
     riskAnalysisId: generateId(),
     isFreeOfCharge: mockPurposeProcessGetResponse.data.isFreeOfCharge,
     title: mockPurposeProcessGetResponse.data.title,
+    // TODO test delegation and test that purpose process is called with the right consumerId
   };
 
   const mockCreatePurposeFromEService = vi
@@ -83,7 +83,7 @@ describe("createReversePurpose", () => {
       mockPost:
         mockInteropBeClients.purposeProcessClient.createPurposeFromEService,
       body: {
-        consumerId: mockEServicePurposeSeed.consumerId,
+        consumerId: mockPurposeProcessGetResponse.data.consumerId,
         dailyCalls: mockEServicePurposeSeed.dailyCalls,
         description: mockEServicePurposeSeed.description,
         eServiceId: mockEServicePurposeSeed.eserviceId,


### PR DESCRIPTION
[PIN-7354](https://pagopa.atlassian.net/browse/PIN-7354)

Purpose creation in the purpose process requires a consumerId ID, which can be set to:
1. the caller tenant or
2. a tenant for whom the caller is the consumer delegate

This consumerId param is also required via M2M for reverse purpose creation.
However, for normal purpose creation, we decided to expose `delegationId` to create a purpose as the consumer delegate. The parameter is just passed down to the process call, causing a Bad Request, and the consumerId is always set to the caller, preventing the creation of a delegated purpose via M2M.

**Solution:**
We want to expose delegationId in both calls, and in case it's set we pass down the delegator as consumerId to the purpose process.

## Before 💥 
The call to the process was sending back a 400 Bad Request error.

<img width="2680" height="778" alt="image" src="https://github.com/user-attachments/assets/cdaff950-51e6-487d-a004-dbe3db4971b3" />


## After 🚀 

### Creating purpose with delegationId
<img width="1355" height="916" alt="image" src="https://github.com/user-attachments/assets/44c4b1a4-ac9e-4f3b-994b-85dc0a531771" />

### Creating reverse purpose with delegationId
<img width="1351" height="642" alt="image" src="https://github.com/user-attachments/assets/994d3507-b45c-47f0-9b50-f86dfc261e40" />

## Creating purpose without delegationId

<img width="1337" height="733" alt="image" src="https://github.com/user-attachments/assets/a9e79d58-08c2-4110-b2af-b6e80ab9ad21" />

## Creating reverse purpose without delegationId
<img width="1344" height="612" alt="image" src="https://github.com/user-attachments/assets/a9fe7cb5-1478-4420-a353-4cc4f8bcfeb8" />


## New error
<img width="1354" height="499" alt="image" src="https://github.com/user-attachments/assets/c8fbf53d-c722-4d4a-b425-57d6354beaaf" />


[PIN-7354]: https://pagopa.atlassian.net/browse/PIN-7354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ