### PR TITLE
PIN-7658 m2mGateway GET /eserviceTemplates/{templateId}/versions/{versionId}/documents/{documentId}

### DIFF
--- a/collections/m2m gateway/eServiceTemplates/Get Eservice  template version document.bru
+++ b/collections/m2m gateway/eServiceTemplates/Get Eservice  template version document.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get eservice template version document
+  type: http
+}
+
+get {
+  url: {{host-m2m-gw}}/eserviceTemplates/:templateId/versions/:versionId/documents/:documentId
+  body: none
+  auth: none
+}
+
+params:path {
+  versionId: {{versionId}}
+  templateId: {{templateId}}
+  documentId: {{documentId}}
+}
+
+headers {
+  Authorization: {{JWT-M2M}}
+}

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -8578,6 +8578,101 @@ paths:
               $ref: "#/components/headers/RateLimitRemainingHeader"
             X-Rate-Limit-Interval:
               $ref: "#/components/headers/RateLimitIntervalHeader"
+  /eserviceTemplates/{templateId}/versions/{versionId}/documents/{documentId}:
+    parameters:
+      - name: templateId
+        in: path
+        description: The E-Service Template ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: versionId
+        in: path
+        description: The ID of the Version
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: documentId
+        in: path
+        description: The ID of the Document to retrieve or delete
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - eserviceTemplates
+      summary: Download an E-Service Template Version Document
+      description: Download a specific Document for the specified E-Service Template Version
+      operationId: downloadEServiceTemplateVersionDocument
+      responses:
+        "200":
+          description: E-Service Template Version Document retrieved, a multipart containing the file and its metadata
+          content:
+            multipart/form-data:
+              schema:
+                $ref: "#/components/schemas/FileDownloadMultipart"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
   /eserviceTemplates/{templateId}/riskAnalyses:
     parameters:
       - name: templateId

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -469,7 +469,12 @@ const eserviceTemplatesRouter = (
         const ctx = fromAppContext(req.ctx);
 
         try {
-          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, SUPPORT_ROLE]);
+          validateAuthorization(ctx, [
+            ADMIN_ROLE,
+            API_ROLE,
+            SUPPORT_ROLE,
+            M2M_ADMIN_ROLE,
+          ]);
 
           const { templateId, templateVersionId, documentId } = req.params;
 

