### PR TITLE
fix(eservice-template-process): correctly handle undefined in update template version agreementApprovalPolicy (PIN-7803)

### DIFF
--- a/packages/eservice-template-process/src/model/domain/apiConverter.ts
+++ b/packages/eservice-template-process/src/model/domain/apiConverter.ts
@@ -73,15 +73,14 @@ export function agreementApprovalPolicyToApiAgreementApprovalPolicy(
 }
 
 export function apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-  input: eserviceTemplateApi.AgreementApprovalPolicy | undefined
+  input: eserviceTemplateApi.AgreementApprovalPolicy
 ): AgreementApprovalPolicy {
   return match<
-    eserviceTemplateApi.AgreementApprovalPolicy | undefined,
+    eserviceTemplateApi.AgreementApprovalPolicy,
     AgreementApprovalPolicy
   >(input)
     .with("AUTOMATIC", () => agreementApprovalPolicy.automatic)
     .with("MANUAL", () => agreementApprovalPolicy.manual)
-    .with(undefined, () => agreementApprovalPolicy.automatic)
     .exhaustive();
 }
 

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -1217,10 +1217,11 @@ export function eserviceTemplateServiceBuilder(
         voucherLifespan: seed.version.voucherLifespan,
         dailyCallsPerConsumer: seed.version.dailyCallsPerConsumer,
         dailyCallsTotal: seed.version.dailyCallsTotal,
-        agreementApprovalPolicy:
-          apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-            seed.version.agreementApprovalPolicy
-          ),
+        agreementApprovalPolicy: seed.version.agreementApprovalPolicy
+          ? apiAgreementApprovalPolicyToAgreementApprovalPolicy(
+              seed.version.agreementApprovalPolicy
+            )
+          : undefined,
         publishedAt: undefined,
         suspendedAt: undefined,
         deprecatedAt: undefined,
@@ -2045,20 +2046,21 @@ async function updateDraftEServiceTemplateVersion(
     .exhaustive();
 
   const updatedAgreementApprovalPolicy = match(updateSeed)
-    .with({ type: "post" }, ({ seed }) =>
-      apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-        seed.agreementApprovalPolicy
-      )
+    .with(
+      { type: "post" },
+      ({ seed }) =>
+        seed.agreementApprovalPolicy &&
+        apiAgreementApprovalPolicyToAgreementApprovalPolicy(
+          seed.agreementApprovalPolicy
+        )
     )
     .with({ type: "patch" }, ({ seed }) =>
-      resolvePatchValue(
-        seed.agreementApprovalPolicy === null
-          ? null
-          : apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-              seed.agreementApprovalPolicy
-            ),
-        eserviceTemplateVersion.agreementApprovalPolicy
-      )
+      match(seed.agreementApprovalPolicy)
+        .with(undefined, () => eserviceTemplateVersion.agreementApprovalPolicy)
+        .with(null, () => undefined)
+        .otherwise((value) =>
+          apiAgreementApprovalPolicyToAgreementApprovalPolicy(value)
+        )
     )
     .exhaustive();
 


### PR DESCRIPTION
## Issue
- [PIN-7803](https://pagopa.atlassian.net/browse/PIN-7803)
## Why
The process was incorrectly processing an `undefined` value (omitted field) from the PATCH payload, defaulting to a `MANUAL` policy instead of retaining the existing policy value. Updates are now correctly ignored when the field is `undefined`.
## Impacted Services
- eservice-template-process 
## Checklist
- [x] Branch contiene la Jira key
- [x] Titolo PR conforme (type(scope): descrizione (KEY))
- [ ] Fix Version impostata in Jira
- [x] Label servizio applicate
