### PR TITLE
PIN-7659 m2mGateway DELETE /eserviceTemplates/{templateId}/versions/{versionId}/documents/{documentId}

### DIFF
--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -769,8 +769,15 @@ paths:
             type: string
             format: uuid
       responses:
-        "204":
+        "200":
           description: Document deleted.
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceTemplate"
         "404":
           description: E-Service template document not found
           content:

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -8673,6 +8673,87 @@ paths:
               $ref: "#/components/headers/RateLimitRemainingHeader"
             X-Rate-Limit-Interval:
               $ref: "#/components/headers/RateLimitIntervalHeader"
+    delete:
+      tags:
+        - eserviceTemplates
+      summary: Delete an E-Service Template Version Document
+      description: Delete a specific Document for the specified E-Service Template Version
+      operationId: deleteEServiceTemplateVersionDocument
+      responses:
+        "204":
+          description: E-Service Template Version Document deleted
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
   /eserviceTemplates/{templateId}/riskAnalyses:
     parameters:
       - name: templateId

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -506,15 +506,22 @@ const eserviceTemplatesRouter = (
         const ctx = fromAppContext(req.ctx);
 
         try {
-          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE]);
+          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
 
-          await eserviceTemplateService.deleteDocument(
-            unsafeBrandId(req.params.templateId),
-            unsafeBrandId(req.params.templateVersionId),
-            unsafeBrandId(req.params.documentId),
-            ctx
-          );
-          return res.status(204).send();
+          const { data: updatedEServiceTemplate, metadata } =
+            await eserviceTemplateService.deleteDocument(
+              unsafeBrandId(req.params.templateId),
+              unsafeBrandId(req.params.templateVersionId),
+              unsafeBrandId(req.params.documentId),
+              ctx
+            );
+          setMetadataVersionHeader(res, metadata);
+
+          return res
+            .status(200)
+            .send(
+              eserviceTemplateToApiEServiceTemplate(updatedEServiceTemplate)
+            );
         } catch (error) {
           const errorRes = makeApiProblem(
             error,

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -1572,7 +1572,10 @@ export function eserviceTemplateServiceBuilder(
         eServiceTemplateVersionId: EServiceTemplateVersionId;
         documentId: EServiceDocumentId;
       },
-      { authData, logger }: WithLogger<AppContext<UIAuthData>>
+      {
+        authData,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<Document> {
       logger.info(
         `Getting EService Document ${documentId.toString()} for EService Template ${eServiceTemplateId} and Version ${eServiceTemplateVersionId}`
@@ -1703,8 +1706,12 @@ export function eserviceTemplateServiceBuilder(
       eserviceTemplateId: EServiceTemplateId,
       eserviceTemplateVersionId: EServiceTemplateVersionId,
       documentId: EServiceDocumentId,
-      { authData, correlationId, logger }: WithLogger<AppContext<UIAuthData>>
-    ): Promise<void> {
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
+    ): Promise<WithMetadata<EServiceTemplate>> {
       logger.info(
         `Deleting Document ${documentId} of Version ${eserviceTemplateVersionId} for EService template ${eserviceTemplateId}`
       );
@@ -1774,7 +1781,14 @@ export function eserviceTemplateServiceBuilder(
             correlationId
           );
 
-      await repository.createEvent(event);
+      const createdEvent = await repository.createEvent(event);
+
+      return {
+        data: updatedEServiceTemplate,
+        metadata: {
+          version: createdEvent.newVersion,
+        },
+      };
     },
   };
 }

--- a/packages/m2m-gateway/src/routers/eserviceTemplateRouter.ts
+++ b/packages/m2m-gateway/src/routers/eserviceTemplateRouter.ts
@@ -284,6 +284,33 @@ const eserviceTemplateRouter = (
           return res.status(errorRes.status).send(errorRes);
         }
       }
+    )
+    .delete(
+      "/eserviceTemplates/:templateId/versions/:versionId/documents/:documentId",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          await eserviceTemplateService.deleteEServiceTemplateVersionDocument(
+            unsafeBrandId(req.params.templateId),
+            unsafeBrandId(req.params.versionId),
+            unsafeBrandId(req.params.documentId),
+            ctx
+          );
+
+          return res.status(204).send();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error deleting document with id ${req.params.documentId} for eservice template ${req.params.templateId} version with id ${req.params.versionId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
     );
 
   return eserviceTemplateRouter;

--- a/packages/m2m-gateway/src/services/eserviceTemplateService.ts
+++ b/packages/m2m-gateway/src/services/eserviceTemplateService.ts
@@ -372,5 +372,31 @@ export function eserviceTemplateServiceBuilder(
         logger
       );
     },
+
+    async deleteEServiceTemplateVersionDocument(
+      templateId: EServiceTemplateId,
+      versionId: EServiceTemplateVersionId,
+      documentId: EServiceDocumentId,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<void> {
+      logger.info(
+        `Deleting document with id ${documentId} from eservice template version with id ${versionId} for eservice template with id ${templateId}`
+      );
+
+      const response =
+        await clients.eserviceTemplateProcessClient.deleteEServiceTemplateDocumentById(
+          undefined,
+          {
+            params: {
+              templateId,
+              templateVersionId: versionId,
+              documentId,
+            },
+            headers,
+          }
+        );
+
+      await pollEServiceTemplate(response, headers);
+    },
   };
 }

