### PR TITLE
fix: fix remainingDailyCalls when threshold is retroactively reduced (PIN-9609)

### DIFF
--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -117,10 +117,6 @@ import {
   GetPurposesFilters as ReadModelGetPurposesFilters,
   ReadModelServiceSQL,
 } from "./readModelServiceSQL.js";
-
-type GetPurposesFilters = Omit<ReadModelGetPurposesFilters, "purposesIds"> & {
-  clientId?: ClientId;
-};
 import { riskAnalysisDocumentBuilder } from "./riskAnalysisDocumentBuilder.js";
 import {
   assertConsistentFreeOfCharge,
@@ -150,6 +146,10 @@ import {
   verifyRequesterIsConsumerOrDelegateConsumer,
   getUpdatedQuotas,
 } from "./validators.js";
+
+type GetPurposesFilters = Omit<ReadModelGetPurposesFilters, "purposesIds"> & {
+  clientId?: ClientId;
+};
 
 const retrievePurpose = async (
   purposeId: PurposeId,
@@ -2025,14 +2025,14 @@ export function purposeServiceBuilder(
         purpose.data.consumerId,
         readModelService
       );
-      const remainingDailyCallsPerConsumer = Math.max(
-        0,
-        quotas.maxDailyCallsPerConsumer - quotas.currentConsumerCalls
-      );
-      const remainingDailyCallsTotal = Math.max(
-        0,
-        quotas.maxDailyCallsTotal - quotas.currentTotalCalls
-      );
+      const remainingDailyCallsPerConsumer =
+        quotas.maxDailyCallsPerConsumer >= quotas.currentConsumerCalls
+          ? quotas.maxDailyCallsPerConsumer - quotas.currentConsumerCalls
+          : quotas.currentConsumerCalls;
+      const remainingDailyCallsTotal =
+        quotas.maxDailyCallsTotal >= quotas.currentTotalCalls
+          ? quotas.maxDailyCallsTotal - quotas.currentTotalCalls
+          : quotas.currentTotalCalls;
       return {
         remainingDailyCallsPerConsumer,
         remainingDailyCallsTotal,

--- a/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
+++ b/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
@@ -105,6 +105,52 @@ describe("getRemainingDailyCalls", () => {
     });
   });
 
+  it("should return the committed daily calls when the threshold was retroactively reduced below it", async () => {
+    const consumerId: TenantId = generateId();
+    const producerId: TenantId = generateId();
+    const eserviceId: EServiceId = generateId();
+
+    const descriptor = {
+      ...getMockDescriptor(descriptorState.published),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+    };
+    const eservice: EService = getMockEService(eserviceId, producerId, [
+      descriptor,
+    ]);
+    const agreement: Agreement = {
+      ...getMockAgreement(eservice.id, consumerId, agreementState.active),
+      descriptorId: descriptor.id,
+      producerId,
+    };
+
+    const consumerPurpose: Purpose = {
+      ...getMockPurpose([
+        {
+          ...getMockPurposeVersion(purposeVersionState.active),
+          dailyCalls: 5,
+        },
+      ]),
+      eserviceId: eservice.id,
+      consumerId,
+    };
+
+    await addOneTenant({ ...getMockTenant(consumerId) });
+    await addOneEService(eservice);
+    await addOneAgreement(agreement);
+    await addOnePurpose(consumerPurpose);
+
+    const result = await purposeService.getRemainingDailyCalls({
+      purposeId: consumerPurpose.id,
+      ctx: getMockContext({ authData: getMockAuthData(consumerId) }),
+    });
+
+    expect(result).toEqual({
+      remainingDailyCallsPerConsumer: 5,
+      remainingDailyCallsTotal: 995,
+    });
+  });
+
   it("should throw purposeNotFound if purpose does not exist", async () => {
     const consumerId: TenantId = generateId();
     const nonExistentPurposeId: PurposeId = generateId();


### PR DESCRIPTION
## Jira Issue
[PIN-9609](https://pagopa.atlassian.net/browse/PIN-9609)

## Context/Why
When a producer lowers `dailyCallsPerConsumer` on a certified attribute below what a consumer already has committed in active purpose versions, `getRemainingDailyCalls` was returning 0.

The bug was in the formula `Math.max(0, threshold - committed)`: when the threshold drops below already-committed calls, it floors to 0. But active purposes are not retroactively invalidated — a consumer who already holds N committed calls should still see those reflected in the remaining calls.

Fix: when `threshold < committed`, return `committed` instead of 0, preserving the consumer's existing approved capacity.

## Services Impacted
- `purpose-process` — `getRemainingDailyCalls` service method
- `backend-for-frontend` — `GET /purposes/:purposeId/remainingDailyCalls` endpoint

## Key Changes
- `purposeService.ts`: when the threshold has been retroactively reduced below committed calls, return `committed` (existing active purposes remain valid)
- `getRemainingDailyCalls.test.ts`: added regression test covering the exact scenario from the ticket (`dailyCallsPerConsumer: 1`, active purpose with `dailyCalls: 5` → expect `remainingDailyCallsPerConsumer: 5`)

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard (type: descrizione (KEY))
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated

[PIN-9609]: https://pagopa.atlassian.net/browse/PIN-9609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