### PR TITLE
chore: extract generic repository factory in domains-analytics-writer

### DIFF
--- a/packages/domains-analytics-writer/src/repository/agreement/agreement.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/agreement/agreement.repository.ts
@@ -1,116 +1,18 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { ITask, IMain } from "pg-promise";
-import { genericInternalError } from "pagopa-interop-models";
-
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import {
-  generateMergeQuery,
-  generateMergeDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
+import { createRepository } from "../createRepository.js";
 import { AgreementDbTable, DeletingDbTable } from "../../model/db/index.js";
-import { config } from "../../config/config.js";
-import { AgreementDeletingSchema } from "../../model/agreement/agreement.js";
 import { AgreementSchema } from "pagopa-interop-kpi-models";
+import { AgreementDeletingSchema } from "../../model/agreement/agreement.js";
 
-export function agreementRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = AgreementDbTable.agreement;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.agreement_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AgreementSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, AgreementSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const agreementRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: AgreementDbTable.agreement,
+    schema: AgreementSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.agreement_deleting_table,
+      deletingSchema: AgreementDeletingSchema,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          AgreementSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AgreementDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          AgreementDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          true,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/agreement/agreementAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/agreement/agreementAttribute.repository.ts
@@ -1,64 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { ITask, IMain } from "pg-promise";
-import { genericInternalError } from "pagopa-interop-models";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { AgreementDbTable } from "../../model/db/index.js";
 import { AgreementAttributeSchema } from "pagopa-interop-kpi-models";
 
-export function agreementAttributeRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = AgreementDbTable.agreement_attribute;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AgreementAttributeSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, AgreementAttributeSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["agreementId", "attributeId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          AgreementAttributeSchema,
-          schemaName,
-          tableName,
-          ["agreementId", "attributeId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const agreementAttributeRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: AgreementDbTable.agreement_attribute,
+    schema: AgreementAttributeSchema,
+    keyColumns: ["agreementId", "attributeId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/agreement/agreementConsumerDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/agreement/agreementConsumerDocument.repository.ts
@@ -1,115 +1,17 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { ITask, IMain } from "pg-promise";
-import { genericInternalError } from "pagopa-interop-models";
 import { DBConnection } from "../../db/db.js";
-import {
-  generateMergeQuery,
-  generateMergeDeleteQuery,
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { AgreementDbTable, DeletingDbTable } from "../../model/db/index.js";
 import { AgreementConsumerDocumentDeletingSchema } from "../../model/agreement/agreementConsumerDocument.js";
 import { AgreementConsumerDocumentSchema } from "pagopa-interop-kpi-models";
 
-export function agreementConsumerDocumentRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = AgreementDbTable.agreement_consumer_document;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.agreement_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AgreementConsumerDocumentSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          AgreementConsumerDocumentSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const agreementConsumerDocumentRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: AgreementDbTable.agreement_consumer_document,
+    schema: AgreementConsumerDocumentSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.agreement_deleting_table,
+      deletingSchema: AgreementConsumerDocumentDeletingSchema,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          AgreementConsumerDocumentSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AgreementConsumerDocumentDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          AgreementConsumerDocumentDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/agreement/agreementContract.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/agreement/agreementContract.repository.ts
@@ -1,64 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { ITask, IMain } from "pg-promise";
-import { genericInternalError } from "pagopa-interop-models";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { AgreementDbTable } from "../../model/db/index.js";
 import { AgreementContractSchema } from "pagopa-interop-kpi-models";
 
-export function agreementContractRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = AgreementDbTable.agreement_contract;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AgreementContractSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, AgreementContractSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["id", "agreementId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          AgreementContractSchema,
-          schemaName,
-          tableName,
-          ["id", "agreementId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const agreementContractRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: AgreementDbTable.agreement_contract,
+    schema: AgreementContractSchema,
+    keyColumns: ["id", "agreementId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/agreement/agreementSignedContract.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/agreement/agreementSignedContract.repository.ts
@@ -1,68 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { ITask, IMain } from "pg-promise";
-import { genericInternalError } from "pagopa-interop-models";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { AgreementDbTable } from "../../model/db/index.js";
 import { AgreementSignedContractSchema } from "pagopa-interop-kpi-models";
 
-export function agreementSignedContractRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = AgreementDbTable.agreement_signed_contract;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AgreementSignedContractSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          AgreementSignedContractSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["id", "agreementId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          AgreementSignedContractSchema,
-          schemaName,
-          tableName,
-          ["id", "agreementId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const agreementSignedContractRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: AgreementDbTable.agreement_signed_contract,
+    schema: AgreementSignedContractSchema,
+    keyColumns: ["id", "agreementId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/agreement/agreementStamp.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/agreement/agreementStamp.repository.ts
@@ -1,64 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { ITask, IMain } from "pg-promise";
-import { genericInternalError } from "pagopa-interop-models";
-import { AgreementDbTable } from "../../model/db/index.js";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
+import { AgreementDbTable } from "../../model/db/index.js";
 import { AgreementStampSchema } from "pagopa-interop-kpi-models";
 
-export function agreementStampRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = AgreementDbTable.agreement_stamp;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AgreementStampSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, AgreementStampSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["agreementId", "kind"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          AgreementStampSchema,
-          schemaName,
-          tableName,
-          ["agreementId", "kind"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const agreementStampRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: AgreementDbTable.agreement_stamp,
+    schema: AgreementStampSchema,
+    keyColumns: ["agreementId", "kind"],
+  });

--- a/packages/domains-analytics-writer/src/repository/attribute/attribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/attribute/attribute.repository.ts
@@ -1,113 +1,18 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import { AttributeDeletingSchema } from "../../model/attribute/attribute.js";
-import {
-  buildColumnSet,
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { DeletingDbTable, AttributeDbTable } from "../../model/db/index.js";
+import { createRepository } from "../createRepository.js";
+import { AttributeDbTable, DeletingDbTable } from "../../model/db/index.js";
 import { AttributeSchema } from "pagopa-interop-kpi-models";
+import { AttributeDeletingSchema } from "../../model/attribute/attribute.js";
 
-export function attributeRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = AttributeDbTable.attribute;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.attribute_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AttributeSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, AttributeSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const attributeRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: AttributeDbTable.attribute,
+    schema: AttributeSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.attribute_deleting_table,
+      deletingSchema: AttributeDeletingSchema,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          AttributeSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: AttributeDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          AttributeDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          true,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/catalog/eservice.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/catalog/eservice.repository.ts
@@ -1,115 +1,19 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import {
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
+import { CatalogDbTable, DeletingDbTable } from "../../model/db/index.js";
 import { EserviceSchema } from "pagopa-interop-kpi-models";
 import { EserviceDeletingSchema } from "../../model/catalog/eservice.js";
-import { CatalogDbTable, DeletingDbTable } from "../../model/db/index.js";
 
-export function eserviceRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = CatalogDbTable.eservice;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.catalog_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, EserviceSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const eserviceRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: CatalogDbTable.eservice,
+    schema: EserviceSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.catalog_deleting_table,
+      deletingSchema: EserviceDeletingSchema,
+      useIdAsSourceDeleteKey: false,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          false,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptor.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptor.repository.ts
@@ -5,12 +5,10 @@ import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
   generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import {
-  generateMergeDeleteQuery,
   generateMergeQuery,
 } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
+import { EserviceDescriptorSchema } from "pagopa-interop-kpi-models";
 import {
   EserviceDescriptorServerUrlsSchema,
   EserviceDescriptorDeletingSchema,
@@ -20,106 +18,27 @@ import {
   CatalogDbTable,
   DeletingDbTable,
 } from "../../model/db/index.js";
-import { EserviceDescriptorSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 
 export function eserviceDescriptorRepository(conn: DBConnection) {
+  const base = createRepository(conn, {
+    tableName: CatalogDbTable.eservice_descriptor,
+    schema: EserviceDescriptorSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.catalog_deleting_table,
+      deletingSchema: EserviceDescriptorDeletingSchema,
+    },
+  });
+
   const schemaName = config.dbSchemaName;
   const tableName = CatalogDbTable.eservice_descriptor;
   const descriptorServerUrlsTableName =
     CatalogDbPartialTable.descriptor_server_urls;
-  const stagingDescriptorServerUrlsTableName = `${CatalogDbPartialTable.descriptor_server_urls}_${config.mergeTableSuffix}`;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.catalog_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+  const stagingDescriptorServerUrlsTableName = `${descriptorServerUrlsTableName}_${config.mergeTableSuffix}`;
 
   return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDescriptorSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, EserviceDescriptorSchema);
-
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceDescriptorSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDescriptorDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceDescriptorDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
+    ...base,
 
     async insertServerUrls(
       t: ITask<unknown>,
@@ -132,7 +51,6 @@ export function eserviceDescriptorRepository(conn: DBConnection) {
           descriptorServerUrlsTableName,
           EserviceDescriptorServerUrlsSchema
         );
-
         await t.none(pgp.helpers.insert(records, cs));
         await t.none(
           generateStagingDeleteQuery(

--- a/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorAttribute.repository.ts
@@ -1,72 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import { EserviceDescriptorAttributeSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { CatalogDbTable } from "../../model/db/index.js";
+import { EserviceDescriptorAttributeSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceDescriptorAttributeRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = CatalogDbTable.eservice_descriptor_attribute;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDescriptorAttributeSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceDescriptorAttributeSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, [
-            "attributeId",
-            "groupId",
-            "descriptorId",
-          ])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceDescriptorAttributeSchema,
-          schemaName,
-          tableName,
-          ["attributeId", "groupId", "descriptorId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const eserviceDescriptorAttributeRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: CatalogDbTable.eservice_descriptor_attribute,
+    schema: EserviceDescriptorAttributeSchema,
+    keyColumns: ["attributeId", "groupId", "descriptorId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorDocument.repository.ts
@@ -1,117 +1,17 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import {
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
+import { CatalogDbTable, DeletingDbTable } from "../../model/db/index.js";
 import { EserviceDescriptorDocumentSchema } from "pagopa-interop-kpi-models";
 import { EserviceDescriptorDocumentDeletingSchema } from "../../model/catalog/eserviceDescriptorDocument.js";
-import { CatalogDbTable, DeletingDbTable } from "../../model/db/index.js";
 
-export function eserviceDescriptorDocumentRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = CatalogDbTable.eservice_descriptor_document;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.catalog_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDescriptorDocumentSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceDescriptorDocumentSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const eserviceDescriptorDocumentRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: CatalogDbTable.eservice_descriptor_document,
+    schema: EserviceDescriptorDocumentSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.catalog_deleting_table,
+      deletingSchema: EserviceDescriptorDocumentDeletingSchema,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceDescriptorDocumentSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDescriptorDocumentDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceDescriptorDocumentDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorInterface.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorInterface.repository.ts
@@ -1,94 +1,36 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
+import { ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import {
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-} from "../../utils/sqlQueryHelper.js";
+import { generateMergeDeleteQuery } from "../../utils/sqlQueryHelper.js";
 import { config } from "../../config/config.js";
 import { EserviceDescriptorInterfaceSchema } from "pagopa-interop-kpi-models";
 import { EserviceDescriptorDocumentOrInterfaceDeletingSchema } from "../../model/catalog/eserviceDescriptorInterface.js";
 import { CatalogDbTable, DeletingDbTable } from "../../model/db/index.js";
+import { createRepository } from "../createRepository.js";
 
 export function eserviceDescriptorInterfaceRepository(conn: DBConnection) {
+  const base = createRepository(conn, {
+    tableName: CatalogDbTable.eservice_descriptor_interface,
+    schema: EserviceDescriptorInterfaceSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName:
+        DeletingDbTable.catalog_descriptor_interface_deleting_table,
+      deletingSchema: EserviceDescriptorDocumentOrInterfaceDeletingSchema,
+    },
+  });
+
   const schemaName = config.dbSchemaName;
   const tableName = CatalogDbTable.eservice_descriptor_interface;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
   const deletingTableName =
     DeletingDbTable.catalog_descriptor_interface_deleting_table;
   const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDescriptorInterfaceSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceDescriptorInterfaceSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
+    ...base,
 
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceDescriptorInterfaceSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDescriptorDocumentOrInterfaceDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceDescriptorDocumentOrInterfaceDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
+    // Custom mergeDeleting: returns the IDs that existed in the target table before deletion
     async mergeDeleting(
       t: ITask<unknown>,
       idsToDelete: string[]
@@ -97,7 +39,7 @@ export function eserviceDescriptorInterfaceRepository(conn: DBConnection) {
         const idParams = idsToDelete.map((_, i) => `$${i + 1}`).join(", ");
 
         const existingIds = await t.map<string>(
-          `SELECT id 
+          `SELECT id
           FROM ${schemaName}.${tableName}
           WHERE id IN (${idParams})`,
           idsToDelete,
@@ -116,16 +58,6 @@ export function eserviceDescriptorInterfaceRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorRejection.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorRejection.repository.ts
@@ -1,66 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import { EserviceDescriptorRejectionReasonSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { CatalogDbTable } from "../../model/db/index.js";
+import { EserviceDescriptorRejectionReasonSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceDescriptorRejectionRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = CatalogDbTable.eservice_descriptor_rejection_reason;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDescriptorRejectionReasonSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceDescriptorRejectionReasonSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["descriptorId"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceDescriptorRejectionReasonSchema,
-          schemaName,
-          tableName,
-          ["descriptorId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const eserviceDescriptorRejectionRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: CatalogDbTable.eservice_descriptor_rejection_reason,
+    schema: EserviceDescriptorRejectionReasonSchema,
+    keyColumns: ["descriptorId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorTemplateVersionRef.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/catalog/eserviceDescriptorTemplateVersionRef.repository.ts
@@ -1,73 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import { EserviceDescriptorTemplateVersionRefSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { CatalogDbTable } from "../../model/db/index.js";
+import { EserviceDescriptorTemplateVersionRefSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceDescriptorTemplateVersionRefRepository(
+export const eserviceDescriptorTemplateVersionRefRepository = (
   conn: DBConnection
-) {
-  const schemaName = config.dbSchemaName;
-  const tableName = CatalogDbTable.eservice_descriptor_template_version_ref;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceDescriptorTemplateVersionRefSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceDescriptorTemplateVersionRefSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, [
-            "descriptorId",
-            "eserviceTemplateVersionId",
-          ])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceDescriptorTemplateVersionRefSchema,
-          schemaName,
-          tableName,
-          ["eserviceTemplateVersionId", "descriptorId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+) =>
+  createRepository(conn, {
+    tableName: CatalogDbTable.eservice_descriptor_template_version_ref,
+    schema: EserviceDescriptorTemplateVersionRefSchema,
+    keyColumns: ["descriptorId", "eserviceTemplateVersionId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/catalog/eserviceRiskAnalysis.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/catalog/eserviceRiskAnalysis.repository.ts
@@ -1,64 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import { EserviceRiskAnalysisSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { CatalogDbTable } from "../../model/db/index.js";
+import { EserviceRiskAnalysisSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceRiskAnalysisRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = CatalogDbTable.eservice_risk_analysis;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceRiskAnalysisSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, EserviceRiskAnalysisSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["id", "eserviceId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceRiskAnalysisSchema,
-          schemaName,
-          tableName,
-          ["id", "eserviceId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const eserviceRiskAnalysisRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: CatalogDbTable.eservice_risk_analysis,
+    schema: EserviceRiskAnalysisSchema,
+    keyColumns: ["id", "eserviceId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/catalog/eserviceRiskAnalysisAnswer.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/catalog/eserviceRiskAnalysisAnswer.repository.ts
@@ -1,68 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import { EserviceRiskAnalysisAnswerSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { CatalogDbTable } from "../../model/db/index.js";
+import { EserviceRiskAnalysisAnswerSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceRiskAnalysisAnswerRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = CatalogDbTable.eservice_risk_analysis_answer;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceRiskAnalysisAnswerSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceRiskAnalysisAnswerSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["id", "eserviceId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceRiskAnalysisAnswerSchema,
-          schemaName,
-          tableName,
-          ["id", "eserviceId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const eserviceRiskAnalysisAnswerRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: CatalogDbTable.eservice_risk_analysis_answer,
+    schema: EserviceRiskAnalysisAnswerSchema,
+    keyColumns: ["id", "eserviceId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/client/client.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/client.repository.ts
@@ -1,109 +1,18 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { DeletingDbTable, ClientDbTable } from "../../model/db/index.js";
+import { createRepository } from "../createRepository.js";
+import { ClientDbTable, DeletingDbTable } from "../../model/db/index.js";
 import { ClientSchema } from "pagopa-interop-kpi-models";
 import { ClientDeletingSchema } from "../../model/authorization/client.js";
 
-export function clientRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = ClientDbTable.client;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.client_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ClientSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, ClientSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const clientRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: ClientDbTable.client,
+    schema: ClientSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.client_deleting_table,
+      deletingSchema: ClientDeletingSchema,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          ClientSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ClientDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, deletingTableName, ClientDeletingSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          true,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/client/clientKey.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/clientKey.repository.ts
@@ -1,14 +1,13 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { genericInternalError } from "pagopa-interop-models";
 import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
-  generateMergeDeleteQuery,
   generateMergeQuery,
   generateStagingDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
+import { config } from "../../config/config.js";
 import {
   DeletingDbTable,
   ClientDbTable,
@@ -19,108 +18,30 @@ import {
   ClientKeyDeletingSchema,
   ClientKeyUserMigrationSchema,
 } from "../../model/authorization/clientKey.js";
+import { createRepository } from "../createRepository.js";
 
 export function clientKeyRepository(conn: DBConnection) {
+  const base = createRepository(conn, {
+    tableName: ClientDbTable.client_key,
+    schema: ClientKeySchema,
+    keyColumns: ["clientId", "kid"],
+    deleting: {
+      deletingTableName: DeletingDbTable.client_key_deleting_table,
+      deletingSchema: ClientKeyDeletingSchema,
+      useIdAsSourceDeleteKey: false,
+      physicalDelete: false,
+      additionalKeysToUpdate: ["deleted_at"],
+    },
+  });
+
   const schemaName = config.dbSchemaName;
   const tableName = ClientDbTable.client_key;
   const keyRelationshipTableName =
     ClientDbTablePartialTable.key_relationship_migrated;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.client_key_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
 
   return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ClientKeySchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, ClientKeySchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["clientId", "kid"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          ClientKeySchema,
-          schemaName,
-          tableName,
-          ["clientId", "kid"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ClientKeyDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          ClientKeyDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["clientId", "kid"],
-          false,
-          false,
-          ["deleted_at"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
+    ...base,
 
     async insertKeyUserMigration(
       t: ITask<unknown>,

--- a/packages/domains-analytics-writer/src/repository/client/clientPurpose.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/clientPurpose.repository.ts
@@ -1,114 +1,18 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { DeletingDbTable, ClientDbTable } from "../../model/db/index.js";
+import { createRepository } from "../createRepository.js";
+import { ClientDbTable, DeletingDbTable } from "../../model/db/index.js";
 import { ClientPurposeSchema } from "pagopa-interop-kpi-models";
 import { ClientPurposeDeletingSchema } from "../../model/authorization/clientPurpose.js";
 
-export function clientPurposeRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = ClientDbTable.client_purpose;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.client_purpose_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ClientPurposeSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, ClientPurposeSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["clientId", "purposeId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const clientPurposeRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: ClientDbTable.client_purpose,
+    schema: ClientPurposeSchema,
+    keyColumns: ["clientId", "purposeId"],
+    deleting: {
+      deletingTableName: DeletingDbTable.client_purpose_deleting_table,
+      deletingSchema: ClientPurposeDeletingSchema,
+      useIdAsSourceDeleteKey: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          ClientPurposeSchema,
-          schemaName,
-          tableName,
-          ["clientId", "purposeId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ClientPurposeDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          ClientPurposeDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["clientId", "purposeId"],
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/client/clientUser.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/clientUser.repository.ts
@@ -1,114 +1,18 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { DeletingDbTable, ClientDbTable } from "../../model/db/index.js";
+import { createRepository } from "../createRepository.js";
+import { ClientDbTable, DeletingDbTable } from "../../model/db/index.js";
 import { ClientUserSchema } from "pagopa-interop-kpi-models";
 import { ClientUserDeletingSchema } from "../../model/authorization/clientUser.js";
 
-export function clientUserRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = ClientDbTable.client_user;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.client_user_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ClientUserSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, ClientUserSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["clientId", "userId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const clientUserRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: ClientDbTable.client_user,
+    schema: ClientUserSchema,
+    keyColumns: ["clientId", "userId"],
+    deleting: {
+      deletingTableName: DeletingDbTable.client_user_deleting_table,
+      deletingSchema: ClientUserDeletingSchema,
+      useIdAsSourceDeleteKey: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          ClientUserSchema,
-          schemaName,
-          tableName,
-          ["clientId", "userId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ClientUserDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          ClientUserDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["clientId", "userId"],
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/createRepository.ts
+++ b/packages/domains-analytics-writer/src/repository/createRepository.ts
@@ -28,13 +28,13 @@ interface RepositoryConfig<TSchema extends z.ZodRawShape> {
   keyColumns: string[];
 }
 
-export interface BaseRepository<TSchema> {
+interface BaseRepository<TSchema> {
   insert(t: ITask<unknown>, pgp: IMain, records: TSchema[]): Promise<void>;
   merge(t: ITask<unknown>): Promise<void>;
   clean(): Promise<void>;
 }
 
-export interface DeletingRepository<TDeletingSchema> {
+interface DeletingRepository<TDeletingSchema> {
   insertDeleting(
     t: ITask<unknown>,
     pgp: IMain,

--- a/packages/domains-analytics-writer/src/repository/createRepository.ts
+++ b/packages/domains-analytics-writer/src/repository/createRepository.ts
@@ -1,0 +1,184 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { z } from "zod";
+import { IMain, ITask } from "pg-promise";
+import { genericInternalError } from "pagopa-interop-models";
+import { DBConnection } from "../db/db.js";
+import { DeletingDbTable, DomainDbTable } from "../model/db/index.js";
+import { config } from "../config/config.js";
+import {
+  buildColumnSet,
+  generateMergeDeleteQuery,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../utils/sqlQueryHelper.js";
+
+interface DeletingConfig<TDeletingSchema extends z.ZodRawShape> {
+  deletingTableName: DeletingDbTable;
+  deletingSchema: z.ZodObject<TDeletingSchema>;
+  /** Key columns for the mergeDeleting query. Defaults to the main keyColumns if omitted. */
+  deletingKeyColumns?: string[];
+  useIdAsSourceDeleteKey?: boolean;
+  physicalDelete?: boolean;
+  additionalKeysToUpdate?: string[];
+}
+
+interface RepositoryConfig<TSchema extends z.ZodRawShape> {
+  tableName: DomainDbTable;
+  schema: z.ZodObject<TSchema>;
+  keyColumns: string[];
+}
+
+export interface BaseRepository<TSchema> {
+  insert(t: ITask<unknown>, pgp: IMain, records: TSchema[]): Promise<void>;
+  merge(t: ITask<unknown>): Promise<void>;
+  clean(): Promise<void>;
+}
+
+export interface DeletingRepository<TDeletingSchema> {
+  insertDeleting(
+    t: ITask<unknown>,
+    pgp: IMain,
+    records: TDeletingSchema[]
+  ): Promise<void>;
+  mergeDeleting(t: ITask<unknown>): Promise<void>;
+  cleanDeleting(): Promise<void>;
+}
+
+// Overload: with deleting config
+export function createRepository<
+  TSchema extends z.ZodRawShape,
+  TDeletingSchema extends z.ZodRawShape,
+>(
+  conn: DBConnection,
+  repoCfg: RepositoryConfig<TSchema> & {
+    deleting: DeletingConfig<TDeletingSchema>;
+  }
+): BaseRepository<z.infer<z.ZodObject<TSchema>>> &
+  DeletingRepository<z.infer<z.ZodObject<TDeletingSchema>>>;
+
+// Overload: without deleting config
+export function createRepository<TSchema extends z.ZodRawShape>(
+  conn: DBConnection,
+  repoCfg: RepositoryConfig<TSchema>
+): BaseRepository<z.infer<z.ZodObject<TSchema>>>;
+
+// Implementation
+export function createRepository<
+  TSchema extends z.ZodRawShape,
+  TDeletingSchema extends z.ZodRawShape,
+>(
+  conn: DBConnection,
+  repoCfg: RepositoryConfig<TSchema> & {
+    deleting?: DeletingConfig<TDeletingSchema>;
+  }
+): BaseRepository<z.infer<z.ZodObject<TSchema>>> &
+  Partial<DeletingRepository<z.infer<z.ZodObject<TDeletingSchema>>>> {
+  const { tableName, schema, keyColumns } = repoCfg;
+  const schemaName = config.dbSchemaName;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+
+  const base: BaseRepository<z.infer<z.ZodObject<TSchema>>> = {
+    async insert(t, pgp, records) {
+      try {
+        const cs = buildColumnSet(pgp, tableName, schema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          generateStagingDeleteQuery(tableName, keyColumns as any)
+        );
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t) {
+      try {
+        const mergeQuery = generateMergeQuery(
+          schema,
+          schemaName,
+          tableName,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          keyColumns as any
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean() {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+  };
+
+  if (!repoCfg.deleting) {
+    return base;
+  }
+
+  const {
+    deletingTableName,
+    deletingSchema,
+    deletingKeyColumns,
+    useIdAsSourceDeleteKey,
+    physicalDelete,
+    additionalKeysToUpdate,
+  } = repoCfg.deleting;
+  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
+  const effectiveDeletingKeyColumns = deletingKeyColumns ?? keyColumns;
+
+  return {
+    ...base,
+
+    async insertDeleting(t, pgp, records) {
+      try {
+        const cs = buildColumnSet(pgp, deletingTableName, deletingSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+
+    async mergeDeleting(t) {
+      try {
+        const mergeQuery = generateMergeDeleteQuery(
+          schemaName,
+          tableName,
+          deletingTableName,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          effectiveDeletingKeyColumns as any,
+          useIdAsSourceDeleteKey,
+          physicalDelete,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          additionalKeysToUpdate as any
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging deleting table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanDeleting() {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}

--- a/packages/domains-analytics-writer/src/repository/createRepository.ts
+++ b/packages/domains-analytics-writer/src/repository/createRepository.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 import { IMain, ITask } from "pg-promise";
 import { genericInternalError } from "pagopa-interop-models";
 import { DBConnection } from "../db/db.js";
-import { DeletingDbTable, DomainDbTable } from "../model/db/index.js";
+import {
+  DeletingDbTable,
+  DomainDbTable,
+  DomainDbTableSchemas,
+} from "../model/db/index.js";
 import { config } from "../config/config.js";
 import {
   buildColumnSet,
@@ -12,20 +16,36 @@ import {
   generateStagingDeleteQuery,
 } from "../utils/sqlQueryHelper.js";
 
-interface DeletingConfig<TDeletingSchema extends z.ZodRawShape> {
+type TableKey<TTable extends DomainDbTable> = Extract<
+  keyof z.infer<DomainDbTableSchemas[TTable]>,
+  string
+>;
+type RepositoryKey<
+  TTable extends DomainDbTable,
+  TSchema extends z.ZodRawShape,
+> = Extract<keyof TSchema, TableKey<TTable>>;
+
+interface DeletingConfig<
+  TTable extends DomainDbTable,
+  TSchema extends z.ZodRawShape,
+  TDeletingSchema extends z.ZodRawShape,
+> {
   deletingTableName: DeletingDbTable;
   deletingSchema: z.ZodObject<TDeletingSchema>;
   /** Key columns for the mergeDeleting query. Defaults to the main keyColumns if omitted. */
-  deletingKeyColumns?: string[];
+  deletingKeyColumns?: Array<RepositoryKey<TTable, TSchema>>;
   useIdAsSourceDeleteKey?: boolean;
   physicalDelete?: boolean;
-  additionalKeysToUpdate?: string[];
+  additionalKeysToUpdate?: Array<RepositoryKey<TTable, TSchema>>;
 }
 
-interface RepositoryConfig<TSchema extends z.ZodRawShape> {
-  tableName: DomainDbTable;
+interface RepositoryConfig<
+  TTable extends DomainDbTable,
+  TSchema extends z.ZodRawShape,
+> {
+  tableName: TTable;
   schema: z.ZodObject<TSchema>;
-  keyColumns: string[];
+  keyColumns: Array<RepositoryKey<TTable, TSchema>>;
 }
 
 interface BaseRepository<TSchema> {
@@ -46,30 +66,35 @@ interface DeletingRepository<TDeletingSchema> {
 
 // Overload: with deleting config
 export function createRepository<
+  TTable extends DomainDbTable,
   TSchema extends z.ZodRawShape,
   TDeletingSchema extends z.ZodRawShape,
 >(
   conn: DBConnection,
-  repoCfg: RepositoryConfig<TSchema> & {
-    deleting: DeletingConfig<TDeletingSchema>;
+  repoCfg: RepositoryConfig<TTable, TSchema> & {
+    deleting: DeletingConfig<TTable, TSchema, TDeletingSchema>;
   }
 ): BaseRepository<z.infer<z.ZodObject<TSchema>>> &
   DeletingRepository<z.infer<z.ZodObject<TDeletingSchema>>>;
 
 // Overload: without deleting config
-export function createRepository<TSchema extends z.ZodRawShape>(
+export function createRepository<
+  TTable extends DomainDbTable,
+  TSchema extends z.ZodRawShape,
+>(
   conn: DBConnection,
-  repoCfg: RepositoryConfig<TSchema>
+  repoCfg: RepositoryConfig<TTable, TSchema>
 ): BaseRepository<z.infer<z.ZodObject<TSchema>>>;
 
 // Implementation
 export function createRepository<
+  TTable extends DomainDbTable,
   TSchema extends z.ZodRawShape,
   TDeletingSchema extends z.ZodRawShape,
 >(
   conn: DBConnection,
-  repoCfg: RepositoryConfig<TSchema> & {
-    deleting?: DeletingConfig<TDeletingSchema>;
+  repoCfg: RepositoryConfig<TTable, TSchema> & {
+    deleting?: DeletingConfig<TTable, TSchema, TDeletingSchema>;
   }
 ): BaseRepository<z.infer<z.ZodObject<TSchema>>> &
   Partial<DeletingRepository<z.infer<z.ZodObject<TDeletingSchema>>>> {
@@ -82,10 +107,7 @@ export function createRepository<
       try {
         const cs = buildColumnSet(pgp, tableName, schema);
         await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          generateStagingDeleteQuery(tableName, keyColumns as any)
-        );
+        await t.none(generateStagingDeleteQuery(tableName, keyColumns));
       } catch (error: unknown) {
         throw genericInternalError(
           `Error inserting into staging table ${stagingTableName}: ${error}`
@@ -99,8 +121,7 @@ export function createRepository<
           schema,
           schemaName,
           tableName,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          keyColumns as any
+          keyColumns
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {
@@ -156,12 +177,10 @@ export function createRepository<
           schemaName,
           tableName,
           deletingTableName,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          effectiveDeletingKeyColumns as any,
+          effectiveDeletingKeyColumns,
           useIdAsSourceDeleteKey,
           physicalDelete,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          additionalKeysToUpdate as any
+          additionalKeysToUpdate
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {

--- a/packages/domains-analytics-writer/src/repository/delegation/delegation.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/delegation/delegation.repository.ts
@@ -1,62 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import { DelegationSchema } from "pagopa-interop-kpi-models";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
+import { createRepository } from "../createRepository.js";
 import { DelegationDbTable } from "../../model/db/index.js";
+import { DelegationSchema } from "pagopa-interop-kpi-models";
 
-export function delegationRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = DelegationDbTable.delegation;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: DelegationSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, DelegationSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          DelegationSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const delegationRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: DelegationDbTable.delegation,
+    schema: DelegationSchema,
+    keyColumns: ["id"],
+  });

--- a/packages/domains-analytics-writer/src/repository/delegation/delegationContractDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/delegation/delegationContractDocument.repository.ts
@@ -1,68 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import { DelegationContractDocumentSchema } from "pagopa-interop-kpi-models";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
+import { createRepository } from "../createRepository.js";
 import { DelegationDbTable } from "../../model/db/index.js";
+import { DelegationContractDocumentSchema } from "pagopa-interop-kpi-models";
 
-export function delegationContractDocumentRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = DelegationDbTable.delegation_contract_document;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: DelegationContractDocumentSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          DelegationContractDocumentSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["delegationId", "kind"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          DelegationContractDocumentSchema,
-          schemaName,
-          tableName,
-          ["delegationId", "kind"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const delegationContractDocumentRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: DelegationDbTable.delegation_contract_document,
+    schema: DelegationContractDocumentSchema,
+    keyColumns: ["delegationId", "kind"],
+  });

--- a/packages/domains-analytics-writer/src/repository/delegation/delegationSignedContractDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/delegation/delegationSignedContractDocument.repository.ts
@@ -1,68 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
+import { createRepository } from "../createRepository.js";
 import { DelegationDbTable } from "../../model/db/index.js";
 import { DelegationSignedContractDocumentSchema } from "pagopa-interop-kpi-models";
 
-export function delegationSignedContractDocumentRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = DelegationDbTable.delegation_signed_contract_document;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: DelegationSignedContractDocumentSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          DelegationSignedContractDocumentSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["delegationId", "kind"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          DelegationSignedContractDocumentSchema,
-          schemaName,
-          tableName,
-          ["delegationId", "kind"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const delegationSignedContractDocumentRepository = (
+  conn: DBConnection
+) =>
+  createRepository(conn, {
+    tableName: DelegationDbTable.delegation_signed_contract_document,
+    schema: DelegationSignedContractDocumentSchema,
+    keyColumns: ["delegationId", "kind"],
+  });

--- a/packages/domains-analytics-writer/src/repository/delegation/delegationStamp.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/delegation/delegationStamp.repository.ts
@@ -1,64 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import { DelegationStampSchema } from "pagopa-interop-kpi-models";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
+import { createRepository } from "../createRepository.js";
 import { DelegationDbTable } from "../../model/db/index.js";
+import { DelegationStampSchema } from "pagopa-interop-kpi-models";
 
-export function delegationStampRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = DelegationDbTable.delegation_stamp;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: DelegationStampSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, DelegationStampSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["delegationId", "kind"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          DelegationStampSchema,
-          schemaName,
-          tableName,
-          ["delegationId", "kind"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const delegationStampRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: DelegationDbTable.delegation_stamp,
+    schema: DelegationStampSchema,
+    keyColumns: ["delegationId", "kind"],
+  });

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplate.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplate.repository.ts
@@ -1,14 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateMergeDeleteQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import {
   EserviceTemplateDbTable,
   DeletingDbTable,
@@ -16,101 +8,14 @@ import {
 import { EserviceTemplateSchema } from "pagopa-interop-kpi-models";
 import { EserviceTemplateDeletingSchema } from "../../model/eserviceTemplate/eserviceTemplate.js";
 
-export function eserviceTemplateRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = EserviceTemplateDbTable.eservice_template;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.eservice_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, EserviceTemplateSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const eserviceTemplateRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: EserviceTemplateDbTable.eservice_template,
+    schema: EserviceTemplateSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.eservice_template_deleting_table,
+      deletingSchema: EserviceTemplateDeletingSchema,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceTemplateSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          EserviceTemplateDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          true,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateRiskAnalysis.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateRiskAnalysis.repository.ts
@@ -1,67 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-
+import { createRepository } from "../createRepository.js";
 import { EserviceTemplateDbTable } from "../../model/db/index.js";
 import { EserviceTemplateRiskAnalysisSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceTemplateRiskAnalysisRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = EserviceTemplateDbTable.eservice_template_risk_analysis;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateRiskAnalysisSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceTemplateRiskAnalysisSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceTemplateRiskAnalysisSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const eserviceTemplateRiskAnalysisRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: EserviceTemplateDbTable.eservice_template_risk_analysis,
+    schema: EserviceTemplateRiskAnalysisSchema,
+    keyColumns: ["id"],
+  });

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateRiskAnalysisAnswer.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateRiskAnalysisAnswer.repository.ts
@@ -1,70 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-
+import { createRepository } from "../createRepository.js";
 import { EserviceTemplateDbTable } from "../../model/db/index.js";
 import { EserviceTemplateRiskAnalysisAnswerSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceTemplateRiskAnalysisAnswerRepository(
+export const eserviceTemplateRiskAnalysisAnswerRepository = (
   conn: DBConnection
-) {
-  const schemaName = config.dbSchemaName;
-  const tableName =
-    EserviceTemplateDbTable.eservice_template_risk_analysis_answer;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateRiskAnalysisAnswerSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceTemplateRiskAnalysisAnswerSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceTemplateRiskAnalysisAnswerSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+) =>
+  createRepository(conn, {
+    tableName: EserviceTemplateDbTable.eservice_template_risk_analysis_answer,
+    schema: EserviceTemplateRiskAnalysisAnswerSchema,
+    keyColumns: ["id"],
+  });

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersion.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersion.repository.ts
@@ -1,67 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-
+import { createRepository } from "../createRepository.js";
 import { EserviceTemplateDbTable } from "../../model/db/index.js";
 import { EserviceTemplateVersionSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceTemplateVersionRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = EserviceTemplateDbTable.eservice_template_version;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateVersionSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceTemplateVersionSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceTemplateVersionSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const eserviceTemplateVersionRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: EserviceTemplateDbTable.eservice_template_version,
+    schema: EserviceTemplateVersionSchema,
+    keyColumns: ["id"],
+  });

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionAttribute.repository.ts
@@ -1,73 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { EserviceTemplateDbTable } from "../../model/db/index.js";
 import { EserviceTemplateVersionAttributeSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceTemplateVersionAttributeRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = EserviceTemplateDbTable.eservice_template_version_attribute;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateVersionAttributeSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceTemplateVersionAttributeSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-
-        await t.none(
-          generateStagingDeleteQuery(tableName, [
-            "attributeId",
-            "versionId",
-            "groupId",
-          ])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceTemplateVersionAttributeSchema,
-          schemaName,
-          tableName,
-          ["attributeId", "versionId", "groupId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const eserviceTemplateVersionAttributeRepository = (
+  conn: DBConnection
+) =>
+  createRepository(conn, {
+    tableName: EserviceTemplateDbTable.eservice_template_version_attribute,
+    schema: EserviceTemplateVersionAttributeSchema,
+    keyColumns: ["attributeId", "versionId", "groupId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionDocument.repository.ts
@@ -1,66 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { EserviceTemplateDbTable } from "../../model/db/index.js";
 import { EserviceTemplateVersionDocumentSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceTemplateVersionDocumentRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = EserviceTemplateDbTable.eservice_template_version_document;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateVersionDocumentSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceTemplateVersionDocumentSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceTemplateVersionDocumentSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const eserviceTemplateVersionDocumentRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: EserviceTemplateDbTable.eservice_template_version_document,
+    schema: EserviceTemplateVersionDocumentSchema,
+    keyColumns: ["id"],
+  });

--- a/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionInterface.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/eserviceTemplate/eserviceTemplateVersionInterface.repository.ts
@@ -1,67 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-
+import { createRepository } from "../createRepository.js";
 import { EserviceTemplateDbTable } from "../../model/db/index.js";
 import { EserviceTemplateVersionInterfaceSchema } from "pagopa-interop-kpi-models";
 
-export function eserviceTemplateVersionInterfaceRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = EserviceTemplateDbTable.eservice_template_version_interface;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: EserviceTemplateVersionInterfaceSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          EserviceTemplateVersionInterfaceSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          EserviceTemplateVersionInterfaceSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const eserviceTemplateVersionInterfaceRepository = (
+  conn: DBConnection
+) =>
+  createRepository(conn, {
+    tableName: EserviceTemplateDbTable.eservice_template_version_interface,
+    schema: EserviceTemplateVersionInterfaceSchema,
+    keyColumns: ["id"],
+  });

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychain.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychain.repository.ts
@@ -1,116 +1,22 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
+import { createRepository } from "../createRepository.js";
 import {
-  buildColumnSet,
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import {
-  DeletingDbTable,
   ProducerKeychainDbTable,
+  DeletingDbTable,
 } from "../../model/db/index.js";
 import { ProducerKeychainSchema } from "pagopa-interop-kpi-models";
 import { ProducerKeychainDeletingSchema } from "../../model/authorization/producerKeychain.js";
 
-export function producerKeychainRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = ProducerKeychainDbTable.producer_keychain;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.producer_keychain_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ProducerKeychainSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, ProducerKeychainSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const producerKeychainRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: ProducerKeychainDbTable.producer_keychain,
+    schema: ProducerKeychainSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.producer_keychain_deleting_table,
+      deletingSchema: ProducerKeychainDeletingSchema,
+      useIdAsSourceDeleteKey: false,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          ProducerKeychainSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ProducerKeychainDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          ProducerKeychainDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          false,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deletion flag from ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainEService.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainEService.repository.ts
@@ -1,73 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-
+import { createRepository } from "../createRepository.js";
 import { ProducerKeychainDbTable } from "../../model/db/index.js";
-
 import { ProducerKeychainEServiceSchema } from "pagopa-interop-kpi-models";
 
-export function producerKeychainEServiceRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = ProducerKeychainDbTable.producer_keychain_eservice;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ProducerKeychainEServiceSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          ProducerKeychainEServiceSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, [
-            "producerKeychainId",
-            "eserviceId",
-          ])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          ProducerKeychainEServiceSchema,
-          schemaName,
-          tableName,
-          ["producerKeychainId", "eserviceId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const producerKeychainEServiceRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: ProducerKeychainDbTable.producer_keychain_eservice,
+    schema: ProducerKeychainEServiceSchema,
+    keyColumns: ["producerKeychainId", "eserviceId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainUser.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/producerKeychain/producerKeychainUser.repository.ts
@@ -1,68 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-
+import { createRepository } from "../createRepository.js";
 import { ProducerKeychainDbTable } from "../../model/db/index.js";
 import { ProducerKeychainUserSchema } from "pagopa-interop-kpi-models";
 
-export function producerKeychainUserRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = ProducerKeychainDbTable.producer_keychain_user;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: ProducerKeychainUserSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, ProducerKeychainUserSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, [
-            "producerKeychainId",
-            "userId",
-          ])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          ProducerKeychainUserSchema,
-          schemaName,
-          tableName,
-          ["producerKeychainId", "userId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const producerKeychainUserRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: ProducerKeychainDbTable.producer_keychain_user,
+    schema: ProducerKeychainUserSchema,
+    keyColumns: ["producerKeychainId", "userId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/purpose/purpose.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purpose/purpose.repository.ts
@@ -1,115 +1,19 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { ITask, IMain } from "pg-promise";
-import { genericInternalError } from "pagopa-interop-models";
-
 import { DBConnection } from "../../db/db.js";
-import {
-  generateMergeQuery,
-  generateMergeDeleteQuery,
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
+import { PurposeDbTable } from "../../model/db/purpose.js";
+import { DeletingDbTable } from "../../model/db/deleting.js";
 import { PurposeSchema } from "pagopa-interop-kpi-models";
 import { PurposeDeletingSchema } from "../../model/purpose/purpose.js";
-import { DeletingDbTable } from "../../model/db/deleting.js";
-import { PurposeDbTable } from "../../model/db/index.js";
 
-export function purposeRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeDbTable.purpose;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.purpose_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, PurposeSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const purposeRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: PurposeDbTable.purpose,
+    schema: PurposeSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.purpose_deleting_table,
+      deletingSchema: PurposeDeletingSchema,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          PurposeDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          true,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/purpose/purposeRiskAnalysisAnswer.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purpose/purposeRiskAnalysisAnswer.repository.ts
@@ -1,69 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
 import { DBConnection } from "../../db/db.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { PurposeRiskAnalysisAnswerSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { PurposeDbTable } from "../../model/db/index.js";
+import { PurposeRiskAnalysisAnswerSchema } from "pagopa-interop-kpi-models";
 
-export function purposeRiskAnalysisAnswerRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeDbTable.purpose_risk_analysis_answer;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeRiskAnalysisAnswerSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          PurposeRiskAnalysisAnswerSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["id", "purposeId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeRiskAnalysisAnswerSchema,
-          schemaName,
-          tableName,
-          ["id", "purposeId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const purposeRiskAnalysisAnswerRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: PurposeDbTable.purpose_risk_analysis_answer,
+    schema: PurposeRiskAnalysisAnswerSchema,
+    keyColumns: ["id", "purposeId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/purpose/purposeRiskAnalysisForm.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purpose/purposeRiskAnalysisForm.repository.ts
@@ -1,69 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
 import { DBConnection } from "../../db/db.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { PurposeRiskAnalysisFormSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { PurposeDbTable } from "../../model/db/index.js";
+import { PurposeRiskAnalysisFormSchema } from "pagopa-interop-kpi-models";
 
-export function purposeRiskAnalysisFormRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeDbTable.purpose_risk_analysis_form;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeRiskAnalysisFormSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          PurposeRiskAnalysisFormSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["id", "purposeId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeRiskAnalysisFormSchema,
-          schemaName,
-          tableName,
-          ["id", "purposeId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const purposeRiskAnalysisFormRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: PurposeDbTable.purpose_risk_analysis_form,
+    schema: PurposeRiskAnalysisFormSchema,
+    keyColumns: ["id", "purposeId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/purpose/purposeVersion.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purpose/purposeVersion.repository.ts
@@ -1,116 +1,19 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import {
-  generateMergeQuery,
-  generateMergeDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
+import { createRepository } from "../createRepository.js";
+import { PurposeDbTable } from "../../model/db/purpose.js";
+import { DeletingDbTable } from "../../model/db/deleting.js";
 import { PurposeVersionSchema } from "pagopa-interop-kpi-models";
 import { PurposeVersionDeletingSchema } from "../../model/purpose/purposeVersion.js";
-import { DeletingDbTable, PurposeDbTable } from "../../model/db/index.js";
 
-export function purposeVersionRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeDbTable.purpose_version;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.purpose_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeVersionSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, PurposeVersionSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const purposeVersionRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: PurposeDbTable.purpose_version,
+    schema: PurposeVersionSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.purpose_deleting_table,
+      deletingSchema: PurposeVersionDeletingSchema,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeVersionSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeVersionDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          PurposeVersionDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          true,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/purpose/purposeVersionDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purpose/purposeVersionDocument.repository.ts
@@ -1,65 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
 import { DBConnection } from "../../db/db.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
+import { createRepository } from "../createRepository.js";
+import { PurposeDbTable } from "../../model/db/index.js";
 import { PurposeVersionDocumentSchema } from "pagopa-interop-kpi-models";
-import { PurposeDbTable } from "../../model/db/purpose.js";
 
-export function purposeVersionDocumentRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeDbTable.purpose_version_document;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeVersionDocumentSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, PurposeVersionDocumentSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["id", "purposeVersionId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeVersionDocumentSchema,
-          schemaName,
-          tableName,
-          ["id", "purposeVersionId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const purposeVersionDocumentRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: PurposeDbTable.purpose_version_document,
+    schema: PurposeVersionDocumentSchema,
+    keyColumns: ["id", "purposeVersionId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/purpose/purposeVersionSignedDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purpose/purposeVersionSignedDocument.repository.ts
@@ -1,69 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-
-import { genericInternalError } from "pagopa-interop-models";
-import { ITask, IMain } from "pg-promise";
-import { config } from "../../config/config.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
 import { DBConnection } from "../../db/db.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { PurposeDbTable } from "../../model/db/purpose.js";
+import { createRepository } from "../createRepository.js";
+import { PurposeDbTable } from "../../model/db/index.js";
 import { PurposeVersionSignedDocumentSchema } from "pagopa-interop-kpi-models";
 
-export function purposeVersionSignedDocumentRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeDbTable.purpose_version_signed_document;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeVersionSignedDocumentSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          PurposeVersionSignedDocumentSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["id", "purposeVersionId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeVersionSignedDocumentSchema,
-          schemaName,
-          tableName,
-          ["id", "purposeVersionId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const purposeVersionSignedDocumentRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: PurposeDbTable.purpose_version_signed_document,
+    schema: PurposeVersionSignedDocumentSchema,
+    keyColumns: ["id", "purposeVersionId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/purpose/purposeVersionStamp.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purpose/purposeVersionStamp.repository.ts
@@ -1,64 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { ITask, IMain } from "pg-promise";
-import { genericInternalError } from "pagopa-interop-models";
-import { PurposeDbTable } from "../../model/db/index.js";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { generateMergeQuery } from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
+import { PurposeDbTable } from "../../model/db/index.js";
 import { PurposeVersionStampSchema } from "pagopa-interop-kpi-models";
 
-export function purposeVersionStampRepo(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeDbTable.purpose_version_stamp;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeVersionStampSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, PurposeVersionStampSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["purposeVersionId", "kind"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeVersionStampSchema,
-          schemaName,
-          tableName,
-          ["purposeVersionId", "kind"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const purposeVersionStampRepo = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: PurposeDbTable.purpose_version_stamp,
+    schema: PurposeVersionStampSchema,
+    keyColumns: ["purposeVersionId", "kind"],
+  });

--- a/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplate.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplate.repository.ts
@@ -1,116 +1,21 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
+import { createRepository } from "../createRepository.js";
 import {
-  buildColumnSet,
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+  PurposeTemplateDbTable,
+  DeletingDbTable,
+} from "../../model/db/index.js";
 import { PurposeTemplateSchema } from "pagopa-interop-kpi-models";
 import { PurposeTemplateDeletingSchema } from "../../model/purposeTemplate/purposeTemplate.js";
-import {
-  DeletingDbTable,
-  PurposeTemplateDbTable,
-} from "../../model/db/index.js";
 
-export function purposeTemplateRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeTemplateDbTable.purpose_template;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.purpose_template_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeTemplateSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, PurposeTemplateSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const purposeTemplateRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: PurposeTemplateDbTable.purpose_template,
+    schema: PurposeTemplateSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.purpose_template_deleting_table,
+      deletingSchema: PurposeTemplateDeletingSchema,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeTemplateSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeTemplateDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          PurposeTemplateDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          true,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateEServiceDescriptor.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateEServiceDescriptor.repository.ts
@@ -1,128 +1,26 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
+import { createRepository } from "../createRepository.js";
 import {
-  buildColumnSet,
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import {
-  DeletingDbTable,
   PurposeTemplateDbTable,
+  DeletingDbTable,
 } from "../../model/db/index.js";
 import { PurposeTemplateEServiceDescriptorSchema } from "pagopa-interop-kpi-models";
 import { PurposeTemplateEServiceDescriptorDeletingSchema } from "../../model/purposeTemplate/purposeTemplateEserviceDescriptor.js";
 
-export function purposeTemplateEServiceDescriptorRepository(
+export const purposeTemplateEServiceDescriptorRepository = (
   conn: DBConnection
-) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeTemplateDbTable.purpose_template_eservice_descriptor;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName =
-    DeletingDbTable.purpose_template_eservice_descriptor_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeTemplateEServiceDescriptorSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          PurposeTemplateEServiceDescriptorSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, [
-            "purposeTemplateId",
-            "eserviceId",
-          ])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+) =>
+  createRepository(conn, {
+    tableName: PurposeTemplateDbTable.purpose_template_eservice_descriptor,
+    schema: PurposeTemplateEServiceDescriptorSchema,
+    keyColumns: ["purposeTemplateId", "eserviceId"],
+    deleting: {
+      deletingTableName:
+        DeletingDbTable.purpose_template_eservice_descriptor_deleting_table,
+      deletingSchema: PurposeTemplateEServiceDescriptorDeletingSchema,
+      deletingKeyColumns: ["purposeTemplateId", "eserviceId", "descriptorId"],
+      useIdAsSourceDeleteKey: false,
+      physicalDelete: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeTemplateEServiceDescriptorSchema,
-          schemaName,
-          tableName,
-          ["purposeTemplateId", "eserviceId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeTemplateEServiceDescriptorDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          PurposeTemplateEServiceDescriptorDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["purposeTemplateId", "eserviceId", "descriptorId"],
-          false,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateRiskAnalysisAnswer.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateRiskAnalysisAnswer.repository.ts
@@ -1,69 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { PurposeTemplateDbTable } from "../../model/db/index.js";
 import { PurposeTemplateRiskAnalysisAnswerSchema } from "pagopa-interop-kpi-models";
 
-export function purposeTemplateRiskAnalysisAnswerRepository(
+export const purposeTemplateRiskAnalysisAnswerRepository = (
   conn: DBConnection
-) {
-  const schemaName = config.dbSchemaName;
-  const tableName =
-    PurposeTemplateDbTable.purpose_template_risk_analysis_answer;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeTemplateRiskAnalysisAnswerSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          PurposeTemplateRiskAnalysisAnswerSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeTemplateRiskAnalysisAnswerSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+) =>
+  createRepository(conn, {
+    tableName: PurposeTemplateDbTable.purpose_template_risk_analysis_answer,
+    schema: PurposeTemplateRiskAnalysisAnswerSchema,
+    keyColumns: ["id"],
+  });

--- a/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotation.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotation.repository.ts
@@ -1,69 +1,15 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { PurposeTemplateDbTable } from "../../model/db/index.js";
 import { PurposeTemplateRiskAnalysisAnswerAnnotationSchema } from "pagopa-interop-kpi-models";
 
-export function purposeTemplateRiskAnalysisAnswerAnnotationRepository(
+export const purposeTemplateRiskAnalysisAnswerAnnotationRepository = (
   conn: DBConnection
-) {
-  const schemaName = config.dbSchemaName;
-  const tableName =
-    PurposeTemplateDbTable.purpose_template_risk_analysis_answer_annotation;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeTemplateRiskAnalysisAnswerAnnotationSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          PurposeTemplateRiskAnalysisAnswerAnnotationSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeTemplateRiskAnalysisAnswerAnnotationSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+) =>
+  createRepository(conn, {
+    tableName:
+      PurposeTemplateDbTable.purpose_template_risk_analysis_answer_annotation,
+    schema: PurposeTemplateRiskAnalysisAnswerAnnotationSchema,
+    keyColumns: ["id"],
+  });

--- a/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotationDocument.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotationDocument.repository.ts
@@ -1,69 +1,15 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { PurposeTemplateDbTable } from "../../model/db/index.js";
 import { PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema } from "pagopa-interop-kpi-models";
 
-export function purposeTemplateRiskAnalysisAnswerAnnotationDocumentRepository(
+export const purposeTemplateRiskAnalysisAnswerAnnotationDocumentRepository = (
   conn: DBConnection
-) {
-  const schemaName = config.dbSchemaName;
-  const tableName =
-    PurposeTemplateDbTable.purpose_template_risk_analysis_answer_annotation_document;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+) =>
+  createRepository(conn, {
+    tableName:
+      PurposeTemplateDbTable.purpose_template_risk_analysis_answer_annotation_document,
+    schema: PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema,
+    keyColumns: ["id"],
+  });

--- a/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateRiskAnalysisForm.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateRiskAnalysisForm.repository.ts
@@ -1,68 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
 import { PurposeTemplateDbTable } from "../../model/db/index.js";
 import { PurposeTemplateRiskAnalysisFormSchema } from "pagopa-interop-kpi-models";
 
-export function purposeTemplateRiskAnalysisFormRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = PurposeTemplateDbTable.purpose_template_risk_analysis_form;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: PurposeTemplateRiskAnalysisFormSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          PurposeTemplateRiskAnalysisFormSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["purposeTemplateId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          PurposeTemplateRiskAnalysisFormSchema,
-          schemaName,
-          tableName,
-          ["purposeTemplateId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const purposeTemplateRiskAnalysisFormRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: PurposeTemplateDbTable.purpose_template_risk_analysis_form,
+    schema: PurposeTemplateRiskAnalysisFormSchema,
+    keyColumns: ["purposeTemplateId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/tenant/tenant.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenant.repository.ts
@@ -4,7 +4,6 @@ import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
 import {
   buildColumnSet,
-  generateMergeDeleteQuery,
   generateMergeQuery,
   generateStagingDeleteQuery,
 } from "../../utils/sqlQueryHelper.js";
@@ -19,102 +18,28 @@ import {
   DeletingDbTable,
   TenantDbPartialTable,
 } from "../../model/db/index.js";
+import { createRepository } from "../createRepository.js";
 
 export function tenantRepository(conn: DBConnection) {
+  const base = createRepository(conn, {
+    tableName: TenantDbTable.tenant,
+    schema: TenantSchema,
+    keyColumns: ["id"],
+    deleting: {
+      deletingTableName: DeletingDbTable.tenant_deleting_table,
+      deletingSchema: TenantDeletingSchema,
+      physicalDelete: false,
+    },
+  });
+
   const schemaName = config.dbSchemaName;
   const tableName = TenantDbTable.tenant;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.tenant_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
   const tenantSelfcareUpsertTableName =
     TenantDbPartialTable.tenant_self_care_id;
   const stagingTenantSelfcareUpsertTableName = `${tenantSelfcareUpsertTableName}_${config.mergeTableSuffix}`;
 
   return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, TenantSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["id"]));
-      } catch (error) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          TenantSchema,
-          schemaName,
-          tableName,
-          ["id"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, deletingTableName, TenantDeletingSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id"],
-          true,
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
+    ...base,
 
     async insertTenantSelfcareId(
       t: ITask<unknown>,

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedAttribute.repository.ts
@@ -1,68 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import { TenantCertifiedAttributeSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { TenantDbTable } from "../../model/db/index.js";
+import { TenantCertifiedAttributeSchema } from "pagopa-interop-kpi-models";
 
-export function tenantCertifiedAttributeRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = TenantDbTable.tenant_certified_attribute;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantCertifiedAttributeSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          TenantCertifiedAttributeSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["attributeId", "tenantId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          TenantCertifiedAttributeSchema,
-          schemaName,
-          tableName,
-          ["attributeId", "tenantId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const tenantCertifiedAttributeRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: TenantDbTable.tenant_certified_attribute,
+    schema: TenantCertifiedAttributeSchema,
+    keyColumns: ["attributeId", "tenantId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantDeclaredAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantDeclaredAttribute.repository.ts
@@ -1,68 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import { TenantDeclaredAttributeSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { TenantDbTable } from "../../model/db/index.js";
+import { TenantDeclaredAttributeSchema } from "pagopa-interop-kpi-models";
 
-export function tenantDeclaredAttributeRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = TenantDbTable.tenant_declared_attribute;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantDeclaredAttributeSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          TenantDeclaredAttributeSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["attributeId", "tenantId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          TenantDeclaredAttributeSchema,
-          schemaName,
-          tableName,
-          ["attributeId", "tenantId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const tenantDeclaredAttributeRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: TenantDbTable.tenant_declared_attribute,
+    schema: TenantDeclaredAttributeSchema,
+    keyColumns: ["attributeId", "tenantId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantFeature.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantFeature.repository.ts
@@ -1,64 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import { TenantFeatureSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { TenantDbTable } from "../../model/db/index.js";
+import { TenantFeatureSchema } from "pagopa-interop-kpi-models";
 
-export function tenantFeatureRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = TenantDbTable.tenant_feature;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantFeatureSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, TenantFeatureSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["tenantId", "kind"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          TenantFeatureSchema,
-          schemaName,
-          tableName,
-          ["tenantId", "kind"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const tenantFeatureRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: TenantDbTable.tenant_feature,
+    schema: TenantFeatureSchema,
+    keyColumns: ["tenantId", "kind"],
+  });

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantMail.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantMail.repository.ts
@@ -1,114 +1,19 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeDeleteQuery,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
+import { createRepository } from "../createRepository.js";
+import { TenantDbTable, DeletingDbTable } from "../../model/db/index.js";
 import { TenantMailSchema } from "pagopa-interop-kpi-models";
 import { TenantMailDeletingSchema } from "../../model/tenant/tenantMail.js";
-import { TenantDbTable, DeletingDbTable } from "../../model/db/index.js";
 
-export function tenantMailRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = TenantDbTable.tenant_mail;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-  const deletingTableName = DeletingDbTable.tenant_mail_deleting_table;
-  const stagingDeletingTableName = `${deletingTableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantMailSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(pgp, tableName, TenantMailSchema);
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["id", "tenantId", "createdAt"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
+export const tenantMailRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: TenantDbTable.tenant_mail,
+    schema: TenantMailSchema,
+    keyColumns: ["id", "tenantId", "createdAt"],
+    deleting: {
+      deletingTableName: DeletingDbTable.tenant_mail_deleting_table,
+      deletingSchema: TenantMailDeletingSchema,
+      deletingKeyColumns: ["id", "tenantId"],
+      useIdAsSourceDeleteKey: false,
     },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          TenantMailSchema,
-          schemaName,
-          tableName,
-          ["id", "tenantId", "createdAt"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async insertDeleting(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantMailDeletingSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          deletingTableName,
-          TenantMailDeletingSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into deleting table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-
-    async mergeDeleting(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeDeleteQuery(
-          schemaName,
-          tableName,
-          deletingTableName,
-          ["id", "tenantId"],
-          false
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging deleting table ${stagingDeletingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async cleanDeleting(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingDeletingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning deleting staging table ${stagingDeletingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+  });

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantVerifiedAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantVerifiedAttribute.repository.ts
@@ -1,68 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-import { TenantVerifiedAttributeSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { TenantDbTable } from "../../model/db/index.js";
+import { TenantVerifiedAttributeSchema } from "pagopa-interop-kpi-models";
 
-export function tenantVerifiedAttributeRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = TenantDbTable.tenant_verified_attribute;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantVerifiedAttributeSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          TenantVerifiedAttributeSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, ["attributeId", "tenantId"])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          TenantVerifiedAttributeSchema,
-          schemaName,
-          tableName,
-          ["attributeId", "tenantId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const tenantVerifiedAttributeRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: TenantDbTable.tenant_verified_attribute,
+    schema: TenantVerifiedAttributeSchema,
+    keyColumns: ["attributeId", "tenantId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantVerifiedAttributeRevoker.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantVerifiedAttributeRevoker.repository.ts
@@ -1,72 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-
-import { TenantVerifiedAttributeRevokerSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { TenantDbTable } from "../../model/db/index.js";
+import { TenantVerifiedAttributeRevokerSchema } from "pagopa-interop-kpi-models";
 
-export function tenantVerifiedAttributeRevokerRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = TenantDbTable.tenant_verified_attribute_revoker;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantVerifiedAttributeRevokerSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          TenantVerifiedAttributeRevokerSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, [
-            "tenantId",
-            "tenantVerifiedAttributeId",
-          ])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          TenantVerifiedAttributeRevokerSchema,
-          schemaName,
-          tableName,
-          ["tenantId", "tenantVerifiedAttributeId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const tenantVerifiedAttributeRevokerRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: TenantDbTable.tenant_verified_attribute_revoker,
+    schema: TenantVerifiedAttributeRevokerSchema,
+    keyColumns: ["tenantId", "tenantVerifiedAttributeId"],
+  });

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantVerifiedAttributeVerifier.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantVerifiedAttributeVerifier.repository.ts
@@ -1,72 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { genericInternalError } from "pagopa-interop-models";
-import { IMain, ITask } from "pg-promise";
 import { DBConnection } from "../../db/db.js";
-import {
-  buildColumnSet,
-  generateMergeQuery,
-  generateStagingDeleteQuery,
-} from "../../utils/sqlQueryHelper.js";
-import { config } from "../../config/config.js";
-
-import { TenantVerifiedAttributeVerifierSchema } from "pagopa-interop-kpi-models";
+import { createRepository } from "../createRepository.js";
 import { TenantDbTable } from "../../model/db/index.js";
+import { TenantVerifiedAttributeVerifierSchema } from "pagopa-interop-kpi-models";
 
-export function tenantVerifiedAttributeVerifierRepository(conn: DBConnection) {
-  const schemaName = config.dbSchemaName;
-  const tableName = TenantDbTable.tenant_verified_attribute_verifier;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
-
-  return {
-    async insert(
-      t: ITask<unknown>,
-      pgp: IMain,
-      records: TenantVerifiedAttributeVerifierSchema[]
-    ): Promise<void> {
-      try {
-        const cs = buildColumnSet(
-          pgp,
-          tableName,
-          TenantVerifiedAttributeVerifierSchema
-        );
-        await t.none(pgp.helpers.insert(records, cs));
-        await t.none(
-          generateStagingDeleteQuery(tableName, [
-            "tenantId",
-            "tenantVerifiedAttributeId",
-          ])
-        );
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error inserting into staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-
-    async merge(t: ITask<unknown>): Promise<void> {
-      try {
-        const mergeQuery = generateMergeQuery(
-          TenantVerifiedAttributeVerifierSchema,
-          schemaName,
-          tableName,
-          ["tenantId", "tenantVerifiedAttributeId"]
-        );
-        await t.none(mergeQuery);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
-        );
-      }
-    },
-
-    async clean(): Promise<void> {
-      try {
-        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
-      } catch (error: unknown) {
-        throw genericInternalError(
-          `Error cleaning staging table ${stagingTableName}: ${error}`
-        );
-      }
-    },
-  };
-}
+export const tenantVerifiedAttributeVerifierRepository = (conn: DBConnection) =>
+  createRepository(conn, {
+    tableName: TenantDbTable.tenant_verified_attribute_verifier,
+    schema: TenantVerifiedAttributeVerifierSchema,
+    keyColumns: ["tenantId", "tenantVerifiedAttributeId"],
+  });


### PR DESCRIPTION
## Summary

- Extract `createRepository` factory to eliminate ~4200 lines of duplicated boilerplate across 55 repository files in `domains-analytics-writer`
- Standard repos reduced from ~70-120 lines to ~12-20 lines of declarative configuration
- 4 repos with custom logic (eserviceDescriptor, eserviceDescriptorInterface, clientKey, tenant) use the factory for standard methods and spread custom methods on top
- Stacked on #3120: imports updated to use `pagopa-interop-kpi-models`