### PR TITLE
feat: bind new notifications to the notification system

### DIFF
--- a/packages/commons/src/notification/notificationAdmittedRoles.ts
+++ b/packages/commons/src/notification/notificationAdmittedRoles.ts
@@ -140,6 +140,12 @@ export const notificationAdmittedRoles = {
     [SECURITY_ROLE]: true,
     [SUPPORT_ROLE]: false,
   },
+  clientCreatedDeletedToTenantUsers: {
+    [ADMIN_ROLE]: true,
+    [API_ROLE]: false,
+    [SECURITY_ROLE]: true,
+    [SUPPORT_ROLE]: false,
+  },
 } as const satisfies Record<NotificationType, Record<UserRole, boolean>> &
   Record<NotificationType, Record<typeof SUPPORT_ROLE, false>>; // To ensure that SUPPORT_ROLE cannot receive any notification
 

--- a/packages/email-notification-dispatcher/src/handlers/authorization/handleAuthorizationEvent.ts
+++ b/packages/email-notification-dispatcher/src/handlers/authorization/handleAuthorizationEvent.ts
@@ -17,6 +17,8 @@ import { handleClientPurposeAdded } from "./handleClientPurposeAddedEvent.js";
 import { handleClientPurposeRemoved } from "./handleClientPurposeRemovedEvent.js";
 import { handleProducerKeychainEserviceAdded } from "./handleProducerKeychainEserviceAdded.js";
 import { handleProducerKeychainKeyAdded } from "./handleProducerKeychainKeyAdded.js";
+import { handleClientCreated } from "./handleClientCreated.js";
+import { handleClientDeleted } from "./handleClientDeleted.js";
 
 export async function handleAuthorizationEvent(
   params: HandlerParams<typeof AuthorizationEventV2>
@@ -129,12 +131,28 @@ export async function handleAuthorizationEvent(
         correlationId,
       })
     )
