### PR TITLE
API V2 PATCH draft eservice template versions 

### DIFF
--- a/collections/m2m gateway/eServiceTemplates/Update draft eservice template version.bru
+++ b/collections/m2m gateway/eServiceTemplates/Update draft eservice template version.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Update draft eservice template version
+  type: http
+  seq: 13
+}
+
+patch {
+  url: {{host-m2m-gw}}/eserviceTemplates/:templateId/versions/:versionId
+  body: json
+  auth: none
+}
+
+params:path {
+  versionId: {{eserviceTemplateVersionId}}
+  templateId: {{eserviceTemplateId}}
+}
+
+headers {
+  Authorization: {{JWT-M2M-ADMIN}}
+}
+
+body:json {
+  {
+    "description": "Version description",
+    "voucherLifespan": 100,
+    "dailyCallsPerConsumer": 100,
+    "dailyCallsTotal": 1000,
+    "agreementApprovalPolicy": "AUTOMATIC"
+  }
+}

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -420,6 +420,61 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+    patch:
+      security:
+        - bearerAuth: []
+      tags:
+        - process
+      summary: Patch a draft template version
+      operationId: patchUpdateDraftTemplateVersion
+      description: Patch updates a draft version of the specified E-Service template
+      parameters:
+        - name: templateId
+          in: path
+          description: The E-Service template id
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: templateVersionId
+          in: path
+          description: The E-Service template version Id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: An E-Service template version patch seed
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchUpdateEServiceTemplateVersionSeed"
+        required: true
+      responses:
+        "200":
+          description: Template draft version patched.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceTemplate"
+        "400":
+          description: Invalid input
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /templates/{templateId}/versions/{templateVersionId}/publish:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"
@@ -1438,6 +1493,33 @@ components:
           $ref: "#/components/schemas/AgreementApprovalPolicy"
         attributes:
           $ref: "#/components/schemas/AttributesSeed"
+    PatchUpdateEServiceTemplateVersionSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        description:
+          type: string
+          minLength: 10
+          maxLength: 250
+        voucherLifespan:
+          type: integer
+          format: int32
+          minimum: 60
+          maximum: 86400
+        dailyCallsPerConsumer:
+          description: "maximum number of daily calls that this descriptor can afford."
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        dailyCallsTotal:
+          description: "total daily calls available for this e-service."
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        agreementApprovalPolicy:
+          $ref: "#/components/schemas/AgreementApprovalPolicy"
     UpdateEServiceTemplateVersionQuotasSeed:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -8368,6 +8368,98 @@ paths:
               $ref: "#/components/headers/RateLimitRemainingHeader"
             X-Rate-Limit-Interval:
               $ref: "#/components/headers/RateLimitIntervalHeader"
+    patch:
+      tags:
+        - eserviceTemplates
+      summary: Update a draft E-Service Template Version
+      description: Update an E-Service Template Version in Draft state
+      operationId: updateDraftEServiceTemplateVersion
+      requestBody:
+        description: Updated version data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EServiceTemplateVersionDraftUpdateSeed"
+      responses:
+        "200":
+          description: E-Service Template Version updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceTemplateVersion"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
   /eserviceTemplates/{templateId}/riskAnalyses:
     parameters:
       - name: templateId
@@ -13065,6 +13157,33 @@ components:
           $ref: "#/components/schemas/EServiceMode"
         isSignalHubEnabled:
           type: boolean
+    EServiceTemplateVersionDraftUpdateSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        description:
+          type: string
+          minLength: 10
+          maxLength: 250
+        voucherLifespan:
+          type: integer
+          format: int32
+          minimum: 60
+          maximum: 86400
+        dailyCallsPerConsumer:
+          description: Maximum number of daily calls that this descriptor can afford
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        dailyCallsTotal:
+          description: Total daily calls available for this e-service
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        agreementApprovalPolicy:
+          $ref: "#/components/schemas/AgreementApprovalPolicy"
     EServiceSeed:
       type: object
       additionalProperties: false

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -182,6 +182,40 @@ const eserviceTemplatesRouter = (
         return res.status(errorRes.status).send(errorRes);
       }
     })
