### PR TITLE
[local-testing-improvements] local token generator script

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "prune-modules": "find . -name 'node_modules' -type d -exec rm -rf {} +"
   },
   "devDependencies": {
+    "@aws-sdk/client-kms": "3.840.0",
     "@tsconfig/strictest": "2.0.5",
     "@tsconfig/node-lts": "20.1.3",
     "turbo": "2.2.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@aws-sdk/client-kms':
+        specifier: 3.840.0
+        version: 3.840.0
       '@tsconfig/node-lts':
         specifier: 20.1.3
         version: 20.1.3
@@ -10567,6 +10570,7 @@ packages:
   puppeteer@22.11.2:
     resolution: {integrity: sha512-8fjdQSgW0sq7471ftca24J7sXK+jXZ7OW7Gx+NEBFNyXrcTiBfukEI46gNq6hiMhbLEDT30NeylK/1ZoPdlKSA==}
     engines: {node: '>=18'}
+    deprecated: < 24.9.0 is no longer supported
     hasBin: true
 
   qs@6.11.0:
@@ -12089,9 +12093,9 @@ snapshots:
       '@smithy/middleware-stack': 3.0.10
       '@smithy/node-config-provider': 3.1.11
       '@smithy/node-http-handler': 3.3.1
-      '@smithy/protocol-http': 4.1.7
+      '@smithy/protocol-http': 4.1.8
       '@smithy/smithy-client': 3.4.5
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/url-parser': 3.0.10
       '@smithy/util-base64': 3.0.0
       '@smithy/util-body-length-browser': 3.0.0
@@ -12099,7 +12103,7 @@ snapshots:
       '@smithy/util-defaults-mode-browser': 3.0.28
       '@smithy/util-defaults-mode-node': 3.0.28
       '@smithy/util-endpoints': 2.1.6
-      '@smithy/util-middleware': 3.0.10
+      '@smithy/util-middleware': 3.0.11
       '@smithy/util-retry': 3.0.10
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
@@ -12352,9 +12356,9 @@ snapshots:
       '@smithy/middleware-stack': 3.0.10
       '@smithy/node-config-provider': 3.1.11
       '@smithy/node-http-handler': 3.3.1
-      '@smithy/protocol-http': 4.1.7
+      '@smithy/protocol-http': 4.1.8
       '@smithy/smithy-client': 3.4.5
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/url-parser': 3.0.10
       '@smithy/util-base64': 3.0.0
       '@smithy/util-body-length-browser': 3.0.0
@@ -12362,7 +12366,7 @@ snapshots:
       '@smithy/util-defaults-mode-browser': 3.0.28
       '@smithy/util-defaults-mode-node': 3.0.28
       '@smithy/util-endpoints': 2.1.6
-      '@smithy/util-middleware': 3.0.10
+      '@smithy/util-middleware': 3.0.11
       '@smithy/util-retry': 3.0.10
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
@@ -12429,11 +12433,11 @@ snapshots:
       '@smithy/core': 2.5.4
       '@smithy/node-config-provider': 3.1.11
       '@smithy/property-provider': 3.1.10
-      '@smithy/protocol-http': 4.1.7
+      '@smithy/protocol-http': 4.1.8
       '@smithy/signature-v4': 4.2.4
       '@smithy/smithy-client': 3.4.5
-      '@smithy/types': 3.7.1
-      '@smithy/util-middleware': 3.0.10
+      '@smithy/types': 3.7.2
+      '@smithy/util-middleware': 3.0.11
       fast-xml-parser: 4.4.1
       tslib: 2.8.1
 
@@ -12477,7 +12481,7 @@ snapshots:
       '@aws-sdk/core': 3.693.0
       '@aws-sdk/types': 3.692.0
       '@smithy/property-provider': 3.1.10
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.840.0':
@@ -12507,9 +12511,9 @@ snapshots:
       '@smithy/fetch-http-handler': 4.1.1
       '@smithy/node-http-handler': 3.3.1
       '@smithy/property-provider': 3.1.10
-      '@smithy/protocol-http': 4.1.7
+      '@smithy/protocol-http': 4.1.8
       '@smithy/smithy-client': 3.4.5
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/util-stream': 3.3.1
       tslib: 2.8.1
 
@@ -12594,7 +12598,7 @@ snapshots:
       '@smithy/credential-provider-imds': 3.2.7
       '@smithy/property-provider': 3.1.10
       '@smithy/shared-ini-file-loader': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
@@ -12688,7 +12692,7 @@ snapshots:
       '@smithy/credential-provider-imds': 3.2.7
       '@smithy/property-provider': 3.1.10
       '@smithy/shared-ini-file-loader': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
@@ -12726,7 +12730,7 @@ snapshots:
       '@aws-sdk/types': 3.692.0
       '@smithy/property-provider': 3.1.10
       '@smithy/shared-ini-file-loader': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.840.0':
@@ -12786,7 +12790,7 @@ snapshots:
       '@aws-sdk/types': 3.692.0
       '@smithy/property-provider': 3.1.10
       '@smithy/shared-ini-file-loader': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
@@ -12819,7 +12823,7 @@ snapshots:
       '@aws-sdk/core': 3.693.0
       '@aws-sdk/types': 3.692.0
       '@smithy/property-provider': 3.1.10
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.840.0':
@@ -12935,8 +12939,8 @@ snapshots:
   '@aws-sdk/middleware-host-header@3.693.0':
     dependencies:
       '@aws-sdk/types': 3.692.0
-      '@smithy/protocol-http': 4.1.7
-      '@smithy/types': 3.7.1
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.840.0':
@@ -12961,7 +12965,7 @@ snapshots:
   '@aws-sdk/middleware-logger@3.693.0':
     dependencies:
       '@aws-sdk/types': 3.692.0
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.840.0':
@@ -12980,8 +12984,8 @@ snapshots:
   '@aws-sdk/middleware-recursion-detection@3.693.0':
     dependencies:
       '@aws-sdk/types': 3.692.0
-      '@smithy/protocol-http': 4.1.7
-      '@smithy/types': 3.7.1
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.840.0':
@@ -13037,8 +13041,8 @@ snapshots:
       '@aws-sdk/types': 3.692.0
       '@aws-sdk/util-endpoints': 3.693.0
       '@smithy/core': 2.5.4
-      '@smithy/protocol-http': 4.1.7
-      '@smithy/types': 3.7.1
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.840.0':
@@ -13107,9 +13111,9 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.692.0
       '@smithy/node-config-provider': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/util-config-provider': 3.0.0
-      '@smithy/util-middleware': 3.0.10
+      '@smithy/util-middleware': 3.0.11
       tslib: 2.8.1
 
   '@aws-sdk/region-config-resolver@3.840.0':
@@ -13196,7 +13200,7 @@ snapshots:
 
   '@aws-sdk/types@3.692.0':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@aws-sdk/types@3.840.0':
@@ -13223,7 +13227,7 @@ snapshots:
   '@aws-sdk/util-endpoints@3.693.0':
     dependencies:
       '@aws-sdk/types': 3.692.0
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/util-endpoints': 2.1.6
       tslib: 2.8.1
 
@@ -13255,7 +13259,7 @@ snapshots:
   '@aws-sdk/util-user-agent-browser@3.693.0':
     dependencies:
       '@aws-sdk/types': 3.692.0
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       bowser: 2.11.0
       tslib: 2.8.1
 
@@ -13278,7 +13282,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.693.0
       '@aws-sdk/types': 3.692.0
       '@smithy/node-config-provider': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.840.0':
@@ -14262,7 +14266,7 @@ snapshots:
 
   '@smithy/abort-controller@3.1.8':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/abort-controller@4.0.4':
@@ -14282,9 +14286,9 @@ snapshots:
   '@smithy/config-resolver@3.0.12':
     dependencies:
       '@smithy/node-config-provider': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/util-config-provider': 3.0.0
-      '@smithy/util-middleware': 3.0.10
+      '@smithy/util-middleware': 3.0.11
       tslib: 2.8.1
 
   '@smithy/config-resolver@4.1.4':
@@ -14298,10 +14302,10 @@ snapshots:
   '@smithy/core@2.5.4':
     dependencies:
       '@smithy/middleware-serde': 3.0.10
-      '@smithy/protocol-http': 4.1.7
-      '@smithy/types': 3.7.1
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
       '@smithy/util-body-length-browser': 3.0.0
-      '@smithy/util-middleware': 3.0.10
+      '@smithy/util-middleware': 3.0.11
       '@smithy/util-stream': 3.3.1
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
@@ -14322,7 +14326,7 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 3.1.11
       '@smithy/property-provider': 3.1.10
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/url-parser': 3.0.10
       tslib: 2.8.1
 
@@ -14374,9 +14378,9 @@ snapshots:
 
   '@smithy/fetch-http-handler@4.1.1':
     dependencies:
-      '@smithy/protocol-http': 4.1.7
+      '@smithy/protocol-http': 4.1.8
       '@smithy/querystring-builder': 3.0.10
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/util-base64': 3.0.0
       tslib: 2.8.1
 
@@ -14397,7 +14401,7 @@ snapshots:
 
   '@smithy/hash-node@3.0.10':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/util-buffer-from': 3.0.0
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
@@ -14417,7 +14421,7 @@ snapshots:
 
   '@smithy/invalid-dependency@3.0.10':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.0.4':
@@ -14445,8 +14449,8 @@ snapshots:
 
   '@smithy/middleware-content-length@3.0.12':
     dependencies:
-      '@smithy/protocol-http': 4.1.7
-      '@smithy/types': 3.7.1
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.0.4':
@@ -14461,9 +14465,9 @@ snapshots:
       '@smithy/middleware-serde': 3.0.10
       '@smithy/node-config-provider': 3.1.11
       '@smithy/shared-ini-file-loader': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/url-parser': 3.0.10
-      '@smithy/util-middleware': 3.0.10
+      '@smithy/util-middleware': 3.0.11
       tslib: 2.8.1
 
   '@smithy/middleware-endpoint@4.1.13':
@@ -14480,11 +14484,11 @@ snapshots:
   '@smithy/middleware-retry@3.0.28':
     dependencies:
       '@smithy/node-config-provider': 3.1.11
-      '@smithy/protocol-http': 4.1.7
+      '@smithy/protocol-http': 4.1.8
       '@smithy/service-error-classification': 3.0.10
       '@smithy/smithy-client': 3.4.5
-      '@smithy/types': 3.7.1
-      '@smithy/util-middleware': 3.0.10
+      '@smithy/types': 3.7.2
+      '@smithy/util-middleware': 3.0.11
       '@smithy/util-retry': 3.0.10
       tslib: 2.8.1
       uuid: 9.0.1
@@ -14503,7 +14507,7 @@ snapshots:
 
   '@smithy/middleware-serde@3.0.10':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/middleware-serde@4.0.8':
@@ -14514,7 +14518,7 @@ snapshots:
 
   '@smithy/middleware-stack@3.0.10':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.0.4':
@@ -14526,7 +14530,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 3.1.10
       '@smithy/shared-ini-file-loader': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.1.3':
@@ -14539,9 +14543,9 @@ snapshots:
   '@smithy/node-http-handler@3.3.1':
     dependencies:
       '@smithy/abort-controller': 3.1.8
-      '@smithy/protocol-http': 4.1.7
+      '@smithy/protocol-http': 4.1.8
       '@smithy/querystring-builder': 3.0.10
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.0.6':
@@ -14554,7 +14558,7 @@ snapshots:
 
   '@smithy/property-provider@3.1.10':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/property-provider@4.0.4':
@@ -14564,7 +14568,7 @@ snapshots:
 
   '@smithy/protocol-http@4.1.7':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/protocol-http@4.1.8':
@@ -14579,7 +14583,7 @@ snapshots:
 
   '@smithy/querystring-builder@3.0.10':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/util-uri-escape': 3.0.0
       tslib: 2.8.1
 
@@ -14591,7 +14595,7 @@ snapshots:
 
   '@smithy/querystring-parser@3.0.10':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.0.4':
@@ -14601,7 +14605,7 @@ snapshots:
 
   '@smithy/service-error-classification@3.0.10':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
 
   '@smithy/service-error-classification@4.0.6':
     dependencies:
@@ -14609,7 +14613,7 @@ snapshots:
 
   '@smithy/shared-ini-file-loader@3.1.11':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.0.4':
@@ -14664,8 +14668,8 @@ snapshots:
       '@smithy/core': 2.5.4
       '@smithy/middleware-endpoint': 3.2.4
       '@smithy/middleware-stack': 3.0.10
-      '@smithy/protocol-http': 4.1.7
-      '@smithy/types': 3.7.1
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
       '@smithy/util-stream': 3.3.1
       tslib: 2.8.1
 
@@ -14698,7 +14702,7 @@ snapshots:
   '@smithy/url-parser@3.0.10':
     dependencies:
       '@smithy/querystring-parser': 3.0.10
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/url-parser@4.0.4':
@@ -14762,7 +14766,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 3.1.10
       '@smithy/smithy-client': 3.4.5
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       bowser: 2.11.0
       tslib: 2.8.1
 
@@ -14781,7 +14785,7 @@ snapshots:
       '@smithy/node-config-provider': 3.1.11
       '@smithy/property-provider': 3.1.10
       '@smithy/smithy-client': 3.4.5
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.0.21':
@@ -14797,7 +14801,7 @@ snapshots:
   '@smithy/util-endpoints@2.1.6':
     dependencies:
       '@smithy/node-config-provider': 3.1.11
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/util-endpoints@3.0.6':
@@ -14825,7 +14829,7 @@ snapshots:
 
   '@smithy/util-middleware@3.0.10':
     dependencies:
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/util-middleware@3.0.11':
@@ -14841,7 +14845,7 @@ snapshots:
   '@smithy/util-retry@3.0.10':
     dependencies:
       '@smithy/service-error-classification': 3.0.10
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       tslib: 2.8.1
 
   '@smithy/util-retry@4.0.6':
@@ -14854,7 +14858,7 @@ snapshots:
     dependencies:
       '@smithy/fetch-http-handler': 4.1.1
       '@smithy/node-http-handler': 3.3.1
-      '@smithy/types': 3.7.1
+      '@smithy/types': 3.7.2
       '@smithy/util-base64': 3.0.0
       '@smithy/util-buffer-from': 3.0.0
       '@smithy/util-hex-encoding': 3.0.0

--- a/scripts/generate-local-token.js
+++ b/scripts/generate-local-token.js
@@ -1,0 +1,269 @@
+const { randomUUID } = require("crypto");
+const { KMSClient, SignCommand } = require("@aws-sdk/client-kms");
+
+// ============================================================================
+// simply launch this script with `node scripts/generate-local-token.js`
+// to generate a signed JWT token using local-kms
+// ============================================================================
+
+const LOCAL_KMS_ENDPOINT = "http://localhost:4566";
+const LOCAL_REGION = "eu-south-1";
+
+// KMS Key IDs from local-kms-seed/seed.yaml    
+const LOCAL_KEY_IDS = {
+  key: "ffcc9b5b-4612-49b1-9374-9d203a3834f2",
+};
+
+// ============================================================================
+// CONFIGURATION - Change these values for your local development needs
+// ============================================================================
+
+// Token role - Possible values: "admin", "api", "security", "api,security", "m2m", "m2m-admin", "maintenance", "internal"
+const TOKEN_ROLE = "admin";
+
+// Token duration in seconds (default: 86400 = 24 hours)
+const TOKEN_DURATION_SECONDS = 86400;
+
+// Organization ID
+const ORGANIZATION_ID = "69e2865e-65ab-4e48-a638-2037a9ee2ee7"; // PagoPA S.p.A.
+
+// User ID (used for admin and m2m-admin roles)
+const USER_ID = "f07ddb8f-17f9-47d4-b31e-35d1ac10e521";
+
+// Selfcare ID
+const SELFCARE_ID = "1962d21c-c701-4805-93f6-53a877898756";
+
+// payload constants
+const COMMON_EXTERNAL_ID = {
+  origin: "IPA",
+  value: "5N2TR557",
+};
+
+const COMMON_ORGANIZATION_BASE = {
+  name: "PagoPA S.p.A.",
+  fiscal_code: "15376371009",
+  ipaCode: "5N2TR557",
+};
+
+const COMMON_USER_INFO = {
+  name: "Mario",
+  family_name: "Rossi",
+  email: "m.rossi@psp.it",
+};
+
+const AUDIENCES = {
+  ui: "dev.interop.pagopa.it/ui",
+  m2m: "dev.interop.pagopa.it/m2m",
+  internal: "dev.interop.pagopa.it/internal",
+};
+
+function getSessionTokenHeader(kid) {
+  return {
+    alg: "RS256",
+    typ: "at+jwt",
+    kid,
+    use: "sig",
+  };
+}
+
+function createOrganization(organizationId, roles) {
+  return {
+    id: organizationId,
+    ...COMMON_ORGANIZATION_BASE,
+    roles,
+  };
+}
+
+function createUIPayload(basePayload, userRoles, organizationId, roles, uid) {
+  return {
+    ...basePayload,
+    aud: AUDIENCES.ui,
+    externalId: COMMON_EXTERNAL_ID,
+    "user-roles": userRoles,
+    selfcareId: SELFCARE_ID,
+    organizationId,
+    organization: createOrganization(organizationId, roles),
+    uid,
+    ...COMMON_USER_INFO,
+  };
+}
+
+function getSessionTokenPayload(role, sessionDuration) {
+  const issuedAt = Math.round(new Date().getTime() / 1000);
+  const issuer = "dev.interop.pagopa.it";
+
+  const basePayload = {
+    iss: issuer,
+    nbf: issuedAt,
+    iat: issuedAt,
+    exp: issuedAt + sessionDuration,
+    jti: randomUUID(),
+  };
+
+  switch (role) {
+    case "admin":
+      return createUIPayload(
+        basePayload,
+        "admin",
+        ORGANIZATION_ID,
+        [{ partyRole: "MANAGER", role: "admin" }],
+        USER_ID
+      );
+
+    case "api":
+      return createUIPayload(
+        basePayload,
+        "api",
+        ORGANIZATION_ID,
+        [{ partyRole: "MANAGER", role: "api" }],
+        randomUUID()
+      );
+
+    case "security":
+      return createUIPayload(
+        basePayload,
+        "security",
+        ORGANIZATION_ID,
+        [{ partyRole: "MANAGER", role: "security" }],
+        randomUUID()
+      );
+
+    case "api,security":
+      return createUIPayload(
+        basePayload,
+        "api,security",
+        ORGANIZATION_ID,
+        [
+          { partyRole: "MANAGER", role: "api" },
+          { partyRole: "MANAGER", role: "security" },
+        ],
+        randomUUID()
+      );
+
+    case "m2m":
+      return {
+        ...basePayload,
+        aud: AUDIENCES.m2m,
+        role: "m2m",
+        organizationId: ORGANIZATION_ID,
+        client_id: randomUUID(),
+        sub: randomUUID(),
+      };
+
+    case "m2m-admin":
+      return {
+        ...basePayload,
+        aud: AUDIENCES.m2m,
+        role: "m2m-admin",
+        organizationId: ORGANIZATION_ID,
+        adminId: USER_ID,
+        client_id: randomUUID(),
+        sub: randomUUID(),
+      };
+
+    case "maintenance":
+      return {
+        ...basePayload,
+        aud: AUDIENCES.internal,
+        role: "maintenance",
+        sub: randomUUID(),
+      };
+
+    case "internal":
+      return {
+        ...basePayload,
+        aud: AUDIENCES.internal,
+        role: "internal",
+        sub: randomUUID(),
+      };
+
+    default:
+      throw new Error(`Unsupported role: ${role}`);
+  }
+}
+
+function getUnsignedToken(header, payload) {
+  const encodedHeader = b64UrlEncode(JSON.stringify(header));
+  const encodedPayload = b64UrlEncode(JSON.stringify(payload));
+  return `${encodedHeader}.${encodedPayload}`;
+}
+
+function b64ByteUrlEncode(b) {
+  return bufferB64UrlEncode(Buffer.from(b));
+}
+
+function b64UrlEncode(str) {
+  return bufferB64UrlEncode(Buffer.from(str, "binary"));
+}
+
+function bufferB64UrlEncode(b) {
+  return b
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+async function signToken(kid, unsignedToken) {
+  const kmsClient = new KMSClient({
+    region: LOCAL_REGION,
+    endpoint: LOCAL_KMS_ENDPOINT,
+    credentials: {
+      accessKeyId: "local",
+      secretAccessKey: "local",
+    },
+  });
+
+  const signCommand = new SignCommand({
+    KeyId: kid,
+    Message: new TextEncoder().encode(unsignedToken),
+    SigningAlgorithm: "RSASSA_PKCS1_V1_5_SHA_256",
+  });
+
+  const response = await kmsClient.send(signCommand);
+  const responseSignature = response.Signature;
+
+  if (!responseSignature) {
+    throw new Error("JWT Signature failed. Empty signature returned");
+  }
+
+  const kmsSignature = b64ByteUrlEncode(responseSignature);
+  return `${unsignedToken}.${kmsSignature}`;
+}
+
+async function generateLocalToken(role, sessionDuration) {
+  const kid = LOCAL_KEY_IDS.key;
+
+  const sessionTokenHeader = getSessionTokenHeader(kid);
+  const sessionTokenPayload = getSessionTokenPayload(role, sessionDuration);
+
+  const unsignedToken = getUnsignedToken(
+    sessionTokenHeader,
+    sessionTokenPayload
+  );
+
+  const signedToken = await signToken(kid, unsignedToken);
+
+  return signedToken;
+}
+
+async function main() {
+  try {
+    const token = await generateLocalToken(TOKEN_ROLE, TOKEN_DURATION_SECONDS);
+
+    console.log("\n✅ Token generated successfully!");
+    console.log("\nToken details:");
+    console.log(`  Role: ${TOKEN_ROLE}`);
+    console.log(`  Organization ID: ${ORGANIZATION_ID}`);
+    console.log(`  Duration: ${TOKEN_DURATION_SECONDS} seconds`);
+    console.log("\nToken:");
+    console.log(token);
+    console.log("\nYou can add this to your collections/.env file:");
+    console.log(`JWT=${token}`);
+  } catch (error) {
+    console.error("❌ Error generating token:", error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
This PR introduces a JavaScript script (`generate-local-token.js`) to generate a signed JWT bearer token for use in the locally raised environment. The script is customizable to suit various development needs, it is designed to work with the local KMS setup.