--- a/packages/eservice-template-process/test/api/getEServiceTemplateDocument.test.ts
+++ b/packages/eservice-template-process/test/api/getEServiceTemplateDocument.test.ts
@@ -49,6 +49,7 @@ describe("API GET /templates/:templateId/versions/:templateVersionId/documents/:
     authRole.ADMIN_ROLE,
     authRole.API_ROLE,
     authRole.SUPPORT_ROLE,
+    authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
     "Should return 200 for user with role %s",

--- a/packages/m2m-gateway/test/api/eServiceTemplates/downloadEserviceTemplateVersionDocument.test.ts
+++ b/packages/m2m-gateway/test/api/eServiceTemplates/downloadEserviceTemplateVersionDocument.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { generateToken } from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import { generateId } from "pagopa-interop-models";
+import { api, mockEServiceTemplateService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { getMockDownloadedDocument } from "../../mockUtils.js";
+import {
+  testExpectedMultipartResponse,
+  testMultipartResponseParser,
+} from "../../multipartTestUtils.js";
+
+describe("GET /eserviceTemplates/:templateId/versions/:versionId/documents/:documentId router test", () => {
+  const mockDownloadedDoc = getMockDownloadedDocument();
+
+  const makeRequest = async (
+    token: string,
+    templateId: string,
+    versionId: string,
+    documentId: string
+  ) =>
+    request(api)
+      .get(
+        `${appBasePath}/eserviceTemplates/${templateId}/versions/${versionId}/documents/${documentId}`
+      )
+      .set("Authorization", `Bearer ${token}`)
+      .buffer(true)
+      .parse(testMultipartResponseParser);
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.M2M_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+  it.each(authorizedRoles)(
+    "Should return 200 and perform service calls for user with role %s",
+    async (role) => {
+      mockEServiceTemplateService.downloadEServiceTemplateVersionDocument = vi
+        .fn()
+        .mockResolvedValue(mockDownloadedDoc);
+
+      const token = generateToken(role);
+      const res = await makeRequest(
+        token,
+        generateId(),
+        generateId(),
+        generateId()
+      );
+
+      expect(res.status).toBe(200);
+      await testExpectedMultipartResponse(mockDownloadedDoc, res);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      generateId(),
+      generateId()
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 400 if passed an invalid eservice template id", async () => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      "invalidId",
+      generateId(),
+      generateId()
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 if passed an invalid version id", async () => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      "invalidId",
+      generateId()
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 if passed an invalid document id", async () => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      generateId(),
+      "invalidId"
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/m2m-gateway/test/integration/eServiceTemplates/downloadEserviceTemplateVersionDocument.test.ts
+++ b/packages/m2m-gateway/test/integration/eServiceTemplates/downloadEserviceTemplateVersionDocument.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  EServiceTemplateVersionId,
+  EServiceTemplateId,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEserviceDoc,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import { genericLogger } from "pagopa-interop-commons";
+import {
+  eserviceTemplateService,
+  expectApiClientGetToHaveBeenCalledWith,
+  fileManager,
+  mockInteropBeClients,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+import { config } from "../../../src/config/config.js";
+
+describe("downloadEServiceTemplateVersionDocument", () => {
+  const testFileContent =
+    "This is a mock file content for testing purposes.\nOn multiple lines.";
+
+  const mockDocumentId = generateId();
+  const mockDocumentName = "doc.pdf";
+  const mockDocument = getMockedApiEserviceDoc({
+    id: mockDocumentId,
+    name: mockDocumentName,
+    path: `${config.eserviceTemplateDocumentsPath}/${mockDocumentId}/${mockDocumentName}`,
+  });
+  const mockEserviceTemplateProcessResponse = getMockWithMetadata(mockDocument);
+  const mockGetEserviceTemplateDocumentById = vi
+    .fn()
+    .mockResolvedValue(mockEserviceTemplateProcessResponse);
+
+  mockInteropBeClients.eserviceTemplateProcessClient = {
+    getEServiceTemplateDocumentById: mockGetEserviceTemplateDocumentById,
+  } as unknown as PagoPAInteropBeClients["eserviceTemplateProcessClient"];
+
+  beforeEach(() => {
+    // Clear mock counters and call information before each test
+    mockGetEserviceTemplateDocumentById.mockClear();
+  });
+
+  it("Should succeed, perform API clients calls, and retrieve the file", async () => {
+    await fileManager.storeBytes(
+      {
+        bucket: config.eserviceTemplateDocumentsContainer,
+        path: config.eserviceTemplateDocumentsPath,
+        resourceId: mockDocument.id,
+        name: mockDocument.name,
+        content: Buffer.from(testFileContent),
+      },
+      genericLogger
+    );
+
+    expect(
+      (
+        await fileManager.listFiles(
+          config.eserviceTemplateDocumentsContainer,
+          genericLogger
+        )
+      ).at(0)
+    ).toEqual(mockDocument.path);
+
+    const templateId = generateId<EServiceTemplateId>();
+    const versionId = generateId<EServiceTemplateVersionId>();
+    const result =
+      await eserviceTemplateService.downloadEServiceTemplateVersionDocument(
+        templateId,
+        versionId,
+        unsafeBrandId(mockDocument.id),
+        getMockM2MAdminAppContext()
+      );
+
+    const expectedServiceResponse = {
+      id: mockDocument.id,
+      file: new File([Buffer.from(testFileContent)], mockDocument.name, {
+        type: mockDocument.contentType,
+      }),
+      prettyName: mockDocument.prettyName,
+    };
+    expect(result).toEqual(expectedServiceResponse);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet:
+        mockInteropBeClients.eserviceTemplateProcessClient
+          .getEServiceTemplateDocumentById,
+      params: {
+        templateId,
+        templateVersionId: versionId,
+        documentId: mockDocument.id,
+      },
+    });
+  });
+});


### PR DESCRIPTION
Closes [PIN-7658](https://pagopa.atlassian.net/browse/PIN-7658)
[SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/edit-v2/1812562407)

# Description
Implemented `GET /eserviceTemplates/{templateId}/versions/{versionId}/documents/{documentId}` route in m2m gateway

## Implementation
- [x] Finalize SRS
- [x] JIRA task link in PR, with link to SRS
- [x] API spec of the route in `m2mGatewayApi.yml`
- [x] Documentation: description fields in the spec endpoint, response, errors, params, etc. 

## Double-check errors
- [x] Check errors returned by the process API calls (messages should be meaningful, clean, in correct English, etc.)
- [x] Check spec errors: it should list all non-500 errors, also the ones that pass through from the process

# Testing
Checklist:
- [x] Bruno call added to collection
- [x] Smoke test Bruno (attach result screenshot)
- [] Supertest /api tests
- [x] /integration tests for the logic in the service