### PR TITLE
feature: purpose-template-process `DELETE /purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation` (PIN-7663)

### DIFF
--- a/collections/bff/purposeTemplate/Delete Risk Analysis Template Answer Annotation.bru
+++ b/collections/bff/purposeTemplate/Delete Risk Analysis Template Answer Annotation.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Delete Risk Analysis Template Answer Annotation
+  type: http
+  seq: 6
+}
+
+delete {
+  url: {{host-bff}}/purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation
+  body: none
+  auth: none
+}
+
+params:path {
+  purposeTemplateId: {{purposeTemplateId}}
+  answerId: {{answerId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}
+
+vars:post-response {
+  answerId: res.body.id
+}

--- a/collections/purpose-template/Delete Risk Analysis Template Answer Annotation.bru
+++ b/collections/purpose-template/Delete Risk Analysis Template Answer Annotation.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Delete Risk Analysis Template Answer Annotation
+  type: http
+  seq: 6
+}
+
+delete {
+  url: {{host-purpose-template}}/purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation
+  body: none
+  auth: none
+}
+
+params:path {
+  purposeTemplateId: {{purposeTemplateId}}
+  answerId: {{answerId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}
+
+vars:post-response {
+  answerId: res.body.id
+}

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -10587,6 +10587,115 @@ paths:
                 type: integer
                 format: int32
               description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+  /purposeTemplates/{purposeTemplateId}/riskAnalysis/answers/{answerId}/annotation:
+    parameters:
+      - name: purposeTemplateId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: answerId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    delete:
+      tags:
+        - purposeTemplates
+      summary: Delete risk analysis form template answer annotation
+      operationId: deleteRiskAnalysisTemplateAnswerAnnotation
+      description: Delete a risk analysis form template answer annotation
+      responses:
+        "204":
+          description: Risk analysis form template answer annotation deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskAnalysisTemplateAnswerAnnotationDocument"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "404":
+          description: Risk analysis form template answer annotation not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
   "/tenants/{tenantId}/attributes/declared":
     get:
       tags:

--- a/packages/api-clients/open-api/purposeTemplateApi.yml
+++ b/packages/api-clients/open-api/purposeTemplateApi.yml
@@ -583,6 +583,61 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /purposeTemplates/{id}/riskAnalysis/answers/{answerId}/annotation:
+    parameters:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: answerId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    delete:
+      tags:
+        - purposeTemplate
+      summary: Delete risk analysis form template answer annotation
+      operationId: deleteRiskAnalysisTemplateAnswerAnnotation
+      description: Delete a risk analysis form template answer annotation
+      responses:
+        "204":
+          description: Risk analysis form template answer annotation deleted
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RiskAnalysisTemplateAnswerAnnotationDocument"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Risk analysis form template answer annotation not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
 components:
   headers:
     MetadataVersionHeader:

--- a/packages/backend-for-frontend/src/routers/purposeTemplateRouter.ts
+++ b/packages/backend-for-frontend/src/routers/purposeTemplateRouter.ts
@@ -134,14 +134,39 @@ const purposeTemplateRouter = (
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
-          // TODO: add feature flag error mapper if needed
           emptyErrorMapper,
           ctx,
           `Error deleting purpose template ${req.params.purposeTemplateId}`
         );
         return res.status(errorRes.status).send(errorRes);
       }
-    });
+    })
+    .delete(
+      "/purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation",
+      async (req, res) => {
+        const ctx = fromBffAppContext(req.ctx, req.headers);
+
+        try {
+          await purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation(
+            {
+              purposeTemplateId: unsafeBrandId(req.params.purposeTemplateId),
+              answerId: unsafeBrandId(req.params.answerId),
+              ctx,
+            }
+          );
+
+          return res.status(204).send();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error deleting risk analysis template answer annotation for purpose template ${req.params.purposeTemplateId} and answer ${req.params.answerId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    );
 
   return purposeTemplateRouter;
 };

--- a/packages/backend-for-frontend/src/services/purposeTemplateService.ts
+++ b/packages/backend-for-frontend/src/services/purposeTemplateService.ts
@@ -209,6 +209,7 @@ export function purposeTemplateServiceBuilder(
       purposeTemplateId: PurposeTemplateId,
       { headers, logger }: WithLogger<BffAppContext>
     ): Promise<void> {
+      assertFeatureFlagEnabled(config, "featureFlagPurposeTemplate");
       logger.info(`Deleting purpose template ${purposeTemplateId}`);
 
       await purposeTemplateClient.deletePurposeTemplate(undefined, {
@@ -217,6 +218,34 @@ export function purposeTemplateServiceBuilder(
         },
         headers,
       });
+    },
+    async deleteRiskAnalysisTemplateAnswerAnnotation({
+      purposeTemplateId,
+      answerId,
+      ctx,
+    }: {
+      purposeTemplateId: PurposeTemplateId;
+      answerId: PurposeTemplateId;
+      ctx: WithLogger<BffAppContext>;
+    }): Promise<void> {
+      assertFeatureFlagEnabled(config, "featureFlagPurposeTemplate");
+
+      const { headers, logger } = ctx;
+
+      logger.info(
+        `Deleting risk analysis template answer annotation for purpose template ${purposeTemplateId} and answer ${answerId}`
+      );
+
+      await purposeTemplateClient.deleteRiskAnalysisTemplateAnswerAnnotation(
+        undefined,
+        {
+          params: {
+            id: purposeTemplateId,
+            answerId,
+          },
+          headers,
+        }
+      );
     },
   };
 }

--- a/packages/commons/src/risk-analysis-template/riskAnalysisTemplateValidation.ts
+++ b/packages/commons/src/risk-analysis-template/riskAnalysisTemplateValidation.ts
@@ -326,9 +326,10 @@ function buildValidResultAnswer(
         type: "single",
         answer: {
           key: answerKey,
-          value: answerValue.values[0] ?? undefined,
+          value: answerValue.values[0],
           editable: answerValue.editable,
           suggestedValues: answerValue.suggestedValues,
+          annotation: answerValue.annotation,
         },
       })
     )
@@ -339,6 +340,7 @@ function buildValidResultAnswer(
           key: answerKey,
           values: answerValue.values,
           editable: answerValue.editable,
+          annotation: answerValue.annotation,
         },
       })
     )

--- a/packages/purpose-template-process/src/model/domain/errors.ts
+++ b/packages/purpose-template-process/src/model/domain/errors.ts
@@ -21,6 +21,7 @@ export const errorCodes = {
   purposeTemplateNotInExpectedState: "0007",
   riskAnalysisTemplateNotFound: "0008",
   riskAnalysisTemplateAnswerNotFound: "0009",
+  riskAnalysisTemplateAnswerAnnotationNotFound: "0010",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -119,5 +120,16 @@ export function riskAnalysisTemplateAnswerNotFound(
     detail: `No Risk Analysis Template Answer found for Purpose Template ID ${purposeTemplateId} and Answer ID ${answerId}`,
     code: "riskAnalysisTemplateAnswerNotFound",
     title: "Risk Analysis Template Answer Not Found",
+  });
+}
+
+export function riskAnalysisTemplateAnswerAnnotationNotFound(
+  purposeTemplateId: PurposeTemplateId,
+  answerId: RiskAnalysisSingleAnswerId | RiskAnalysisMultiAnswerId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `No Risk Analysis Template Answer Annotation found for Purpose Template ID ${purposeTemplateId} and Answer ID ${answerId}`,
+    code: "riskAnalysisTemplateAnswerAnnotationNotFound",
+    title: "Risk Analysis Template Answer Annotation Not Found",
   });
 }

--- a/packages/purpose-template-process/src/model/domain/errors.ts
+++ b/packages/purpose-template-process/src/model/domain/errors.ts
@@ -4,6 +4,9 @@ import {
   makeApiProblemBuilder,
   PurposeTemplateId,
   PurposeTemplateState,
+  RiskAnalysisFormTemplateId,
+  RiskAnalysisMultiAnswerId,
+  RiskAnalysisSingleAnswerId,
   TenantId,
   TenantKind,
 } from "pagopa-interop-models";
@@ -16,6 +19,8 @@ export const errorCodes = {
   ruleSetNotFoundError: "0005",
   tenantNotAllowed: "0006",
   purposeTemplateNotInExpectedState: "0007",
+  riskAnalysisTemplateNotFound: "0008",
+  riskAnalysisTemplateAnswerNotFound: "0009",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -88,5 +93,31 @@ export function purposeTemplateNotInExpectedState(
     detail: `Purpose Template ${purposeTemplateId} not in expected state (current state: ${currentState}, expected states: ${expectedStates.toString()})`,
     code: "purposeTemplateNotInExpectedState",
     title: "Purpose Template not in expected state",
+  });
+}
+
+export function riskAnalysisTemplateNotFound(
+  purposeTemplateId: PurposeTemplateId,
+  riskAnalysisTemplateId?: RiskAnalysisFormTemplateId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `No Risk Analysis Template found for Purpose Template ID ${purposeTemplateId}${
+      riskAnalysisTemplateId
+        ? ` and Risk Analysis Template ID ${riskAnalysisTemplateId}`
+        : ""
+    }`,
+    code: "riskAnalysisTemplateNotFound",
+    title: "Risk Analysis Template Not Found",
+  });
+}
+
+export function riskAnalysisTemplateAnswerNotFound(
+  purposeTemplateId: PurposeTemplateId,
+  answerId: RiskAnalysisSingleAnswerId | RiskAnalysisMultiAnswerId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `No Risk Analysis Template Answer found for Purpose Template ID ${purposeTemplateId} and Answer ID ${answerId}`,
+    code: "riskAnalysisTemplateAnswerNotFound",
+    title: "Risk Analysis Template Answer Not Found",
   });
 }

--- a/packages/purpose-template-process/src/model/domain/toEvent.ts
+++ b/packages/purpose-template-process/src/model/domain/toEvent.ts
@@ -42,3 +42,24 @@ export function toCreateEventPurposeTemplateDraftDeleted({
     },
   };
 }
+
+export function toCreateEventPurposeTemplateDraftUpdated({
+  purposeTemplate,
+  correlationId,
+  version,
+}: {
+  purposeTemplate: PurposeTemplate;
+  correlationId: CorrelationId;
+  version: number;
+}): CreateEvent<PurposeTemplateEventV2> {
+  return {
+    streamId: purposeTemplate.id,
+    version,
+    correlationId,
+    event: {
+      type: "PurposeTemplateDraftUpdated",
+      event_version: 2,
+      data: { purposeTemplate: toPurposeTemplateV2(purposeTemplate) },
+    },
+  };
+}

--- a/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
+++ b/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
@@ -17,6 +17,7 @@ import { makeApiProblem } from "../model/domain/errors.js";
 import {
   createPurposeTemplateErrorMapper,
   deletePurposeTemplateErrorMapper,
+  deleteRiskAnalysisTemplateAnswerAnnotationErrorMapper,
   getPurposeTemplateErrorMapper,
   getPurposeTemplatesErrorMapper,
 } from "../utilities/errorMappers.js";
@@ -256,7 +257,33 @@ const purposeTemplateRouter = (
         return res.status(501);
       }
       return res.status(501);
