### PR TITLE
Pin 7516 get eservices descriptor attributes

### DIFF
--- a/collections/m2m gateway/eservices/Get eservice descriptor certified attribute.bru
+++ b/collections/m2m gateway/eservices/Get eservice descriptor certified attribute.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get eservice descriptor certified attribute
+  type: http
+  seq: 33
+}
+
+get {
+  url: {{host-m2m-gw}}/eservices/:eserviceId/descriptors/:descriptorId/certifiedAttributes?offset=0&limit=50
+  body: none
+  auth: none
+}
+
+params:query {
+  offset: 0
+  limit: 50
+}
+
+params:path {
+  descriptorId: {{descriptorId}}
+  eserviceId: {{eserviceId}}
+}
+
+headers {
+  Authorization: {{JWT-M2M}}
+}

--- a/collections/m2m gateway/eservices/Get eservice descriptor declared attribute.bru
+++ b/collections/m2m gateway/eservices/Get eservice descriptor declared attribute.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get eservice descriptor declared attribute
+  type: http
+  seq: 34
+}
+
+get {
+  url: {{host-m2m-gw}}/eservices/:eserviceId/descriptors/:descriptorId/declaredAttributes?offset=0&limit=50
+  body: none
+  auth: none
+}
+
+params:query {
+  offset: 0
+  limit: 50
+}
+
+params:path {
+  descriptorId: {{descriptorId}}
+  eserviceId: {{eserviceId}}
+}
+
+headers {
+  Authorization: {{JWT-M2M}}
+}

--- a/collections/m2m gateway/eservices/Get eservice descriptor verified attribute.bru
+++ b/collections/m2m gateway/eservices/Get eservice descriptor verified attribute.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get eservice descriptor verified attribute
+  type: http
+  seq: 35
+}
+
+get {
+  url: {{host-m2m-gw}}/eservices/:eserviceId/descriptors/:descriptorId/verifiedAttributes?offset=0&limit=50
+  body: none
+  auth: none
+}
+
+params:query {
+  offset: 0
+  limit: 50
+}
+
+params:path {
+  descriptorId: {{descriptorId}}
+  eserviceId: {{eserviceId}}
+}
+
+headers {
+  Authorization: {{JWT-M2M}}
+}

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -6016,6 +6016,96 @@ paths:
         schema:
           type: string
           format: uuid
+    get:
+      tags:
+        - eservices
+      summary: List E-Service Descriptors Certified Attributes
+      description: Retrieve a list of E-Service Descriptors Certified Attributes based on filters
+      operationId: getEServiceDescriptorCertifiedAttributes
+      parameters:
+        - in: query
+          name: offset
+          description: Pagination starting position
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+        - in: query
+          name: limit
+          description: Maximum number of results to return
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 50
+      responses:
+        "200":
+          description: E-Service Descriptors Certified Attributes retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceDescriptorAttributes"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
     put:
       tags:
         - eservices
@@ -6124,6 +6214,96 @@ paths:
         schema:
           type: string
           format: uuid
+    get:
+      tags:
+        - eservices
+      summary: List E-Service Descriptors Declared Attributes
+      description: Retrieve a list of E-Service Descriptors Declared Attributes based on filters
+      operationId: getEServiceDescriptorDeclaredAttributes
+      parameters:
+        - in: query
+          name: offset
+          description: Pagination starting position
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+        - in: query
+          name: limit
+          description: Maximum number of results to return
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 50
+      responses:
+        "200":
+          description: E-Service Descriptors Declared Attributes retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceDescriptorAttributes"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
     put:
       tags:
         - eservices
@@ -6232,6 +6412,96 @@ paths:
         schema:
           type: string
           format: uuid
+    get:
+      tags:
+        - eservices
+      summary: List E-Service Descriptors Verified Attributes
+      description: Retrieve a list of E-Service Descriptors Verified Attributes based on filters
+      operationId: getEServiceDescriptorVerifiedAttributes
+      parameters:
+        - in: query
+          name: offset
+          description: Pagination starting position
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+        - in: query
+          name: limit
+          description: Maximum number of results to return
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 50
+      responses:
+        "200":
+          description: E-Service Descriptors Verified Attributes retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceDescriptorAttributes"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
     put:
       tags:
         - eservices

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -6019,8 +6019,8 @@ paths:
     get:
       tags:
         - eservices