--- a/packages/m2m-gateway/test/api/eServiceTemplates/deleteEServiceTemplateVersionDocument.test.ts
+++ b/packages/m2m-gateway/test/api/eServiceTemplates/deleteEServiceTemplateVersionDocument.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { generateToken } from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import { generateId } from "pagopa-interop-models";
+import { api, mockEServiceTemplateService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("DELETE /eserviceTemplates/:templateId/versions/:versionId/documents/:documentId router test", () => {
+  const templateId = generateId();
+  const versionId = generateId();
+  const documentId = generateId();
+
+  const makeRequest = async (
+    token: string,
+    templateId: string,
+    versionId: string,
+    documentId: string
+  ) =>
+    request(api)
+      .delete(
+        `${appBasePath}/eserviceTemplates/${templateId}/versions/${versionId}/documents/${documentId}`
+      )
+      .set("Authorization", `Bearer ${token}`);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+
+  it.each(authorizedRoles)(
+    "Should return 204 and perform service calls for user with role %s",
+    async (role) => {
+      mockEServiceTemplateService.deleteEServiceTemplateVersionDocument = vi
+        .fn()
+        .mockResolvedValue(undefined);
+      const token = generateToken(role);
+      const res = await makeRequest(token, templateId, versionId, documentId);
+      expect(res.status).toBe(204);
+      expect(
+        mockEServiceTemplateService.deleteEServiceTemplateVersionDocument
+      ).toHaveBeenCalledWith(
+        templateId,
+        versionId,
+        documentId,
+        expect.any(Object)
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, templateId, versionId, documentId);
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 400 for incorrect value for eservice template id", async () => {
+    mockEServiceTemplateService.deleteEServiceTemplateVersionDocument = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, "INVALID ID", versionId, documentId);
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 for incorrect value for version id", async () => {
+    mockEServiceTemplateService.deleteEServiceTemplateVersionDocument = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, templateId, "INVALID ID", documentId);
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 for incorrect value for document id", async () => {
+    mockEServiceTemplateService.deleteEServiceTemplateVersionDocument = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, templateId, versionId, "INVALID ID");
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/m2m-gateway/test/integration/eServiceTemplates/deleteEServiceTemplateVersionDocument.test.ts
+++ b/packages/m2m-gateway/test/integration/eServiceTemplates/deleteEServiceTemplateVersionDocument.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, vi, beforeEach, expect } from "vitest";
+import {
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockWithMetadata,
+  getMockedApiEserviceTemplateVersion,
+  getMockedApiEserviceDoc,
+  getMockedApiEServiceTemplate,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceTemplateService,
+  expectApiClientPostToHaveBeenCalledWith,
+  expectApiClientGetToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { config } from "../../../src/config/config.js";
+
+describe("deleteEServiceTemplateVersionDocument", () => {
+  const mockDocument = getMockedApiEserviceDoc();
+  const mockVersion = { ...getMockedApiEserviceTemplateVersion(), docs: [] };
+  const mockEServiceTemplate = getMockedApiEServiceTemplate({
+    versions: [mockVersion],
+  });
+
+  const mockGetEServiceTemplateResponse =
+    getMockWithMetadata(mockEServiceTemplate);
+
+  const mockDeleteEServiceTemplateDocumentById = vi
+    .fn()
+    .mockResolvedValue(mockGetEServiceTemplateResponse);
+  const mockGetEServiceTemplate = vi.fn(
+    mockPollingResponse(mockGetEServiceTemplateResponse, 2)
+  );
+
+  mockInteropBeClients.eserviceTemplateProcessClient = {
+    deleteEServiceTemplateDocumentById: mockDeleteEServiceTemplateDocumentById,
+    getEServiceTemplateById: mockGetEServiceTemplate,
+  } as unknown as PagoPAInteropBeClients["eserviceTemplateProcessClient"];
+
+  beforeEach(() => {
+    mockDeleteEServiceTemplateDocumentById.mockClear();
+    mockGetEServiceTemplate.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    mockGetEServiceTemplate.mockResolvedValueOnce(
+      mockGetEServiceTemplateResponse
+    );
+
+    await eserviceTemplateService.deleteEServiceTemplateVersionDocument(
+      unsafeBrandId(mockEServiceTemplate.id),
+      unsafeBrandId(mockVersion.id),
+      unsafeBrandId(mockDocument.id),
+      getMockM2MAdminAppContext()
+    );
+
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.eserviceTemplateProcessClient
+          .deleteEServiceTemplateDocumentById,
+      params: {
+        templateId: mockEServiceTemplate.id,
+        templateVersionId: mockVersion.id,
+        documentId: mockDocument.id,
+      },
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet:
+        mockInteropBeClients.eserviceTemplateProcessClient
+          .getEServiceTemplateById,
+      params: { templateId: mockEServiceTemplate.id },
+    });
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the document DELETE call has no metadata", async () => {
+    mockDeleteEServiceTemplateDocumentById.mockResolvedValueOnce({
+      ...mockGetEServiceTemplateResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceTemplateService.deleteEServiceTemplateVersionDocument(
+        unsafeBrandId(mockGetEServiceTemplateResponse.data.id),
+        unsafeBrandId(mockGetEServiceTemplateResponse.data.versions[0].id),
+        unsafeBrandId(mockDocument.id),
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the polling GET call has no metadata", async () => {
+    mockGetEServiceTemplate.mockResolvedValueOnce({
+      ...mockGetEServiceTemplateResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceTemplateService.deleteEServiceTemplateVersionDocument(
+        unsafeBrandId(mockGetEServiceTemplateResponse.data.id),
+        unsafeBrandId(mockGetEServiceTemplateResponse.data.versions[0].id),
+        unsafeBrandId(mockDocument.id),
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEServiceTemplate.mockImplementation(
+      mockPollingResponse(
+        mockGetEServiceTemplateResponse,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      eserviceTemplateService.deleteEServiceTemplateVersionDocument(
+        unsafeBrandId(mockGetEServiceTemplateResponse.data.id),
+        unsafeBrandId(mockGetEServiceTemplateResponse.data.versions[0].id),
+        unsafeBrandId(mockDocument.id),
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEServiceTemplate).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});


### PR DESCRIPTION
Closes [PIN-7659](https://pagopa.atlassian.net/browse/PIN-7659)
[SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/edit-v2/1812562407)

# Description
Implemented `DELETE /eserviceTemplates/{templateId}/versions/{versionId}/documents/{documentId}` route in m2m gateway

## Implementation
- [x] Finalize SRS
- [x] JIRA task link in PR, with link to SRS
- [x] API spec of the route in `m2mGatewayApi.yml`
- [x] Documentation: description fields in the spec endpoint, response, errors, params, etc. 

## Double-check errors
- [x] Check errors returned by the process API calls (messages should be meaningful, clean, in correct English, etc.)
- [x] Check spec errors: it should list all non-500 errors, also the ones that pass through from the process

# Testing
Checklist:
- [x] Bruno call added to collection
- [x] Smoke test Bruno (attach result screenshot)
- [] Supertest /api tests
- [x] /integration tests for the logic in the service