### PR TITLE
feature: add common purpose-template-process validators and errors (PIN-7841)

### DIFF
--- a/packages/purpose-template-process/src/model/domain/errors.ts
+++ b/packages/purpose-template-process/src/model/domain/errors.ts
@@ -3,6 +3,12 @@ import {
   ApiError,
   makeApiProblemBuilder,
   PurposeTemplateId,
+  PurposeTemplateState,
+  RiskAnalysisFormTemplateId,
+  RiskAnalysisMultiAnswerId,
+  RiskAnalysisSingleAnswerId,
+  RiskAnalysisTemplateAnswerAnnotationDocumentId,
+  TenantId,
   TenantKind,
 } from "pagopa-interop-models";
 
@@ -12,6 +18,13 @@ export const errorCodes = {
   purposeTemplateNotFound: "0003",
   riskAnalysisTemplateValidationFailed: "0004",
   ruleSetNotFoundError: "0005",
+  tenantNotAllowed: "0006",
+  purposeTemplateNotInExpectedStates: "0007",
+  purposeTemplateStateConflict: "0008",
+  purposeTemplateRiskAnalysisFormNotFound: "0009",
+  riskAnalysisTemplateAnswerNotFound: "0010",
+  riskAnalysisTemplateAnswerAnnotationNotFound: "0011",
+  riskAnalysisTemplateAnswerAnnotationDocumentNotFound: "0012",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -64,5 +77,85 @@ export function ruleSetNotFoundError(
     detail: `No risk analysis rule set found for target tenant kind ${tenantKind}`,
     code: "ruleSetNotFoundError",
     title: "No risk analysis rule set found for target tenant kind",
+  });
+}
+
+export function tenantNotAllowed(tenantId: TenantId): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Tenant ${tenantId} is not allowed to perform the operation because it's not the creator`,
+    code: "tenantNotAllowed",
+    title: "Tenant not allowed",
+  });
+}
+
+export function purposeTemplateNotInExpectedStates(
+  purposeTemplateId: PurposeTemplateId,
+  currentState: PurposeTemplateState,
+  expectedStates: PurposeTemplateState[]
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Purpose Template ${purposeTemplateId} not in expected states (current state: ${currentState}, expected states: ${expectedStates.toString()})`,
+    code: "purposeTemplateNotInExpectedStates",
+    title: "Purpose Template not in expected states",
+  });
+}
+
+export function purposeTemplateStateConflict(
+  purposeTemplateId: PurposeTemplateId,
+  state: PurposeTemplateState
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Purpose Template ${purposeTemplateId} is already in state ${state}`,
+    code: "purposeTemplateStateConflict",
+    title: "Purpose Template state conflict",
+  });
+}
+
+export function purposeTemplateRiskAnalysisFormNotFound(
+  purposeTemplateId: PurposeTemplateId,
+  riskAnalysisTemplateId?: RiskAnalysisFormTemplateId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `No Risk Analysis Template Form found for Purpose Template ${purposeTemplateId}${
+      riskAnalysisTemplateId
+        ? ` and Risk Analysis Template Form ${riskAnalysisTemplateId}`
+        : ""
+    }`,
+    code: "purposeTemplateRiskAnalysisFormNotFound",
+    title: "Purpose Template Risk Analysis Form Not Found",
+  });
+}
+
+export function riskAnalysisTemplateAnswerNotFound(
+  purposeTemplateId: PurposeTemplateId,
+  answerId: RiskAnalysisSingleAnswerId | RiskAnalysisMultiAnswerId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `No Risk Analysis Template Answer found for Purpose Template ${purposeTemplateId} and Answer ${answerId}`,
+    code: "riskAnalysisTemplateAnswerNotFound",
+    title: "Risk Analysis Template Answer Not Found",
+  });
+}
+
+export function riskAnalysisTemplateAnswerAnnotationNotFound(
+  purposeTemplateId: PurposeTemplateId,
+  answerId: RiskAnalysisSingleAnswerId | RiskAnalysisMultiAnswerId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `No Risk Analysis Template Answer Annotation found for Purpose Template ${purposeTemplateId} and Answer ${answerId}`,
+    code: "riskAnalysisTemplateAnswerAnnotationNotFound",
+    title: "Risk Analysis Template Answer Annotation Not Found",
+  });
+}
+
+export function riskAnalysisTemplateAnswerAnnotationDocumentNotFound(
+  purposeTemplateId: PurposeTemplateId,
+  answerId: RiskAnalysisSingleAnswerId | RiskAnalysisMultiAnswerId,
+  documentId: RiskAnalysisTemplateAnswerAnnotationDocumentId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `No Risk Analysis Template Answer Annotation Document found for Purpose Template ${purposeTemplateId}, Answer ${answerId} and Document ${documentId}`,
+    code: "riskAnalysisTemplateAnswerAnnotationDocumentNotFound",
+    title: "Risk Analysis Template Answer Annotation Document Not Found",
   });
 }

