### PR TITLE
Added APIV2 e-service document upload common implementations 

### DIFF
--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -1045,12 +1045,15 @@ paths:
             schema:
               $ref: "#/components/schemas/CreateEServiceDescriptorDocumentSeed"
       responses:
-        "200":
+        "201":
           description: EService Document created
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EService"
+                $ref: "#/components/schemas/EServiceDoc"
         "400":
           description: Invalid input
           content:
@@ -2972,6 +2975,7 @@ components:
         - prettyName
         - path
         - checksum
+        - uploadDate
       properties:
         id:
           type: string
@@ -2986,6 +2990,9 @@ components:
           type: string
         checksum:
           type: string
+        uploadDate:
+          type: string
+          format: date-time
         contacts:
           $ref: "#/components/schemas/DescriptorInterfaceContacts"
     EServiceDescriptionUpdateSeed:

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -1637,6 +1637,7 @@ components:
         - prettyName
         - path
         - checksum
+        - uploadDate
       properties:
         id:
           type: string
@@ -1651,6 +1652,9 @@ components:
           type: string
         checksum:
           type: string
+        uploadDate:
+          type: string
+          format: date-time
     EServiceTemplateDescriptionUpdateSeed:
       type: object
       additionalProperties: false

--- a/packages/catalog-process/src/model/domain/apiConverter.ts
+++ b/packages/catalog-process/src/model/domain/apiConverter.ts
@@ -144,6 +144,7 @@ export const documentToApiDocument = (
   prettyName: document.prettyName,
   path: document.path,
   checksum: document.checksum,
+  uploadDate: document.uploadDate.toJSON(),
 });
 
 export const descriptorToApiDescriptor = (

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -366,18 +366,22 @@ const eservicesRouter = (
 
         try {
           // The same check is done in the backend-for-frontend, if you change this check, change it there too
-          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE]);
+          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
 
-          const updatedEService = await catalogService.uploadDocument(
-            unsafeBrandId(req.params.eServiceId),
-            unsafeBrandId(req.params.descriptorId),
-            req.body,
-            ctx
-          );
+          const { data: document, metadata } =
+            await catalogService.uploadDocument(
+              unsafeBrandId(req.params.eServiceId),
+              unsafeBrandId(req.params.descriptorId),
+              req.body,
+              ctx
+            );
+
+          setMetadataVersionHeader(res, metadata);
+
           return res
-            .status(200)
+            .status(201)
             .send(
-              catalogApi.EService.parse(eServiceToApiEService(updatedEService))
+              catalogApi.EServiceDoc.parse(documentToApiDocument(document))
             );
         } catch (error) {
           const errorRes = makeApiProblem(

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -115,7 +115,7 @@ function isDescriptorUpdatableAfterPublish(descriptor: Descriptor): boolean {
 export async function assertRequesterIsDelegateProducerOrProducer(
   producerId: TenantId,
   eserviceId: EServiceId,
-  authData: UIAuthData | M2MAuthData,
+  authData: UIAuthData | M2MAuthData | M2MAdminAuthData,
   readModelService: ReadModelService
 ): Promise<void> {
   // Search for active producer delegation
@@ -141,7 +141,7 @@ export async function assertRequesterIsDelegateProducerOrProducer(
 
 export function assertRequesterIsProducer(
   producerId: TenantId,
-  authData: UIAuthData | M2MAuthData
+  authData: UIAuthData | M2MAuthData | M2MAdminAuthData
 ): void {
   if (producerId !== authData.organizationId) {
     throw operationForbidden;

--- a/packages/catalog-process/test/integration/uploadDocument.test.ts
+++ b/packages/catalog-process/test/integration/uploadDocument.test.ts
@@ -63,7 +63,7 @@ describe("upload Document", () => {
       };
       await addOneEService(eservice);
 
-      const returnedEService = await catalogService.uploadDocument(
+      const returnedDocument = await catalogService.uploadDocument(
         eservice.id,
         descriptor.id,
         buildInterfaceSeed(),
@@ -80,22 +80,23 @@ describe("upload Document", () => {
         payload: writtenEvent.data,
       });
 
+      const expectedDocument: Document = {
+        ...mockDocument,
+        id: unsafeBrandId(
+          writtenPayload.eservice!.descriptors[0]!.interface!.id
+        ),
+        checksum: writtenPayload.eservice!.descriptors[0]!.interface!.checksum,
+        uploadDate: new Date(
+          writtenPayload.eservice!.descriptors[0]!.interface!.uploadDate
+        ),
+      };
+
       const expectedEservice = toEServiceV2({
         ...eservice,
         descriptors: [
           {
             ...descriptor,
-            interface: {
-              ...mockDocument,
-              id: unsafeBrandId(
-                writtenPayload.eservice!.descriptors[0]!.interface!.id
-              ),
-              checksum:
-                writtenPayload.eservice!.descriptors[0]!.interface!.checksum,
-              uploadDate: new Date(
-                writtenPayload.eservice!.descriptors[0]!.interface!.uploadDate
-              ),
-            },
+            interface: expectedDocument,
             serverUrls: ["pagopa.it"],
           },
         ],
@@ -103,7 +104,12 @@ describe("upload Document", () => {
 
       expect(writtenPayload.descriptorId).toEqual(descriptor.id);
       expect(writtenPayload.eservice).toEqual(expectedEservice);
-      expect(writtenPayload.eservice).toEqual(toEServiceV2(returnedEService));
+      expect(returnedDocument).toEqual({
+        data: expectedDocument,
+        metadata: {
+          version: 1,
+        },
+      });
     }
   );
   it.each(
@@ -132,7 +138,7 @@ describe("upload Document", () => {
       await addOneEService(eservice);
       await addOneDelegation(delegation);
 
-      const returnedEService = await catalogService.uploadDocument(
+      const returnedDocument = await catalogService.uploadDocument(
         eservice.id,
         descriptor.id,
         buildInterfaceSeed(),
@@ -149,22 +155,23 @@ describe("upload Document", () => {
         payload: writtenEvent.data,
       });
 
+      const expectedDocument: Document = {
+        ...mockDocument,
+        id: unsafeBrandId(
+          writtenPayload.eservice!.descriptors[0]!.interface!.id
+        ),
+        checksum: writtenPayload.eservice!.descriptors[0]!.interface!.checksum,
+        uploadDate: new Date(
+          writtenPayload.eservice!.descriptors[0]!.interface!.uploadDate
+        ),
+      };
+
       const expectedEservice = toEServiceV2({
         ...eservice,
         descriptors: [
           {
             ...descriptor,
-            interface: {
-              ...mockDocument,
-              id: unsafeBrandId(
-                writtenPayload.eservice!.descriptors[0]!.interface!.id
-              ),
-              checksum:
-                writtenPayload.eservice!.descriptors[0]!.interface!.checksum,
-              uploadDate: new Date(
-                writtenPayload.eservice!.descriptors[0]!.interface!.uploadDate
-              ),
-            },
+            interface: expectedDocument,
             serverUrls: ["pagopa.it"],
           },
         ],
@@ -172,7 +179,12 @@ describe("upload Document", () => {
 
       expect(writtenPayload.descriptorId).toEqual(descriptor.id);
       expect(writtenPayload.eservice).toEqual(expectedEservice);
-      expect(writtenPayload.eservice).toEqual(toEServiceV2(returnedEService));
+      expect(returnedDocument).toEqual({
+        data: expectedDocument,
+        metadata: {
+          version: 1,
+        },
+      });
     }
   );
   it("should throw eServiceNotFound if the eservice doesn't exist", () => {

--- a/packages/commons-test/src/apiMocks.ts
+++ b/packages/commons-test/src/apiMocks.ts
@@ -395,6 +395,7 @@ export function getMockedApiEserviceDoc({
     prettyName: "Interface Document",
     path,
     checksum: "mock-checksum",
+    uploadDate: new Date().toISOString(),
     contacts: generateMock(catalogApi.DescriptorInterfaceContacts),
   };
 }

--- a/packages/eservice-template-instances-updater/src/eserviceTemplateInstancesUpdaterConsumerServiceV2.ts
+++ b/packages/eservice-template-instances-updater/src/eserviceTemplateInstancesUpdaterConsumerServiceV2.ts
@@ -4,6 +4,7 @@ import {
   CorrelationId,
   Descriptor,
   descriptorState,
+  Document,
   EService,
   EServiceTemplate,
   EServiceTemplateEventEnvelope,
@@ -353,7 +354,7 @@ function getTemplateDocumentFromEvent(
   msg: EServiceTemplateEventEnvelope & {
     data: { documentId: string; eserviceTemplateVersionId: string };
   }
-): catalogApi.EServiceDoc {
+): Document {
   const eserviceTemplateVersion = getTemplateVersionFromEvent(msg);
 
   const doc = eserviceTemplateVersion.docs.find(
@@ -431,7 +432,7 @@ async function commitUpdateToTemplateInstances(
 }
 
 async function cloneDocument(
-  doc: catalogApi.EServiceDoc,
+  doc: Document,
   fileManager: FileManager,
   logger: Logger
 ): Promise<catalogApi.CreateEServiceDescriptorDocumentSeed> {

--- a/packages/eservice-template-process/src/model/domain/apiConverter.ts
+++ b/packages/eservice-template-process/src/model/domain/apiConverter.ts
@@ -112,6 +112,7 @@ export const documentToApiDocument = (
   prettyName: document.prettyName,
   path: document.path,
   checksum: document.checksum,
+  uploadDate: document.uploadDate.toJSON(),
 });
 
 export const eserviceTemplateVersionToApiEServiceTemplateVersion = (

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -45,6 +45,7 @@ import {
   eserviceTemplateToApiEServiceTemplate,
   eserviceTemplateVersionToApiEServiceTemplateVersion,
   apiEServiceTemplateVersionStateToEServiceTemplateVersionState,
+  documentToApiDocument,
 } from "../model/domain/apiConverter.js";
 
 const eserviceTemplatesRouter = (
@@ -445,7 +446,9 @@ const eserviceTemplatesRouter = (
               },
               ctx
             );
-          return res.status(200).send(eServiceTemplateDocument);
+          return res
+            .status(200)
+            .send(documentToApiDocument(eServiceTemplateDocument));
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/m2m-gateway/src/api/eserviceApiConverter.ts
+++ b/packages/m2m-gateway/src/api/eserviceApiConverter.ts
@@ -57,3 +57,15 @@ export function toM2MGatewayApiEServiceDescriptor(
     templateVersionId: descriptor.templateVersionRef?.id,
   };
 }
+
+export function toM2MGatewayApiDocument(
+  document: catalogApi.EServiceDoc
+): m2mGatewayApi.Document {
+  return {
+    id: document.id,
+    name: document.name,
+    prettyName: document.prettyName,
+    createdAt: document.uploadDate,
+    contentType: document.contentType,
+  };
+}


### PR DESCRIPTION
Updated `catalog-process`'s  document creation route. 
- Changed status code from`200` to `201`; 
- Added Metadata version header; 
- Updated the response schema to return `EServiceDoc` instead of `EService`.
- Added `uploadDate` property  to `EServiceDoc` `catalogApi`'s schema to make it compatible with the m2m's one.
- Added `M2M_ADMIN_ROLE` in route's authorization.

Also:
- Added `uploadEServiceDocument` common function in `m2mGateway` package