-      summary: List E-Service Descriptors Certified Attributes
-      description: Retrieve a list of E-Service Descriptors Certified Attributes based on filters
+      summary: List E-Service Descriptor Certified Attributes
+      description: Retrieve a list of E-Service Descriptors Certified Attributes
       operationId: getEServiceDescriptorCertifiedAttributes
       parameters:
         - in: query
@@ -6217,8 +6217,8 @@ paths:
     get:
       tags:
         - eservices
-      summary: List E-Service Descriptors Declared Attributes
-      description: Retrieve a list of E-Service Descriptors Declared Attributes based on filters
+      summary: List E-Service Descriptor Declared Attributes
+      description: Retrieve a list of E-Service Descriptor Declared Attributes
       operationId: getEServiceDescriptorDeclaredAttributes
       parameters:
         - in: query
@@ -6415,8 +6415,8 @@ paths:
     get:
       tags:
         - eservices
-      summary: List E-Service Descriptors Verified Attributes
-      description: Retrieve a list of E-Service Descriptors Verified Attributes based on filters
+      summary: List E-Service Descriptor Verified Attributes
+      description: Retrieve a list of E-Service Descriptor Verified Attributes
       operationId: getEServiceDescriptorVerifiedAttributes
       parameters:
         - in: query

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -6020,7 +6020,7 @@ paths:
       tags:
         - eservices
       summary: List E-Service Descriptor Certified Attributes
-      description: Retrieve a list of E-Service Descriptors Certified Attributes
+      description: Retrieve a list of E-Service Descriptor Certified Attributes
       operationId: getEServiceDescriptorCertifiedAttributes
       parameters:
         - in: query

--- a/packages/m2m-gateway/src/routers/eserviceRouter.ts
+++ b/packages/m2m-gateway/src/routers/eserviceRouter.ts
@@ -763,6 +763,86 @@ const eserviceRouter = (
         }
       }
     )
