### PR TITLE
feature: purpose-template-process DELETE /purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation/documents/:documentId (PIN-7665)

### DIFF
--- a/collections/bff/purposeTemplate/Delete Risk Analysis Template Answer Annotation Document.bru
+++ b/collections/bff/purposeTemplate/Delete Risk Analysis Template Answer Annotation Document.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Delete Risk Analysis Template Answer Annotation Document
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{host-bff}}/purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation/documents/:documentId
+  body: none
+  auth: none
+}
+
+params:path {
+  purposeTemplateId: {{purposeTemplateId}}
+  answerId: {{answerId}}
+  documentId: {{documentId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}

--- a/collections/purpose-template/Delete Risk Analysis Template Answer Annotation Document.bru
+++ b/collections/purpose-template/Delete Risk Analysis Template Answer Annotation Document.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Delete Risk Analysis Template Answer Annotation Document
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{host-purpose-template}}/purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation/documents/:documentId
+  body: none
+  auth: none
+}
+
+params:path {
+  purposeTemplateId: {{purposeTemplateId}}
+  answerId: {{answerId}}
+  documentId: {{documentId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -10697,6 +10697,117 @@ paths:
                 type: integer
                 format: int32
               description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+  /purposeTemplates/{purposeTemplateId}/riskAnalysis/answers/{answerId}/annotation/documents/{documentId}:
+    parameters:
+      - name: purposeTemplateId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: answerId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: documentId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    delete:
+      tags:
+        - purposeTemplates
+      summary: Delete risk analysis form template answer annotation document
+      operationId: deleteRiskAnalysisTemplateAnswerAnnotationDocument
+      description: Delete a risk analysis form template answer annotation document
+      responses:
+        "204":
+          description: Risk analysis form template answer annotation document deleted
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "404":
+          description: Risk analysis form template answer annotation document not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
   "/tenants/{tenantId}/attributes/declared":
     get:
       tags:

--- a/packages/api-clients/open-api/purposeTemplateApi.yml
+++ b/packages/api-clients/open-api/purposeTemplateApi.yml
@@ -631,6 +631,60 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /purposeTemplates/{id}/riskAnalysis/answers/{answerId}/annotation/documents/{documentId}:
+    parameters:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: answerId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: documentId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    delete:
+      tags:
+        - purposeTemplate
+      summary: Delete risk analysis form template answer annotation document
+      operationId: deleteRiskAnalysisTemplateAnswerAnnotationDocument
+      description: Delete a risk analysis form template answer annotation document
+      responses:
+        "204":
+          description: Risk analysis form template answer annotation document deleted
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Risk analysis form template answer annotation document not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
 components:
   headers:
     MetadataVersionHeader:

--- a/packages/backend-for-frontend/src/routers/purposeTemplateRouter.ts
+++ b/packages/backend-for-frontend/src/routers/purposeTemplateRouter.ts
@@ -166,6 +166,33 @@ const purposeTemplateRouter = (
           return res.status(errorRes.status).send(errorRes);
         }
       }
+    )
+    .delete(
+      "/purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation/documents/:documentId",
+      async (req, res) => {
+        const ctx = fromBffAppContext(req.ctx, req.headers);
+
+        try {
+          await purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument(
+            {
+              purposeTemplateId: unsafeBrandId(req.params.purposeTemplateId),
+              answerId: unsafeBrandId(req.params.answerId),
+              documentId: unsafeBrandId(req.params.documentId),
+              ctx,
+            }
+          );
+
+          return res.status(204).send();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error deleting risk analysis template answer annotation document ${req.params.documentId} for purpose template ${req.params.purposeTemplateId} and answer ${req.params.answerId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
     );
 
   return purposeTemplateRouter;

--- a/packages/backend-for-frontend/src/services/purposeTemplateService.ts
+++ b/packages/backend-for-frontend/src/services/purposeTemplateService.ts
@@ -248,6 +248,37 @@ export function purposeTemplateServiceBuilder(
         }
       );
     },
+    async deleteRiskAnalysisTemplateAnswerAnnotationDocument({
+      purposeTemplateId,
+      answerId,
+      documentId,
+      ctx,
+    }: {
+      purposeTemplateId: PurposeTemplateId;
+      answerId: PurposeTemplateId;
+      documentId: string;
+      ctx: WithLogger<BffAppContext>;
+    }): Promise<void> {
+      assertFeatureFlagEnabled(config, "featureFlagPurposeTemplate");
+
+      const { headers, logger } = ctx;
+
+      logger.info(
+        `Deleting risk analysis template answer annotation document ${documentId} for purpose template ${purposeTemplateId} and answer ${answerId}`
+      );
+
+      await purposeTemplateClient.deleteRiskAnalysisTemplateAnswerAnnotationDocument(
+        undefined,
+        {
+          params: {
+            id: purposeTemplateId,
+            answerId,
+            documentId,
+          },
+          headers,
+        }
+      );
+    },
   };
 }
 export type PurposeTemplateService = ReturnType<

