### PR TITLE
feature: purpose-template-process POST /purposeTemplates/:id/archive (PIN-7662)

### DIFF
--- a/collections/bff/purposeTemplate/Archive Purpose Template.bru
+++ b/collections/bff/purposeTemplate/Archive Purpose Template.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Archive Purpose Template
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{host-bff}}/purposeTemplates/:purposeTemplateId/archive
+  auth: none
+}
+
+params:path {
+  purposeTemplateId: {{purposeTemplateId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}

--- a/collections/purpose-template/Archive Purpose Template.bru
+++ b/collections/purpose-template/Archive Purpose Template.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Archive Purpose Template
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{host-purpose-template}}/purposeTemplates/:purposeTemplateId/archive
+  auth: none
+}
+
+params:path {
+  purposeTemplateId: {{purposeTemplateId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -10849,6 +10849,131 @@ paths:
                 type: integer
                 format: int32
               description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+  /purposeTemplates/{purposeTemplateId}/archive:
+    parameters:
+      - name: purposeTemplateId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      summary: Archive Purpose Template
+      description: Archives a purpose template by id (from Suspended State to Archived State)
+      operationId: archivePurposeTemplate
+      tags:
+        - purposeTemplates
+      responses:
+        "200":
+          description: Purpose Template Archived
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PurposeTemplate"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "403":
+          description: Organization not allowed
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "404":
+          description: Purpose Template Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
   "/tenants/{tenantId}/attributes/declared":
     get:
       tags:

--- a/packages/backend-for-frontend/src/routers/purposeTemplateRouter.ts
+++ b/packages/backend-for-frontend/src/routers/purposeTemplateRouter.ts
@@ -184,6 +184,26 @@ const purposeTemplateRouter = (
         );
         return res.status(errorRes.status).send(errorRes);
       }
+    })
+    .post("/purposeTemplates/:purposeTemplateId/archive", async (req, res) => {
+      const ctx = fromBffAppContext(req.ctx, req.headers);
+
+      try {
+        const response = await purposeTemplateService.archivePurposeTemplate(
+          unsafeBrandId(req.params.purposeTemplateId),
+          ctx
+        );
+
+        return res.status(200).send(bffApi.PurposeTemplate.parse(response));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx,
+          `Error archiving purpose template ${req.params.purposeTemplateId}`
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
     });
 
   return purposeTemplateRouter;

--- a/packages/backend-for-frontend/src/services/purposeTemplateService.ts
+++ b/packages/backend-for-frontend/src/services/purposeTemplateService.ts
@@ -262,6 +262,25 @@ export function purposeTemplateServiceBuilder(
 
       return bffApi.PurposeTemplate.parse(result);
     },
+    async archivePurposeTemplate(
+      purposeTemplateId: PurposeTemplateId,
+      { logger, headers }: WithLogger<BffAppContext>
+    ): Promise<bffApi.PurposeTemplate> {
+      assertFeatureFlagEnabled(config, "featureFlagPurposeTemplate");
+
+      logger.info(`Archiving purpose template ${purposeTemplateId}`);
+      const result = await purposeTemplateClient.archivePurposeTemplate(
+        undefined,
+        {
+          params: {
+            id: purposeTemplateId,
+          },
+          headers,
+        }
+      );
+
+      return bffApi.PurposeTemplate.parse(result);
+    },
   };
 }
 export type PurposeTemplateService = ReturnType<

--- a/packages/backend-for-frontend/test/api/purposeTemplateRouter/archivePurposeTemplate.test.ts
+++ b/packages/backend-for-frontend/test/api/purposeTemplateRouter/archivePurposeTemplate.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateId, PurposeTemplateId } from "pagopa-interop-models";
+import request from "supertest";
+import { generateToken } from "pagopa-interop-commons-test/src/mockedPayloadForToken.js";
+import { authRole } from "pagopa-interop-commons";
+import { bffApi } from "pagopa-interop-api-clients";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { api, clients } from "../../vitest.api.setup.js";
+import { getMockBffApiPurposeTemplate } from "../../mockUtils.js";
+
+describe("API POST /purposeTemplates/{purposeTemplateId}/archive", () => {
+  const mockArchivedPurposeTemplate = getMockBffApiPurposeTemplate(
+    bffApi.PurposeTemplateState.Enum.ARCHIVED
+  );
+
+  beforeEach(() => {
+    clients.purposeTemplateProcessClient.archivePurposeTemplate = vi
+      .fn()
+      .mockResolvedValue(mockArchivedPurposeTemplate);
+  });
+
+  const makeRequest = async (
+    token: string,
+    purposeTemplateId: PurposeTemplateId
+  ): Promise<request.Response> =>
+    request(api)
+      .post(`${appBasePath}/purposeTemplates/${purposeTemplateId}/archive`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId());
+
+  it("Should return 200 for user with role Admin", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, mockArchivedPurposeTemplate.id);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockArchivedPurposeTemplate);
+  });
+
+  it("Should return 400 for invalid purpose template id", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, "invalid" as PurposeTemplateId);
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/purpose-template-process/src/model/domain/toEvent.ts
+++ b/packages/purpose-template-process/src/model/domain/toEvent.ts
@@ -84,3 +84,24 @@ export function toCreateEventPurposeTemplateSuspended({
     },
   };
 }
