### PR TITLE
hotfix: error in mapper for Eservice Document Interface fields (PIN-7793)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -7446,6 +7446,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CreatedEServiceDescriptor"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
         "403":
           description: Forbidden
           content:

--- a/packages/backend-for-frontend/src/utilities/errorMappers.ts
+++ b/packages/backend-for-frontend/src/utilities/errorMappers.ts
@@ -192,6 +192,10 @@ export const createEServiceDocumentErrorMapper = (
     .with(
       "invalidContentTypeDetected",
       "invalidEserviceInterfaceFileDetected",
+      "interfaceExtractingSoapFieldValueError",
+      "interfaceExtractingInfoError",
+      "soapFileParsingError",
+      "openapiVersionNotRecognized",
       "invalidServerUrl",
       "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST
@@ -206,6 +210,10 @@ export const createEServiceTemplateDocumentErrorMapper = (
     .with(
       "invalidContentTypeDetected",
       "invalidEserviceInterfaceFileDetected",
+      "interfaceExtractingSoapFieldValueError",
+      "interfaceExtractingInfoError",
+      "soapFileParsingError",
+      "openapiVersionNotRecognized",
       "invalidServerUrl",
       "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST

--- a/packages/backend-for-frontend/src/utilities/errorMappers.ts
+++ b/packages/backend-for-frontend/src/utilities/errorMappers.ts
@@ -195,7 +195,6 @@ export const createEServiceDocumentErrorMapper = (
       "interfaceExtractingSoapFieldValueError",
       "interfaceExtractingInfoError",
       "soapFileParsingError",
-      "openapiVersionNotRecognized",
       "invalidServerUrl",
       "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST
@@ -213,7 +212,6 @@ export const createEServiceTemplateDocumentErrorMapper = (
       "interfaceExtractingSoapFieldValueError",
       "interfaceExtractingInfoError",
       "soapFileParsingError",
-      "openapiVersionNotRecognized",
       "invalidServerUrl",
       "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST
@@ -287,6 +285,10 @@ export const addEServiceInterfaceByTemplateErrorMapper = (
       "eserviceTemplateInterfaceNotFound",
       "invalidContentTypeDetected",
       "eserviceTemplateInterfaceDataNotValid",
+      "invalidEserviceInterfaceData",
+      "invalidServerUrl",
+      "soapFileParsingError",
+      "interfaceExtractingSoapFieldValueError",
       "invalidInterfaceFile",
       "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST

--- a/packages/backend-for-frontend/test/api/catalogRouter/addEServiceTemplateInstanceInterfaceRest.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/addEServiceTemplateInstanceInterfaceRest.test.ts
@@ -4,8 +4,12 @@ import {
   DescriptorId,
   generateId,
   invalidContentTypeDetected,
+  invalidInterfaceData,
   invalidInterfaceFileDetected,
+  invalidServerUrl,
   interfaceExtractingInfoError,
+  interfaceExtractingSoapFieldError,
+  parsingSoapFileError,
   EServiceId,
 } from "pagopa-interop-models";
 import request from "supertest";
@@ -97,6 +101,25 @@ describe("API POST /templates/eservices/:eServiceId/descriptors/:descriptorId/in
       expectedStatus: 400,
     },
     { error: interfaceExtractingInfoError(), expectedStatus: 400 },
+    {
+      error: invalidInterfaceData({
+        id: mockEService.id,
+        isEserviceTemplate: true,
+      }),
+      expectedStatus: 400,
+    },
+    {
+      error: invalidServerUrl({
+        id: mockEService.id,
+        isEserviceTemplate: true,
+      }),
+      expectedStatus: 400,
+    },
+    { error: parsingSoapFileError(), expectedStatus: 400 },
+    {
+      error: interfaceExtractingSoapFieldError("invalid-field"),
+      expectedStatus: 400,
+    },
   ])(
     "Should return $expectedStatus for $error.code",
     async ({ error, expectedStatus }) => {

--- a/packages/backend-for-frontend/test/api/catalogRouter/addEServiceTemplateInstanceInterfaceSoap.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/addEServiceTemplateInstanceInterfaceSoap.test.ts
@@ -4,8 +4,12 @@ import {
   DescriptorId,
   generateId,
   invalidContentTypeDetected,
+  invalidInterfaceData,
   invalidInterfaceFileDetected,
+  invalidServerUrl,
   interfaceExtractingInfoError,
+  interfaceExtractingSoapFieldError,
+  parsingSoapFileError,
   EServiceId,
 } from "pagopa-interop-models";
 import request from "supertest";
@@ -97,6 +101,25 @@ describe("API POST /templates/eservices/:eServiceId/descriptors/:descriptorId/in
       expectedStatus: 400,
     },
     { error: interfaceExtractingInfoError(), expectedStatus: 400 },
+    {
+      error: invalidInterfaceData({
+        id: mockEService.id,
+        isEserviceTemplate: true,
+      }),
+      expectedStatus: 400,
+    },
+    {
+      error: invalidServerUrl({
+        id: mockEService.id,
+        isEserviceTemplate: true,
+      }),
+      expectedStatus: 400,
+    },
+    { error: parsingSoapFileError(), expectedStatus: 400 },
+    {
+      error: interfaceExtractingSoapFieldError("invalid-field"),
+      expectedStatus: 400,
+    },
   ])(
     "Should return $expectedStatus for $error.code",
     async ({ error, expectedStatus }) => {

--- a/packages/backend-for-frontend/test/api/catalogRouter/createEServiceDocument.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/createEServiceDocument.test.ts
@@ -5,7 +5,7 @@ import {
   EServiceId,
   generateId,
   interfaceExtractingInfoError,
-  interfaceExtractingSoapFiledError,
+  interfaceExtractingSoapFieldError,
   invalidContentTypeDetected,
   invalidInterfaceFileDetected,
   openapiVersionNotRecognized,
@@ -93,7 +93,7 @@ describe("API POST /eservices/:eServiceId/descriptors/:descriptorId/documents", 
       expectedStatus: 400,
     },
     {
-      error: interfaceExtractingSoapFiledError("field-name"),
+      error: interfaceExtractingSoapFieldError("field-name"),
       expectedStatus: 400,
     },
     {

--- a/packages/backend-for-frontend/test/api/catalogRouter/createEServiceDocument.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/createEServiceDocument.test.ts
@@ -4,8 +4,12 @@ import {
   DescriptorId,
   EServiceId,
   generateId,
+  interfaceExtractingInfoError,
+  interfaceExtractingSoapFiledError,
   invalidContentTypeDetected,
   invalidInterfaceFileDetected,
+  openapiVersionNotRecognized,
+  parsingSoapFileError,
 } from "pagopa-interop-models";
 import request from "supertest";
 import { generateToken } from "pagopa-interop-commons-test/index.js";
@@ -86,6 +90,22 @@ describe("API POST /eservices/:eServiceId/descriptors/:descriptorId/documents", 
         id: generateId(),
         isEserviceTemplate: false,
       }),
+      expectedStatus: 400,
+    },
+    {
+      error: interfaceExtractingSoapFiledError("field-name"),
+      expectedStatus: 400,
+    },
+    {
+      error: interfaceExtractingInfoError(),
+      expectedStatus: 400,
+    },
+    {
+      error: parsingSoapFileError(),
+      expectedStatus: 400,
+    },
+    {
+      error: openapiVersionNotRecognized("invalid-version"),
       expectedStatus: 400,
     },
   ])(

--- a/packages/backend-for-frontend/test/api/eserviceTemplateRouter/createEServiceTemplateDocument.test.ts
+++ b/packages/backend-for-frontend/test/api/eserviceTemplateRouter/createEServiceTemplateDocument.test.ts
@@ -6,6 +6,10 @@ import {
   generateId,
   invalidContentTypeDetected,
   invalidInterfaceFileDetected,
+  interfaceExtractingInfoError,
+  interfaceExtractingSoapFiledError,
+  openapiVersionNotRecognized,
+  parsingSoapFileError,
 } from "pagopa-interop-models";
 import { generateToken } from "pagopa-interop-commons-test";
 import { authRole } from "pagopa-interop-commons";
@@ -86,6 +90,22 @@ describe("API POST /eservices/templates/:eServiceTemplateId/versions/:eServiceTe
         id: generateId(),
         isEserviceTemplate: true,
       }),
+      expectedStatus: 400,
+    },
+    {
+      error: interfaceExtractingSoapFiledError("field-name"),
+      expectedStatus: 400,
+    },
+    {
+      error: interfaceExtractingInfoError(),
+      expectedStatus: 400,
+    },
+    {
+      error: parsingSoapFileError(),
+      expectedStatus: 400,
+    },
+    {
+      error: openapiVersionNotRecognized("invalid-version"),
       expectedStatus: 400,
     },
   ])(

--- a/packages/backend-for-frontend/test/api/eserviceTemplateRouter/createEServiceTemplateDocument.test.ts
+++ b/packages/backend-for-frontend/test/api/eserviceTemplateRouter/createEServiceTemplateDocument.test.ts
@@ -7,7 +7,7 @@ import {
   invalidContentTypeDetected,
   invalidInterfaceFileDetected,
   interfaceExtractingInfoError,
-  interfaceExtractingSoapFiledError,
+  interfaceExtractingSoapFieldError,
   openapiVersionNotRecognized,
   parsingSoapFileError,
 } from "pagopa-interop-models";
@@ -93,7 +93,7 @@ describe("API POST /eservices/templates/:eServiceTemplateId/versions/:eServiceTe
       expectedStatus: 400,
     },
     {
-      error: interfaceExtractingSoapFiledError("field-name"),
+      error: interfaceExtractingSoapFieldError("field-name"),
       expectedStatus: 400,
     },
     {

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -686,10 +686,7 @@ export const addEServiceTemplateInstanceInterfaceErrorMapper = (
       "invalidContentTypeDetected",
       "documentPrettyNameDuplicate",
       "notValidDescriptor",
-      "interfaceExtractingSoapFieldValueError",
-      "soapFileParsingError",
-      "openapiVersionNotRecognized",
-      "invalidServerUrl",
+      "invalidEserviceInterfaceData",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .with(

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -686,7 +686,10 @@ export const addEServiceTemplateInstanceInterfaceErrorMapper = (
       "invalidContentTypeDetected",
       "documentPrettyNameDuplicate",
       "notValidDescriptor",
+      "interfaceExtractingSoapFieldValueError",
+      "soapFileParsingError",
       "openapiVersionNotRecognized",
+      "invalidServerUrl",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .with(

--- a/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
+++ b/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
@@ -276,11 +276,21 @@ describe("addEServiceTemplateInstanceInterface", () => {
           eservice.id,
           descriptor.id,
         ]);
+        invalidCases.push([
+          { ...restBody, serverUrls: ["wwwinvalidcom"] },
+          eservice.id,
+          descriptor.id,
+        ]);
       }
 
       if (technology === "Soap") {
         invalidCases.push([
           { serverUrls: "not-an-array" },
+          eservice.id,
+          descriptor.id,
+        ]);
+        invalidCases.push([
+          { serverUrls: ["wwwinvalidcom"] },
           eservice.id,
           descriptor.id,
         ]);

--- a/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
+++ b/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
@@ -11,9 +11,13 @@ import {
   EServiceId,
   generateId,
   interfaceExtractingInfoError,
+  interfaceExtractingSoapFiledError,
   invalidContentTypeDetected,
   invalidInterfaceFileDetected,
+  invalidServerUrl,
+  openapiVersionNotRecognized,
   operationForbidden,
+  parsingSoapFileError,
   technology,
   Technology,
   TenantId,
@@ -205,6 +209,25 @@ describe("addEServiceTemplateInstanceInterface", () => {
         },
         {
           error: notValidDescriptorState(descriptor.id, descriptor.state),
+          expectedStatus: 400,
+        },
+        {
+          error: interfaceExtractingSoapFiledError("field-name"),
+          expectedStatus: 400,
+        },
+        {
+          error: parsingSoapFileError(),
+          expectedStatus: 400,
+        },
+        {
+          error: openapiVersionNotRecognized("invalid-version"),
+          expectedStatus: 400,
+        },
+        {
+          error: invalidServerUrl({
+            id: "invalid",
+            isEserviceTemplate: true,
+          }),
           expectedStatus: 400,
         },
       ])(

--- a/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
+++ b/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
@@ -11,13 +11,10 @@ import {
   EServiceId,
   generateId,
   interfaceExtractingInfoError,
-  interfaceExtractingSoapFiledError,
   invalidContentTypeDetected,
+  invalidInterfaceData,
   invalidInterfaceFileDetected,
-  invalidServerUrl,
-  openapiVersionNotRecognized,
   operationForbidden,
-  parsingSoapFileError,
   technology,
   Technology,
   TenantId,
@@ -212,20 +209,8 @@ describe("addEServiceTemplateInstanceInterface", () => {
           expectedStatus: 400,
         },
         {
-          error: interfaceExtractingSoapFiledError("field-name"),
-          expectedStatus: 400,
-        },
-        {
-          error: parsingSoapFileError(),
-          expectedStatus: 400,
-        },
-        {
-          error: openapiVersionNotRecognized("invalid-version"),
-          expectedStatus: 400,
-        },
-        {
-          error: invalidServerUrl({
-            id: "invalid",
+          error: invalidInterfaceData({
+            id: eservice.id,
             isEserviceTemplate: true,
           }),
           expectedStatus: 400,

--- a/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
+++ b/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
@@ -564,7 +564,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         },
         genericLogger
       );
-      const mockEserviceTemplateVersion = {
+      const mockEserviceTemplateVersion: EServiceTemplateVersion = {
         ...getMockEServiceTemplateVersion(
           generateId<EServiceTemplateVersionId>(),
           eserviceTemplateVersionState.published
@@ -572,14 +572,14 @@ describe("addEServiceTemplateInstanceInterface", () => {
         interface: { ...interfaceDoc, path: interfacePath },
       };
 
-      const mockEServiceTemplate = {
+      const mockEServiceTemplate: EServiceTemplate = {
         ...getMockEServiceTemplate(
           generateId<EServiceTemplateId>(),
           generateId<TenantId>(),
           [mockEserviceTemplateVersion]
         ),
       };
-      const mockDescriptor = {
+      const mockDescriptor: Descriptor = {
         ...getMockDescriptor(),
         templateVersionRef: {
           id: mockEServiceTemplate.versions[0].id,

--- a/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
+++ b/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
@@ -30,6 +30,7 @@ import {
   EServiceTemplateVersionId,
   eserviceTemplateVersionState,
   generateId,
+  invalidInterfaceData,
   operationForbidden,
   Technology,
   TenantId,
@@ -544,6 +545,76 @@ describe("addEServiceTemplateInstanceInterface", () => {
           getMockContext({ authData })
         )
       ).rejects.toThrow(eserviceInterfaceDataNotValid());
+    });
+
+    it("should throw an invalidInterfaceData if provided serverUrls are invalid", async () => {
+      const authData = getMockAuthData();
+      const eserviceId = generateId<EServiceId>();
+      const interfaceDoc = getMockDocument();
+
+      const interfacePath = await fileManager.storeBytes(
+        {
+          bucket: config.s3Bucket,
+          path: interfaceDoc.path,
+          resourceId: interfaceDoc.id,
+          name: interfaceDoc.name,
+          content: Buffer.from(
+            await readFileContent("test.openapi.3.0.2.yaml")
+          ),
+        },
+        genericLogger
+      );
+      const mockEserviceTemplateVersion = {
+        ...getMockEServiceTemplateVersion(
+          generateId<EServiceTemplateVersionId>(),
+          eserviceTemplateVersionState.published
+        ),
+        interface: { ...interfaceDoc, path: interfacePath },
+      };
+
+      const mockEServiceTemplate = {
+        ...getMockEServiceTemplate(
+          generateId<EServiceTemplateId>(),
+          generateId<TenantId>(),
+          [mockEserviceTemplateVersion]
+        ),
+      };
+      const mockDescriptor = {
+        ...getMockDescriptor(),
+        templateVersionRef: {
+          id: mockEServiceTemplate.versions[0].id,
+        },
+      };
+
+      const mockEService: EService = {
+        ...getMockEService(eserviceId, authData.organizationId, [
+          mockDescriptor,
+        ]),
+        templateId: mockEServiceTemplate.id,
+      };
+
+      await addOneEServiceTemplate(mockEServiceTemplate);
+      await addOneEService(mockEService);
+
+      await expect(
+        catalogService.addEServiceTemplateInstanceInterface(
+          eserviceId,
+          mockDescriptor.id,
+          {
+            contactName: "Jhon Doe",
+            contactUrl: "https://fun.tester.johnny.info",
+            contactEmail: "johnnyd@funnytester.com",
+            termsAndConditionsUrl: "https://fun.tester.johnny.terms.com",
+            serverUrls: ["wwwinvalidcom"],
+          },
+          getMockContext({ authData })
+        )
+      ).rejects.toThrow(
+        invalidInterfaceData({
+          id: eserviceId,
+          isEserviceTemplate: true,
+        })
+      );
     });
   });
   describe("API REST", () => {

--- a/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
+++ b/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
@@ -547,10 +547,13 @@ describe("addEServiceTemplateInstanceInterface", () => {
       ).rejects.toThrow(eserviceInterfaceDataNotValid());
     });
 
-    it("should throw an invalidInterfaceData if provided serverUrls are invalid", async () => {
+    it("should throw invalidInterfaceData if the template interface file has an unrecognized extension", async () => {
       const authData = getMockAuthData();
       const eserviceId = generateId<EServiceId>();
-      const interfaceDoc = getMockDocument();
+      const interfaceDoc: Document = {
+        ...getMockDocument(),
+        name: "interface.txt",
+      };
 
       const interfacePath = await fileManager.storeBytes(
         {
@@ -600,12 +603,18 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           eserviceId,
           mockDescriptor.id,
+          "Rest",
           {
-            contactName: "Jhon Doe",
+            contactName: "John Doe",
             contactUrl: "https://fun.tester.johnny.info",
             contactEmail: "johnnyd@funnytester.com",
             termsAndConditionsUrl: "https://fun.tester.johnny.terms.com",
-            serverUrls: ["wwwinvalidcom"],
+            serverUrls: [
+              {
+                url: "https://valid-server.example.com",
+                description: "Valid server description",
+              },
+            ],
           },
           getMockContext({ authData })
         )

--- a/packages/commons-test/test/retrieveServerUrlsAPI.test.ts
+++ b/packages/commons-test/test/retrieveServerUrlsAPI.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { retrieveServerUrlsAPI } from "pagopa-interop-commons";
 import {
   generateId,
-  interfaceExtractingSoapFiledError,
+  interfaceExtractingSoapFieldError,
   invalidInterfaceFileDetected,
   invalidServerUrl,
   openapiVersionNotRecognized,
@@ -189,7 +189,7 @@ describe("retrieveServerUrlsAPI", () => {
         id: generateId(),
         isEserviceTemplate: false,
       })
-    ).rejects.toThrow(interfaceExtractingSoapFiledError("soap:address"));
+    ).rejects.toThrow(interfaceExtractingSoapFieldError("soap:address"));
   });
   it("should throw an error if there are no operations in WSDL", async () => {
     const soapDoc = {
@@ -211,7 +211,7 @@ describe("retrieveServerUrlsAPI", () => {
         id: generateId(),
         isEserviceTemplate: false,
       })
-    ).rejects.toThrow(interfaceExtractingSoapFiledError("soap:operation"));
+    ).rejects.toThrow(interfaceExtractingSoapFieldError("soap:operation"));
   });
   it("should throw error for unsupported OpenAPI version", async () => {
     const invalidDoc = {

--- a/packages/commons-test/test/retrieveServerUrlsAPI.test.ts
+++ b/packages/commons-test/test/retrieveServerUrlsAPI.test.ts
@@ -232,6 +232,40 @@ describe("retrieveServerUrlsAPI", () => {
     ).rejects.toThrow(openapiVersionNotRecognized("1.0"));
   });
 
+  it("should throw invalidServerUrl for OpenAPI 3.x without servers", async () => {
+    const resource = { id: generateId(), isEserviceTemplate: false };
+    const noServersDoc = {
+      name: "test.json",
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          openapi: "3.0.0",
+          info: { title: "No servers", version: "1.0.0" },
+        })
+      ),
+    } as unknown as File;
+
+    await expect(
+      retrieveServerUrlsAPI(noServersDoc, "INTERFACE", "Rest", resource)
+    ).rejects.toThrow(invalidServerUrl(resource));
+  });
+
+  it("should throw invalidServerUrl for OpenAPI 2.0 without host", async () => {
+    const resource = { id: generateId(), isEserviceTemplate: false };
+    const noHostDoc = {
+      name: "test.json",
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          openapi: "2.0",
+          paths: [{}],
+        })
+      ),
+    } as unknown as File;
+
+    await expect(
+      retrieveServerUrlsAPI(noHostDoc, "INTERFACE", "Rest", resource)
+    ).rejects.toThrow(invalidServerUrl(resource));
+  });
+
   it("should throw error for invalid JSON in REST interface", async () => {
     const resource = { id: generateId(), isEserviceTemplate: false };
     const invalidDoc = {

--- a/packages/commons/src/eservice-documents/eserviceDocumentUtils.ts
+++ b/packages/commons/src/eservice-documents/eserviceDocumentUtils.ts
@@ -85,7 +85,11 @@ const getInterfaceFileType = (
 
 const retrieveServerUrlsRestAPI = (
   fileType: EserviceRestInterfaceType,
-  file: string
+  file: string,
+  resource: {
+    id: string;
+    isEserviceTemplate: boolean;
+  }
 ): string[] => {
   const openApi = parseOpenApi(fileType, file);
   const { data: version, error } = z.string().safeParse(openApi.openapi);
@@ -94,9 +98,9 @@ const retrieveServerUrlsRestAPI = (
     throw openapiVersionNotRecognized("nd");
   }
   return match(version)
-    .with("2.0", () => retrieveServerUrlsOpenApiV2(openApi))
+    .with("2.0", () => retrieveServerUrlsOpenApiV2(openApi, resource))
     .with(P.string.startsWith("3."), () =>
-      retriesceServerUrlsOpenApiV3(openApi)
+      retriesceServerUrlsOpenApiV3(openApi, resource)
     )
     .otherwise(() => {
       throw openapiVersionNotRecognized(version);
@@ -310,7 +314,7 @@ export const retrieveServerUrlsAPI = async (
           technology: technology.rest,
           fileType: P.union("json", "yaml"),
         },
-        (f) => retrieveServerUrlsRestAPI(f.fileType, fileContent)
+        (f) => retrieveServerUrlsRestAPI(f.fileType, fileContent, resource)
       )
       .with(
         {

--- a/packages/commons/src/eservice-documents/restFileParser.ts
+++ b/packages/commons/src/eservice-documents/restFileParser.ts
@@ -1,6 +1,7 @@
 import YAML from "yaml";
 import { match } from "ts-pattern";
 import { z } from "zod";
+import { invalidServerUrl } from "pagopa-interop-models";
 import {
   eserviceInterfaceAllowedFileType,
   EserviceRestInterfaceType,
@@ -16,7 +17,11 @@ export const parseOpenApi = (
     .with("yaml", () => YAML.parse(file))
     .exhaustive();
 export const retrieveServerUrlsOpenApiV2 = (
-  openApi: Record<string, unknown>
+  openApi: Record<string, unknown>,
+  resource: {
+    id: string;
+    isEserviceTemplate: boolean;
+  }
 ): string[] => {
   const { data, error } = z
     .object({
@@ -26,20 +31,24 @@ export const retrieveServerUrlsOpenApiV2 = (
     .safeParse(openApi);
 
   if (error) {
-    throw error;
+    throw invalidServerUrl(resource);
   }
 
   return [data.host];
 };
 
 export const retriesceServerUrlsOpenApiV3 = (
-  openApi: Record<string, unknown>
+  openApi: Record<string, unknown>,
+  resource: {
+    id: string;
+    isEserviceTemplate: boolean;
+  }
 ): string[] => {
   const { data: servers, error } = z
     .array(z.object({ url: z.string() }))
     .safeParse(openApi.servers);
   if (error) {
-    throw error;
+    throw invalidServerUrl(resource);
   }
 
   return servers.flatMap((s) => s.url);

--- a/packages/commons/src/eservice-documents/soapFileParser.ts
+++ b/packages/commons/src/eservice-documents/soapFileParser.ts
@@ -4,7 +4,7 @@ import { XMLBuilder, XMLParser } from "fast-xml-parser";
 import {
   buildingSoapFileError,
   interfaceExtractingInfoError,
-  interfaceExtractingSoapFiledError,
+  interfaceExtractingSoapFieldError,
   parsingSoapFileError,
 } from "pagopa-interop-models";
 import { match, P } from "ts-pattern";
@@ -38,10 +38,10 @@ const extractAddress = (parsedXml: any): string[] => {
           )
       )
       .otherwise(() => {
-        throw interfaceExtractingSoapFiledError("soap:address");
+        throw interfaceExtractingSoapFieldError("soap:address");
       });
   } catch (e) {
-    throw interfaceExtractingSoapFiledError("soap:address");
+    throw interfaceExtractingSoapFieldError("soap:address");
   }
 };
 
@@ -76,10 +76,10 @@ const extractEndpoints = (parsedXml: any): string[] => {
           )
       )
       .otherwise(() => {
-        throw interfaceExtractingSoapFiledError("soap:operation");
+        throw interfaceExtractingSoapFieldError("soap:operation");
       });
   } catch (e) {
-    throw interfaceExtractingSoapFiledError("soap:operation");
+    throw interfaceExtractingSoapFieldError("soap:operation");
   }
 };
 

--- a/packages/m2m-gateway-v3/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway-v3/src/utils/errorMappers.ts
@@ -210,7 +210,6 @@ export const uploadEServiceDescriptorInterfaceErrorMapper = (
       "interfaceExtractingSoapFieldValueError",
       "interfaceExtractingInfoError",
       "soapFileParsingError",
-      "openapiVersionNotRecognized",
       "invalidServerUrl",
       "openapiVersionNotRecognized",
       "eServiceAsyncExchangeNotEnabled",

--- a/packages/m2m-gateway-v3/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway-v3/src/utils/errorMappers.ts
@@ -207,6 +207,10 @@ export const uploadEServiceDescriptorInterfaceErrorMapper = (
     .with(
       "invalidContentTypeDetected",
       "invalidEserviceInterfaceFileDetected",
+      "interfaceExtractingSoapFieldValueError",
+      "interfaceExtractingInfoError",
+      "soapFileParsingError",
+      "openapiVersionNotRecognized",
       "invalidServerUrl",
       "openapiVersionNotRecognized",
       "eServiceAsyncExchangeNotEnabled",

--- a/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
@@ -4,6 +4,13 @@ import { generateToken, getMockDPoPProof } from "pagopa-interop-commons-test";
 import {
   ApiError,
   generateId,
+  interfaceExtractingInfoError,
+  interfaceExtractingSoapFieldError,
+  invalidContentTypeDetected,
+  invalidInterfaceFileDetected,
+  invalidServerUrl,
+  openapiVersionNotRecognized,
+  parsingSoapFileError,
   pollingMaxRetriesExceeded,
 } from "pagopa-interop-models";
 import { AuthRole, authRole } from "pagopa-interop-commons";
@@ -238,6 +245,67 @@ describe("POST /eservices/:eserviceId/descriptors/:descriptorId/interface router
       );
 
       expect(res.status).toBe(status);
+    }
+  );
+
+  it.each([
+    {
+      error: invalidContentTypeDetected(
+        {
+          id: generateId(),
+          isEserviceTemplate: true,
+        },
+        "contentType",
+        "REST"
+      ),
+      expectedStatus: 400,
+    },
+    {
+      error: invalidInterfaceFileDetected({
+        id: generateId(),
+        isEserviceTemplate: true,
+      }),
+      expectedStatus: 400,
+    },
+    {
+      error: interfaceExtractingSoapFieldError("invalid-field"),
+      expectedStatus: 400,
+    },
+    {
+      error: interfaceExtractingInfoError(),
+      expectedStatus: 400,
+    },
+    {
+      error: parsingSoapFileError(),
+      expectedStatus: 400,
+    },
+    {
+      error: openapiVersionNotRecognized("invalid-version"),
+      expectedStatus: 400,
+    },
+    {
+      error: invalidServerUrl({
+        id: generateId(),
+        isEserviceTemplate: true,
+      }),
+      expectedStatus: 400,
+    },
+  ])(
+    "Should return $expectedStatus in case of $error",
+    async ({ error, expectedStatus }) => {
+      mockEserviceService.uploadEServiceDescriptorInterface = vi
+        .fn()
+        .mockRejectedValue(error);
+
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        generateId(),
+        generateId(),
+        mockFileUpload
+      );
+
+      expect(res.status).toBe(expectedStatus);
     }
   );
 

--- a/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
@@ -291,7 +291,7 @@ describe("POST /eservices/:eserviceId/descriptors/:descriptorId/interface router
       expectedStatus: 400,
     },
   ])(
-    "Should return $expectedStatus in case of $error",
+    "Should return $expectedStatus in case of $error.code",
     async ({ error, expectedStatus }) => {
       mockEserviceService.uploadEServiceDescriptorInterface = vi
         .fn()

--- a/packages/m2m-gateway-v3/test/integration/eservices/uploadEServiceDescriptorInterface.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/uploadEServiceDescriptorInterface.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { catalogApi, m2mGatewayApiV3 } from "pagopa-interop-api-clients";
 import {
+  invalidContentTypeDetected,
+  invalidServerUrl,
   pollingMaxRetriesExceeded,
+  technology,
   unsafeBrandId,
 } from "pagopa-interop-models";
 import {
@@ -160,6 +163,85 @@ servers:
       params: { eServiceId: mockGetEServiceResponse.data.id },
     });
     expect(mockGetEService).toHaveBeenCalledTimes(3);
+  });
+
+  it("Should throw invalidContentTypeDetected in case the file uploaded has an invalid content type", async () => {
+    const invalidFile = new File(
+      [mockFileUpload.file],
+      mockFileUpload.file.name,
+      {
+        type: "",
+        lastModified: mockFileUpload.file.lastModified,
+      }
+    );
+
+    const invalidFileUpload = {
+      file: invalidFile,
+      prettyName: mockFileUpload.prettyName,
+    };
+
+    await expect(
+      eserviceService.uploadEServiceDescriptorInterface(
+        unsafeBrandId(mockGetEServiceResponse.data.id),
+        unsafeBrandId(mockDescriptor.id),
+        invalidFileUpload,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      invalidContentTypeDetected(
+        {
+          id: mockGetEServiceResponse.data.id,
+          isEserviceTemplate: false,
+        },
+        "invalid",
+        technology.rest
+      )
+    );
+  });
+
+  it("Should throw invalidServerUrl in case the server urls are invalid", async () => {
+    const invalidServerUrls = ["invalidserverurl", "invalidserverurl2"];
+    const mockFileBuffer = Buffer.from(
+      `
+openapi: "3.0.2"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: ${invalidServerUrls[0]}
+  - url: ${invalidServerUrls[1]}
+    `.trim()
+    );
+
+    const mockFileUpload: m2mGatewayApiV3.FileUploadMultipart = {
+      file: new File([mockFileBuffer], mockAddDocumentResponse.data.name, {
+        type: mockAddDocumentResponse.data.contentType,
+      }),
+      prettyName: mockAddDocumentResponse.data.prettyName,
+    };
+
+    await expect(
+      eserviceService.uploadEServiceDescriptorInterface(
+        unsafeBrandId(mockGetEServiceResponse.data.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockFileUpload,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      invalidServerUrl({
+        id: mockGetEServiceResponse.data.id,
+        isEserviceTemplate: false,
+      })
+    );
   });
 
   it("Should throw missingMetadata in case the data returned by the POST call has no metadata", async () => {

--- a/packages/m2m-gateway-v3/test/integration/eservices/uploadEServiceDescriptorInterface.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/uploadEServiceDescriptorInterface.test.ts
@@ -166,6 +166,8 @@ servers:
   });
 
   it("Should throw invalidContentTypeDetected in case the file uploaded has an invalid content type", async () => {
+    mockGetEService.mockResolvedValueOnce(mockGetEServiceResponse);
+
     const invalidFile = new File(
       [mockFileUpload.file],
       mockFileUpload.file.name,
@@ -200,6 +202,8 @@ servers:
   });
 
   it("Should throw invalidServerUrl in case the server urls are invalid", async () => {
+    mockGetEService.mockResolvedValueOnce(mockGetEServiceResponse);
+
     const invalidServerUrls = ["invalidserverurl", "invalidserverurl2"];
     const mockFileBuffer = Buffer.from(
       `

--- a/packages/m2m-gateway/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway/src/utils/errorMappers.ts
@@ -165,6 +165,10 @@ export const uploadEServiceDescriptorInterfaceErrorMapper = (
     .with(
       "invalidContentTypeDetected",
       "invalidEserviceInterfaceFileDetected",
+      "interfaceExtractingSoapFieldValueError",
+      "interfaceExtractingInfoError",
+      "soapFileParsingError",
+      "openapiVersionNotRecognized",
       "invalidServerUrl",
       "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST

--- a/packages/m2m-gateway/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway/src/utils/errorMappers.ts
@@ -168,7 +168,6 @@ export const uploadEServiceDescriptorInterfaceErrorMapper = (
       "interfaceExtractingSoapFieldValueError",
       "interfaceExtractingInfoError",
       "soapFileParsingError",
-      "openapiVersionNotRecognized",
       "invalidServerUrl",
       "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST

--- a/packages/m2m-gateway/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
+++ b/packages/m2m-gateway/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
@@ -4,7 +4,7 @@ import { generateToken } from "pagopa-interop-commons-test";
 import {
   generateId,
   interfaceExtractingInfoError,
-  interfaceExtractingSoapFiledError,
+  interfaceExtractingSoapFieldError,
   invalidContentTypeDetected,
   invalidInterfaceFileDetected,
   invalidServerUrl,
@@ -180,7 +180,7 @@ describe("POST /eservices/:eserviceId/descriptors/:descriptorId/interface router
       expectedStatus: 400,
     },
     {
-      error: interfaceExtractingSoapFiledError("invalid-field"),
+      error: interfaceExtractingSoapFieldError("invalid-field"),
       expectedStatus: 400,
     },
     {

--- a/packages/m2m-gateway/test/integration/eservices/uploadEServiceDescriptorInterface.test.ts
+++ b/packages/m2m-gateway/test/integration/eservices/uploadEServiceDescriptorInterface.test.ts
@@ -166,6 +166,8 @@ servers:
   });
 
   it("Should throw invalidContentTypeDetected in case the file uploaded has an invalid content type", async () => {
+    mockGetEService.mockResolvedValueOnce(mockGetEServiceResponse);
+
     const invalidFile = new File(
       [mockFileUpload.file],
       mockFileUpload.file.name,
@@ -200,6 +202,8 @@ servers:
   });
 
   it("Should throw invalidServerUrl in case the server urls are invalid", async () => {
+    mockGetEService.mockResolvedValueOnce(mockGetEServiceResponse);
+
     const invalidServerUrls = ["invalidserverurl", "invalidserverurl2"];
     const mockFileBuffer = Buffer.from(
       `

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -801,7 +801,7 @@ export function interfaceExtractingInfoError(): ApiError<CommonErrorCodes> {
   });
 }
 
-export function interfaceExtractingSoapFiledError(
+export function interfaceExtractingSoapFieldError(
   fieldName: string
 ): ApiError<CommonErrorCodes> {
   return new ApiError({


### PR DESCRIPTION
## Issue
- [PIN-7793](https://pagopa.atlassian.net/browse/PIN-7793)

## Context / Why
This PR adds error mapping for the tracked error in `backend-for-frontend` and also adds parsing errors when using `verifyAndCreateDocument` from commons in `m2m-gateway` and `catalog-process`.

## Impacted services
- backend-for-frontent
- m2m-gateway
- m2m-gateway-v3
- catalog-process

## Manual tests
### Before
<img width="2556" height="914" alt="Screenshot from 2025-12-16 16-32-39" src="https://github.com/user-attachments/assets/299de60e-2592-4b01-bb11-ffae2a886f0c" />

### After
<img width="2556" height="914" alt="Screenshot from 2025-12-16 17-38-57" src="https://github.com/user-attachments/assets/396d15e4-6c3b-4d14-afb1-d1928cc535bb" />


[PIN-7793]: https://pagopa.atlassian.net/browse/PIN-7793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