### PR TITLE
PIN-7443 - Increase catalog limit to 200 in BFF and catalog-process

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -2647,7 +2647,7 @@ paths:
             type: integer
             format: int32
             minimum: 1
-            maximum: 50
+            maximum: 200
       responses:
         "200":
           description: A list of EServices

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -145,7 +145,7 @@ paths:
             type: integer
             format: int32
             minimum: 1
-            maximum: 50
+            maximum: 200
       responses:
         "200":
           description: A list of E-Service

--- a/packages/backend-for-frontend/test/api/catalogRouter/getCatalog.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/getCatalog.test.ts
@@ -85,7 +85,7 @@ describe("API GET /catalog", () => {
     { query: { limit: 10 } },
     { query: { offset: -1, limit: 10 } },
     { query: { offset: 0, limit: -2 } },
-    { query: { offset: 0, limit: 55 } },
+    { query: { offset: 0, limit: 201 } },
     { query: { offset: "invalid", limit: 10 } },
     { query: { offset: 0, limit: "invalid" } },
   ])("Should return 400 if passed an invalid parameter", async ({ query }) => {


### PR DESCRIPTION
This PR increases the limit of the catalog listing to 200 in both the `BFF` and the `catalog-process`. This is needed when creating a purpose because there are more than 50 e-services with the same name.