### PR TITLE
PIN-7436 - Add error 403 mapping to `retrievePurpose` in `api-gateway`

### DIFF
--- a/packages/api-gateway/src/services/purposeService.ts
+++ b/packages/api-gateway/src/services/purposeService.ts
@@ -9,6 +9,7 @@ import {
   catalogApi,
   delegationApi,
 } from "pagopa-interop-api-clients";
+import { operationForbidden } from "pagopa-interop-models";
 import {
   AgreementProcessClient,
   CatalogProcessClient,
@@ -69,6 +70,7 @@ const retrievePurpose = async (
     })
     .catch((res) => {
       throw clientStatusCodeToError(res, {
+        403: operationForbidden,
         404: purposeNotFound(purposeId),
       });
     });


### PR DESCRIPTION
This PR adds the error 403 mapping to the `retrievePurpose` function in the `api-gateway`.

BEFORE
<img width="740" height="354" alt="Screenshot 2025-08-25 at 16 02 07" src="https://github.com/user-attachments/assets/a53267da-ec5e-42c2-baec-7d7a75acad2b" />
AFTER
<img width="741" height="356" alt="Screenshot 2025-08-25 at 16 02 26" src="https://github.com/user-attachments/assets/2554f274-546b-4b8c-a5f1-4f9a7b1b3c99" />