--- a/packages/purpose-template-process/src/services/validators.ts
+++ b/packages/purpose-template-process/src/services/validators.ts
@@ -1,17 +1,48 @@
-import { RiskAnalysisFormTemplate, TenantKind } from "pagopa-interop-models";
+import {
+  PurposeTemplate,
+  purposeTemplateState,
+  PurposeTemplateState,
+  RiskAnalysisFormTemplate,
+  TenantId,
+  TenantKind,
+} from "pagopa-interop-models";
 import { purposeTemplateApi } from "pagopa-interop-api-clients";
 import {
+  M2MAdminAuthData,
+  M2MAuthData,
   RiskAnalysisTemplateValidatedForm,
   riskAnalysisValidatedFormTemplateToNewRiskAnalysisFormTemplate,
+  UIAuthData,
   validatePurposeTemplateRiskAnalysis,
 } from "pagopa-interop-commons";
 import { match } from "ts-pattern";
 import {
   missingFreeOfChargeReason,
   purposeTemplateNameConflict,
+  purposeTemplateNotInExpectedStates,
+  purposeTemplateRiskAnalysisFormNotFound,
+  purposeTemplateStateConflict,
   riskAnalysisTemplateValidationFailed,
+  tenantNotAllowed,
 } from "../model/domain/errors.js";
 import { ReadModelServiceSQL } from "./readModelServiceSQL.js";