--- a/packages/purpose-template-process/src/model/domain/errors.ts
+++ b/packages/purpose-template-process/src/model/domain/errors.ts
@@ -7,6 +7,7 @@ import {
   RiskAnalysisFormTemplateId,
   RiskAnalysisMultiAnswerId,
   RiskAnalysisSingleAnswerId,
+  RiskAnalysisTemplateAnswerAnnotationDocumentId,
   TenantId,
   TenantKind,
 } from "pagopa-interop-models";
@@ -22,6 +23,7 @@ export const errorCodes = {
   riskAnalysisTemplateNotFound: "0008",
   riskAnalysisTemplateAnswerNotFound: "0009",
   riskAnalysisTemplateAnswerAnnotationNotFound: "0010",
+  riskAnalysisTemplateAnswerAnnotationDocumentNotFound: "0011",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -131,5 +133,17 @@ export function riskAnalysisTemplateAnswerAnnotationNotFound(
     detail: `No Risk Analysis Template Answer Annotation found for Purpose Template ID ${purposeTemplateId} and Answer ID ${answerId}`,
     code: "riskAnalysisTemplateAnswerAnnotationNotFound",
     title: "Risk Analysis Template Answer Annotation Not Found",
+  });
+}
+
+export function riskAnalysisTemplateAnswerAnnotationDocumentNotFound(
+  purposeTemplateId: PurposeTemplateId,
+  answerId: RiskAnalysisSingleAnswerId | RiskAnalysisMultiAnswerId,
+  documentId: RiskAnalysisTemplateAnswerAnnotationDocumentId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `No Risk Analysis Template Answer Annotation Document found for Purpose Template ID ${purposeTemplateId}, Answer ID ${answerId} and Document ID ${documentId}`,
+    code: "riskAnalysisTemplateAnswerAnnotationDocumentNotFound",
+    title: "Risk Analysis Template Answer Annotation Document Not Found",
   });
 }

