### PR TITLE
Fixing broken m2m test for delete eservice risk analysis

### DIFF
--- a/packages/m2m-gateway/test/integration/eservices/deleteEserviceRiskAnalysis.test.ts
+++ b/packages/m2m-gateway/test/integration/eservices/deleteEserviceRiskAnalysis.test.ts
@@ -25,13 +25,12 @@ describe("deleteEserviceRiskAnalysis", () => {
   const mockRiskAnalysis: catalogApi.EServiceRiskAnalysis =
     mockEService.riskAnalysis[0]!;
 
-  const mockDeleteRiskAnalysis = vi
-    .fn()
-    .mockResolvedValue(getMockWithMetadata({}));
+  const mockEServiceResponse = getMockWithMetadata(mockEService);
+  const mockGetEService = vi.fn(mockPollingResponse(mockEServiceResponse, 2));
 
-  const mockGetEService = vi.fn(
-    mockPollingResponse(getMockWithMetadata(mockEService), 2)
-  );
+  const mockDeleteRiskAnalysis = vi.fn().mockResolvedValue({
+    metadata: mockEServiceResponse.metadata,
+  });
 
   mockInteropBeClients.catalogProcessClient = {
     getEServiceById: mockGetEService,


### PR DESCRIPTION
See last CI run: https://github.com/pagopa/interop-be-monorepo/actions/runs/17400717307/job/49404960579