+
+const isRequesterCreator = (
+  creatorId: TenantId,
+  authData: Pick<UIAuthData | M2MAuthData | M2MAdminAuthData, "organizationId">
+): boolean => authData.organizationId === creatorId;
+
+const isPurposeTemplateActive = (
+  currentPurposeTemplateState: PurposeTemplateState
+): boolean => currentPurposeTemplateState === purposeTemplateState.active;
+
+const isPurposeTemplateArchived = (
+  currentPurposeTemplateState: PurposeTemplateState
+): boolean => currentPurposeTemplateState === purposeTemplateState.archived;
+
+const isPurposeTemplateDraft = (
+  currentPurposeTemplateState: PurposeTemplateState
+): boolean => currentPurposeTemplateState === purposeTemplateState.draft;
 
 export const assertConsistentFreeOfCharge = (
   isFreeOfCharge: boolean,
@@ -41,17 +72,17 @@ export const assertPurposeTemplateTitleIsNotDuplicated = async ({
 };
 
 export function validateAndTransformRiskAnalysisTemplate(
-  purposeRiskAnalysisForm:
+  riskAnalysisFormTemplate:
     | purposeTemplateApi.RiskAnalysisFormTemplateSeed
     | undefined,
   tenantKind: TenantKind
 ): RiskAnalysisFormTemplate | undefined {
-  if (!purposeRiskAnalysisForm) {
+  if (!riskAnalysisFormTemplate) {
     return undefined;
   }
 
   const validatedForm = validateRiskAnalysisTemplateOrThrow({
-    riskAnalysisForm: purposeRiskAnalysisForm,
+    riskAnalysisFormTemplate,
     tenantKind,
   });
 
@@ -60,15 +91,15 @@ export function validateAndTransformRiskAnalysisTemplate(
   );
 }
 
-function validateRiskAnalysisTemplateOrThrow({
-  riskAnalysisForm,
+export function validateRiskAnalysisTemplateOrThrow({
+  riskAnalysisFormTemplate,
   tenantKind,
 }: {
-  riskAnalysisForm: purposeTemplateApi.RiskAnalysisFormTemplateSeed;
+  riskAnalysisFormTemplate: purposeTemplateApi.RiskAnalysisFormTemplateSeed;
   tenantKind: TenantKind;
 }): RiskAnalysisTemplateValidatedForm {
   const result = validatePurposeTemplateRiskAnalysis(
-    riskAnalysisForm,
+    riskAnalysisFormTemplate,
     tenantKind
   );
 
@@ -78,4 +109,106 @@ function validateRiskAnalysisTemplateOrThrow({
     })
     .with({ type: "valid" }, ({ value }) => value)
     .exhaustive();
+}
+
+export const assertPurposeTemplateIsDraft = (
+  purposeTemplate: PurposeTemplate
+): void => {
+  if (!isPurposeTemplateDraft(purposeTemplate.state)) {
+    throw purposeTemplateNotInExpectedStates(
+      purposeTemplate.id,
+      purposeTemplate.state,
+      [purposeTemplateState.draft]
+    );
+  }
+};
+
+export const assertRequesterIsCreator = (
+  creatorId: TenantId,
+  authData: Pick<UIAuthData | M2MAdminAuthData, "organizationId">
+): void => {
+  if (!isRequesterCreator(creatorId, authData)) {
+    throw tenantNotAllowed(authData.organizationId);
+  }
+};
+
+export const assertRequesterCanRetrievePurposeTemplate = async (
+  purposeTemplate: PurposeTemplate,
+  authData: Pick<UIAuthData | M2MAuthData | M2MAdminAuthData, "organizationId">
+): Promise<void> => {
+  if (
+    !isPurposeTemplateActive(purposeTemplate.state) &&
+    !isRequesterCreator(purposeTemplate.creatorId, authData)
+  ) {
+    throw tenantNotAllowed(authData.organizationId);
+  }
+};
+
+export const assertPurposeTemplateStateIsValid = (
+  purposeTemplate: PurposeTemplate,
+  expectedInitialStates: PurposeTemplateState[],
+  conflictState?: PurposeTemplateState
+): void => {
+  match(purposeTemplate)
+    .when(
+      (p) => p.state === conflictState,
+      () => {
+        throw purposeTemplateStateConflict(
+          purposeTemplate.id,
+          purposeTemplate.state
+        );
+      }
+    )
+    .when(
+      (p) => !expectedInitialStates.includes(p.state),
+      () => {
+        throw purposeTemplateNotInExpectedStates(
+          purposeTemplate.id,
+          purposeTemplate.state,
+          expectedInitialStates
+        );
+      }
+    );
+};
+
+export const assertActivatableState = (
+  purposeTemplate: PurposeTemplate,
+  expectedInitialState: PurposeTemplateState
+): void => {
+  assertPurposeTemplateStateIsValid(
+    purposeTemplate,
+    [expectedInitialState],
+    purposeTemplateState.active
+  );
+};
+
+export const assertSuspendableState = (
+  purposeTemplate: PurposeTemplate
+): void => {
+  assertPurposeTemplateStateIsValid(
+    purposeTemplate,
+    [purposeTemplateState.active],
+    purposeTemplateState.suspended
+  );
+};
+
+export const archivableInitialStates = Object.values(
+  purposeTemplateState
+).filter((state) => !isPurposeTemplateArchived(state));
+export const assertArchivableState = (
+  purposeTemplate: PurposeTemplate
+): void => {
+  assertPurposeTemplateStateIsValid(
+    purposeTemplate,
+    archivableInitialStates,
+    purposeTemplateState.archived
+  );
+};
+
+export function assertPurposeTemplateHasRiskAnalysisForm(
+  purposeTemplate: PurposeTemplate
+): void {
+  if (!purposeTemplate.purposeRiskAnalysisForm) {
+    throw purposeTemplateRiskAnalysisFormNotFound(purposeTemplate.id);
+  }
 }


### PR DESCRIPTION
## Issue
- [PIN-7841](https://pagopa.atlassian.net/browse/PIN-7841)

## Context / Why
This PR adds the common validators and errors to the `purpose-template-process`. This is to not re-write the same code in different PRs.

## Impacted services
- purpose-template-process

## Checklist
- [x] Add common validators to `purpose-template-process`
- [x] Add common errors to `purpose-template-process`

[PIN-7841]: https://pagopa.atlassian.net/browse/PIN-7841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