### PR TITLE
fix: fix remainingDailyCalls when certified attribute is revoked (PIN-9610)

### DIFF
--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -117,10 +117,6 @@ import {
   GetPurposesFilters as ReadModelGetPurposesFilters,
   ReadModelServiceSQL,
 } from "./readModelServiceSQL.js";
-
-type GetPurposesFilters = Omit<ReadModelGetPurposesFilters, "purposesIds"> & {
-  clientId?: ClientId;
-};
 import { riskAnalysisDocumentBuilder } from "./riskAnalysisDocumentBuilder.js";
 import {
   assertConsistentFreeOfCharge,
@@ -150,6 +146,10 @@ import {
   verifyRequesterIsConsumerOrDelegateConsumer,
   getUpdatedQuotas,
 } from "./validators.js";
+
+type GetPurposesFilters = Omit<ReadModelGetPurposesFilters, "purposesIds"> & {
+  clientId?: ClientId;
+};
 
 const retrievePurpose = async (
   purposeId: PurposeId,
@@ -2023,7 +2023,8 @@ export function purposeServiceBuilder(
       const quotas = await getUpdatedQuotas(
         eservice,
         purpose.data.consumerId,
-        readModelService
+        readModelService,
+        true
       );
       const remainingDailyCallsPerConsumer = Math.max(
         0,

--- a/packages/purpose-process/src/services/validators.ts
+++ b/packages/purpose-process/src/services/validators.ts
@@ -264,10 +264,25 @@ export async function isOverQuota(
   );
 }
 
+/**
+ * Returns the current quota usage and limits for a consumer on a given eservice.
+ *
+ * By default, revoked certified attributes are ignored when computing the
+ * daily call limit. This is correct when checking whether a new purpose can
+ * be activated: if an attribute is revoked, the consumer no longer qualifies
+ * for the higher limit.
+ *
+ * Pass `includeRevokedCertifiedAttributes = true` when showing how many calls
+ * are still available for purposes that are already active. In that case the
+ * revoked attribute must still count, because the purpose was legitimately
+ * activated when the attribute was valid and its capacity should not suddenly
+ * drop to zero.
+ */
 export async function getUpdatedQuotas(
   eservice: EService,
   consumerId: TenantId,
-  readModelService: ReadModelServiceSQL
+  readModelService: ReadModelServiceSQL,
+  includeRevokedCertifiedAttributes = false
 ): Promise<UpdatedQuotas> {
   const allPurposes = await readModelService.getAllPurposes({
     eservicesIds: [eservice.id],
@@ -316,7 +331,8 @@ export async function getUpdatedQuotas(
     tenant.attributes
       .filter(
         (a) =>
-          a.type === tenantAttributeType.CERTIFIED && !a.revocationTimestamp
+          a.type === tenantAttributeType.CERTIFIED &&
+          (includeRevokedCertifiedAttributes || !a.revocationTimestamp)
       )
       .map((a) => a.id)
   );

--- a/packages/purpose-process/src/services/validators.ts
+++ b/packages/purpose-process/src/services/validators.ts
@@ -264,20 +264,6 @@ export async function isOverQuota(
   );
 }
 
-/**
- * Returns the current quota usage and limits for a consumer on a given eservice.
- *
- * By default, revoked certified attributes are ignored when computing the
- * daily call limit. This is correct when checking whether a new purpose can
- * be activated: if an attribute is revoked, the consumer no longer qualifies
- * for the higher limit.
- *
- * Pass `includeRevokedCertifiedAttributes = true` when showing how many calls
- * are still available for purposes that are already active. In that case the
- * revoked attribute must still count, because the purpose was legitimately
- * activated when the attribute was valid and its capacity should not suddenly
- * drop to zero.
- */
 export async function getUpdatedQuotas(
   eservice: EService,
   consumerId: TenantId,

--- a/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
+++ b/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   Agreement,
+  AttributeId,
   EService,
   EServiceId,
   Purpose,
@@ -11,6 +12,7 @@ import {
   descriptorState,
   generateId,
   purposeVersionState,
+  tenantAttributeType,
 } from "pagopa-interop-models";
 import {
   getMockAgreement,
@@ -102,6 +104,74 @@ describe("getRemainingDailyCalls", () => {
     expect(result).toEqual({
       remainingDailyCallsPerConsumer: 50,
       remainingDailyCallsTotal: 850,
+    });
+  });
+
+  it("should return remaining daily calls based on revoked certified attribute threshold", async () => {
+    const consumerId: TenantId = generateId();
+    const producerId: TenantId = generateId();
+    const eserviceId: EServiceId = generateId();
+    const attributeId: AttributeId = generateId();
+
+    const descriptor = {
+      ...getMockDescriptor(descriptorState.published),
+      dailyCallsPerConsumer: 10,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: attributeId,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 100,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = getMockEService(eserviceId, producerId, [
+      descriptor,
+    ]);
+    const agreement: Agreement = {
+      ...getMockAgreement(eservice.id, consumerId, agreementState.active),
+      descriptorId: descriptor.id,
+      producerId,
+    };
+    const consumerPurpose: Purpose = {
+      ...getMockPurpose([
+        {
+          ...getMockPurposeVersion(purposeVersionState.active),
+          dailyCalls: 11,
+        },
+      ]),
+      eserviceId: eservice.id,
+      consumerId,
+    };
+
+    await addOneTenant(
+      getMockTenant(consumerId, [
+        {
+          id: attributeId,
+          type: tenantAttributeType.CERTIFIED,
+          assignmentTimestamp: new Date(),
+          revocationTimestamp: new Date(),
+        },
+      ])
+    );
+    await addOneEService(eservice);
+    await addOneAgreement(agreement);
+    await addOnePurpose(consumerPurpose);
+
+    const result = await purposeService.getRemainingDailyCalls({
+      purposeId: consumerPurpose.id,
+      ctx: getMockContext({ authData: getMockAuthData(consumerId) }),
+    });
+
+    expect(result).toEqual({
+      remainingDailyCallsPerConsumer: 89,
+      remainingDailyCallsTotal: 989,
     });
   });
 


### PR DESCRIPTION
## Jira Issue
[PIN-9610](https://pagopa.atlassian.net/browse/PIN-9610)

## Context
- When a consumer's certified attribute is revoked, the `remainingDailyCallsPerConsumer` for already-active purposes drops to 0 instead of keeping the value computed at activation time.
- The root cause is that `getUpdatedQuotas` filtered out revoked attributes, so the per-consumer threshold fell back to the base descriptor value (10 in the reported scenario) which was lower than the already-committed calls (11), resulting in 0 remaining.

## Services Affected
- `purpose-process`

## Key Changes
- Added `includeRevokedCertifiedAttributes` flag to `getUpdatedQuotas` in `validators.ts`, defaulting to `false` (existing behavior for activation checks).
- `getRemainingDailyCalls` in `purposeService.ts` now calls `getUpdatedQuotas` with `true`, so revoked attributes still count when computing remaining calls for active purposes.
- Added regression test covering the revoked attribute scenario.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection updated (if required)

[PIN-9610]: https://pagopa.atlassian.net/browse/PIN-9610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