+    .get(
+      "/eservices/:eserviceId/descriptors/:descriptorId/certifiedAttributes",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ROLE, M2M_ADMIN_ROLE]);
+
+          const attributes =
+            await eserviceService.getEserviceDescriptorCertifiedAttributes(
+              unsafeBrandId(req.params.eserviceId),
+              unsafeBrandId(req.params.descriptorId),
+              ctx
+            );
+          return res
+            .status(200)
+            .send(m2mGatewayApi.EServiceDescriptorAttributes.parse(attributes));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            getEServiceDescriptorAttributesErrorMapper,
+            ctx,
+            `Error retrieving certified attributes for descriptor with id ${req.params.descriptorId} for eservice with id ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .get(
+      "/eservices/:eserviceId/descriptors/:descriptorId/declaredAttributes",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+        try {
+          validateAuthorization(ctx, [M2M_ROLE, M2M_ADMIN_ROLE]);
+          const attributes =
+            await eserviceService.getEserviceDescriptorDeclaredAttributes(
+              unsafeBrandId(req.params.eserviceId),
+              unsafeBrandId(req.params.descriptorId),
+              ctx
+            );
+          return res
+            .status(200)
+            .send(m2mGatewayApi.EServiceDescriptorAttributes.parse(attributes));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            getEServiceDescriptorAttributesErrorMapper,
+            ctx,
+            `Error retrieving declared attributes for descriptor with id ${req.params.descriptorId} for eservice with id ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .get(
+      "/eservices/:eserviceId/descriptors/:descriptorId/verifiedAttributes",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+        try {
+          validateAuthorization(ctx, [M2M_ROLE, M2M_ADMIN_ROLE]);
+          const attributes =
+            await eserviceService.getEserviceDescriptorVerifiedAttributes(
+              unsafeBrandId(req.params.eserviceId),
+              unsafeBrandId(req.params.descriptorId),
+              ctx
+            );
+          return res
+            .status(200)
+            .send(m2mGatewayApi.EServiceDescriptorAttributes.parse(attributes));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            getEServiceDescriptorAttributesErrorMapper,
+            ctx,
+            `Error retrieving verified attributes for descriptor with id ${req.params.descriptorId} for eservice with id ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
     .put(
       "/eservices/:eserviceId/descriptors/:descriptorId/certifiedAttributes",
       async (req, res) => {

--- a/packages/m2m-gateway/src/services/eserviceService.ts
+++ b/packages/m2m-gateway/src/services/eserviceService.ts
@@ -861,7 +861,7 @@ export function eserviceServiceBuilder(
       return await retrieveEServiceDescriptorAttributes(
         await retrieveEServiceById(headers, eserviceId),
         descriptorId,
-        "certified"
+        "verified"
       );
     },
 

--- a/packages/m2m-gateway/src/services/eserviceService.ts
+++ b/packages/m2m-gateway/src/services/eserviceService.ts
@@ -75,6 +75,18 @@ export function eserviceServiceBuilder(
     );
   }
 
+  async function retrieveEServiceDescriptorAttributes(
+    eservice: WithMaybeMetadata<catalogApi.EService>,
+    descriptorId: DescriptorId,
+    attributeKind: keyof catalogApi.Attributes
+  ): Promise<m2mGatewayApi.EServiceDescriptorAttributes> {
+    const descriptor = retrieveEServiceDescriptorById(eservice, descriptorId);
+
+    return toM2MGatewayApiEServiceDescriptorAttributes(
+      descriptor.attributes[attributeKind]
+    );
+  }
+
   const retrieveEServiceById = async (
     headers: M2MGatewayAppContext["headers"],
     eserviceId: EServiceId
@@ -809,6 +821,48 @@ export function eserviceServiceBuilder(
       }
 
       return toM2MGatewayApiEServiceRiskAnalysis(createdRiskAnalysis);
+    },
+    async getEserviceDescriptorCertifiedAttributes(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApi.EServiceDescriptorAttributes> {
+      logger.info(
+        `Retrieving Certified Attributes for E-Service ${eserviceId} Descriptor ${descriptorId}`
+      );
+      return await retrieveEServiceDescriptorAttributes(
+        await retrieveEServiceById(headers, eserviceId),
+        descriptorId,
+        "certified"
+      );
+    },
+    async getEserviceDescriptorDeclaredAttributes(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApi.EServiceDescriptorAttributes> {
+      logger.info(
+        `Retrieving Declared Attributes for E-Service ${eserviceId} Descriptor ${descriptorId}`
+      );
+      return await retrieveEServiceDescriptorAttributes(
+        await retrieveEServiceById(headers, eserviceId),
+        descriptorId,
+        "declared"
+      );
+    },
+    async getEserviceDescriptorVerifiedAttributes(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApi.EServiceDescriptorAttributes> {
+      logger.info(
+        `Retrieving Verified Attributes for E-Service ${eserviceId} Descriptor ${descriptorId}`
+      );
+      return await retrieveEServiceDescriptorAttributes(
+        await retrieveEServiceById(headers, eserviceId),
+        descriptorId,
+        "certified"
+      );
     },
 
     async updateEServiceDescriptorCertifiedAttributes(


### PR DESCRIPTION
Closes [PIN-7516](https://pagopa.atlassian.net/browse/PIN-7516)
[SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/1812562407/DRAFT+SRS+API+V2+Parte+2#%5BPIN-7516%5D-%E2%80%93-Listing-attributi-e-service-descriptor)

# Description
Implemented `GET /eservices/:eserviceId/descriptors/:descriptorId/certifiedAttributes` route in m2m gateway
Implemented `GET /eservices/:eserviceId/descriptors/:descriptorId/declaredAttributes` route in m2m gateway
Implemented `GET /eservices/:eserviceId/descriptors/:descriptorId/verifiedAttributes` route in m2m gateway

## Implementation
- [x] Finalize SRS
- [x] JIRA task link in PR, with link to SRS
- [x] API spec of the route in `m2mGatewayApi.yml`
- [x] Documentation: description fields in the spec endpoint, response, errors, params, etc. 

## Double-check errors
- [x] Check errors returned by the process API calls (messages should be meaningful, clean, in correct English, etc.)
- [x] Check spec errors: it should list all non-500 errors, also the ones that pass through from the process

# Testing
Checklist:
- [x] Bruno call added to collection
- [x] Smoke test Bruno (attach result screenshot)
- [ ] Supertest /api tests
- [ ] /integration tests for the logic in the service

# Screen


## Certified Attribute
<img width="1043" height="499" alt="certifiedAttribute" src="https://github.com/user-attachments/assets/0ef9f478-4036-4231-ab10-8a7bf12302b9" />

## Declared Attribute
<img width="1043" height="499" alt="declaredAttribute" src="https://github.com/user-attachments/assets/6b032b14-340b-4515-b70c-ea84ddd370d5" />

## Verfied Attribute
<img width="1043" height="499" alt="verifiedAttribute" src="https://github.com/user-attachments/assets/7932d0fc-e794-47d4-9f59-e548b301a597" />

[PIN-7516]: https://pagopa.atlassian.net/browse/PIN-7516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