### PR TITLE
PIN-7364 Fix getLogoUrl in bff

### DIFF
--- a/packages/backend-for-frontend/src/services/tenantService.ts
+++ b/packages/backend-for-frontend/src/services/tenantService.ts
@@ -72,7 +72,7 @@ export function tenantServiceBuilder(
       return institution.logo;
     } catch (error) {
       logger.warn(
-        `Error retrieving logo for tenant ${selfcareId} from selfcare`
+        `Error retrieving logo for tenant ${selfcareId} from selfcare - ${error}`
       );
       return undefined;
     }


### PR DESCRIPTION
It seems the call to retrieve the tenants' logos from selfcare make the entire `/tenants` endpoint crash if one of those is not found.