--- a/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
+++ b/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
@@ -17,6 +17,7 @@ import { makeApiProblem } from "../model/domain/errors.js";
 import {
   createPurposeTemplateErrorMapper,
   deletePurposeTemplateErrorMapper,
+  deleteRiskAnalysisTemplateAnswerAnnotationDocumentErrorMapper,
   deleteRiskAnalysisTemplateAnswerAnnotationErrorMapper,
   getPurposeTemplateErrorMapper,
   getPurposeTemplatesErrorMapper,
@@ -278,6 +279,33 @@ const purposeTemplateRouter = (
           const errorRes = makeApiProblem(
             error,
             deleteRiskAnalysisTemplateAnswerAnnotationErrorMapper,
+            ctx
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .delete(
+      "/purposeTemplates/:id/riskAnalysis/answers/:answerId/annotation/documents/:documentId",
+      async (req, res) => {
+        const ctx = fromAppContext(req.ctx);
+
+        try {
+          validateAuthorization(ctx, [ADMIN_ROLE, M2M_ADMIN_ROLE]);
+
+          await purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument(
+            {
+              purposeTemplateId: unsafeBrandId(req.params.id),
+              answerId: unsafeBrandId(req.params.answerId),
+              documentId: unsafeBrandId(req.params.documentId),
+              ctx,
+            }
+          );
+          return res.status(204).send();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            deleteRiskAnalysisTemplateAnswerAnnotationDocumentErrorMapper,
             ctx
           );
           return res.status(errorRes.status).send(errorRes);

--- a/packages/purpose-template-process/src/services/readModelServiceSQL.ts
+++ b/packages/purpose-template-process/src/services/readModelServiceSQL.ts
@@ -8,6 +8,7 @@ import {
   RiskAnalysisMultiAnswerId,
   RiskAnalysisSingleAnswerId,
   RiskAnalysisTemplateAnswerAnnotationDocument,
+  RiskAnalysisTemplateAnswerAnnotationDocumentId,
   RiskAnalysisTemplateMultiAnswer,
   RiskAnalysisTemplateSingleAnswer,
   Tenant,
@@ -350,6 +351,51 @@ export function readModelServiceBuilderSQL({
 
       return aggregateRiskAnalysisTemplateAnswer(
         toRiskAnalysisTemplateAnswerAggregator(queryResult)
+      );
+    },
+    async getRiskAnalysisTemplateAnswerAnnotationDocument(
+      purposeTemplateId: PurposeTemplateId,
+      answerId: RiskAnalysisSingleAnswerId | RiskAnalysisMultiAnswerId,
+      documentId: RiskAnalysisTemplateAnswerAnnotationDocumentId
+    ): Promise<RiskAnalysisTemplateAnswerAnnotationDocument | undefined> {
+      const queryResult = await readModelDB
+        .select({
+          riskAnalysisAnswerAnnotationDocument:
+            purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate,
+        })
+        .from(
+          purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate
+        )
+        .innerJoin(
+          purposeTemplateRiskAnalysisAnswerAnnotationInReadmodelPurposeTemplate,
+          eq(
+            purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate.annotationId,
+            purposeTemplateRiskAnalysisAnswerAnnotationInReadmodelPurposeTemplate.id
+          )
+        )
+        .where(
+          and(
+            eq(
+              purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate.purposeTemplateId,
+              purposeTemplateId
+            ),
+            eq(
+              purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate.id,
+              documentId
+            ),
+            eq(
+              purposeTemplateRiskAnalysisAnswerAnnotationInReadmodelPurposeTemplate.answerId,
+              answerId
+            )
+          )
+        );
+
+      if (queryResult.length === 0) {
+        return undefined;
+      }
+
+      return toRiskAnalysisTemplateAnswerAnnotationDocument(
+        queryResult[0].riskAnalysisAnswerAnnotationDocument
       );
     },
   };

--- a/packages/purpose-template-process/src/utilities/errorMappers.ts
+++ b/packages/purpose-template-process/src/utilities/errorMappers.ts
@@ -61,3 +61,17 @@ export const deleteRiskAnalysisTemplateAnswerAnnotationErrorMapper = (
     )
     .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const deleteRiskAnalysisTemplateAnswerAnnotationDocumentErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("purposeTemplateNotInExpectedState", () => HTTP_STATUS_CONFLICT)
+    .with(
+      "purposeTemplateNotFound",
+      "riskAnalysisTemplateNotFound",
+      "riskAnalysisTemplateAnswerAnnotationDocumentNotFound",
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/purpose-template-process/test/api/deleteRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
+++ b/packages/purpose-template-process/test/api/deleteRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import {
+  generateId,
+  PurposeTemplateId,
+  purposeTemplateState,
+  RiskAnalysisMultiAnswerId,
+  RiskAnalysisSingleAnswerId,
+  RiskAnalysisTemplateAnswerAnnotationDocumentId,
+  RiskAnalysisTemplateSingleAnswer,
+  tenantKind,
+} from "pagopa-interop-models";
+import {
+  generateToken,
+  getMockRiskAnalysisTemplateAnswerAnnotation,
+  getMockRiskAnalysisTemplateAnswerAnnotationDocument,
+  getMockValidRiskAnalysisFormTemplate,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { api, purposeTemplateService } from "../vitest.api.setup.js";
+import {
+  purposeTemplateNotFound,
+  purposeTemplateNotInExpectedState,
+  riskAnalysisTemplateAnswerAnnotationDocumentNotFound,
+  riskAnalysisTemplateNotFound,
+  tenantNotAllowed,
+} from "../../src/model/domain/errors.js";
+
+describe("API /purposeTemplates/{id}/riskAnalysis/answers/{answerId}/annotation/documents/{documentId}", () => {
+  const purposeTemplateId = generateId<PurposeTemplateId>();
+  const riskAnalysisTemplate = getMockValidRiskAnalysisFormTemplate(
+    tenantKind.PA
+  );
+  const annotationDocument =
+    getMockRiskAnalysisTemplateAnswerAnnotationDocument();
+  const answer: RiskAnalysisTemplateSingleAnswer = {
+    ...riskAnalysisTemplate.singleAnswers[0],
+    annotation: {
+      ...getMockRiskAnalysisTemplateAnswerAnnotation(),
+      docs: [annotationDocument],
+    },
+  };
+
+  purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument = vi
+    .fn()
+    .mockResolvedValue({});
+
+  const makeRequest = async (
+    token: string,
+    id: PurposeTemplateId = purposeTemplateId,
+    answerId:
+      | RiskAnalysisSingleAnswerId
+      | RiskAnalysisMultiAnswerId = answer.id,
+    documentId: RiskAnalysisTemplateAnswerAnnotationDocumentId = annotationDocument.id
+  ) =>
+    request(api)
+      .delete(
+        `/purposeTemplates/${id}/riskAnalysis/answers/${answerId}/annotation/documents/${documentId}`
+      )
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send();
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+  it.each(authorizedRoles)(
+    "Should return 204 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(204);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, purposeTemplateId);
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {
+      error: purposeTemplateNotInExpectedState(
+        purposeTemplateId,
+        purposeTemplateState.active,
+        [purposeTemplateState.draft]
+      ),
+      expectedStatus: 409,
+    },
+    {
+      error: purposeTemplateNotFound(purposeTemplateId),
+      expectedStatus: 404,
+    },
+    {
+      error: riskAnalysisTemplateNotFound(purposeTemplateId),
+      expectedStatus: 404,
+    },
+    {
+      error: riskAnalysisTemplateAnswerAnnotationDocumentNotFound(
+        purposeTemplateId,
+        answer.id,
+        annotationDocument.id
+      ),
+      expectedStatus: 404,
+    },
+    {
+      error: tenantNotAllowed(generateId()),
+      expectedStatus: 403,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument =
+        vi.fn().mockRejectedValue(error);
+
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, purposeTemplateId);
+
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+
+  it.each([
+    {
+      name: "invalid purpose template id",
+      run: (token: string) =>
+        makeRequest(token, "invalid" as PurposeTemplateId),
+    },
+    {
+      name: "invalid answer id",
+      run: (token: string) =>
+        makeRequest(
+          token,
+          purposeTemplateId,
+          "invalid" as RiskAnalysisSingleAnswerId
+        ),
+    },
+    {
+      name: "invalid document id",
+      run: (token: string) =>
+        makeRequest(
+          token,
+          purposeTemplateId,
+          answer.id,
+          "invalid" as RiskAnalysisTemplateAnswerAnnotationDocumentId
+        ),
+    },
+  ])("Should return 400 if an $name is passed", async ({ run }) => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await run(token);
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/purpose-template-process/test/integration/deleteRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
+++ b/packages/purpose-template-process/test/integration/deleteRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
@@ -1,0 +1,287 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import { genericLogger } from "pagopa-interop-commons";
+import {
+  decodeProtobufPayload,
+  getMockContext,
+  getMockAuthData,
+  getMockRiskAnalysisTemplateAnswerAnnotationDocument,
+  getMockPurposeTemplate,
+  getMockRiskAnalysisTemplateAnswerAnnotation,
+  getMockValidRiskAnalysisFormTemplate,
+} from "pagopa-interop-commons-test";
+import {
+  RiskAnalysisFormTemplate,
+  tenantKind,
+  PurposeTemplate,
+  toPurposeTemplateV2,
+  purposeTemplateState,
+  TenantId,
+  generateId,
+  PurposeTemplateDraftUpdatedV2,
+  RiskAnalysisMultiAnswerId,
+  RiskAnalysisTemplateAnswerAnnotationDocumentId,
+} from "pagopa-interop-models";
+import { expect, describe, it, vi } from "vitest";
+import { config } from "../../src/config/config.js";
+import {
+  addOnePurposeTemplate,
+  fileManager,
+  purposeTemplateService,
+  readLastPurposeTemplateEvent,
+} from "../integrationUtils.js";
+import {
+  purposeTemplateNotFound,
+  purposeTemplateNotInExpectedState,
+  riskAnalysisTemplateAnswerAnnotationDocumentNotFound,
+  riskAnalysisTemplateNotFound,
+  tenantNotAllowed,
+} from "../../src/model/domain/errors.js";
+
+describe("deleteRiskAnalysisTemplateAnswerAnnotationDocumentDocument", () => {
+  const mockDocument1 = getMockRiskAnalysisTemplateAnswerAnnotationDocument();
+  const mockDocument2 = getMockRiskAnalysisTemplateAnswerAnnotationDocument();
+  const annotationDocument1 = {
+    ...mockDocument1,
+    path: `${config.purposeTemplateDocumentsPath}/${mockDocument1.id}/${mockDocument1.name}`,
+  };
+  const annotationDocument2 = {
+    ...mockDocument2,
+    path: `${config.purposeTemplateDocumentsPath}/${mockDocument2.id}/${mockDocument2.name}`,
+  };
+
+  const incompleteRiskAnalysisFormTemplate =
+    getMockValidRiskAnalysisFormTemplate(tenantKind.PA);
+  const riskAnalysisFormTemplate: RiskAnalysisFormTemplate = {
+    ...incompleteRiskAnalysisFormTemplate,
+    singleAnswers: [
+      {
+        ...incompleteRiskAnalysisFormTemplate.singleAnswers[0],
+        annotation: {
+          ...getMockRiskAnalysisTemplateAnswerAnnotation(),
+          docs: [annotationDocument1, annotationDocument2],
+        },
+      },
+    ],
+  };
+
+  const purposeTemplate: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    purposeRiskAnalysisForm: riskAnalysisFormTemplate,
+  };
+
+  it("should write on event-store for the deletion of a risk analysis template answer annotation document", async () => {
+    vi.spyOn(fileManager, "delete");
+
+    await addOnePurposeTemplate(purposeTemplate);
+
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.purposeTemplateDocumentsPath,
+        resourceId: annotationDocument1.id,
+        name: annotationDocument1.name,
+        content: Buffer.from("test-test"),
+      },
+      genericLogger
+    );
+
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.purposeTemplateDocumentsPath,
+        resourceId: annotationDocument2.id,
+        name: annotationDocument2.name,
+        content: Buffer.from("test-test"),
+      },
+      genericLogger
+    );
+
+    const filePathsBeforeDeletion = await fileManager.listFiles(
+      config.s3Bucket,
+      genericLogger
+    );
+    expect(filePathsBeforeDeletion).toContain(annotationDocument1.path);
+    expect(filePathsBeforeDeletion).toContain(annotationDocument2.path);
+
+    const response =
+      await purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument(
+        {
+          purposeTemplateId: purposeTemplate.id,
+          answerId: riskAnalysisFormTemplate.singleAnswers[0].id,
+          documentId: annotationDocument1.id,
+          ctx: getMockContext({
+            authData: getMockAuthData(purposeTemplate.creatorId),
+          }),
+        }
+      );
+
+    const annotationDocumentDeletionEvent = await readLastPurposeTemplateEvent(
+      purposeTemplate.id
+    );
+
+    expect(annotationDocumentDeletionEvent).toMatchObject({
+      stream_id: purposeTemplate.id,
+      version: "1",
+      type: "PurposeTemplateDraftUpdated",
+      event_version: 2,
+    });
+
+    const annotationDocumentDeletionPayload = decodeProtobufPayload({
+      messageType: PurposeTemplateDraftUpdatedV2,
+      payload: annotationDocumentDeletionEvent.data,
+    });
+
+    const expectedPurposeTemplate: PurposeTemplate = {
+      ...purposeTemplate,
+      purposeRiskAnalysisForm: {
+        ...riskAnalysisFormTemplate,
+        singleAnswers: [
+          {
+            ...riskAnalysisFormTemplate.singleAnswers[0],
+            annotation: {
+              ...riskAnalysisFormTemplate.singleAnswers[0].annotation!,
+              docs: [annotationDocument2],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(annotationDocumentDeletionPayload.purposeTemplate).toEqual(
+      toPurposeTemplateV2(expectedPurposeTemplate)
+    );
+
+    expect(response).toBeUndefined();
+
+    expect(fileManager.delete).toHaveBeenCalledWith(
+      config.s3Bucket,
+      annotationDocument1.path,
+      genericLogger
+    );
+
+    const filePathsAfterDeletion = await fileManager.listFiles(
+      config.s3Bucket,
+      genericLogger
+    );
+    expect(filePathsAfterDeletion).not.toContain(annotationDocument1.path);
+    expect(filePathsAfterDeletion).toContain(annotationDocument2.path);
+  });
+
+  it("should throw purposeTemplateNotFound if the purpose template doesn't exist", () => {
+    void expect(
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument(
+        {
+          purposeTemplateId: purposeTemplate.id,
+          answerId: riskAnalysisFormTemplate.singleAnswers[0].id,
+          documentId: annotationDocument1.id,
+          ctx: getMockContext({
+            authData: getMockAuthData(purposeTemplate.creatorId),
+          }),
+        }
+      )
+    ).rejects.toThrowError(purposeTemplateNotFound(purposeTemplate.id));
+  });
+
+  it("should throw tenantNotAllowed if the requester is not the creator", async () => {
+    const requesterId = generateId<TenantId>();
+
+    await addOnePurposeTemplate(purposeTemplate);
+    expect(
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument(
+        {
+          purposeTemplateId: purposeTemplate.id,
+          answerId: riskAnalysisFormTemplate.singleAnswers[0].id,
+          documentId: annotationDocument1.id,
+          ctx: getMockContext({
+            authData: getMockAuthData(requesterId),
+          }),
+        }
+      )
+    ).rejects.toThrowError(tenantNotAllowed(requesterId));
+  });
+
+  it("should throw riskAnalysisTemplateNotFound if the purpose template doesn't have a risk analysis template", async () => {
+    const purposeTemplateWithoutRiskAnalysisTemplate = getMockPurposeTemplate();
+
+    await addOnePurposeTemplate(purposeTemplateWithoutRiskAnalysisTemplate);
+    expect(
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument(
+        {
+          purposeTemplateId: purposeTemplateWithoutRiskAnalysisTemplate.id,
+          answerId: generateId(),
+          documentId: generateId(),
+          ctx: getMockContext({
+            authData: getMockAuthData(
+              purposeTemplateWithoutRiskAnalysisTemplate.creatorId
+            ),
+          }),
+        }
+      )
+    ).rejects.toThrowError(
+      riskAnalysisTemplateNotFound(
+        purposeTemplateWithoutRiskAnalysisTemplate.id
+      )
+    );
+  });
+
+  it("should throw riskAnalysisTemplateAnswerAnnotationDocumentNotFound if the risk analysis template answer annotation document doesn't exist", async () => {
+    const answerId = generateId<RiskAnalysisMultiAnswerId>();
+    const documentId =
+      generateId<RiskAnalysisTemplateAnswerAnnotationDocumentId>();
+
+    await addOnePurposeTemplate(purposeTemplate);
+    expect(
+      purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument(
+        {
+          purposeTemplateId: purposeTemplate.id,
+          answerId,
+          documentId,
+          ctx: getMockContext({
+            authData: getMockAuthData(purposeTemplate.creatorId),
+          }),
+        }
+      )
+    ).rejects.toThrowError(
+      riskAnalysisTemplateAnswerAnnotationDocumentNotFound(
+        purposeTemplate.id,
+        answerId,
+        documentId
+      )
+    );
+  });
+
+  it.each(
+    Object.values(purposeTemplateState).filter(
+      (state) => state !== purposeTemplateState.draft
+    )
+  )(
+    "should throw purposeTemplateNotInExpectedState if the purpose template is in %s state",
+    async (state) => {
+      const purposeTemplateNotInWrongState: PurposeTemplate = {
+        ...purposeTemplate,
+        state,
+      };
+
+      await addOnePurposeTemplate(purposeTemplateNotInWrongState);
+      expect(
+        purposeTemplateService.deleteRiskAnalysisTemplateAnswerAnnotationDocument(
+          {
+            purposeTemplateId: purposeTemplate.id,
+            answerId: riskAnalysisFormTemplate.singleAnswers[0].id,
+            documentId: annotationDocument1.id,
+            ctx: getMockContext({
+              authData: getMockAuthData(purposeTemplate.creatorId),
+            }),
+          }
+        )
+      ).rejects.toThrowError(
+        purposeTemplateNotInExpectedState(
+          purposeTemplateNotInWrongState.id,
+          purposeTemplateNotInWrongState.state,
+          [purposeTemplateState.draft]
+        )
+      );
+    }
+  );
+});


### PR DESCRIPTION
## Issue
- [PIN-7665](https://pagopa.atlassian.net/browse/PIN-7665)

## Context / Why
This PR adds the logic and tests for the `DELETE /purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation/documents/:documentId` in both the `purpose-template-process` and the `BFF`.

## Impacted services
- backend-for-frontend, purpose-template-process

## Checklist
- [x] Add Bruno file for `purpose-template-process`
- [x] Add endpoint logic in `purpose-template-process`
- [x] Add endpoint tests in `purpose-template-process`
- [x] Add Bruno file for `backend-for-frontend`
- [x] Add endpoint logic in `backend-for-frontend`
- [x] Add endpoint tests in `backend-for-frontend`