+
+export function toCreateEventPurposeTemplateArchived({
+  purposeTemplate,
+  version,
+  correlationId,
+}: {
+  purposeTemplate: PurposeTemplate;
+  version: number;
+  correlationId: CorrelationId;
+}): CreateEvent<PurposeTemplateEventV2> {
+  return {
+    streamId: purposeTemplate.id,
+    version,
+    correlationId,
+    event: {
+      type: "PurposeTemplateArchived",
+      event_version: 2,
+      data: { purposeTemplate: toPurposeTemplateV2(purposeTemplate) },
+    },
+  };
+}

--- a/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
+++ b/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
@@ -21,6 +21,7 @@ import { PurposeTemplateService } from "../services/purposeTemplateService.js";
 import { makeApiProblem } from "../model/domain/errors.js";
 import {
   activatePurposeTemplateErrorMapper,
+  archivePurposeTemplateErrorMapper,
   createPurposeTemplateErrorMapper,
   getPurposeTemplateErrorMapper,
   getPurposeTemplatesErrorMapper,
@@ -278,12 +279,33 @@ const purposeTemplateRouter = (
     })
     .post("/purposeTemplates/:id/archive", async (req, res) => {
       const ctx = fromAppContext(req.ctx);
+
       try {
         validateAuthorization(ctx, [ADMIN_ROLE, M2M_ADMIN_ROLE]);
+
+        const { data: purposeTemplate, metadata } =
+          await purposeTemplateService.archivePurposeTemplate(
+            unsafeBrandId(req.params.id),
+            ctx
+          );
+
+        setMetadataVersionHeader(res, metadata);
+
+        return res
+          .status(200)
+          .send(
+            purposeTemplateApi.PurposeTemplate.parse(
+              purposeTemplateToApiPurposeTemplate(purposeTemplate)
+            )
+          );
       } catch (error) {
-        return res.status(501);
+        const errorRes = makeApiProblem(
+          error,
+          archivePurposeTemplateErrorMapper,
+          ctx
+        );
+        return res.status(errorRes.status).send(errorRes);
       }
-      return res.status(501);
     })
     .post("/purposeTemplates/:id/publish", async (req, res) => {
       const ctx = fromAppContext(req.ctx);

--- a/packages/purpose-template-process/src/services/validators.ts
+++ b/packages/purpose-template-process/src/services/validators.ts
@@ -157,3 +157,16 @@ export const assertSuspendableState = (
     purposeTemplateState.active,
   ]);
 };
+
+export const archivableInitialStates = Object.values(
+  purposeTemplateState
+).filter((state) => state !== purposeTemplateState.archived);
+export const assertArchivableState = (
+  purposeTemplate: PurposeTemplate
+): void => {
+  assertState(
+    purposeTemplate,
+    purposeTemplateState.archived,
+    archivableInitialStates
+  );
+};

