### PR TITLE
bugfix: add annotation to  `buildValidResultAnswer` (risk analysis template validation)

### DIFF
--- a/packages/commons/src/risk-analysis-template/riskAnalysisTemplateValidation.ts
+++ b/packages/commons/src/risk-analysis-template/riskAnalysisTemplateValidation.ts
@@ -326,9 +326,10 @@ function buildValidResultAnswer(
         type: "single",
         answer: {
           key: answerKey,
-          value: answerValue.values[0] ?? undefined,
+          value: answerValue.values[0],
           editable: answerValue.editable,
           suggestedValues: answerValue.suggestedValues,
+          annotation: answerValue.annotation,
         },
       })
     )
@@ -339,6 +340,7 @@ function buildValidResultAnswer(
           key: answerKey,
           values: answerValue.values,
           editable: answerValue.editable,
+          annotation: answerValue.annotation,
         },
       })
     )


### PR DESCRIPTION
## Issue
- [PIN-7833](https://pagopa.atlassian.net/browse/PIN-7833)

## Context / Why
This PR adds the annotation to the `buildValidResultAnswer` function which is used during the risk analysis template validation process.

## Impacted services
- commons

## Checklist
- [x] Add annotation to  `buildValidResultAnswer`