-    });
+    })
+    .delete(
+      "/purposeTemplates/:id/riskAnalysis/answers/:answerId/annotation",
+      async (req, res) => {
+        const ctx = fromAppContext(req.ctx);
+
+        try {
+          validateAuthorization(ctx, [ADMIN_ROLE, M2M_ADMIN_ROLE]);
+
+          await purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation(
+            {
+              purposeTemplateId: unsafeBrandId(req.params.id),
+              answerId: unsafeBrandId(req.params.answerId),
+              ctx,
+            }
+          );
+          return res.status(204).send();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            deleteRiskAnalysisTemplateAnswerAnnotationErrorMapper,
+            ctx
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    );
 
   return purposeTemplateRouter;
 };

--- a/packages/purpose-template-process/src/services/purposeTemplateService.ts
+++ b/packages/purpose-template-process/src/services/purposeTemplateService.ts
@@ -8,6 +8,10 @@ import {
   ListResult,
   RiskAnalysisFormTemplate,
   TenantKind,
+  RiskAnalysisTemplateMultiAnswer,
+  RiskAnalysisTemplateSingleAnswer,
+  RiskAnalysisMultiAnswerId,
+  RiskAnalysisSingleAnswerId,
 } from "pagopa-interop-models";
 import { purposeTemplateApi } from "pagopa-interop-api-clients";
 import {
@@ -24,11 +28,14 @@ import {
 } from "pagopa-interop-commons";
 import {
   purposeTemplateNotFound,
+  riskAnalysisTemplateAnswerNotFound,
+  riskAnalysisTemplateNotFound,
   ruleSetNotFoundError,
 } from "../model/domain/errors.js";
 import {
   toCreateEventPurposeTemplateAdded,
   toCreateEventPurposeTemplateDraftDeleted,
+  toCreateEventPurposeTemplateDraftUpdated,
 } from "../model/domain/toEvent.js";
 import { config } from "../config/config.js";
 import {
@@ -71,7 +78,10 @@ function getDefaultRiskAnalysisFormTemplate(
   };
 }
 
-async function deleteRiskAnalysisTemplateAnswerAnnotationDocuments({
+/*
+Deletes all the annotations documents associated to the purpose template
+*/
+async function deleteAllRiskAnalysisTemplateAnswerAnnotationDocuments({
   purposeTemplate,
   fileManager,
   readModelService,
@@ -96,6 +106,46 @@ async function deleteRiskAnalysisTemplateAnswerAnnotationDocuments({
       await fileManager.delete(config.s3Bucket, doc.path, logger);
     })
   );
+}
+
+/*
+Deletes all the documents associated to one purpose template answer annotation
+*/
+async function deleteRiskAnalysisTemplateAnswerAnnotationDocuments({
+  purposeTemplateId,
+  answerId,
+  fileManager,
+  readModelService,
+  logger,
+}: {
+  purposeTemplateId: PurposeTemplateId;
+  answerId: RiskAnalysisSingleAnswerId | RiskAnalysisMultiAnswerId;
+  fileManager: FileManager;
+  readModelService: ReadModelServiceSQL;
+  logger: Logger;
+}): Promise<
+  RiskAnalysisTemplateSingleAnswer | RiskAnalysisTemplateMultiAnswer
+> {
+  const answer = await readModelService.getRiskAnalysisTemplateAnswer(
+    purposeTemplateId,
+    answerId
+  );
+  if (!answer) {
+    throw riskAnalysisTemplateAnswerNotFound(purposeTemplateId, answerId);
+  }
+
+  await Promise.all(
+    answer.annotation
+      ? answer.annotation.docs.map(async (doc) => {
+          await fileManager.delete(config.s3Bucket, doc.path, logger);
+        })
+      : []
+  );
+
+  return {
+    ...answer,
+    annotation: undefined,
+  };
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -220,7 +270,7 @@ export function purposeTemplateServiceBuilder(
       assertRequesterIsCreator(purposeTemplate.data, authData);
       assertPurposeTemplateIsDraft(purposeTemplate.data);
 
-      await deleteRiskAnalysisTemplateAnswerAnnotationDocuments({
+      await deleteAllRiskAnalysisTemplateAnswerAnnotationDocuments({
         purposeTemplate: purposeTemplate.data,
         fileManager,
         readModelService,
@@ -234,6 +284,85 @@ export function purposeTemplateServiceBuilder(
           correlationId,
         })
       );
+    },
+    async deleteRiskAnalysisTemplateAnswerAnnotation({
+      purposeTemplateId,
+      answerId,
+      ctx,
+    }: {
+      purposeTemplateId: PurposeTemplateId;
+      answerId: RiskAnalysisSingleAnswerId | RiskAnalysisMultiAnswerId;
+      ctx: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>;
+    }): Promise<
+      WithMetadata<
+        RiskAnalysisTemplateSingleAnswer | RiskAnalysisTemplateMultiAnswer
+      >
+    > {
+      const { authData, logger, correlationId } = ctx;
+
+      logger.info(
+        `Deleting risk analysis template answer annotation for purpose template ${purposeTemplateId} and answer ${answerId}`
+      );
+
+      const purposeTemplate = await retrievePurposeTemplate(
+        purposeTemplateId,
+        readModelService
+      );
+
+      const purposeRiskAnalysisTemplateForm =
+        purposeTemplate.data.purposeRiskAnalysisForm;
+      if (!purposeRiskAnalysisTemplateForm) {
+        throw riskAnalysisTemplateNotFound(purposeTemplateId);
+      }
+
+      assertRequesterIsCreator(purposeTemplate.data, authData);
+      assertPurposeTemplateIsDraft(purposeTemplate.data);
+
+      const answerWithDeletedAnnotation =
+        await deleteRiskAnalysisTemplateAnswerAnnotationDocuments({
+          purposeTemplateId,
+          answerId,
+          fileManager,
+          readModelService,
+          logger,
+        });
+
+      const updateAnswerWithoutAnnotation = <
+        T extends
+          | RiskAnalysisTemplateSingleAnswer
+          | RiskAnalysisTemplateMultiAnswer
+      >(
+        answer: T
+      ): T =>
+        answer.id === answerId ? { ...answer, annotation: undefined } : answer;
+
+      const updatedPurposeTemplate: PurposeTemplate = {
+        ...purposeTemplate.data,
+        purposeRiskAnalysisForm: {
+          ...purposeRiskAnalysisTemplateForm,
+          singleAnswers: purposeRiskAnalysisTemplateForm.singleAnswers.map(
+            updateAnswerWithoutAnnotation
+          ),
+          multiAnswers: purposeRiskAnalysisTemplateForm.multiAnswers.map(
+            updateAnswerWithoutAnnotation
+          ),
+        },
+      };
+
+      const event = await repository.createEvent(
+        toCreateEventPurposeTemplateDraftUpdated({
+          purposeTemplate: updatedPurposeTemplate,
+          version: purposeTemplate.metadata.version,
+          correlationId,
+        })
+      );
+
+      return {
+        data: answerWithDeletedAnnotation,
+        metadata: {
+          version: event.newVersion,
+        },
+      };
     },
   };
 }

--- a/packages/purpose-template-process/src/services/purposeTemplateService.ts
+++ b/packages/purpose-template-process/src/services/purposeTemplateService.ts
@@ -28,6 +28,7 @@ import {
 } from "pagopa-interop-commons";
 import {
   purposeTemplateNotFound,
+  riskAnalysisTemplateAnswerAnnotationNotFound,
   riskAnalysisTemplateAnswerNotFound,
   riskAnalysisTemplateNotFound,
   ruleSetNotFoundError,
@@ -132,6 +133,13 @@ async function deleteRiskAnalysisTemplateAnswerAnnotationDocuments({
   );
   if (!answer) {
     throw riskAnalysisTemplateAnswerNotFound(purposeTemplateId, answerId);
+  }
+
+  if (!answer.annotation) {
+    throw riskAnalysisTemplateAnswerAnnotationNotFound(
+      purposeTemplateId,
+      answerId
+    );
   }
 
   await Promise.all(

--- a/packages/purpose-template-process/src/services/readModelServiceSQL.ts
+++ b/packages/purpose-template-process/src/services/readModelServiceSQL.ts
@@ -334,11 +334,11 @@ export function readModelServiceBuilderSQL({
         .where(
           and(
             eq(
-              purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate.purposeTemplateId,
+              purposeTemplateRiskAnalysisAnswerInReadmodelPurposeTemplate.purposeTemplateId,
               purposeTemplateId
             ),
             eq(
-              purposeTemplateRiskAnalysisAnswerAnnotationInReadmodelPurposeTemplate.answerId,
+              purposeTemplateRiskAnalysisAnswerInReadmodelPurposeTemplate.id,
               answerId
             )
           )

--- a/packages/purpose-template-process/src/utilities/errorMappers.ts
+++ b/packages/purpose-template-process/src/utilities/errorMappers.ts
@@ -46,3 +46,17 @@ export const deletePurposeTemplateErrorMapper = (
     .with("purposeTemplateNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const deleteRiskAnalysisTemplateAnswerAnnotationErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("purposeTemplateNotInExpectedState", () => HTTP_STATUS_CONFLICT)
+    .with(
+      "purposeTemplateNotFound",
+      "riskAnalysisTemplateNotFound",
+      "riskAnalysisTemplateAnswerNotFound",
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/purpose-template-process/src/utilities/errorMappers.ts
+++ b/packages/purpose-template-process/src/utilities/errorMappers.ts
@@ -56,6 +56,7 @@ export const deleteRiskAnalysisTemplateAnswerAnnotationErrorMapper = (
       "purposeTemplateNotFound",
       "riskAnalysisTemplateNotFound",
       "riskAnalysisTemplateAnswerNotFound",
+      "riskAnalysisTemplateAnswerAnnotationNotFound",
       () => HTTP_STATUS_NOT_FOUND
     )
     .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)

--- a/packages/purpose-template-process/test/api/deleteRiskAnalysisTemplateAnswerAnnotation.test.ts
+++ b/packages/purpose-template-process/test/api/deleteRiskAnalysisTemplateAnswerAnnotation.test.ts
@@ -1,0 +1,137 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import {
+  generateId,
+  PurposeTemplateId,
+  purposeTemplateState,
+  RiskAnalysisMultiAnswerId,
+  RiskAnalysisSingleAnswerId,
+  RiskAnalysisTemplateSingleAnswer,
+  tenantKind,
+} from "pagopa-interop-models";
+import {
+  generateToken,
+  getMockValidRiskAnalysisFormTemplate,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { api, purposeTemplateService } from "../vitest.api.setup.js";
+import {
+  purposeTemplateNotFound,
+  purposeTemplateNotInExpectedState,
+  riskAnalysisTemplateAnswerNotFound,
+  riskAnalysisTemplateNotFound,
+  tenantNotAllowed,
+} from "../../src/model/domain/errors.js";
+
+describe("API /purposeTemplates/{id}/riskAnalysis/answers/{answerId}/annotation", () => {
+  const purposeTemplateId = generateId<PurposeTemplateId>();
+  const riskAnalysisTemplate = getMockValidRiskAnalysisFormTemplate(
+    tenantKind.PA
+  );
+  const answerWithoutAnnotation: RiskAnalysisTemplateSingleAnswer = {
+    ...riskAnalysisTemplate.singleAnswers[0],
+    annotation: undefined,
+  };
+
+  purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation = vi
+    .fn()
+    .mockResolvedValue(answerWithoutAnnotation);
+
+  const makeRequest = async (
+    token: string,
+    id: PurposeTemplateId = purposeTemplateId,
+    answerId:
+      | RiskAnalysisSingleAnswerId
+      | RiskAnalysisMultiAnswerId = answerWithoutAnnotation.id
+  ) =>
+    request(api)
+      .delete(
+        `/purposeTemplates/${id}/riskAnalysis/answers/${answerId}/annotation`
+      )
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send();
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+  it.each(authorizedRoles)(
+    "Should return 204 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(204);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, purposeTemplateId);
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {
+      error: purposeTemplateNotInExpectedState(
+        purposeTemplateId,
+        purposeTemplateState.active,
+        [purposeTemplateState.draft]
+      ),
+      expectedStatus: 409,
+    },
+    {
+      error: purposeTemplateNotFound(purposeTemplateId),
+      expectedStatus: 404,
+    },
+    {
+      error: riskAnalysisTemplateNotFound(purposeTemplateId),
+      expectedStatus: 404,
+    },
+    {
+      error: riskAnalysisTemplateAnswerNotFound(
+        purposeTemplateId,
+        answerWithoutAnnotation.id
+      ),
+      expectedStatus: 404,
+    },
+    {
+      error: tenantNotAllowed(generateId()),
+      expectedStatus: 403,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation = vi
+        .fn()
+        .mockRejectedValue(error);
+
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, purposeTemplateId);
+
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+
+  it("Should return 400 if an invalid purpose template id is passed", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, "invalid" as PurposeTemplateId);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 if an invalid answer id is passed", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      purposeTemplateId,
+      "invalid" as RiskAnalysisSingleAnswerId
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/purpose-template-process/test/integration/deleteRiskAnalysisTemplateAnswerAnnotation.test.ts
+++ b/packages/purpose-template-process/test/integration/deleteRiskAnalysisTemplateAnswerAnnotation.test.ts
@@ -1,0 +1,266 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import { genericLogger } from "pagopa-interop-commons";
+import {
+  decodeProtobufPayload,
+  getMockContext,
+  getMockAuthData,
+  getMockRiskAnalysisTemplateAnswerAnnotationDocument,
+  getMockPurposeTemplate,
+  getMockRiskAnalysisTemplateAnswerAnnotation,
+  getMockValidRiskAnalysisFormTemplate,
+} from "pagopa-interop-commons-test";
+import {
+  RiskAnalysisFormTemplate,
+  tenantKind,
+  PurposeTemplate,
+  toPurposeTemplateV2,
+  purposeTemplateState,
+  TenantId,
+  generateId,
+  PurposeTemplateDraftUpdatedV2,
+  RiskAnalysisMultiAnswerId,
+} from "pagopa-interop-models";
+import { expect, describe, it, vi } from "vitest";
+import { config } from "../../src/config/config.js";
+import {
+  addOnePurposeTemplate,
+  fileManager,
+  purposeTemplateService,
+  readLastPurposeTemplateEvent,
+} from "../integrationUtils.js";
+import {
+  purposeTemplateNotFound,
+  purposeTemplateNotInExpectedState,
+  riskAnalysisTemplateAnswerNotFound,
+  riskAnalysisTemplateNotFound,
+  tenantNotAllowed,
+} from "../../src/model/domain/errors.js";
+
+describe("deleteRiskAnalysisTemplateAnswerAnnotation", () => {
+  const mockDocument1 = getMockRiskAnalysisTemplateAnswerAnnotationDocument();
+  const mockDocument2 = getMockRiskAnalysisTemplateAnswerAnnotationDocument();
+  const annotationDocument1 = {
+    ...mockDocument1,
+    path: `${config.purposeTemplateDocumentsPath}/${mockDocument1.id}/${mockDocument1.name}`,
+  };
+  const annotationDocument2 = {
+    ...mockDocument2,
+    path: `${config.purposeTemplateDocumentsPath}/${mockDocument2.id}/${mockDocument2.name}`,
+  };
+
+  const incompleteRiskAnalysisFormTemplate =
+    getMockValidRiskAnalysisFormTemplate(tenantKind.PA);
+  const riskAnalysisFormTemplate: RiskAnalysisFormTemplate = {
+    ...incompleteRiskAnalysisFormTemplate,
+    singleAnswers: [
+      {
+        ...incompleteRiskAnalysisFormTemplate.singleAnswers[0],
+        annotation: {
+          ...getMockRiskAnalysisTemplateAnswerAnnotation(),
+          docs: [annotationDocument1, annotationDocument2],
+        },
+      },
+    ],
+  };
+
+  const purposeTemplate: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    purposeRiskAnalysisForm: riskAnalysisFormTemplate,
+  };
+
+  it("should write on event-store for the deletion of a risk analysis template answer annotation and delete the associated documents", async () => {
+    vi.spyOn(fileManager, "delete");
+
+    await addOnePurposeTemplate(purposeTemplate);
+
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.purposeTemplateDocumentsPath,
+        resourceId: annotationDocument1.id,
+        name: annotationDocument1.name,
+        content: Buffer.from("test-test"),
+      },
+      genericLogger
+    );
+
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.purposeTemplateDocumentsPath,
+        resourceId: annotationDocument2.id,
+        name: annotationDocument2.name,
+        content: Buffer.from("test-test"),
+      },
+      genericLogger
+    );
+
+    const filePathsBeforeDeletion = await fileManager.listFiles(
+      config.s3Bucket,
+      genericLogger
+    );
+    expect(filePathsBeforeDeletion).toContain(annotationDocument1.path);
+    expect(filePathsBeforeDeletion).toContain(annotationDocument2.path);
+
+    const response =
+      await purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation({
+        purposeTemplateId: purposeTemplate.id,
+        answerId: riskAnalysisFormTemplate.singleAnswers[0].id,
+        ctx: getMockContext({
+          authData: getMockAuthData(purposeTemplate.creatorId),
+        }),
+      });
+
+    const annotationDeletionEvent = await readLastPurposeTemplateEvent(
+      purposeTemplate.id
+    );
+
+    expect(annotationDeletionEvent).toMatchObject({
+      stream_id: purposeTemplate.id,
+      version: "1",
+      type: "PurposeTemplateDraftUpdated",
+      event_version: 2,
+    });
+
+    const purposeDeletionPayload = decodeProtobufPayload({
+      messageType: PurposeTemplateDraftUpdatedV2,
+      payload: annotationDeletionEvent.data,
+    });
+
+    const expectedAnswerWithoutAnnotation = {
+      ...riskAnalysisFormTemplate.singleAnswers[0],
+      annotation: undefined,
+    };
+    const expectedPurposeTemplate: PurposeTemplate = {
+      ...purposeTemplate,
+      purposeRiskAnalysisForm: {
+        ...riskAnalysisFormTemplate,
+        singleAnswers: [expectedAnswerWithoutAnnotation],
+      },
+    };
+
+    expect(purposeDeletionPayload.purposeTemplate).toEqual(
+      toPurposeTemplateV2(expectedPurposeTemplate)
+    );
+
+    expect(response).toEqual({
+      data: expectedAnswerWithoutAnnotation,
+      metadata: { version: 1 },
+    });
+
+    expect(fileManager.delete).toHaveBeenCalledWith(
+      config.s3Bucket,
+      annotationDocument1.path,
+      genericLogger
+    );
+    expect(fileManager.delete).toHaveBeenCalledWith(
+      config.s3Bucket,
+      annotationDocument2.path,
+      genericLogger
+    );
+
+    const filePathsAfterDeletion = await fileManager.listFiles(
+      config.s3Bucket,
+      genericLogger
+    );
+    expect(filePathsAfterDeletion).not.toContain(annotationDocument1.path);
+    expect(filePathsAfterDeletion).not.toContain(annotationDocument2.path);
+  });
+
+  it("should throw purposeTemplateNotFound if the purpose template doesn't exist", () => {
+    void expect(
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation({
+        purposeTemplateId: purposeTemplate.id,
+        answerId: riskAnalysisFormTemplate.singleAnswers[0].id,
+        ctx: getMockContext({
+          authData: getMockAuthData(purposeTemplate.creatorId),
+        }),
+      })
+    ).rejects.toThrowError(purposeTemplateNotFound(purposeTemplate.id));
+  });
+
+  it("should throw tenantNotAllowed if the requester is not the creator", async () => {
+    const requesterId = generateId<TenantId>();
+
+    await addOnePurposeTemplate(purposeTemplate);
+    expect(
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation({
+        purposeTemplateId: purposeTemplate.id,
+        answerId: riskAnalysisFormTemplate.singleAnswers[0].id,
+        ctx: getMockContext({
+          authData: getMockAuthData(requesterId),
+        }),
+      })
+    ).rejects.toThrowError(tenantNotAllowed(requesterId));
+  });
+
+  it("should throw riskAnalysisTemplateNotFound if the purpose template doesn't have a risk analysis template", async () => {
+    const purposeTemplateWithoutRiskAnalysisTemplate = getMockPurposeTemplate();
+
+    await addOnePurposeTemplate(purposeTemplateWithoutRiskAnalysisTemplate);
+    expect(
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation({
+        purposeTemplateId: purposeTemplateWithoutRiskAnalysisTemplate.id,
+        answerId: generateId(),
+        ctx: getMockContext({
+          authData: getMockAuthData(
+            purposeTemplateWithoutRiskAnalysisTemplate.creatorId
+          ),
+        }),
+      })
+    ).rejects.toThrowError(
+      riskAnalysisTemplateNotFound(
+        purposeTemplateWithoutRiskAnalysisTemplate.id
+      )
+    );
+  });
+
+  it("should throw riskAnalysisTemplateAnswerNotFound if the purpose template doesn't have the risk analysis template answer", async () => {
+    const answerId = generateId<RiskAnalysisMultiAnswerId>();
+
+    await addOnePurposeTemplate(purposeTemplate);
+    expect(
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation({
+        purposeTemplateId: purposeTemplate.id,
+        answerId,
+        ctx: getMockContext({
+          authData: getMockAuthData(purposeTemplate.creatorId),
+        }),
+      })
+    ).rejects.toThrowError(
+      riskAnalysisTemplateAnswerNotFound(purposeTemplate.id, answerId)
+    );
+  });
+
+  it.each(
+    Object.values(purposeTemplateState).filter(
+      (state) => state !== purposeTemplateState.draft
+    )
+  )(
+    "should throw purposeTemplateNotInExpectedState if the purpose template is not in %s state",
+    async (state) => {
+      const purposeTemplateNotInWrongState: PurposeTemplate = {
+        ...purposeTemplate,
+        state,
+      };
+
+      await addOnePurposeTemplate(purposeTemplateNotInWrongState);
+      expect(
+        purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotation({
+          purposeTemplateId: purposeTemplate.id,
+          answerId: riskAnalysisFormTemplate.singleAnswers[0].id,
+          ctx: getMockContext({
+            authData: getMockAuthData(purposeTemplate.creatorId),
+          }),
+        })
+      ).rejects.toThrowError(
+        purposeTemplateNotInExpectedState(
+          purposeTemplateNotInWrongState.id,
+          purposeTemplateNotInWrongState.state,
+          [purposeTemplateState.draft]
+        )
+      );
+    }
+  );
+});


### PR DESCRIPTION
## Issue
- [PIN-7664](https://pagopa.atlassian.net/browse/PIN-7664)

## Context / Why
This PR adds the logic and tests for the `DELETE /purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation` in both the `purpose-template-process` and the `BFF`.

## Impacted services
- backend-for-frontend, purpose-template-process

## Checklist
- [x] Add Bruno file for `purpose-template-process`
- [x] Add endpoint logic in `purpose-template-process`
- [x] Add endpoint tests in `purpose-template-process`
- [x] Add Bruno file for `backend-for-frontend`
- [x] Add endpoint logic in `backend-for-frontend`
- [x] Add endpoint tests in `backend-for-frontend`