--- a/packages/purpose-template-process/src/utilities/errorMappers.ts
+++ b/packages/purpose-template-process/src/utilities/errorMappers.ts
@@ -62,3 +62,12 @@ export const suspendPurposeTemplateErrorMapper = (
     .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
     .with("purposeTemplateNotFound", () => HTTP_STATUS_NOT_FOUND)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const archivePurposeTemplateErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("purposeTemplateStateConflict", () => HTTP_STATUS_CONFLICT)
+    .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
+    .with("purposeTemplateNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/purpose-template-process/test/api/archivePurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/api/archivePurposeTemplate.test.ts
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { purposeTemplateApi } from "pagopa-interop-api-clients";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  generateToken,
+  getMockPurposeTemplate,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import request from "supertest";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import {
+  generateId,
+  PurposeTemplateId,
+  purposeTemplateState,
+} from "pagopa-interop-models";
+import { purposeTemplateToApiPurposeTemplate } from "../../src/model/domain/apiConverter.js";
+import { api, purposeTemplateService } from "../vitest.api.setup.js";
+import {
+  purposeTemplateNotFound,
+  purposeTemplateStateConflict,
+  tenantNotAllowed,
+} from "../../src/model/domain/errors.js";
+
+describe("API POST /purposeTemplates/{id}/archive", () => {
+  const purposeTemplate = getMockPurposeTemplate();
+  const serviceResponse = getMockWithMetadata(purposeTemplate);
+
+  const apiResponse = purposeTemplateApi.PurposeTemplate.parse(
+    purposeTemplateToApiPurposeTemplate(purposeTemplate)
+  );
+
+  beforeEach(() => {
+    purposeTemplateService.archivePurposeTemplate = vi
+      .fn()
+      .mockResolvedValue(serviceResponse);
+  });
+
+  const makeRequest = async (
+    token: string,
+    purposeTemplateId: PurposeTemplateId = purposeTemplate.id
+  ) =>
+    request(api)
+      .post(`/purposeTemplates/${purposeTemplateId}/archive`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId());
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(apiResponse);
+      expect(res.headers["x-metadata-version"]).toBe(
+        serviceResponse.metadata.version.toString()
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { error: tenantNotAllowed(generateId()), expectedStatus: 403 },
+    {
+      error: purposeTemplateNotFound(generateId()),
+      expectedStatus: 404,
+    },
+    {
+      error: purposeTemplateStateConflict(
+        generateId(),
+        purposeTemplateState.archived
+      ),
+      expectedStatus: 409,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      purposeTemplateService.archivePurposeTemplate = vi
+        .fn()
+        .mockRejectedValue(error);
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+
+  it("Should return 400 if passed invalid data: %s", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, "invalid" as PurposeTemplateId);
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/purpose-template-process/test/integration/archivePurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/archivePurposeTemplate.test.ts
@@ -1,0 +1,166 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {
+  decodeProtobufPayload,
+  getMockAuthData,
+  getMockContext,
+  getMockPurposeTemplate,
+  getMockRiskAnalysisTemplateAnswerAnnotation,
+  getMockRiskAnalysisTemplateAnswerAnnotationDocument,
+  getMockValidRiskAnalysisFormTemplate,
+  sortPurposeTemplate,
+} from "pagopa-interop-commons-test";
+import {
+  generateId,
+  tenantKind,
+  TenantId,
+  PurposeTemplate,
+  RiskAnalysisFormTemplate,
+  RiskAnalysisTemplateMultiAnswer,
+  RiskAnalysisTemplateSingleAnswer,
+  purposeTemplateState,
+  toPurposeTemplateV2,
+  PurposeTemplateArchivedV2,
+} from "pagopa-interop-models";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  addOnePurposeTemplate,
+  purposeTemplateService,
+  readLastPurposeTemplateEvent,
+} from "../integrationUtils.js";
+import {
+  purposeTemplateStateConflict,
+  tenantNotAllowed,
+} from "../../src/model/domain/errors.js";
+import { archivableInitialStates } from "../../src/services/validators.js";
+
+describe("archivePurposeTemplate", () => {
+  const creatorId = generateId<TenantId>();
+  const incompleteRiskAnalysisFormTemplate =
+    getMockValidRiskAnalysisFormTemplate(tenantKind.PA);
+  const riskAnalysisFormTemplate: RiskAnalysisFormTemplate = {
+    ...incompleteRiskAnalysisFormTemplate,
+    singleAnswers: incompleteRiskAnalysisFormTemplate.singleAnswers.map(
+      (a): RiskAnalysisTemplateSingleAnswer => ({
+        ...a,
+        annotation: {
+          ...getMockRiskAnalysisTemplateAnswerAnnotation(),
+          docs: [getMockRiskAnalysisTemplateAnswerAnnotationDocument()],
+        },
+        suggestedValues: [],
+      })
+    ),
+    multiAnswers: incompleteRiskAnalysisFormTemplate.multiAnswers.map(
+      (a): RiskAnalysisTemplateMultiAnswer => ({
+        ...a,
+        annotation: {
+          ...getMockRiskAnalysisTemplateAnswerAnnotation(),
+          docs: [getMockRiskAnalysisTemplateAnswerAnnotationDocument()],
+        },
+      })
+    ),
+  };
+
+  const purposeTemplate: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    updatedAt: new Date(),
+    purposeRiskAnalysisForm: riskAnalysisFormTemplate,
+    purposeFreeOfChargeReason: "Free of charge reason",
+    purposeDailyCalls: 100,
+    state: purposeTemplateState.active,
+    creatorId,
+  };
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date());
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it.each(archivableInitialStates)(
+    "should write on event-store for the archiving of a purpose template in %s state",
+    async (state) => {
+      const metadataVersion = 1;
+      await addOnePurposeTemplate(
+        { ...purposeTemplate, state },
+        metadataVersion
+      );
+
+      const archiveResponse =
+        await purposeTemplateService.archivePurposeTemplate(
+          purposeTemplate.id,
+          getMockContext({ authData: getMockAuthData(creatorId) })
+        );
+
+      const updatedPurposeTemplate = archiveResponse.data;
+
+      const writtenEvent = await readLastPurposeTemplateEvent(
+        purposeTemplate.id
+      );
+
+      const expectedMetadataVersion = metadataVersion + 1;
+
+      expect(writtenEvent).toMatchObject({
+        stream_id: purposeTemplate.id,
+        version: String(expectedMetadataVersion),
+        type: "PurposeTemplateArchived",
+        event_version: 2,
+      });
+
+      const expectedPurposeTemplate: PurposeTemplate = {
+        ...purposeTemplate,
+        state: purposeTemplateState.archived,
+        updatedAt: new Date(),
+      };
+
+      const writtenPayload = decodeProtobufPayload({
+        messageType: PurposeTemplateArchivedV2,
+        payload: writtenEvent.data,
+      });
+
+      expect(sortPurposeTemplate(writtenPayload.purposeTemplate)).toEqual(
+        sortPurposeTemplate(toPurposeTemplateV2(expectedPurposeTemplate))
+      );
+      expect(archiveResponse).toMatchObject({
+        data: updatedPurposeTemplate,
+        metadata: { version: expectedMetadataVersion },
+      });
+    }
+  );
+
+  it("should throw tenantNotAllowed if the caller is not the creator of the purpose template", async () => {
+    await addOnePurposeTemplate(purposeTemplate);
+
+    const otherTenantId = generateId<TenantId>();
+
+    await expect(async () => {
+      await purposeTemplateService.archivePurposeTemplate(
+        purposeTemplate.id,
+        getMockContext({ authData: getMockAuthData(otherTenantId) })
+      );
+    }).rejects.toThrowError(tenantNotAllowed(otherTenantId));
+  });
+
+  it(`should throw purposeTemplateStateConflict if the purpose template is archived`, async () => {
+    const purposeTemplateWithUnexpectedState: PurposeTemplate = {
+      ...purposeTemplate,
+      state: purposeTemplateState.archived,
+    };
+
+    await addOnePurposeTemplate(purposeTemplateWithUnexpectedState);
+
+    await expect(async () => {
+      await purposeTemplateService.archivePurposeTemplate(
+        purposeTemplateWithUnexpectedState.id,
+        getMockContext({ authData: getMockAuthData(creatorId) })
+      );
+    }).rejects.toThrowError(
+      purposeTemplateStateConflict(
+        purposeTemplateWithUnexpectedState.id,
+        purposeTemplateWithUnexpectedState.state
+      )
+    );
+  });
+});


### PR DESCRIPTION
## Issue
- [PIN-7662](https://pagopa.atlassian.net/browse/PIN-7662)

## Context / Why
This PR adds the logic and tests for the `POST /purposeTemplates/:id/archive` in both the `purpose-template-process` and the `BFF`.

## Impacted services
- backend-for-frontend, purpose-template-process

## Checklist
- [x] Add Bruno file for `purpose-template-process`
- [x] Add endpoint logic in `purpose-template-process`
- [x] Add endpoint tests in `purpose-template-process`
- [x] Add Bruno file for `backend-for-frontend`
- [x] Add endpoint logic in `backend-for-frontend`
- [x] Add endpoint tests in `backend-for-frontend`