### PR TITLE
PIN-7498 Add date validation to risk analysis

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -2173,7 +2173,9 @@ export function catalogServiceBuilder(
 
       const validatedRiskAnalysisForm = validateRiskAnalysisSchemaOrThrow(
         eserviceRiskAnalysisSeed.riskAnalysisForm,
-        tenant.kind
+        tenant.kind,
+        new Date() // [todo remove comment] risk analysis creation
+        // drawback: the date of the risk analysis is set below in the function riskAnalysisValidatedFormToNewRiskAnalysis
       );
 
       const newRiskAnalysis: RiskAnalysis =
@@ -2249,7 +2251,9 @@ export function catalogServiceBuilder(
 
       const validatedRiskAnalysisForm = validateRiskAnalysisSchemaOrThrow(
         eserviceRiskAnalysisSeed.riskAnalysisForm,
-        tenant.kind
+        tenant.kind,
+        new Date() // [todo remove comment] risk analysis update
+        // drawback: the date of the risk analysis is replaced below in the function riskAnalysisValidatedFormToNewRiskAnalysis
       );
 
       const updatedRiskAnalysis: RiskAnalysis = {

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -202,9 +202,15 @@ export function assertHasNoDraftOrWaitingForApprovalDescriptor(
 
 export function validateRiskAnalysisSchemaOrThrow(
   riskAnalysisForm: catalogApi.EServiceRiskAnalysisSeed["riskAnalysisForm"],
-  tenantKind: TenantKind
+  tenantKind: TenantKind,
+  dateForValidation: Date
 ): RiskAnalysisValidatedForm {
-  const result = validateRiskAnalysis(riskAnalysisForm, true, tenantKind);
+  const result = validateRiskAnalysis(
+    riskAnalysisForm,
+    true,
+    tenantKind,
+    dateForValidation
+  );
   if (result.type === "invalid") {
     throw riskAnalysisValidationFailed(result.issues);
   } else {
@@ -226,7 +232,8 @@ export function assertRiskAnalysisIsValidForPublication(
         riskAnalysis.riskAnalysisForm
       ),
       false,
-      tenantKind
+      tenantKind,
+      riskAnalysis.createdAt
     );
 
     if (result.type === "invalid") {

--- a/packages/commons/src/risk-analysis/riskAnalysisValidationErrors.ts
+++ b/packages/commons/src/risk-analysis/riskAnalysisValidationErrors.ts
@@ -2,7 +2,7 @@ import { InternalError, TenantKind } from "pagopa-interop-models";
 
 type RiskAnalysisValidationIssueCode =
   | "noRulesVersionFoundError"
-  | "unexpectedRulesVersionError"
+  | "expiredRulesVersionError"
   | "unexpectedFieldError"
   | "unexpectedFieldValueError"
   | "dependencyNotFoundError"
@@ -31,12 +31,12 @@ export function noRulesVersionFoundError(
   });
 }
 
-export function unexpectedRulesVersionError(
+export function expiredRulesVersionError(
   version: string
 ): RiskAnalysisValidationIssue {
   return new RiskAnalysisValidationIssue({
-    code: "unexpectedRulesVersionError",
-    detail: `Unexpected ruleset version ${version}`,
+    code: "expiredRulesVersionError",
+    detail: `Expired ruleset version ${version}`,
   });
 }
 

--- a/packages/commons/src/risk-analysis/rules/PA/1.0.ts
+++ b/packages/commons/src/risk-analysis/rules/PA/1.0.ts
@@ -1,5 +1,6 @@
 export const pa1 = {
   version: "1.0",
+  expiration: new Date("2025-01-01"),
   questions: [
     {
       id: "purpose",

--- a/packages/commons/src/risk-analysis/rules/PA/2.0.ts
+++ b/packages/commons/src/risk-analysis/rules/PA/2.0.ts
@@ -1,5 +1,6 @@
 export const pa2 = {
   version: "2.0",
+  expiration: new Date("2025-01-01"),
   questions: [
     {
       id: "purpose",

--- a/packages/commons/src/risk-analysis/rules/PA/3.0.ts
+++ b/packages/commons/src/risk-analysis/rules/PA/3.0.ts
@@ -1,5 +1,6 @@
 export const pa3 = {
   version: "3.0",
+  expiration: new Date("2026-01-01"),
   questions: [
     {
       id: "purpose",

--- a/packages/commons/src/risk-analysis/rules/PRIVATE/1.0.ts
+++ b/packages/commons/src/risk-analysis/rules/PRIVATE/1.0.ts
@@ -1,5 +1,6 @@
 export const private1 = {
   version: "1.0",
+  expiration: new Date("2025-01-01"),
   questions: [
     {
       id: "purpose",

--- a/packages/commons/src/risk-analysis/rules/PRIVATE/2.0.ts
+++ b/packages/commons/src/risk-analysis/rules/PRIVATE/2.0.ts
@@ -1,5 +1,6 @@
 export const private2 = {
   version: "2.0",
+  expiration: new Date("2026-01-01"),
   questions: [
     {
       id: "purpose",

--- a/packages/commons/src/risk-analysis/rules/riskAnalysisFormRules.ts
+++ b/packages/commons/src/risk-analysis/rules/riskAnalysisFormRules.ts
@@ -75,6 +75,7 @@ export type FormQuestionRules = z.infer<typeof FormQuestionRules>;
 
 export const RiskAnalysisFormRules = z.object({
   version: z.string(),
+  expiration: z.date(),
   questions: z.array(FormQuestionRules),
 });
 export type RiskAnalysisFormRules = z.infer<typeof RiskAnalysisFormRules>;

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -239,9 +239,15 @@ const replaceEServiceTemplateVersion = (
 
 export function validateRiskAnalysisSchemaOrThrow(
   riskAnalysisForm: eserviceTemplateApi.EServiceTemplateRiskAnalysisSeed["riskAnalysisForm"],
-  tenantKind: TenantKind
+  tenantKind: TenantKind,
+  dateForValidation: Date
 ): RiskAnalysisValidatedForm {
-  const result = validateRiskAnalysis(riskAnalysisForm, true, tenantKind);
+  const result = validateRiskAnalysis(
+    riskAnalysisForm,
+    true,
+    tenantKind,
+    dateForValidation
+  );
   if (result.type === "invalid") {
     throw riskAnalysisValidationFailed(result.issues);
   } else {
@@ -880,7 +886,8 @@ export function eserviceTemplateServiceBuilder(
 
       const validatedRiskAnalysisForm = validateRiskAnalysisSchemaOrThrow(
         createRiskAnalysis.riskAnalysisForm,
-        createRiskAnalysis.tenantKind
+        createRiskAnalysis.tenantKind,
+        new Date()
       );
 
       const newRiskAnalysis: EServiceTemplateRiskAnalysis =
@@ -965,7 +972,8 @@ export function eserviceTemplateServiceBuilder(
 
       const validatedForm = validateRiskAnalysisSchemaOrThrow(
         updateRiskAnalysisSeed.riskAnalysisForm,
-        updateRiskAnalysisSeed.tenantKind
+        updateRiskAnalysisSeed.tenantKind,
+        riskAnalysisToUpdate.createdAt
       );
 
       const updatedRiskAnalysisForm: RiskAnalysisForm = {

--- a/packages/eservice-template-process/src/services/validators.ts
+++ b/packages/eservice-template-process/src/services/validators.ts
@@ -163,7 +163,8 @@ export function assertRiskAnalysisIsValidForPublication(
         riskAnalysis.riskAnalysisForm
       ),
       false,
-      riskAnalysis.tenantKind
+      riskAnalysis.tenantKind,
+      riskAnalysis.createdAt
     );
 
     if (result.type === "invalid") {

--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -288,7 +288,8 @@ export function purposeServiceBuilder(
         ? isRiskAnalysisFormValid(
             purpose.data.riskAnalysisForm,
             false,
-            tenantKind
+            tenantKind,
+            purpose.data.createdAt
           )
         : true;
 
@@ -826,7 +827,8 @@ export function purposeServiceBuilder(
         ? isRiskAnalysisFormValid(
             purpose.data.riskAnalysisForm,
             false,
-            tenantKind
+            tenantKind,
+            purpose.data.createdAt
           )
         : true;
 
@@ -979,6 +981,7 @@ export function purposeServiceBuilder(
             riskAnalysisFormToRiskAnalysisFormToValidate(riskAnalysisForm),
           schemaOnlyValidation: false,
           tenantKind,
+          dateForValidation: purpose.data.createdAt,
         });
       }
 
@@ -1210,10 +1213,13 @@ export function purposeServiceBuilder(
         readModelService
       );
 
+      const createdAt = new Date();
+
       const validatedFormSeed = validateAndTransformRiskAnalysis(
         purposeSeed.riskAnalysisForm,
         false,
-        await retrieveTenantKind(authData.organizationId, readModelService)
+        await retrieveTenantKind(authData.organizationId, readModelService),
+        createdAt
       );
 
       await retrieveActiveAgreement(eserviceId, consumerId, readModelService);
@@ -1229,7 +1235,7 @@ export function purposeServiceBuilder(
         id: generateId(),
         title: purposeSeed.title,
         description: purposeSeed.description,
-        createdAt: new Date(),
+        createdAt,
         eserviceId,
         consumerId,
         delegationId,
@@ -1304,17 +1310,20 @@ export function purposeServiceBuilder(
         title: seed.title,
       });
 
+      const createdAt = new Date();
+
       validateRiskAnalysisOrThrow({
         riskAnalysisForm: riskAnalysisFormToRiskAnalysisFormToValidate(
           riskAnalysis.riskAnalysisForm
         ),
         schemaOnlyValidation: false,
         tenantKind: producerKind,
+        dateForValidation: createdAt,
       });
 
       const newVersion: PurposeVersion = {
         id: generateId(),
-        createdAt: new Date(),
+        createdAt,
         state: purposeVersionState.draft,
         dailyCalls: seed.dailyCalls,
       };
@@ -1449,7 +1458,8 @@ export function purposeServiceBuilder(
               clonedRiskAnalysisForm
             ),
             false,
-            tenantKind
+            tenantKind,
+            currentDate
           ).type === "valid"
         : false;
 
@@ -1626,7 +1636,8 @@ const performUpdatePurpose = async (
       ? validateAndTransformRiskAnalysis(
           updateContent.riskAnalysisForm,
           true,
-          tenantKind
+          tenantKind,
+          purpose.data.createdAt
         )
       : purpose.data.riskAnalysisForm;
 
@@ -1659,7 +1670,8 @@ const performUpdatePurpose = async (
     isRiskAnalysisValid: isRiskAnalysisFormValid(
       updatedPurpose.riskAnalysisForm,
       false,
-      tenantKind
+      tenantKind,
+      purpose.data.createdAt
     ),
   };
 };

--- a/packages/purpose-process/src/services/validators.ts
+++ b/packages/purpose-process/src/services/validators.ts
@@ -48,7 +48,8 @@ import {
 export const isRiskAnalysisFormValid = (
   riskAnalysisForm: RiskAnalysisForm | undefined,
   schemaOnlyValidation: boolean,
-  tenantKind: TenantKind
+  tenantKind: TenantKind,
+  dateForValidation: Date
 ): boolean => {
   if (riskAnalysisForm === undefined) {
     return false;
@@ -57,7 +58,8 @@ export const isRiskAnalysisFormValid = (
       validateRiskAnalysis(
         riskAnalysisFormToRiskAnalysisFormToValidate(riskAnalysisForm),
         schemaOnlyValidation,
-        tenantKind
+        tenantKind,
+        dateForValidation
       ).type === "valid"
     );
   }
@@ -113,15 +115,18 @@ export function validateRiskAnalysisOrThrow({
   riskAnalysisForm,
   schemaOnlyValidation,
   tenantKind,
+  dateForValidation,
 }: {
   riskAnalysisForm: purposeApi.RiskAnalysisFormSeed;
   schemaOnlyValidation: boolean;
   tenantKind: TenantKind;
+  dateForValidation: Date;
 }): RiskAnalysisValidatedForm {
   const result = validateRiskAnalysis(
     riskAnalysisForm,
     schemaOnlyValidation,
-    tenantKind
+    tenantKind,
+    dateForValidation
   );
   if (result.type === "invalid") {
     throw riskAnalysisValidationFailed(result.issues);
@@ -133,7 +138,8 @@ export function validateRiskAnalysisOrThrow({
 export function validateAndTransformRiskAnalysis(
   riskAnalysisForm: purposeApi.RiskAnalysisFormSeed | undefined,
   schemaOnlyValidation: boolean,
-  tenantKind: TenantKind
+  tenantKind: TenantKind,
+  dateForValidation: Date
 ): PurposeRiskAnalysisForm | undefined {
   if (!riskAnalysisForm) {
     return undefined;
@@ -142,6 +148,7 @@ export function validateAndTransformRiskAnalysis(
     riskAnalysisForm,
     schemaOnlyValidation,
     tenantKind,
+    dateForValidation,
   });
 
   return {


### PR DESCRIPTION
This PR changes the risk analysis validation. Before, it had to use the latest form rules available. With this change, it could you any form rules version, as long as that version is not expired yet. The date that is compared with the expiration is:
- `risk analysis creation date`, for risk analysis belonging to the eservice
- `purpose creation date` for risk analysis belonging to the purpose