### PR TITLE
[PIN-7420] bugfix: forbidden tenant 403 status code

### DIFF
--- a/packages/m2m-gateway/src/model/errors.ts
+++ b/packages/m2m-gateway/src/model/errors.ts
@@ -56,6 +56,7 @@ export const errorCodes = {
   eserviceDescriptorAttributeGroupNotFound: "0036",
   eserviceTemplateVersionAttributeGroupNotFound: "0037",
   purposeTemplateRiskAnalysisFormNotFound: "0038",
+  forbiddenOperationOnTenant: "0039",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -322,6 +323,16 @@ export function cannotEditDeclaredAttributesForTenant(
     }`,
     code: "cannotEditDeclaredAttributesForTenant",
     title: "Tenant cannot edit declared attributes",
+  });
+}
+
+export function forbiddenOperationOnTenant(
+  targetTenantId: TenantId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Operation not allowed on tenant ${targetTenantId}`,
+    code: "forbiddenOperationOnTenant",
+    title: "Forbidden operation on tenant",
   });
 }
 

--- a/packages/m2m-gateway/src/routers/tenantRouter.ts
+++ b/packages/m2m-gateway/src/routers/tenantRouter.ts
@@ -15,6 +15,7 @@ import { fromM2MGatewayAppContext } from "../utils/context.js";
 import {
   getTenantsErrorMapper,
   assignTenantDeclaredAttributeErrorMapper,
+  getTenantVerifiedAttributeRevokersErrorMapper,
 } from "../utils/errorMappers.js";
 
 const tenantRouter = (
@@ -362,7 +363,7 @@ const tenantRouter = (
         } catch (error) {
           const errorRes = makeApiProblem(
             error,
-            emptyErrorMapper,
+            getTenantVerifiedAttributeRevokersErrorMapper,
             ctx,
             `Error retrieving revokers for verified attribute ${req.params.attributeId} of tenant ${req.params.tenantId}`
           );

--- a/packages/m2m-gateway/src/services/tenantService.ts
+++ b/packages/m2m-gateway/src/services/tenantService.ts
@@ -32,7 +32,10 @@ import {
   tenantDeclaredAttributeNotFound,
   tenantVerifiedAttributeNotFound,
 } from "../model/errors.js";
-import { assertTenantCanEditDeclaredAttributes } from "../utils/validators/tenantValidators.js";
+import {
+  assertTenantCanEditDeclaredAttributes,
+  assertTenantIsSelf,
+} from "../utils/validators/tenantValidators.js";
 
 function retrieveDeclaredAttributes(
   tenant: tenantApi.Tenant
@@ -412,11 +415,13 @@ export function tenantServiceBuilder(clients: PagoPAInteropBeClients) {
         limit,
         offset,
       }: m2mGatewayApi.GetTenantVerifiedAttributeRevokersQueryParams,
-      { logger, headers }: WithLogger<M2MGatewayAppContext>
+      { logger, headers, authData }: WithLogger<M2MGatewayAppContext>
     ): Promise<m2mGatewayApi.TenantVerifiedAttributeRevokers> {
       logger.info(
         `Retrieving revokers for verified attribute ${attributeId} of tenant ${tenantId}`
       );
+
+      assertTenantIsSelf(authData, tenantId);
 
       const {
         data: { results, totalCount },

--- a/packages/m2m-gateway/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway/src/utils/errorMappers.ts
@@ -293,3 +293,10 @@ export const getPurposeTemplateRiskAnalysisErrorMapper = (
       () => HTTP_STATUS_NOT_FOUND
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const getTenantVerifiedAttributeRevokersErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("forbiddenOperationOnTenant", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/m2m-gateway/src/utils/validators/tenantValidators.ts
+++ b/packages/m2m-gateway/src/utils/validators/tenantValidators.ts
@@ -1,7 +1,10 @@
 import { delegationApi } from "pagopa-interop-api-clients";
 import { DelegationId, TenantId } from "pagopa-interop-models";
 import { M2MAdminAuthData } from "pagopa-interop-commons";
-import { cannotEditDeclaredAttributesForTenant } from "../../model/errors.js";
+import {
+  cannotEditDeclaredAttributesForTenant,
+  forbiddenOperationOnTenant,
+} from "../../model/errors.js";
 import { DelegationProcessClient } from "../../clients/clientsProvider.js";
 import { M2MGatewayAppContext } from "../context.js";
 import { assertRequesterIsDelegateConsumer } from "./delegationValidators.js";
@@ -31,5 +34,14 @@ export async function assertTenantCanEditDeclaredAttributes(
     if (delegation.delegatorId !== targetTenantId) {
       throw cannotEditDeclaredAttributesForTenant(targetTenantId, delegation);
     }
+  }
+}
+
+export function assertTenantIsSelf(
+  authData: M2MAdminAuthData,
+  targetTenantId: TenantId
+): void {
+  if (authData.organizationId !== targetTenantId) {
+    throw forbiddenOperationOnTenant(targetTenantId);
   }
 }


### PR DESCRIPTION
please check [PIN-7420](https://pagopa.atlassian.net/browse/PIN-7420)

Considering the nature of the bug, I've applied the change only for m2m routes, without interfering with the underlyng services they're built upon (tenant-process in this case).
If you think that the change is required also for internal services, let me know! We can discuss the improvement and challenge the requirements.

[PIN-7420]: https://pagopa.atlassian.net/browse/PIN-7420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