+    .patch(
+      "/templates/:templateId/versions/:templateVersionId",
+      async (req, res) => {
+        const ctx = fromAppContext(req.ctx);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          const { data: eserviceTemplate, metadata } =
+            await eserviceTemplateService.patchUpdateDraftTemplateVersion(
+              unsafeBrandId(req.params.templateId),
+              unsafeBrandId(req.params.templateVersionId),
+              req.body,
+              ctx
+            );
+          setMetadataVersionHeader(res, metadata);
+
+          return res
+            .status(200)
+            .send(
+              eserviceTemplateApi.EServiceTemplate.parse(
+                eserviceTemplateToApiEServiceTemplate(eserviceTemplate)
+              )
+            );
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            updateDraftTemplateVersionErrorMapper,
+            ctx
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
     .post("/templates/:templateId", async (req, res) => {
       const ctx = fromAppContext(req.ctx);
 

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -41,6 +41,7 @@ import {
   TenantId,
   Tenant,
   EServiceTemplateEvent,
+  agreementApprovalPolicy,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { eserviceTemplateApi } from "pagopa-interop-api-clients";
@@ -437,6 +438,99 @@ export function eserviceTemplateServiceBuilder(
       await repository.createEvent(event);
 
       return updatedEServiceTemplate;
+    },
+    async patchUpdateDraftTemplateVersion(
+      eserviceTemplateId: EServiceTemplateId,
+      eserviceTemplateVersionId: EServiceTemplateVersionId,
+      seed: Partial<{
+        description: string;
+        voucherLifespan: number;
+        dailyCallsPerConsumer: number;
+        dailyCallsTotal: number;
+        agreementApprovalPolicy: "AUTOMATIC" | "MANUAL";
+      }>,
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
+    ): Promise<WithMetadata<EServiceTemplate>> {
+      logger.info(
+        `Patch update draft e-service template version ${eserviceTemplateVersionId} for EService template ${eserviceTemplateId}`
+      );
+
+      const eserviceTemplate = await retrieveEServiceTemplate(
+        eserviceTemplateId,
+        readModelService
+      );
+
+      assertRequesterEServiceTemplateCreator(
+        eserviceTemplate.data.creatorId,
+        authData
+      );
+
+      const eserviceTemplateVersion = retrieveEServiceTemplateVersion(
+        eserviceTemplateVersionId,
+        eserviceTemplate.data
+      );
+
+      if (
+        eserviceTemplateVersion.state !== eserviceTemplateVersionState.draft
+      ) {
+        throw notValidEServiceTemplateVersionState(
+          eserviceTemplateVersionId,
+          eserviceTemplateVersion.state
+        );
+      }
+
+      // Only check consistency if both dailyCallsPerConsumer and dailyCallsTotal are provided
+      if (
+        seed.dailyCallsPerConsumer !== undefined &&
+        seed.dailyCallsTotal !== undefined
+      ) {
+        assertConsistentDailyCalls(seed);
+      }
+
+      const updatedVersion: EServiceTemplateVersion = {
+        ...eserviceTemplateVersion,
+        ...(seed.agreementApprovalPolicy !== undefined && {
+          agreementApprovalPolicy:
+            seed.agreementApprovalPolicy === "AUTOMATIC"
+              ? agreementApprovalPolicy.automatic
+              : agreementApprovalPolicy.manual,
+        }),
+        ...(seed.dailyCallsPerConsumer !== undefined && {
+          dailyCallsPerConsumer: seed.dailyCallsPerConsumer,
+        }),
+        ...(seed.dailyCallsTotal !== undefined && {
+          dailyCallsTotal: seed.dailyCallsTotal,
+        }),
+        ...(seed.description !== undefined && {
+          description: seed.description,
+        }),
+        ...(seed.voucherLifespan !== undefined && {
+          voucherLifespan: seed.voucherLifespan,
+        }),
+      };
+
+      const updatedEServiceTemplate = replaceEServiceTemplateVersion(
+        eserviceTemplate.data,
+        updatedVersion
+      );
+
+      const creationEvent = toCreateEventEServiceTemplateDraftVersionUpdated(
+        eserviceTemplateId,
+        eserviceTemplate.metadata.version,
+        eserviceTemplateVersionId,
+        updatedEServiceTemplate,
+        correlationId
+      );
+      const event = await repository.createEvent(creationEvent);
+
+      return {
+        data: updatedEServiceTemplate,
+        metadata: { version: event.newVersion },
+      };
     },
     async suspendEServiceTemplateVersion(
       eserviceTemplateId: EServiceTemplateId,

--- a/packages/eservice-template-process/test/api/patchUpdateDraftEserviceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/api/patchUpdateDraftEserviceTemplateVersion.test.ts
@@ -1,0 +1,203 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import {
+  EServiceTemplateId,
+  EServiceTemplateVersionId,
+  eserviceTemplateVersionState,
+  generateId,
+  operationForbidden,
+} from "pagopa-interop-models";
+import {
+  generateToken,
+  getMockEServiceTemplate,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { eserviceTemplateApi } from "pagopa-interop-api-clients";
+import { api, eserviceTemplateService } from "../vitest.api.setup.js";
+import { eserviceTemplateToApiEServiceTemplate } from "../../src/model/domain/apiConverter.js";
+import {
+  eserviceTemplateNotFound,
+  eserviceTemplateVersionNotFound,
+  inconsistentDailyCalls,
+  notValidEServiceTemplateVersionState,
+} from "../../src/model/domain/errors.js";
+
+describe("PATCH /templates/:templateId/versions/:templateVersionId router test", () => {
+  const mockEserviceTemplate = getMockEServiceTemplate();
+  const serviceResponse = getMockWithMetadata(mockEserviceTemplate);
+  const apiEserviceTemplate = eserviceTemplateApi.EServiceTemplate.parse(
+    eserviceTemplateToApiEServiceTemplate(mockEserviceTemplate)
+  );
+
+  const eserviceTemplateSeed: eserviceTemplateApi.PatchUpdateEServiceTemplateVersionSeed =
+    {
+      description: "updated description",
+      voucherLifespan: 120,
+      dailyCallsPerConsumer: 200,
+      dailyCallsTotal: 1000,
+      agreementApprovalPolicy: "MANUAL",
+    };
+
+  eserviceTemplateService.patchUpdateDraftTemplateVersion = vi
+    .fn()
+    .mockResolvedValue(serviceResponse);
+
+  const makeRequest = async (
+    token: string,
+    templateId: EServiceTemplateId = mockEserviceTemplate.id,
+    templateVersionId: EServiceTemplateVersionId = mockEserviceTemplate
+      .versions[0].id,
+    body: eserviceTemplateApi.PatchUpdateEServiceTemplateVersionSeed = eserviceTemplateSeed
+  ) =>
+    request(api)
+      .patch(`/templates/${templateId}/versions/${templateVersionId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(apiEserviceTemplate);
+      expect(res.headers["x-metadata-version"]).toBe(
+        serviceResponse.metadata.version.toString()
+      );
+    }
+  );
+
+  it.each([
+    {},
+    { description: "updated description" },
+    {
+      description: "updated description",
+      voucherLifespan: 200,
+    },
+    {
+      description: "updated description",
+      voucherLifespan: 200,
+      dailyCallsPerConsumer: 300,
+    },
+    {
+      description: "updated description",
+      voucherLifespan: 200,
+      dailyCallsPerConsumer: 300,
+      dailyCallsTotal: 1500,
+    },
+    {
+      description: "updated description",
+      voucherLifespan: 200,
+      dailyCallsPerConsumer: 300,
+      dailyCallsTotal: 1500,
+      agreementApprovalPolicy: "AUTOMATIC" as const,
+    },
+  ] as eserviceTemplateApi.PatchUpdateEServiceTemplateVersionSeed[])(
+    "Should return 200 with partial seed (seed #%#)",
+    async (seed) => {
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        mockEserviceTemplate.id,
+        mockEserviceTemplate.versions[0].id,
+        seed
+      );
+      expect(res.status).toBe(200);
+    }
+  );
+
+  it.each([
+    [
+      { description: 123 },
+      mockEserviceTemplate.id,
+      mockEserviceTemplate.versions[0].id,
+    ],
+    [
+      { voucherLifespan: "invalid" },
+      mockEserviceTemplate.id,
+      mockEserviceTemplate.versions[0].id,
+    ],
+    [
+      { dailyCallsPerConsumer: null },
+      mockEserviceTemplate.id,
+      mockEserviceTemplate.versions[0].id,
+    ],
+    [
+      { dailyCallsTotal: -1 },
+      mockEserviceTemplate.id,
+      mockEserviceTemplate.versions[0].id,
+    ],
+    [
+      { agreementApprovalPolicy: "INVALID" },
+      mockEserviceTemplate.id,
+      mockEserviceTemplate.versions[0].id,
+    ],
+    [eserviceTemplateSeed, "invalidId", mockEserviceTemplate.versions[0].id],
+    [eserviceTemplateSeed, mockEserviceTemplate.id, "invalidId"],
+  ])(
+    "Should return 400 if passed invalid seed or IDs (seed #%#)",
+    async (body, templateId, templateVersionId) => {
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        templateId as EServiceTemplateId,
+        templateVersionId as EServiceTemplateVersionId,
+        body as eserviceTemplateApi.PatchUpdateEServiceTemplateVersionSeed
+      );
+
+      expect(res.status).toBe(400);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {
+      error: eserviceTemplateNotFound(mockEserviceTemplate.id),
+      expectedStatus: 404,
+    },
+    {
+      error: eserviceTemplateVersionNotFound(
+        mockEserviceTemplate.id,
+        mockEserviceTemplate.versions[0].id
+      ),
+      expectedStatus: 404,
+    },
+    {
+      error: operationForbidden,
+      expectedStatus: 403,
+    },
+    {
+      error: notValidEServiceTemplateVersionState(
+        mockEserviceTemplate.versions[0].id,
+        eserviceTemplateVersionState.draft
+      ),
+      expectedStatus: 400,
+    },
+    {
+      error: inconsistentDailyCalls(),
+      expectedStatus: 400,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      eserviceTemplateService.patchUpdateDraftTemplateVersion = vi
+        .fn()
+        .mockRejectedValueOnce(error);
+
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+});

--- a/packages/m2m-gateway/src/routers/eserviceTemplateRouter.ts
+++ b/packages/m2m-gateway/src/routers/eserviceTemplateRouter.ts
@@ -149,6 +149,36 @@ const eserviceTemplateRouter = (
         return res.status(errorRes.status).send(errorRes);
       }
     })
+    .patch(
+      "/eserviceTemplates/:templateId/versions/:versionId",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          const version =
+            await eserviceTemplateService.updateDraftEServiceTemplateVersion(
+              unsafeBrandId(req.params.templateId),
+              unsafeBrandId(req.params.versionId),
+              req.body,
+              ctx
+            );
+
+          return res
+            .status(200)
+            .send(m2mGatewayApi.EServiceTemplateVersion.parse(version));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error updating eservice template ${req.params.templateId} version ${req.params.versionId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
     .get(
       "/eserviceTemplates/:templateId/versions/:versionId",
       async (req, res) => {

--- a/packages/m2m-gateway/src/services/eserviceTemplateService.ts
+++ b/packages/m2m-gateway/src/services/eserviceTemplateService.ts
@@ -265,7 +265,39 @@ export function eserviceTemplateServiceBuilder(
       const polledResource = await pollEServiceTemplate(response, headers);
       return toM2MGatewayEServiceTemplate(polledResource.data);
     },
+    async updateDraftEServiceTemplateVersion(
+      templateId: EServiceTemplateId,
+      versionId: EServiceTemplateVersionId,
+      seed: {
+        description?: string;
+        voucherLifespan?: number;
+        dailyCallsPerConsumer?: number;
+        dailyCallsTotal?: number;
+        agreementApprovalPolicy?: "AUTOMATIC" | "MANUAL";
+      },
+      { logger, headers }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApi.EServiceTemplateVersion> {
+      logger.info(
+        `Updating version ${versionId} of eservice template with id ${templateId}`
+      );
 
+      const response =
+        await clients.eserviceTemplateProcessClient.patchUpdateDraftTemplateVersion(
+          seed,
+          {
+            params: { templateId, templateVersionId: versionId },
+            headers,
+          }
+        );
+      const polledResource = await pollEServiceTemplate(response, headers);
+
+      return toM2MGatewayEServiceTemplateVersion(
+        retrieveEServiceTemplateVersionById(
+          polledResource,
+          unsafeBrandId(versionId)
+        )
+      );
+    },
     async updatePublishedEServiceTemplateVersionQuotas(
       templateId: EServiceTemplateId,
       templateVersionId: EServiceTemplateVersionId,


### PR DESCRIPTION
[PIN-7616](https://pagopa.atlassian.net/browse/PIN-7616)

[SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/1812562407/DRAFT+SRS+API+V2+Parte+2#%5BPIN-7616%5D-Creazione-nuova-Versione-EService-Template-%E2%80%93-POST-%2FeserviceTemplates%2F%7BeServiceTemplateId%7D%2Fversions)

# Description
Implemented `PATCH /eserviceTemplates/{templateId}/versions/{versionId}` route in m2m gateway

## Implementation
- [x] Finalize SRS
- [x] JIRA task link in PR, with link to SRS
- [x] API spec of the route in `m2mGatewayApi.yml`
- [x] Documentation: description fields in the spec endpoint, response, errors, params, etc. 

## Double-check errors
- [x] Check errors returned by the process API calls (messages should be meaningful, clean, in correct English, etc.)
- [x] Check spec errors: it should list all non-500 errors, also the ones that pass through from the process

# Testing
Checklist:
- [x] Bruno call added to collection
- [x] Smoke test Bruno (attach result screenshot)
- [ ] Supertest /api tests
- [ ] /integration tests for the logic in the service

# Screen

## Creation
<img width="658" height="259" alt="Create" src="https://github.com/user-attachments/assets/b09a0df5-cbb9-4105-a5ce-4a9278f4c740" />

## Patch
<img width="658" height="259" alt="PATCH1" src="https://github.com/user-attachments/assets/db0d2965-997a-4123-9c0e-392a47b0bc31" />
<img width="658" height="259" alt="PATCH" src="https://github.com/user-attachments/assets/9e9f0dd5-8eef-4899-875b-c3efceeb452d" />

