### PR TITLE
fix(m2m-gateway): fix missing error handling for missing e-service template versions (PIN-7799)

### DIFF
--- a/packages/m2m-gateway/src/routers/eserviceTemplateRouter.ts
+++ b/packages/m2m-gateway/src/routers/eserviceTemplateRouter.ts
@@ -15,6 +15,10 @@ import { fromM2MGatewayAppContext } from "../utils/context.js";
 import {
   getEServiceTemplateRiskAnalysisErrorMapper,
   getEServiceTemplateVersionErrorMapper,
+  getEServiceTemplateVersionDocumentsErrorMapper,
+  suspendEServiceTemplateVersionErrorMapper,
+  unsuspendEServiceTemplateVersionErrorMapper,
+  publishEServiceTemplateVersionErrorMapper,
 } from "../utils/errorMappers.js";
 import { sendDownloadedDocumentAsFormData } from "../utils/fileDownload.js";
 
@@ -232,7 +236,7 @@ const eserviceTemplateRouter = (
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
-            emptyErrorMapper,
+            suspendEServiceTemplateVersionErrorMapper,
             ctx,
             `Error suspending eservice template ${req.params.templateId} version ${req.params.versionId}`
           );
@@ -261,7 +265,7 @@ const eserviceTemplateRouter = (
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
-            emptyErrorMapper,
+            unsuspendEServiceTemplateVersionErrorMapper,
             ctx,
             `Error unsuspending eservice template ${req.params.templateId} version ${req.params.versionId}`
           );
@@ -290,7 +294,7 @@ const eserviceTemplateRouter = (
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
-            emptyErrorMapper,
+            publishEServiceTemplateVersionErrorMapper,
             ctx,
             `Error publishing eservice template ${req.params.templateId} version ${req.params.versionId}`
           );
@@ -373,7 +377,7 @@ const eserviceTemplateRouter = (
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
-            emptyErrorMapper,
+            getEServiceTemplateVersionDocumentsErrorMapper,
             ctx,
             `Error retrieving documents for eservice template ${req.params.templateId} version with id ${req.params.versionId}`
           );

--- a/packages/m2m-gateway/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway/src/utils/errorMappers.ts
@@ -194,3 +194,31 @@ export const getEServiceTemplateRiskAnalysisErrorMapper = (
   match(error.code)
     .with("eserviceTemplateRiskAnalysisNotFound", () => HTTP_STATUS_NOT_FOUND)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const getEServiceTemplateVersionDocumentsErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("eserviceTemplateVersionNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const suspendEServiceTemplateVersionErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("eserviceTemplateVersionNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const unsuspendEServiceTemplateVersionErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("eserviceTemplateVersionNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const publishEServiceTemplateVersionErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("eserviceTemplateVersionNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
## Issue
- [PIN-7799](https://pagopa.atlassian.net/browse/PIN-7799)
## Why
Some routes of the e-service template router were missing error handling in case of e-service template version not found.
This PR adds the missing error mappers.
## Impacted Services
- m2m-gateway 
## Checklist
- [x] Branch contiene la Jira key
- [x] Titolo PR conforme (type(scope): descrizione (KEY))
- [ ] Fix Version impostata in Jira
- [x] Label servizio applicate


<img width="1641" height="1046" alt="Screenshot 2025-09-26 alle 11 40 07" src="https://github.com/user-attachments/assets/c08aabbe-b1bc-4ec8-8664-994574911d30" />