### PR TITLE
feat(readmodel): added group id e-service attribute group order consistency test (PIN-7848)

### DIFF
--- a/packages/readmodel/test/eserviceAggregator.test.ts
+++ b/packages/readmodel/test/eserviceAggregator.test.ts
@@ -10,10 +10,14 @@ import {
   agreementApprovalPolicy,
   Descriptor,
   EService,
+  EServiceAddedV2,
+  EserviceAttributes,
   EServiceTemplateId,
   EServiceTemplateVersionRef,
+  fromEServiceV2,
   generateId,
   tenantKind,
+  toEServiceV2,
 } from "pagopa-interop-models";
 import { describe, it, expect } from "vitest";
 import { splitEserviceIntoObjectsSQL } from "../src/catalog/splitters.js";
@@ -135,5 +139,128 @@ describe("E-service aggregator", () => {
       data: eservice,
       metadata: { version: 1 },
     });
+  });
+
+  /**
+   * !! IMPORTANT !!
+   * This test ensures that the order of attribute groups are consistent with the original order
+   * in the descriptor, even after protobuf deserialization, splitting,
+   * aggregating a reserialization of the eservice object.
+   *
+   * This is important because some functionalities in APIV2 (e.g. in-add attributes endpoints)
+   * rely on the order of these groups.
+   */
+  it("should keep the descriptor attributes group order by groupIndex", () => {
+    const descriptorCertifiedAttributeGroups: EserviceAttributes["certified"] =
+      [
+        [getMockEServiceAttribute()],
+        [getMockEServiceAttribute(), getMockEServiceAttribute()],
+        [getMockEServiceAttribute(), getMockEServiceAttribute()],
+        [
+          getMockEServiceAttribute(),
+          getMockEServiceAttribute(),
+          getMockEServiceAttribute(),
+        ],
+      ];
+
+    const descriptorVerifiedAttributeGroups: EserviceAttributes["verified"] = [
+      [getMockEServiceAttribute()],
+      [getMockEServiceAttribute(), getMockEServiceAttribute()],
+      [getMockEServiceAttribute(), getMockEServiceAttribute()],
+      [
+        getMockEServiceAttribute(),
+        getMockEServiceAttribute(),
+        getMockEServiceAttribute(),
+      ],
+    ];
+
+    const descriptorDeclaredAttributeGroups: EserviceAttributes["declared"] = [
+      [getMockEServiceAttribute()],
+      [getMockEServiceAttribute(), getMockEServiceAttribute()],
+      [getMockEServiceAttribute(), getMockEServiceAttribute()],
+      [
+        getMockEServiceAttribute(),
+        getMockEServiceAttribute(),
+        getMockEServiceAttribute(),
+      ],
+    ];
+
+    const descriptor: Descriptor = {
+      ...getMockDescriptor(),
+      attributes: {
+        certified: descriptorCertifiedAttributeGroups,
+        verified: descriptorVerifiedAttributeGroups,
+        declared: descriptorDeclaredAttributeGroups,
+      },
+    };
+
+    const eservice = getMockEService(undefined, undefined, [descriptor]);
+    const serialized = EServiceAddedV2.toBinary({
+      eservice: toEServiceV2(eservice),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const _ of Array(100)) {
+      const deserialized = EServiceAddedV2.fromBinary(serialized).eservice;
+
+      if (!deserialized) {
+        throw new Error("Deserialized eservice is undefined");
+      }
+
+      const deserializedEService = fromEServiceV2(deserialized);
+
+      const {
+        eserviceSQL,
+        riskAnalysesSQL,
+        riskAnalysisAnswersSQL,
+        descriptorsSQL,
+        attributesSQL,
+        interfacesSQL,
+        documentsSQL,
+        rejectionReasonsSQL,
+        templateVersionRefsSQL,
+      } = splitEserviceIntoObjectsSQL(deserializedEService, 1);
+
+      const aggregatedEservice = aggregateEservice({
+        eserviceSQL,
+        riskAnalysesSQL,
+        riskAnalysisAnswersSQL,
+        descriptorsSQL,
+        attributesSQL,
+        interfacesSQL,
+        documentsSQL,
+        rejectionReasonsSQL,
+        templateVersionRefsSQL,
+      }).data;
+
+      const aggregatedDescriptor = aggregatedEservice.descriptors[0];
+
+      expect(aggregatedDescriptor.attributes.certified).toHaveLength(
+        descriptorCertifiedAttributeGroups.length
+      );
+      aggregatedDescriptor.attributes.certified.forEach((group, index) => {
+        expect(group).toHaveLength(
+          descriptorCertifiedAttributeGroups[index].length
+        );
+      });
+
+      expect(aggregatedDescriptor.attributes.verified).toHaveLength(
+        descriptorVerifiedAttributeGroups.length
+      );
+      aggregatedDescriptor.attributes.verified.forEach((group, index) => {
+        expect(group).toHaveLength(
+          descriptorVerifiedAttributeGroups[index].length
+        );
+      });
+
+      expect(aggregatedDescriptor.attributes.declared).toHaveLength(
+        descriptorDeclaredAttributeGroups.length
+      );
+      aggregatedDescriptor.attributes.declared.forEach((group, index) => {
+        expect(group).toHaveLength(
+          descriptorDeclaredAttributeGroups[index].length
+        );
+      });
+    }
   });
 });


### PR DESCRIPTION
## Issue
- [PIN-7848](https://pagopa.atlassian.net/browse/PIN-7848)

## Contesto / Perché
Added tests that ensures that the order of attribute groups are consistent with the original order in the descriptor, even after protobuf deserialization, splitting, aggregating a reserialization of the e-service object.

This is important because some functionalities in APIV2 (e.g. in-add attributes endpoints) rely on the order of these groups.

## Servizi / Scope impattati
- `readmodel`

## Checklist Tracciabilità
- [ ] Branch contiene la Jira key
- [ ] Titolo PR conforme (type(scope): descrizione (KEY))
- [ ] Fix Version impostata in Jira
- [ ] Label servizio applicate