### PR TITLE
hotfix: PIN-7773 Allow api user to edit attributes of published descriptor

### DIFF
--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -1134,7 +1134,7 @@ const eservicesRouter = (
         const ctx = fromAppContext(req.ctx);
 
         try {
-          validateAuthorization(ctx, [ADMIN_ROLE]);
+          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
 
           const updatedEService =
             await catalogService.updateDescriptorAttributes(

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -2788,7 +2788,11 @@ export function catalogServiceBuilder(
       eserviceId: EServiceId,
       descriptorId: DescriptorId,
       seed: catalogApi.AttributesSeed,
-      { authData, correlationId, logger }: WithLogger<AppContext<UIAuthData>>
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<EService> {
       logger.info(
         `Updating attributes of Descriptor ${descriptorId} for EService ${eserviceId}`


### PR DESCRIPTION
This PR allows `API_ROLE` and `M2M_ADMIN_ROLE` to update attributes of a descriptor after publication.