### PR TITLE
PIN-7818 m2mGateway DELETE /eserviceTemplates/{templateId}

### DIFF
--- a/collections/eservice-template/Delete Eservice Template.bru
+++ b/collections/eservice-template/Delete Eservice Template.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Delete Eservice Template
+  type: http
+}
+
+delete {
+  url: {{host-template}}/templates/:eserviceTemplateId
+  body: json
+  auth: none
+}
+
+params:path {
+  eserviceTemplateId: {{eserviceTemplateId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}
+
+body:json {
+  {
+      "name": "{{name}}",
+      "description": "this is a test again",
+      "technology": "REST",
+      "mode": "DELIVER",
+      "descriptor": {
+          "audience": [ "string" ],
+          "voucherLifespan": 86400,
+          "dailyCallsPerConsumer": 100,
+          "dailyCallsTotal": 100,
+          "agreementApprovalPolicy": "AUTOMATIC"
+      }
+  }
+}

--- a/collections/m2m gateway/eServiceTemplates/Delete Eservice Template.bru
+++ b/collections/m2m gateway/eServiceTemplates/Delete Eservice Template.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Delete eservice template
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{host-m2m-gw}}/eserviceTemplates/:templateId
+  body: none
+  auth: none
+}
+
+params:path {
+  templateId: {{templateId}}
+}
+
+headers {
+  Authorization: {{JWT-M2M-ADMIN}}
+}

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -274,6 +274,29 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+    delete:
+      security:
+        - bearerAuth: []
+      tags:
+        - process
+      summary: Deletes an e-service template
+      operationId: deleteEServiceTemplate
+      description: Deletes the specified E-Service Template
+      responses:
+        "204":
+          description: EService Template deleted
+        "400":
+          description: Invalid input
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /templates/{templateId}/versions:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -8176,6 +8176,87 @@ paths:
               $ref: "#/components/headers/RateLimitRemainingHeader"
             X-Rate-Limit-Interval:
               $ref: "#/components/headers/RateLimitIntervalHeader"
+    delete:
+      tags:
+        - eserviceTemplates
+      summary: Delete an E-Service Template in Draft state
+      operationId: deleteEServiceTemplate
+      description: Delete an E-Service Template in Draft state
+      responses:
+        "204":
+          description: E-Service Template deleted
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
   /eserviceTemplates/{templateId}/description:
     parameters:
       - name: templateId

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -41,6 +41,7 @@ import {
   updateDocumentErrorMapper,
   deleteDocumentErrorMapper,
   getEServiceTemplatesErrorMapper,
+  deleteEServiceTemplateErrorMapper,
 } from "../utilities/errorMappers.js";
 import {
   eserviceTemplateToApiEServiceTemplate,
@@ -178,6 +179,26 @@ const eserviceTemplatesRouter = (
         const errorRes = makeApiProblem(
           error,
           getEServiceTemplateErrorMapper,
+          ctx
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
+    .delete("/templates/:templateId", async (req, res) => {
+      const ctx = fromAppContext(req.ctx);
+
+      try {
+        validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
+
+        await eserviceTemplateService.deleteEServiceTemplate(
+          unsafeBrandId(req.params.templateId),
+          ctx
+        );
+        return res.status(204).send();
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          deleteEServiceTemplateErrorMapper,
           ctx
         );
         return res.status(errorRes.status).send(errorRes);

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -1823,6 +1823,68 @@ export function eserviceTemplateServiceBuilder(
         },
       };
     },
+
+    async deleteEServiceTemplate(
+      templateId: EServiceTemplateId,
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
+    ): Promise<void> {
+      logger.info(`Deleting EService Template ${templateId}`);
+
+      const eserviceTemplate = await retrieveEServiceTemplate(
+        templateId,
+        readModelService
+      );
+      assertRequesterEServiceTemplateCreator(
+        eserviceTemplate.data.creatorId,
+        authData
+      );
+      assertIsDraftEServiceTemplate(eserviceTemplate.data);
+
+      if (eserviceTemplate.data.versions.length === 0) {
+        const eserviceTemplateDeletionEvent =
+          toCreateEventEServiceTemplateDeleted(
+            eserviceTemplate.data.id,
+            eserviceTemplate.metadata.version,
+            eserviceTemplate.data,
+            correlationId
+          );
+        await repository.createEvent(eserviceTemplateDeletionEvent);
+      } else {
+        await deleteVersionInterfaceAndDocs(
+          eserviceTemplate.data.versions[0],
+          fileManager,
+          logger
+        );
+
+        const eserviceTemplateWithoutVersions: EServiceTemplate = {
+          ...eserviceTemplate.data,
+          versions: [],
+        };
+        const versionDeletionEvent =
+          toCreateEventEServiceTemplateDraftVersionDeleted(
+            eserviceTemplate.data.id,
+            eserviceTemplate.metadata.version,
+            eserviceTemplate.data.versions[0].id,
+            eserviceTemplateWithoutVersions,
+            correlationId
+          );
+        const eserviceTemplateDeletionEvent =
+          toCreateEventEServiceTemplateDeleted(
+            eserviceTemplate.data.id,
+            eserviceTemplate.metadata.version + 1,
+            eserviceTemplateWithoutVersions,
+            correlationId
+          );
+        await repository.createEvents([
+          versionDeletionEvent,
+          eserviceTemplateDeletionEvent,
+        ]);
+      }
+    },
   };
 }
 
@@ -2167,3 +2229,20 @@ async function updateDraftEServiceTemplateVersion(
     metadata: { version: event.newVersion },
   };
 }