+    .with({ type: "ClientAdded" }, ({ data: { client } }) =>
+      handleClientCreated({
+        clientV2Msg: client,
+        logger,
+        readModelService,
+        templateService,
+        correlationId,
+      })
+    )
+    .with({ type: "ClientDeleted" }, ({ data: { client } }) =>
+      handleClientDeleted({
+        clientV2Msg: client,
+        logger,
+        readModelService,
+        templateService,
+        correlationId,
+      })
+    )
     .with(
       {
         type: P.union(
-          "ClientAdded",
           "ClientAdminSet",
-          "ClientDeleted",
           "ClientUserAdded",
           "ClientAdminRoleRevoked",
           "ClientAdminRemoved",

--- a/packages/email-notification-dispatcher/src/handlers/authorization/handleAuthorizationEvent.ts
+++ b/packages/email-notification-dispatcher/src/handlers/authorization/handleAuthorizationEvent.ts
@@ -30,7 +30,12 @@ export async function handleAuthorizationEvent(
   } = params;
   return match(decodedMessage)
     .with(
-      { type: "ProducerKeychainEServiceAdded" },
+      {
+        type: P.union(
+          "ProducerKeychainEServiceAdded",
+          "ProducerKeychainEServiceRemoved"
+        ),
+      },
       ({ data: { eserviceId } }) =>
         handleProducerKeychainEserviceAdded({
           eserviceId: unsafeBrandId<EServiceId>(eserviceId),
@@ -136,7 +141,6 @@ export async function handleAuthorizationEvent(
           "ProducerKeychainAdded",
           "ProducerKeychainDeleted",
           "ProducerKeychainUserAdded",
-          "ProducerKeychainEServiceRemoved"
         ),
       },
       () => {

--- a/packages/email-notification-dispatcher/src/handlers/authorization/handleClientCreated.ts
+++ b/packages/email-notification-dispatcher/src/handlers/authorization/handleClientCreated.ts
@@ -1,0 +1,80 @@
+import {
+  EmailNotificationMessagePayload,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+  fromClientV2,
+} from "pagopa-interop-models";
+import {
+  eventMailTemplateType,
+  retrieveHTMLTemplate,
+  retrieveTenant,
+} from "../../services/utils.js";
+import {
+  getRecipientsForTenants,
+  mapRecipientToEmailPayload,
+} from "../handlerCommons.js";
+import { config } from "../../config/config.js";
+import { HandlerCommonParams } from "../../models/handlerParams.js";
+import { ClientV2 } from "pagopa-interop-models";
+
+const notificationType: NotificationType = "clientCreatedDeletedToTenantUsers";
+
+export type ClientCreatedHandlerParams = HandlerCommonParams & {
+  clientV2Msg?: ClientV2;
+};
+
+export async function handleClientCreated(
+  data: ClientCreatedHandlerParams
+): Promise<EmailNotificationMessagePayload[]> {
+  const {
+    clientV2Msg,
+    readModelService,
+    logger,
+    templateService,
+    correlationId,
+  } = data;
+
+  if (!clientV2Msg) {
+    throw missingKafkaMessageDataError("client", "ClientAdded");
+  }
+
+  const client = fromClientV2(clientV2Msg);
+
+  const [htmlTemplate, consumer] = await Promise.all([
+    retrieveHTMLTemplate(eventMailTemplateType.clientCreatedMailTemplate),
+    retrieveTenant(client.consumerId, readModelService),
+  ]);
+
+  const targets = await getRecipientsForTenants({
+    tenants: [consumer],
+    notificationType,
+    readModelService,
+    logger,
+    includeTenantContactEmails: false,
+  });
+
+  if (targets.length === 0) {
+    logger.info(
+      `No targets found for tenant. Client ${client.id}, no emails to dispatch.`
+    );
+    return [];
+  }
+
+  return targets.map((t) => ({
+    correlationId: correlationId ?? generateId(),
+    email: {
+      subject: `Nuovo client "${client.name}" creato`,
+      body: templateService.compileHtml(htmlTemplate, {
+        title: `Nuovo client "${client.name}" creato`,
+        notificationType,
+        entityId: client.id,
+        ...(t.type === "Tenant" ? { recipientName: consumer.name } : {}),
+        clientName: client.name,
+        bffUrl: config.bffUrl,
+      }),
+    },
+    tenantId: t.tenantId,
+    ...mapRecipientToEmailPayload(t),
+  }));
+}

--- a/packages/email-notification-dispatcher/src/handlers/authorization/handleClientDeleted.ts
+++ b/packages/email-notification-dispatcher/src/handlers/authorization/handleClientDeleted.ts
@@ -1,0 +1,80 @@
+import {
+  EmailNotificationMessagePayload,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+  fromClientV2,
+} from "pagopa-interop-models";
+import {
+  eventMailTemplateType,
+  retrieveHTMLTemplate,
+  retrieveTenant,
+} from "../../services/utils.js";
+import {
+  getRecipientsForTenants,
+  mapRecipientToEmailPayload,
+} from "../handlerCommons.js";
+import { config } from "../../config/config.js";
+import { HandlerCommonParams } from "../../models/handlerParams.js";
+import { ClientV2 } from "pagopa-interop-models";
+
+const notificationType: NotificationType = "clientCreatedDeletedToTenantUsers";
+
+export type ClientDeletedHandlerParams = HandlerCommonParams & {
+  clientV2Msg?: ClientV2;
+};
+
+export async function handleClientDeleted(
+  data: ClientDeletedHandlerParams
+): Promise<EmailNotificationMessagePayload[]> {
+  const {
+    clientV2Msg,
+    readModelService,
+    logger,
+    templateService,
+    correlationId,
+  } = data;
+
+  if (!clientV2Msg) {
+    throw missingKafkaMessageDataError("client", "ClientDeleted");
+  }
+
+  const client = fromClientV2(clientV2Msg);
+
+  const [htmlTemplate, consumer] = await Promise.all([
+    retrieveHTMLTemplate(eventMailTemplateType.clientDeletedMailTemplate),
+    retrieveTenant(client.consumerId, readModelService),
+  ]);
+
+  const targets = await getRecipientsForTenants({
+    tenants: [consumer],
+    notificationType,
+    readModelService,
+    logger,
+    includeTenantContactEmails: false,
+  });
+
+  if (targets.length === 0) {
+    logger.info(
+      `No targets found for tenant. Client ${client.id}, no emails to dispatch.`
+    );
+    return [];
+  }
+
+  return targets.map((t) => ({
+    correlationId: correlationId ?? generateId(),
+    email: {
+      subject: `Client "${client.name}" eliminato`,
+      body: templateService.compileHtml(htmlTemplate, {
+        title: `Client "${client.name}" eliminato`,
+        notificationType,
+        entityId: client.id,
+        ...(t.type === "Tenant" ? { recipientName: consumer.name } : {}),
+        clientName: client.name,
+        bffUrl: config.bffUrl,
+      }),
+    },
+    tenantId: t.tenantId,
+    ...mapRecipientToEmailPayload(t),
+  }));
+}

--- a/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantDeclaredAttributeAssigned.ts
+++ b/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantDeclaredAttributeAssigned.ts
@@ -1,0 +1,82 @@
+import {
+  EmailNotificationMessagePayload,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+  fromTenantV2,
+} from "pagopa-interop-models";
+import {
+  eventMailTemplateType,
+  retrieveHTMLTemplate,
+} from "../../services/utils.js";
+import {
+  getRecipientsForTenants,
+  mapRecipientToEmailPayload,
+  retrieveAttribute,
+  TenantHandlerParams,
+} from "../handlerCommons.js";
+import { config } from "../../config/config.js";
+
+const notificationType: NotificationType =
+  "certifiedVerifiedAttributeAssignedRevokedToAssignee";
+
+export async function handleTenantDeclaredAttributeAssigned(
+  data: TenantHandlerParams
+): Promise<EmailNotificationMessagePayload[]> {
+  const {
+    tenantV2Msg,
+    attributeId,
+    readModelService,
+    logger,
+    templateService,
+    correlationId,
+  } = data;
+
+  if (!tenantV2Msg) {
+    throw missingKafkaMessageDataError(
+      "tenant",
+      "TenantDeclaredAttributeAssigned"
+    );
+  }
+
+  const tenant = fromTenantV2(tenantV2Msg);
+
+  const [htmlTemplate, attribute] = await Promise.all([
+    retrieveHTMLTemplate(
+      eventMailTemplateType.tenantDeclaredAttributeAssignedMailTemplate
+    ),
+    retrieveAttribute(attributeId, readModelService),
+  ]);
+
+  const targets = await getRecipientsForTenants({
+    tenants: [tenant],
+    notificationType,
+    readModelService,
+    logger,
+    includeTenantContactEmails: false,
+  });
+
+  if (targets.length === 0) {
+    logger.info(
+      `No targets found for tenant. Tenant ${tenant.id}, no emails to dispatch.`
+    );
+    return [];
+  }
+
+  return targets.map((t) => ({
+    correlationId: correlationId ?? generateId(),
+    email: {
+      subject: `Hai auto-dichiarato un nuovo attributo`,
+      body: templateService.compileHtml(htmlTemplate, {
+        title: `Hai auto-dichiarato un nuovo attributo`,
+        notificationType,
+        entityId: tenant.id,
+        ...(t.type === "Tenant" ? { recipientName: tenant.name } : {}),
+        attributeName: attribute.name,
+        bffUrl: config.bffUrl,
+      }),
+    },
+    tenantId: t.tenantId,
+    ...mapRecipientToEmailPayload(t),
+  }));
+}

--- a/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantDeclaredAttributeRevoked.ts
+++ b/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantDeclaredAttributeRevoked.ts
@@ -1,0 +1,82 @@
+import {
+  EmailNotificationMessagePayload,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+  fromTenantV2,
+} from "pagopa-interop-models";
+import {
+  eventMailTemplateType,
+  retrieveHTMLTemplate,
+} from "../../services/utils.js";
+import {
+  getRecipientsForTenants,
+  mapRecipientToEmailPayload,
+  retrieveAttribute,
+  TenantHandlerParams,
+} from "../handlerCommons.js";
+import { config } from "../../config/config.js";
+
+const notificationType: NotificationType =
+  "certifiedVerifiedAttributeAssignedRevokedToAssignee";
+
+export async function handleTenantDeclaredAttributeRevoked(
+  data: TenantHandlerParams
+): Promise<EmailNotificationMessagePayload[]> {
+  const {
+    tenantV2Msg,
+    attributeId,
+    readModelService,
+    logger,
+    templateService,
+    correlationId,
+  } = data;
+
+  if (!tenantV2Msg) {
+    throw missingKafkaMessageDataError(
+      "tenant",
+      "TenantDeclaredAttributeRevoked"
+    );
+  }
+
+  const tenant = fromTenantV2(tenantV2Msg);
+
+  const [htmlTemplate, attribute] = await Promise.all([
+    retrieveHTMLTemplate(
+      eventMailTemplateType.tenantDeclaredAttributeRevokedMailTemplate
+    ),
+    retrieveAttribute(attributeId, readModelService),
+  ]);
+
+  const targets = await getRecipientsForTenants({
+    tenants: [tenant],
+    notificationType,
+    readModelService,
+    logger,
+    includeTenantContactEmails: false,
+  });
+
+  if (targets.length === 0) {
+    logger.info(
+      `No targets found for tenant. Tenant ${tenant.id}, no emails to dispatch.`
+    );
+    return [];
+  }
+
+  return targets.map((t) => ({
+    correlationId: correlationId ?? generateId(),
+    email: {
+      subject: `Un tuo attributo dichiarato è stato revocato`,
+      body: templateService.compileHtml(htmlTemplate, {
+        title: `Un tuo attributo dichiarato è stato revocato`,
+        notificationType,
+        entityId: tenant.id,
+        ...(t.type === "Tenant" ? { recipientName: tenant.name } : {}),
+        attributeName: attribute.name,
+        bffUrl: config.bffUrl,
+      }),
+    },
+    tenantId: t.tenantId,
+    ...mapRecipientToEmailPayload(t),
+  }));
+}

--- a/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantEvent.ts
+++ b/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantEvent.ts
@@ -10,6 +10,8 @@ import { handleTenantCertifiedAttributeAssigned } from "./handleTenantCertifiedA
 import { handleTenantCertifiedAttributeRevoked } from "./handleTenantCertifiedAttributeRevoked.js";
 import { handleTenantVerifiedAttributeAssigned } from "./handleTenantVerifiedAttributeAssigned.js";
 import { handleTenantVerifiedAttributeRevoked } from "./handleTenantVerifiedAttributeRevoked.js";
+import { handleTenantDeclaredAttributeAssigned } from "./handleTenantDeclaredAttributeAssigned.js";
+import { handleTenantDeclaredAttributeRevoked } from "./handleTenantDeclaredAttributeRevoked.js";
 
 export async function handleTenantEvent(
   params: HandlerParams<typeof TenantEventV2>
@@ -71,12 +73,34 @@ export async function handleTenantEvent(
         })
     )
     .with(
+      { type: "TenantDeclaredAttributeAssigned" },
+      ({ data: { tenant, attributeId } }) =>
+        handleTenantDeclaredAttributeAssigned({
+          tenantV2Msg: tenant,
+          attributeId: unsafeBrandId<AttributeId>(attributeId),
+          logger,
+          readModelService,
+          templateService,
+          correlationId,
+        })
+    )
+    .with(
+      { type: "TenantDeclaredAttributeRevoked" },
+      ({ data: { tenant, attributeId } }) =>
+        handleTenantDeclaredAttributeRevoked({
+          tenantV2Msg: tenant,
+          attributeId: unsafeBrandId<AttributeId>(attributeId),
+          logger,
+          readModelService,
+          templateService,
+          correlationId,
+        })
+    )
+    .with(
       {
         type: P.union(
           "TenantOnboarded",
           "TenantOnboardDetailsUpdated",
-          "TenantDeclaredAttributeAssigned",
-          "TenantDeclaredAttributeRevoked",
           "TenantVerifiedAttributeExpirationUpdated",
           "TenantVerifiedAttributeExtensionUpdated",
           "MaintenanceTenantDeleted",

--- a/packages/email-notification-dispatcher/src/resources/templates/client-created-mail.html
+++ b/packages/email-notification-dispatcher/src/resources/templates/client-created-mail.html
@@ -1,0 +1,86 @@
+{{> common-header }}
+<tr>
+  <td
+    align="left"
+    class="title"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 24px;
+      padding-right: 0px;
+      padding-bottom: 8px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        line-height: 1;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- H4 Desktop (from MUI Italia)-->
+      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 8px;
+      padding-right: 0px;
+      padding-bottom: 0px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <p style="margin-bottom: 0px">
+        Gentile
+        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+      </p>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="font-size: 0px; padding: 0px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- Body 1 Desktop (from MUI Italia)-->
+      <p>
+        Ti informiamo che è stato creato un nuovo client
+        "{{ clientName }}" per il tuo ente.
+      </p>
+    </div>
+  </td>
+</tr>
+{{> common-footer }}

--- a/packages/email-notification-dispatcher/src/resources/templates/client-deleted-mail.html
+++ b/packages/email-notification-dispatcher/src/resources/templates/client-deleted-mail.html
@@ -1,0 +1,86 @@
+{{> common-header }}
+<tr>
+  <td
+    align="left"
+    class="title"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 24px;
+      padding-right: 0px;
+      padding-bottom: 8px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        line-height: 1;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- H4 Desktop (from MUI Italia)-->
+      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 8px;
+      padding-right: 0px;
+      padding-bottom: 0px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <p style="margin-bottom: 0px">
+        Gentile
+        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+      </p>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="font-size: 0px; padding: 0px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- Body 1 Desktop (from MUI Italia)-->
+      <p>
+        Ti informiamo che il client "{{ clientName }}" del tuo ente è stato
+        eliminato.
+      </p>
+    </div>
+  </td>
+</tr>
+{{> common-footer }}

--- a/packages/email-notification-dispatcher/src/resources/templates/tenant-declared-attribute-assigned-mail.html
+++ b/packages/email-notification-dispatcher/src/resources/templates/tenant-declared-attribute-assigned-mail.html
@@ -1,0 +1,86 @@
+{{> common-header }}
+<tr>
+  <td
+    align="left"
+    class="title"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 24px;
+      padding-right: 0px;
+      padding-bottom: 8px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        line-height: 1;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- H4 Desktop (from MUI Italia)-->
+      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 8px;
+      padding-right: 0px;
+      padding-bottom: 0px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <p style="margin-bottom: 0px">
+        Gentile
+        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+      </p>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="font-size: 0px; padding: 0px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- Body 1 Desktop (from MUI Italia)-->
+      <p>
+        Il tuo ente ha auto-dichiarato l'attributo "{{ attributeName }}". Puoi
+        ora utilizzarlo nelle richieste di fruizione.
+      </p>
+    </div>
+  </td>
+</tr>
+{{> common-footer }}

--- a/packages/email-notification-dispatcher/src/resources/templates/tenant-declared-attribute-revoked-mail.html
+++ b/packages/email-notification-dispatcher/src/resources/templates/tenant-declared-attribute-revoked-mail.html
@@ -1,0 +1,88 @@
+{{> common-header }}
+<tr>
+  <td
+    align="left"
+    class="title"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 24px;
+      padding-right: 0px;
+      padding-bottom: 8px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        line-height: 1;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- H4 Desktop (from MUI Italia)-->
+      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 8px;
+      padding-right: 0px;
+      padding-bottom: 0px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <p style="margin-bottom: 0px">
+        Gentile
+        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+      </p>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="font-size: 0px; padding: 0px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- Body 1 Desktop (from MUI Italia)-->
+      <p>
+        Ti informiamo che il tuo ente ha revocato l'attributo dichiarato
+        "{{ attributeName }}". Tutte le richieste di fruizione che utilizzano
+        tale attributo subiranno una sospensione. Non potrai più utilizzare
+        questo attributo per le future richieste di fruizione.
+      </p>
+    </div>
+  </td>
+</tr>
+{{> common-footer }}

--- a/packages/email-notification-dispatcher/src/services/utils.ts
+++ b/packages/email-notification-dispatcher/src/services/utils.ts
@@ -103,6 +103,8 @@ export const eventMailTemplateType = {
     "tenant-declared-attribute-assigned-mail",
   tenantDeclaredAttributeRevokedMailTemplate:
     "tenant-declared-attribute-revoked-mail",
+  clientCreatedMailTemplate: "client-created-mail",
+  clientDeletedMailTemplate: "client-deleted-mail",
   producerKeychainKeyDeletedMailTemplate: "producer-keychain-key-deleted-mail",
   producerKeychainDeletedMailTemplate: "producer-keychain-deleted-mail",
   clientKeyDeletedMailTemplate: "client-key-deleted-mail",

--- a/packages/email-notification-dispatcher/src/services/utils.ts
+++ b/packages/email-notification-dispatcher/src/services/utils.ts
@@ -99,6 +99,10 @@ export const eventMailTemplateType = {
     "tenant-verified-attribute-assigned-mail",
   tenantVerifiedAttributeRevokedMailTemplate:
     "tenant-verified-attribute-revoked-mail",
+  tenantDeclaredAttributeAssignedMailTemplate:
+    "tenant-declared-attribute-assigned-mail",
+  tenantDeclaredAttributeRevokedMailTemplate:
+    "tenant-declared-attribute-revoked-mail",
   producerKeychainKeyDeletedMailTemplate: "producer-keychain-key-deleted-mail",
   producerKeychainDeletedMailTemplate: "producer-keychain-deleted-mail",
   clientKeyDeletedMailTemplate: "client-key-deleted-mail",

--- a/packages/in-app-notification-dispatcher/src/handlers/authorizations/handleAuthorizationEvent.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/authorizations/handleAuthorizationEvent.ts
@@ -9,6 +9,7 @@ import { handleClientAddedRemovedToProducer } from "./handleClientAddedRemovedTo
 import { handleEserviceStateChangedToConsumer } from "./handleEserviceStateChangedToConsumer.js";
 import { handleClientKeyAddedDeletedToClientUsers } from "./handleClientKeyAddedDeletedToClientUsers.js";
 import { handleProducerKeychainKeyAddedDeletedToClientUsers } from "./handleProducerKeychainKeyAddedDeletedToClientUsers.js";
+import { handleClientCreatedDeletedToTenantUsers } from "./handleClientCreatedDeletedToTenantUsers.js";
 
 export async function handleAuthorizationEvent(
   decodedMessage: AuthorizationEventEnvelopeV2,
@@ -70,10 +71,15 @@ export async function handleAuthorizationEvent(
     )
     .with(
       {
+        type: P.union("ClientAdded", "ClientDeleted"),
+      },
+      (msg) =>
+        handleClientCreatedDeletedToTenantUsers(msg, logger, readModelService)
+    )
+    .with(
+      {
         type: P.union(
-          "ClientAdded",
           "ClientAdminSet",
-          "ClientDeleted",
           "ClientUserAdded",
           "ClientAdminRoleRevoked",
           "ClientAdminRemoved",

--- a/packages/in-app-notification-dispatcher/src/handlers/authorizations/handleAuthorizationEvent.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/authorizations/handleAuthorizationEvent.ts
@@ -29,7 +29,12 @@ export async function handleAuthorizationEvent(
         )
     )
     .with(
-      { type: "ProducerKeychainEServiceAdded" },
+      {
+        type: P.union(
+          "ProducerKeychainEServiceAdded",
+          "ProducerKeychainEServiceRemoved"
+        ),
+      },
       ({ data: { eserviceId } }) =>
         handleEserviceStateChangedToConsumer(
           eserviceId,
@@ -72,7 +77,6 @@ export async function handleAuthorizationEvent(
           "ClientUserAdded",
           "ClientAdminRoleRevoked",
           "ClientAdminRemoved",
-          "ProducerKeychainEServiceRemoved",
           "ProducerKeychainAdded",
           "ProducerKeychainDeleted",
           "ProducerKeychainUserAdded"

--- a/packages/in-app-notification-dispatcher/src/handlers/authorizations/handleClientCreatedDeletedToTenantUsers.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/authorizations/handleClientCreatedDeletedToTenantUsers.ts
@@ -1,0 +1,65 @@
+import {
+  AuthorizationEventEnvelopeV2,
+  fromClientV2,
+  missingKafkaMessageDataError,
+  NewNotification,
+} from "pagopa-interop-models";
+import { Logger } from "pagopa-interop-commons";
+import { match } from "ts-pattern";
+import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
+import { getNotificationRecipients } from "../handlerCommons.js";
+import { inAppTemplates } from "../../templates/inAppTemplates.js";
+
+type ClientCreatedDeletedEventType = "ClientAdded" | "ClientDeleted";
+
+type ClientCreatedDeletedEvent = Extract<
+  AuthorizationEventEnvelopeV2,
+  { type: ClientCreatedDeletedEventType }
+>;
+
+export async function handleClientCreatedDeletedToTenantUsers(
+  decodedMessage: ClientCreatedDeletedEvent,
+  logger: Logger,
+  readModelService: ReadModelServiceSQL
+): Promise<NewNotification[]> {
+  if (!decodedMessage.data.client) {
+    throw missingKafkaMessageDataError("client", decodedMessage.type);
+  }
+
+  logger.info(
+    `Sending in-app notification for handleClientCreatedDeletedToTenantUsers ${decodedMessage.data.client.id} eventType ${decodedMessage.type}`
+  );
+
+  const client = fromClientV2(decodedMessage.data.client);
+
+  const usersWithNotifications = await getNotificationRecipients(
+    [client.consumerId],
+    "clientCreatedDeletedToTenantUsers",
+    readModelService,
+    logger
+  );
+
+  if (usersWithNotifications.length === 0) {
+    logger.info(
+      `No users with notifications enabled for clientCreatedDeletedToTenantUsers message`
+    );
+    return [];
+  }
+
+  const body = match(decodedMessage.type)
+    .with("ClientAdded", () =>
+      inAppTemplates.clientCreatedToTenantUsers(client.name)
+    )
+    .with("ClientDeleted", () =>
+      inAppTemplates.clientDeletedToTenantUsers(client.name)
+    )
+    .exhaustive();
+
+  return usersWithNotifications.map(({ userId, tenantId }) => ({
+    userId,
+    tenantId,
+    body,
+    notificationType: "clientCreatedDeletedToTenantUsers" as const,
+    entityId: client.id,
+  }));
+}

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleDeclaredAttributeAssignedRevokedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleDeclaredAttributeAssignedRevokedToAssignee.ts
@@ -1,0 +1,69 @@
+import {
+  AttributeId,
+  fromTenantV2,
+  missingKafkaMessageDataError,
+  NewNotification,
+  TenantV2,
+} from "pagopa-interop-models";
+import { Logger } from "pagopa-interop-commons";
+import { match } from "ts-pattern";
+import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
+import {
+  getNotificationRecipients,
+  retrieveAttribute,
+} from "../handlerCommons.js";
+import { inAppTemplates } from "../../templates/inAppTemplates.js";
+
+type DeclaredAttributeAssignedRevokedEventType =
+  | "TenantDeclaredAttributeAssigned"
+  | "TenantDeclaredAttributeRevoked";
+
+export async function handleDeclaredAttributeAssignedRevokedToAssignee(
+  tenantV2Msg: TenantV2 | undefined,
+  attributeId: AttributeId,
+  logger: Logger,
+  readModelService: ReadModelServiceSQL,
+  eventType: DeclaredAttributeAssignedRevokedEventType
+): Promise<NewNotification[]> {
+  if (!tenantV2Msg) {
+    throw missingKafkaMessageDataError("tenant", eventType);
+  }
+  logger.info(
+    `Handle declared attribute assigned/revoked in-app notification for ${eventType} tenant ${tenantV2Msg.id}`
+  );
+
+  const tenant = fromTenantV2(tenantV2Msg);
+
+  const usersWithNotifications = await getNotificationRecipients(
+    [tenant.id],
+    "certifiedVerifiedAttributeAssignedRevokedToAssignee",
+    readModelService,
+    logger
+  );
+
+  if (usersWithNotifications.length === 0) {
+    logger.info(
+      `No users with notifications enabled for ${eventType} tenant ${tenant.id}`
+    );
+    return [];
+  }
+
+  const attribute = await retrieveAttribute(attributeId, readModelService);
+
+  const body = match(eventType)
+    .with("TenantDeclaredAttributeAssigned", () =>
+      inAppTemplates.declaredAttributeAssignedToAssignee(attribute.name)
+    )
+    .with("TenantDeclaredAttributeRevoked", () =>
+      inAppTemplates.declaredAttributeRevokedToAssignee(attribute.name)
+    )
+    .exhaustive();
+
+  return usersWithNotifications.map(({ userId, tenantId }) => ({
+    userId,
+    tenantId,
+    body,
+    notificationType: "certifiedVerifiedAttributeAssignedRevokedToAssignee",
+    entityId: attribute.id,
+  }));
+}

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleTenantEvent.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleTenantEvent.ts
@@ -8,6 +8,7 @@ import { Logger } from "pagopa-interop-commons";
 import { P, match } from "ts-pattern";
 import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
 import { handleCertifiedVerifiedAttributeAssignedRevokedToAssignee } from "./handleCertifiedVerifiedAttributeAssignedRevokedToAssignee.js";
+import { handleDeclaredAttributeAssignedRevokedToAssignee } from "./handleDeclaredAttributeAssignedRevokedToAssignee.js";
 
 export async function handleTenantEvent(
   decodedMessage: TenantEventEnvelopeV2,
@@ -36,10 +37,24 @@ export async function handleTenantEvent(
     .with(
       {
         type: P.union(
+          "TenantDeclaredAttributeAssigned",
+          "TenantDeclaredAttributeRevoked"
+        ),
+      },
+      ({ data: { tenant, attributeId }, type }) =>
+        handleDeclaredAttributeAssignedRevokedToAssignee(
+          tenant,
+          unsafeBrandId<AttributeId>(attributeId),
+          logger,
+          readModelService,
+          type
+        )
+    )
+    .with(
+      {
+        type: P.union(
           "TenantOnboarded",
           "TenantOnboardDetailsUpdated",
-          "TenantDeclaredAttributeAssigned",
-          "TenantDeclaredAttributeRevoked",
           "TenantVerifiedAttributeExpirationUpdated",
           "TenantVerifiedAttributeExtensionUpdated",
           "MaintenanceTenantDeleted",

--- a/packages/in-app-notification-dispatcher/src/templates/inAppTemplates.ts
+++ b/packages/in-app-notification-dispatcher/src/templates/inAppTemplates.ts
@@ -317,6 +317,10 @@ export const inAppTemplates = {
     revokerName: string
   ): string =>
     `Ti informiamo che l'ente certificatore  ${revokerName} ha revocato l'attributo ${attributeKind} "${attributeName}". Tutte le richieste di fruizione che utilizzano tale attributo subiranno una sospensione. Non potrai più utilizzare questo attributo per le future richieste di fruizione.`,
+  declaredAttributeAssignedToAssignee: (attributeName: string): string =>
+    `Il tuo ente ha auto-dichiarato l'attributo "${attributeName}". Puoi ora utilizzarlo nelle richieste di fruizione.`,
+  declaredAttributeRevokedToAssignee: (attributeName: string): string =>
+    `Ti informiamo che il tuo ente ha revocato l'attributo dichiarato "${attributeName}". Tutte le richieste di fruizione che utilizzano tale attributo subiranno una sospensione. Non potrai più utilizzare questo attributo per le future richieste di fruizione.`,
   producerKeychainEServiceAddedToConsumer: (
     producerName: string,
     eserviceName: string

--- a/packages/in-app-notification-dispatcher/src/templates/inAppTemplates.ts
+++ b/packages/in-app-notification-dispatcher/src/templates/inAppTemplates.ts
@@ -332,6 +332,10 @@ export const inAppTemplates = {
     `Ti informiamo che è stata aggiunta una nuova chiave e-service al client ${clientName}.`,
   clientUserDeletedToClientUsers: (clientName: string): string =>
     `Una chiave associata al client ${clientName} non è più considerata sicura, in quanto l'operatore che l'ha caricata non è più attivo. La chiave deve essere sostituita per garantire la sicurezza e l'operatività.`,
+  clientCreatedToTenantUsers: (clientName: string): string =>
+    `Ti informiamo che è stato creato un nuovo client "${clientName}" per il tuo ente.`,
+  clientDeletedToTenantUsers: (clientName: string): string =>
+    `Ti informiamo che il client "${clientName}" del tuo ente è stato eliminato.`,
   producerKeychainKeyDeletedToClientUsers: (
     producerKeychainName: string,
     kid: string

--- a/packages/models/proto/v2/notification-config/notification-config.proto
+++ b/packages/models/proto/v2/notification-config/notification-config.proto
@@ -29,6 +29,7 @@ message NotificationConfigV2 {
   bool producerKeychainKeyAddedDeletedToClientUsers = 21;
   bool purposeQuotaAdjustmentRequestToProducer = 22;
   bool purposeOverQuotaStateToConsumer = 23;
+  bool clientCreatedDeletedToTenantUsers = 24;
 }
 
 message TenantNotificationConfigV2 {

--- a/packages/models/src/notification/notification.ts
+++ b/packages/models/src/notification/notification.ts
@@ -31,6 +31,7 @@ export const NotificationType = z.enum([
   "producerKeychainKeyAddedDeletedToClientUsers", // 25: Variazioni sullo stato delle chiavi collegate ad un client (ProducerKeychain)
   "purposeQuotaAdjustmentRequestToProducer", // 06: Richiesta adeguamento piano di carico finalità
   "purposeOverQuotaStateToConsumer", // 14: Superamento soglia piano di carico finalità
+  "clientCreatedDeletedToTenantUsers", // 26: Creazione o eliminazione di un client
 ]);
 export type NotificationType = z.infer<typeof NotificationType>;
 

--- a/packages/readmodel/src/notification-config/aggregators.ts
+++ b/packages/readmodel/src/notification-config/aggregators.ts
@@ -143,6 +143,9 @@ export const aggregateUserNotificationConfig = ({
     purposeOverQuotaStateToConsumer: enabledInAppNotifications.includes(
       "purposeOverQuotaStateToConsumer"
     ),
+    clientCreatedDeletedToTenantUsers: enabledInAppNotifications.includes(
+      "clientCreatedDeletedToTenantUsers"
+    ),
   };
   const emailConfig: NotificationConfig = {
     agreementSuspendedUnsuspendedToProducer: enabledEmailNotifications.includes(
@@ -216,6 +219,9 @@ export const aggregateUserNotificationConfig = ({
     ),
     purposeOverQuotaStateToConsumer: enabledEmailNotifications.includes(
       "purposeOverQuotaStateToConsumer"
+    ),
+    clientCreatedDeletedToTenantUsers: enabledEmailNotifications.includes(
+      "clientCreatedDeletedToTenantUsers"
     ),
   };
 


### PR DESCRIPTION
## Summary
- Bind `ProducerKeychainEServiceRemoved` to existing `eserviceStateChangedToConsumer` handler (both in-app and email dispatchers)
- Add `TenantDeclaredAttributeAssigned/Revoked` with new handlers using existing `certifiedVerifiedAttributeAssignedRevokedToAssignee` notification type (simpler than certified/verified — no assigner/revoker resolution)
- Add `ClientAdded/ClientDeleted` with new `clientCreatedDeletedToTenantUsers` notification type, handlers, proto schema update, role config (ADMIN + SECURITY), and email templates