### PR TITLE
hotfix(bff): add UTF-8 encoding and safe ASCII fallback for filenames (PIN-7865)

### DIFF
--- a/docker/local-kms-seed/jwks.json
+++ b/docker/local-kms-seed/jwks.json
@@ -2,10 +2,17 @@
   "keys": [
     {
       "kty": "RSA",
-      "n": "2ncTYh2u309cDgYzNdz09nfFgvvFyPnZsruDDJIjsn568ZEsI2FFItBsdL1lzADbtqaBq-R6EGX9Odglzk_zneZKKMWVxjrLGW_IOCvr6tiy_JvwYrLiNHPOhl7OJhD5X7N6t8TyXsNz2jigHrazHO_HONYQcRr5z9Nz_n7LAyF_98COjRmm5hexaUltSywg-EVfvrQEhHwk5mavs91rO9QH7aoHIruR7f1lAy7v65DbVUNR7950m5kjyK7DVv7CC97wfg2eXmC93_1Jlc9stqTntf_4Sp99HkiRuAg7r90Ej8B0iZAAzOmAtTrnX0L79_nh2ZOWLYe2Q0vKLfsGhw",
+      "n": "2XJmso3hcl3dPmBgh7f-K6Gl_pZoIMThSMCRudTnSPv6LeY-VQv4vxVrYlNMaCLKQ09Xwf1rbjFcByWOKNVo63E-Qim6tgXNJgiFcTlkT-tNESN60DmPNR7ib2ssoNfhOy6rjO5FXP2k6u5Do4kkRlrHQembIsMt2l99ZwWhmqZas3dWuV0RfvA4OZxig9xpJdrizQsKc6oQa47B5SKuNnNQA7HSFyxJHx94ACywsgLfuX9dGx-q1B5--YbRNQvdFp-KPzCH1T2K_l-cs-HEQc7Vdg7ddNGWjPq6xwtTHitCqNfSPLH570AOFdGocMN4DZSZfwyOGNQjXt6z_lhwRw",
       "e": "AQAB",
       "alg": "RS256",
-      "kid": "aca0625c-e107-42ae-944a-158422af5d92"
+      "kid": "41e3a8e9-5982-4a6d-b531-850774bfd961"
+    },
+    {
+      "kty": "RSA",
+      "n": "k5JxTIGte3mNfH5l7PuJCzZ3q2Ri7XuMop8SKQqFE7-xbrjmdM5pFK9gznrbsHWr2FB-w9C_oSGBDn4vyKGmnPWR2lTzBD9lmsEpEUKOs3ZlMSbpkWJOHCELocgq4kRAGxifTodqfj4uakGWHBFzIQ-79QVYzZ0B_3dsaUU9AOOa7TgiV9bbyhkWVWGzT8uGhi-F84M1VwVnsG8I3NI9YhwOs_JRufuh-ZvFnRcPuWTVAgcDYoZW94mpXvl0Kw8l2YoyTrl9xqvDOObA_axu1EWptJOD-65BQDDG-YLMvfxV9fnIlX59o6kbc2I6qFtrtvZCGLDPs_jE-k8_6hfAJw",
+      "e": "AQAB",
+      "alg": "RS256",
+      "kid": "ffcc9b5b-4612-49b1-9374-9d203a3834f2"
     }
   ]
 }


### PR DESCRIPTION
## Issue
- [PIN-7865](https://pagopa.atlassian.net/browse/PIN-7865?atlOrigin=eyJpIjoiYzIwNDM2NzAzZGVjNDY5MmExYjc5NzhjYjMzMWI3ODQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Context / Why
Filenames containing non-ASCII characters were not handled correctly during file download.  
UTF-8 encoding (`filename*`) and an ASCII-safe fallback (`filename`) have been added to ensure compatibility with both modern and legacy browsers.  

## Impacted Services / Scope
- bff

## Traceability Checklist
- [x] Branch contains the Jira key
- [x] PR title is compliant (feat(download): support UTF-8 filenames with encoded header and safe ASCII fallback (PIN-123))
- [ ] Fix Version set in Jira
- [x] Service labels applied


[PIN-7865]: https://pagopa.atlassian.net/browse/PIN-7865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

(Test was made with an e-service named the same as the one that was failing in PROD "PCP – CodeList")
<img width="1641" height="1046" alt="Screenshot 2025-10-03 alle 17 06 28" src="https://github.com/user-attachments/assets/5f1b2b32-d2af-4b6a-b732-182e47b37a39" />