+
+const deleteVersionInterfaceAndDocs = async (
+  version: EServiceTemplateVersion,
+  fileManager: FileManager,
+  logger: Logger
+): Promise<void> => {
+  const versionInterface = version.interface;
+  if (versionInterface !== undefined) {
+    await fileManager.delete(config.s3Bucket, versionInterface.path, logger);
+  }
+
+  const deleteVersionDocs = version.docs.map((doc: Document) =>
+    fileManager.delete(config.s3Bucket, doc.path, logger)
+  );
+
+  await Promise.all(deleteVersionDocs);
+};

--- a/packages/eservice-template-process/src/utilities/errorMappers.ts
+++ b/packages/eservice-template-process/src/utilities/errorMappers.ts
@@ -21,6 +21,15 @@ export const getEServiceTemplateErrorMapper = (
     .with("eserviceTemplateNotFound", () => HTTP_STATUS_NOT_FOUND)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
+export const deleteEServiceTemplateErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("eserviceTemplateNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
+    .with("eserviceTemplateNotInDraftState", () => HTTP_STATUS_CONFLICT)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
 export const suspendEServiceTemplateVersionErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>

--- a/packages/eservice-template-process/test/api/deleteEserviceTemplate.test.ts
+++ b/packages/eservice-template-process/test/api/deleteEserviceTemplate.test.ts
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import {
+  EServiceTemplate,
+  EServiceTemplateId,
+  generateId,
+  operationForbidden,
+} from "pagopa-interop-models";
+import {
+  generateToken,
+  getMockEServiceTemplate,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { api, eserviceTemplateService } from "../vitest.api.setup.js";
+import {
+  eserviceTemplateNotFound,
+  eserviceTemplateNotInDraftState,
+} from "../../src/model/domain/errors.js";
+
+describe("API /templates/{templateId} authorization test", () => {
+  const eserviceTemplate: EServiceTemplate = getMockEServiceTemplate();
+
+  eserviceTemplateService.deleteEServiceTemplate = vi
+    .fn()
+    .mockResolvedValue({});
+
+  const makeRequest = async (token: string, templateId: EServiceTemplateId) =>
+    request(api)
+      .delete(`/templates/${templateId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send();
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.API_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+  it.each(authorizedRoles)(
+    "Should return 204 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token, eserviceTemplate.id);
+      expect(res.status).toBe(204);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, eserviceTemplate.id);
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {
+      error: eserviceTemplateNotInDraftState(eserviceTemplate.id),
+      expectedStatus: 409,
+    },
+    {
+      error: eserviceTemplateNotFound(eserviceTemplate.id),
+      expectedStatus: 404,
+    },
+    {
+      error: operationForbidden,
+      expectedStatus: 403,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      eserviceTemplateService.deleteEServiceTemplate = vi
+        .fn()
+        .mockRejectedValue(error);
+
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, eserviceTemplate.id);
+
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+
+  it.each([{}, { templateId: "invalidId" }])(
+    "Should return 400 if passed invalid params: %s",
+    async ({ templateId }) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, templateId as EServiceTemplateId);
+
+      expect(res.status).toBe(400);
+    }
+  );
+});

--- a/packages/eservice-template-process/test/integration/deleteEserviceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/deleteEserviceTemplate.test.ts
@@ -1,0 +1,241 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import { genericLogger } from "pagopa-interop-commons";
+import {
+  decodeProtobufPayload,
+  getMockContext,
+  getMockAuthData,
+  readEventByStreamIdAndVersion,
+  getMockDocument,
+  getMockEServiceTemplate,
+  getMockEServiceTemplateVersion,
+} from "pagopa-interop-commons-test";
+import {
+  EServiceTemplate,
+  EServiceTemplateVersion,
+  eserviceTemplateVersionState,
+  operationForbidden,
+  toEServiceTemplateV2,
+  EServiceTemplateDeletedV2,
+  EServiceTemplateDraftVersionDeletedV2,
+} from "pagopa-interop-models";
+import { expect, describe, it, vi } from "vitest";
+import {
+  eserviceTemplateNotFound,
+  eserviceTemplateNotInDraftState,
+} from "../../src/model/domain/errors.js";
+import { config } from "../../src/config/config.js";
+import {
+  addOneEServiceTemplate,
+  eserviceTemplateService,
+  postgresDB,
+  fileManager,
+  readLastEserviceTemplateEvent,
+} from "../integrationUtils.js";
+
+describe("delete eserviceTemplate", () => {
+  const mockEserviceTemplateVersion = getMockEServiceTemplateVersion();
+  const mockEServiceTemplate = getMockEServiceTemplate();
+  it("should write on event-store for the deletion of an eserviceTemplate (eserviceTemplate with no versions)", async () => {
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      versions: [],
+    };
+    await addOneEServiceTemplate(eserviceTemplate);
+    await eserviceTemplateService.deleteEServiceTemplate(
+      eserviceTemplate.id,
+      getMockContext({ authData: getMockAuthData(eserviceTemplate.creatorId) })
+    );
+    const writtenEvent = await readLastEserviceTemplateEvent(
+      eserviceTemplate.id
+    );
+    expect(writtenEvent).toMatchObject({
+      stream_id: eserviceTemplate.id,
+      version: "1",
+      type: "EServiceTemplateDeleted",
+      event_version: 2,
+    });
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceTemplateDeletedV2,
+      payload: writtenEvent.data,
+    });
+    expect(writtenPayload.eserviceTemplate?.id).toBe(eserviceTemplate.id);
+  });
+
+  it("should write on event-store for the deletion of an eserviceTemplate (eserviceTemplate with a draft version only) and delete the interface and documents of the draft version", async () => {
+    vi.spyOn(fileManager, "delete");
+
+    const mockDocument = getMockDocument();
+    const mockInterface = getMockDocument();
+    const document = {
+      ...mockDocument,
+      name: `${mockDocument.name}`,
+      path: `${config.eserviceTemplateDocumentsPath}/${mockDocument.id}/${mockDocument.name}`,
+    };
+    const interfaceDocument = {
+      ...mockInterface,
+      name: `${mockDocument.name}_interface`,
+      path: `${config.eserviceTemplateDocumentsPath}/${mockInterface.id}/${mockInterface.name}_interface`,
+    };
+
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.eserviceTemplateDocumentsPath,
+        resourceId: interfaceDocument.id,
+        name: interfaceDocument.name,
+        content: Buffer.from("testtest"),
+      },
+      genericLogger
+    );
+
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.eserviceTemplateDocumentsPath,
+        resourceId: document.id,
+        name: document.name,
+        content: Buffer.from("testtest"),
+      },
+      genericLogger
+    );
+
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).toContain(interfaceDocument.path);
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).toContain(document.path);
+
+    const version: EServiceTemplateVersion = {
+      ...mockEserviceTemplateVersion,
+      interface: interfaceDocument,
+      state: eserviceTemplateVersionState.draft,
+      docs: [document],
+    };
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      versions: [version],
+    };
+    await addOneEServiceTemplate(eserviceTemplate);
+    await eserviceTemplateService.deleteEServiceTemplate(
+      eserviceTemplate.id,
+      getMockContext({ authData: getMockAuthData(eserviceTemplate.creatorId) })
+    );
+
+    const versionDeletionEvent = await readEventByStreamIdAndVersion(
+      eserviceTemplate.id,
+      1,
+      "eservice_template",
+      postgresDB
+    );
+    const eserviceTemplateDeletionEvent = await readLastEserviceTemplateEvent(
+      eserviceTemplate.id
+    );
+
+    expect(versionDeletionEvent).toMatchObject({
+      stream_id: eserviceTemplate.id,
+      version: "1",
+      type: "EServiceTemplateDraftVersionDeleted",
+      event_version: 2,
+    });
+    expect(eserviceTemplateDeletionEvent).toMatchObject({
+      stream_id: eserviceTemplate.id,
+      version: "2",
+      type: "EServiceTemplateDeleted",
+      event_version: 2,
+    });
+
+    const versionDeletionPayload = decodeProtobufPayload({
+      messageType: EServiceTemplateDraftVersionDeletedV2,
+      payload: versionDeletionEvent.data,
+    });
+    const eserviceTemplateDeletionPayload = decodeProtobufPayload({
+      messageType: EServiceTemplateDeletedV2,
+      payload: eserviceTemplateDeletionEvent.data,
+    });
+
+    const expectedEserviceTemplateWithoutVersions: EServiceTemplate = {
+      ...eserviceTemplate,
+      versions: [],
+    };
+    expect(eserviceTemplateDeletionPayload.eserviceTemplate?.id).toBe(
+      mockEServiceTemplate.id
+    );
+    expect(versionDeletionPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(
+        expectedEserviceTemplateWithoutVersions
+      ),
+      eserviceTemplateVersionId: eserviceTemplate.versions[0].id,
+    });
+
+    expect(fileManager.delete).toHaveBeenCalledWith(
+      config.s3Bucket,
+      interfaceDocument.path,
+      genericLogger
+    );
+    expect(fileManager.delete).toHaveBeenCalledWith(
+      config.s3Bucket,
+      document.path,
+      genericLogger
+    );
+
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).not.toContain(interfaceDocument.path);
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).not.toContain(document.path);
+  });
+
+  it("should throw eserviceTemplateNotFound if the eserviceTemplate doesn't exist", () => {
+    void expect(
+      eserviceTemplateService.deleteEServiceTemplate(
+        mockEServiceTemplate.id,
+        getMockContext({
+          authData: getMockAuthData(mockEServiceTemplate.creatorId),
+        })
+      )
+    ).rejects.toThrowError(eserviceTemplateNotFound(mockEServiceTemplate.id));
+  });
+
+  it("should throw operationForbidden if the requester is not the creator", async () => {
+    await addOneEServiceTemplate(mockEServiceTemplate);
+    expect(
+      eserviceTemplateService.deleteEServiceTemplate(
+        mockEServiceTemplate.id,
+        getMockContext({})
+      )
+    ).rejects.toThrowError(operationForbidden);
+  });
+
+  it("should throw eserviceTemplateNotInDraftState if the eserviceTemplate has both draft and non-draft versions", async () => {
+    const version1: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      version: 1,
+      interface: getMockDocument(),
+      state: eserviceTemplateVersionState.published,
+      publishedAt: new Date(),
+    };
+    const version2: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      version: 2,
+      interface: getMockDocument(),
+      state: eserviceTemplateVersionState.draft,
+    };
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      versions: [version1, version2],
+    };
+    await addOneEServiceTemplate(eserviceTemplate);
+    expect(
+      eserviceTemplateService.deleteEServiceTemplate(
+        eserviceTemplate.id,
+        getMockContext({
+          authData: getMockAuthData(eserviceTemplate.creatorId),
+        })
+      )
+    ).rejects.toThrowError(
+      eserviceTemplateNotInDraftState(eserviceTemplate.id)
+    );
+  });
+});

--- a/packages/m2m-gateway/src/routers/eserviceTemplateRouter.ts
+++ b/packages/m2m-gateway/src/routers/eserviceTemplateRouter.ts
@@ -130,6 +130,26 @@ const eserviceTemplateRouter = (
         return res.status(errorRes.status).send(errorRes);
       }
     })
+    .delete("/eserviceTemplates/:templateId", async (req, res) => {
+      const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+      try {
+        validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+        await eserviceTemplateService.deleteEServiceTemplate(
+          unsafeBrandId(req.params.templateId),
+          ctx
+        );
+        return res.status(204).send();
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx,
+          `Error deleting eservice template with id ${req.params.templateId}`
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
     .patch("/eserviceTemplates/:templateId/description", async (req, res) => {
       const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
 

--- a/packages/m2m-gateway/src/services/eserviceTemplateService.ts
+++ b/packages/m2m-gateway/src/services/eserviceTemplateService.ts
@@ -26,6 +26,7 @@ import {
   pollResourceWithMetadata,
   isPolledVersionAtLeastResponseVersion,
   isPolledVersionAtLeastMetadataTargetVersion,
+  pollResourceUntilDeletion,
 } from "../utils/polling.js";
 import { uploadEServiceTemplateDocument } from "../utils/fileUpload.js";
 import { downloadDocument, DownloadedDocument } from "../utils/fileDownload.js";
@@ -105,6 +106,14 @@ export function eserviceTemplateServiceBuilder(
     )({
       condition: isPolledVersionAtLeastMetadataTargetVersion(metadata),
     });
+
+  const pollEserviceTemplateUntilDeletion = (
+    templateId: string,
+    headers: M2MGatewayAppContext["headers"]
+  ): Promise<void> =>
+    pollResourceUntilDeletion(() =>
+      retrieveEServiceTemplateById(headers, unsafeBrandId(templateId))
+    )({});
 
   return {
     async getEServiceTemplateById(
@@ -696,6 +705,22 @@ export function eserviceTemplateServiceBuilder(
         versionId
       );
       return toM2MGatewayEServiceTemplateVersion(version);
+    },
+
+    async deleteEServiceTemplate(
+      templateId: EServiceTemplateId,
+      { logger, headers }: WithLogger<M2MGatewayAppContext>
+    ): Promise<void> {
+      logger.info(`Deleting eservice template with id ${templateId}`);
+
+      await clients.eserviceTemplateProcessClient.deleteEServiceTemplate(
+        undefined,
+        {
+          params: { templateId },
+          headers,
+        }
+      );
+      await pollEserviceTemplateUntilDeletion(templateId, headers);
     },
   };
 }

--- a/packages/m2m-gateway/test/api/eServiceTemplates/deleteEserviceTemplate.test.ts
+++ b/packages/m2m-gateway/test/api/eServiceTemplates/deleteEserviceTemplate.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  generateToken,
+  getMockedApiEServiceTemplate,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import { generateId } from "pagopa-interop-models";
+import { api, mockEServiceTemplateService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { toM2MGatewayEServiceTemplate } from "../../../src/api/eserviceTemplateApiConverter.js";
+
+describe("DELETE /eserviceTemplates/{templateId} router test", () => {
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+
+  const makeRequest = async (token: string, templateId: string) =>
+    request(api)
+      .delete(`${appBasePath}/eserviceTemplates/${templateId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send();
+
+  const mockApiEserviceTemplate = getMockedApiEServiceTemplate();
+  const mockM2MEserviceResponse = toM2MGatewayEServiceTemplate(
+    mockApiEserviceTemplate
+  );
+
+  it.each(authorizedRoles)(
+    "Should return 204 and perform service calls for user with role %s",
+    async (role) => {
+      mockEServiceTemplateService.deleteEServiceTemplate = vi.fn();
+
+      const token = generateToken(role);
+      const res = await makeRequest(token, mockM2MEserviceResponse.id);
+      expect(res.status).toBe(204);
+    }
+  );
+
+  it("Should return 400 for incorrect value for eservice template id", async () => {
+    mockEServiceTemplateService.deleteEServiceTemplate = vi.fn();
+
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, "INVALID ID");
+    expect(res.status).toBe(400);
+  });
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, generateId());
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/m2m-gateway/test/integration/eServiceTemplates/deleteEserviceTemplate.test.ts
+++ b/packages/m2m-gateway/test/integration/eServiceTemplates/deleteEserviceTemplate.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEServiceTemplate,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockDeletionPollingResponse,
+  mockInteropBeClients,
+  eserviceTemplateService,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+import { config } from "../../../src/config/config.js";
+
+describe("deleteEServiceTemplate", () => {
+  const mockApiEServiceTemplate = getMockWithMetadata(
+    getMockedApiEServiceTemplate()
+  );
+
+  const mockDeleteEServiceTemplate = vi.fn();
+  const mockGetEServiceTemplate = vi.fn(
+    mockDeletionPollingResponse(mockApiEServiceTemplate, 2)
+  );
+
+  mockInteropBeClients.eserviceTemplateProcessClient = {
+    getEServiceTemplateById: mockGetEServiceTemplate,
+    deleteEServiceTemplate: mockDeleteEServiceTemplate,
+  } as unknown as PagoPAInteropBeClients["eserviceTemplateProcessClient"];
+
+  beforeEach(() => {
+    mockDeleteEServiceTemplate.mockClear();
+    mockGetEServiceTemplate.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    await eserviceTemplateService.deleteEServiceTemplate(
+      unsafeBrandId(mockApiEServiceTemplate.data.id),
+      getMockM2MAdminAppContext()
+    );
+
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.eserviceTemplateProcessClient
+          .deleteEServiceTemplate,
+      params: { templateId: mockApiEServiceTemplate.data.id },
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet:
+        mockInteropBeClients.eserviceTemplateProcessClient
+          .getEServiceTemplateById,
+      params: { templateId: mockApiEServiceTemplate.data.id },
+    });
+    expect(
+      mockInteropBeClients.eserviceTemplateProcessClient.getEServiceTemplateById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEServiceTemplate.mockImplementation(
+      mockDeletionPollingResponse(
+        mockApiEServiceTemplate,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      eserviceTemplateService.deleteEServiceTemplate(
+        unsafeBrandId(mockApiEServiceTemplate.data.id),
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEServiceTemplate).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});


### PR DESCRIPTION
[PIN-7818](https://pagopa.atlassian.net/browse/PIN-7818)

[SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/1812562407/DRAFT+SRS+API+V2+Parte+2#%5BPIN-7616%5D-Creazione-nuova-Versione-EService-Template-%E2%80%93-POST-%2FeserviceTemplates%2F%7BeServiceTemplateId%7D%2Fversions)

# Description
Implemented `DELETE /eserviceTemplates/{templateId}` route in m2m gateway and eservice-template-process

## Implementation
- [x] Finalize SRS
- [x] JIRA task link in PR, with link to SRS
- [x] API spec of the route in `m2mGatewayApi.yml`
- [x] Documentation: description fields in the spec endpoint, response, errors, params, etc. 

## Double-check errors
- [x] Check errors returned by the process API calls (messages should be meaningful, clean, in correct English, etc.)
- [x] Check spec errors: it should list all non-500 errors, also the ones that pass through from the process

# Testing
Checklist:
- [x] Bruno call added to collection
- [x] Smoke test Bruno (attach result screenshot)
- [x] Supertest /api tests
- [x] /integration tests for the logic in the service

# Screen
<img width="889" height="698" alt="Screenshot 2025-09-30 alle 15 29 40" src="https://github.com/user-attachments/assets/89444879-128e-4cdb-8510-60523c25f257" />