### PR TITLE
fix: scope dailyCalls assertion to strong tag to avoid UUID false positives

### DIFF
--- a/packages/email-notification-dispatcher/test/handleNewPurposeVersionWaitingForApprovalToConsumer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleNewPurposeVersionWaitingForApprovalToConsumer.test.ts
@@ -320,8 +320,8 @@ describe("handleNewPurposeVersionWaitingForApprovalOverthreshold", async () => {
 
     expect(messages.length).toBe(2);
     messages.forEach((message) => {
-      expect(message.email.body).toContain("2000");
-      expect(message.email.body).not.toContain("500");
+      expect(message.email.body).toContain("<strong>2000</strong>");
+      expect(message.email.body).not.toContain("<strong>500</strong>");
     });
   });
 });


### PR DESCRIPTION
## Jira Issue
N/A — no Jira key (test flakiness fix)

## Context/Why
The test `should use dailyCallsPerConsumer from the latest published descriptor` was asserting `not.toContain("500")` against the full HTML email body. Since UUIDs are hex-based (0-9, a-f), a randomly generated purposeId or selfcareId could contain the substring `500` inside the deeplink URL, causing a spurious failure ~1 every few hundred runs.

## Services Impacted
- email-notification-dispatcher (test only)

## Key Changes
- Replaced `toContain("2000")` / `not.toContain("500")` with `toContain("<strong>2000</strong>")` / `not.toContain("<strong>500</strong>")` so the assertion matches only the template-rendered value, which is always HTML-wrapped, never a raw UUID.

## Traceability Checklist
- [ ] Branch name contain the Jira key
- [x] PR title is compliant with the standard (type: descrizione (KEY))
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated