### PR TITLE
fix: fix remaining daily calls 500 on suspended agreement (PIN-9637)

### DIFF
--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -117,10 +117,6 @@ import {
   GetPurposesFilters as ReadModelGetPurposesFilters,
   ReadModelServiceSQL,
 } from "./readModelServiceSQL.js";
-
-type GetPurposesFilters = Omit<ReadModelGetPurposesFilters, "purposesIds"> & {
-  clientId?: ClientId;
-};
 import { riskAnalysisDocumentBuilder } from "./riskAnalysisDocumentBuilder.js";
 import {
   assertConsistentFreeOfCharge,
@@ -150,6 +146,10 @@ import {
   verifyRequesterIsConsumerOrDelegateConsumer,
   getUpdatedQuotas,
 } from "./validators.js";
+
+type GetPurposesFilters = Omit<ReadModelGetPurposesFilters, "purposesIds"> & {
+  clientId?: ClientId;
+};
 
 const retrievePurpose = async (
   purposeId: PurposeId,
@@ -258,6 +258,21 @@ export const retrieveActiveAgreement = async (
     throw agreementNotFound(eserviceId, consumerId);
   }
   return activeAgreement;
+};
+
+const retrieveActiveOrSuspendedAgreement = async (
+  eserviceId: EServiceId,
+  consumerId: TenantId,
+  readModelService: ReadModelServiceSQL
+): Promise<Agreement> => {
+  const agreement = await readModelService.getActiveOrSuspendedAgreement(
+    eserviceId,
+    consumerId
+  );
+  if (agreement === undefined) {
+    throw agreementNotFound(eserviceId, consumerId);
+  }
+  return agreement;
 };
 
 const retrieveRiskAnalysis = (
@@ -2020,11 +2035,19 @@ export function purposeServiceBuilder(
         readModelService
       );
 
-      const quotas = await getUpdatedQuotas(
-        eservice,
+      const agreement = await retrieveActiveOrSuspendedAgreement(
+        purpose.data.eserviceId,
         purpose.data.consumerId,
         readModelService
       );
+
+      const quotas = await getUpdatedQuotas(
+        eservice,
+        purpose.data.consumerId,
+        agreement.descriptorId,
+        readModelService
+      );
+
       const remainingDailyCallsPerConsumer = Math.max(
         0,
         quotas.maxDailyCallsPerConsumer - quotas.currentConsumerCalls

--- a/packages/purpose-process/src/services/readModelServiceSQL.ts
+++ b/packages/purpose-process/src/services/readModelServiceSQL.ts
@@ -400,6 +400,23 @@ export function readModelServiceBuilderSQL({
         )
       )?.data;
     },
+    async getActiveOrSuspendedAgreement(
+      eserviceId: EServiceId,
+      consumerId: TenantId
+    ): Promise<Agreement | undefined> {
+      return (
+        await agreementReadModelServiceSQL.getAgreementByFilter(
+          and(
+            eq(agreementInReadmodelAgreement.eserviceId, eserviceId),
+            eq(agreementInReadmodelAgreement.consumerId, consumerId),
+            inArray(agreementInReadmodelAgreement.state, [
+              agreementState.active,
+              agreementState.suspended,
+            ])
+          )
+        )
+      )?.data;
+    },
     async getAllPurposes(
       filters: Pick<
         GetPurposesFilters,

--- a/packages/purpose-process/src/services/validators.ts
+++ b/packages/purpose-process/src/services/validators.ts
@@ -14,6 +14,7 @@ import {
   DelegationId,
   delegationKind,
   delegationState,
+  DescriptorId,
   EService,
   EServiceId,
   EServiceMode,
@@ -251,9 +252,16 @@ export async function isOverQuota(
   dailyCalls: number,
   readModelService: ReadModelServiceSQL
 ): Promise<boolean> {
+  const agreement = await retrieveActiveAgreement(
+    eservice.id,
+    purpose.consumerId,
+    readModelService
+  );
+
   const quotas = await getUpdatedQuotas(
     eservice,
     purpose.consumerId,
+    agreement.descriptorId,
     readModelService
   );
 
@@ -267,6 +275,7 @@ export async function isOverQuota(
 export async function getUpdatedQuotas(
   eservice: EService,
   consumerId: TenantId,
+  descriptorId: DescriptorId,
   readModelService: ReadModelServiceSQL
 ): Promise<UpdatedQuotas> {
   const allPurposes = await readModelService.getAllPurposes({
@@ -277,12 +286,6 @@ export async function getUpdatedQuotas(
 
   const consumerPurposes = allPurposes.filter(
     (p) => p.consumerId === consumerId
-  );
-
-  const agreement = await retrieveActiveAgreement(
-    eservice.id,
-    consumerId,
-    readModelService
   );
 
   const getActiveVersions = (purposes: Purpose[]): PurposeVersion[] =>
@@ -300,11 +303,11 @@ export async function getUpdatedQuotas(
   const allPurposesRequestsSum = aggregateDailyCalls(allPurposesActiveVersions);
 
   const currentDescriptor = eservice.descriptors.find(
-    (d) => d.id === agreement.descriptorId
+    (d) => d.id === descriptorId
   );
 
   if (!currentDescriptor) {
-    throw descriptorNotFound(eservice.id, agreement.descriptorId);
+    throw descriptorNotFound(eservice.id, descriptorId);
   }
 
   const tenant = await readModelService.getTenantById(consumerId);

--- a/packages/purpose-process/src/utilities/errorMappers.ts
+++ b/packages/purpose-process/src/utilities/errorMappers.ts
@@ -329,6 +329,11 @@ export const getRemainingDailyCallsErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)
-    .with("purposeNotFound", () => HTTP_STATUS_NOT_FOUND)
-    .with("tenantIsNotTheConsumer", () => HTTP_STATUS_FORBIDDEN)
+    .with("purposeNotFound", "eserviceNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with(
+      "tenantIsNotTheConsumer",
+      "tenantIsNotTheDelegatedConsumer",
+      () => HTTP_STATUS_FORBIDDEN
+    )
+    .with("agreementNotFound", () => HTTP_STATUS_BAD_REQUEST)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/purpose-process/test/api/getRemainingDailyCalls.test.ts
+++ b/packages/purpose-process/test/api/getRemainingDailyCalls.test.ts
@@ -7,8 +7,11 @@ import request from "supertest";
 import { purposeApi } from "pagopa-interop-api-clients";
 import { api, purposeService } from "../vitest.api.setup.js";
 import {
+  agreementNotFound,
+  eserviceNotFound,
   purposeNotFound,
   tenantIsNotTheConsumer,
+  tenantIsNotTheDelegatedConsumer,
 } from "../../src/model/domain/errors.js";
 import { remainingDailyCallsToApiRemainingDailyCalls } from "../../src/model/domain/apiConverter.js";
 
@@ -79,6 +82,18 @@ describe("API GET /purposes/{purposeId}/remainingDailyCalls test", () => {
     {
       error: tenantIsNotTheConsumer(generateId(), undefined),
       expectedStatus: 403,
+    },
+    {
+      error: agreementNotFound(generateId(), generateId()),
+      expectedStatus: 400,
+    },
+    {
+      error: tenantIsNotTheDelegatedConsumer(generateId(), undefined),
+      expectedStatus: 403,
+    },
+    {
+      error: eserviceNotFound(generateId()),
+      expectedStatus: 404,
     },
   ])(
     "Should return $expectedStatus for $error.code",

--- a/packages/purpose-process/test/api/validators.test.ts
+++ b/packages/purpose-process/test/api/validators.test.ts
@@ -284,7 +284,6 @@ describe("getUpdatedQuotas", () => {
   const consumerId = "consumer-id" as TenantId;
   const descriptorId = "descriptor-id" as DescriptorId;
   const producerId = "producer-id" as TenantId;
-  const agreementId = "agreement-id";
   const selfcareId = "selfcare-id";
   const attributeId = "attribute-id" as AttributeId;
 
@@ -325,34 +324,6 @@ describe("getUpdatedQuotas", () => {
     riskAnalysis: [],
   };
 
-  const agreement: Agreement = {
-    id: unsafeBrandId(agreementId),
-    eserviceId,
-    descriptorId,
-    producerId: eservice.producerId,
-    consumerId,
-    state: "Active",
-    verifiedAttributes: [],
-    certifiedAttributes: [],
-    declaredAttributes: [],
-    suspendedByConsumer: undefined,
-    suspendedByProducer: undefined,
-    suspendedByPlatform: undefined,
-    createdAt: new Date(),
-    updatedAt: undefined,
-    consumerDocuments: [],
-    stamps: {
-      submission: undefined,
-      activation: undefined,
-      rejection: undefined,
-      suspensionByProducer: undefined,
-      suspensionByConsumer: undefined,
-      upgrade: undefined,
-      archiving: undefined,
-    },
-    contract: undefined,
-  };
-
   const tenant: Tenant = {
     id: consumerId,
     kind: tenantKind.PA,
@@ -373,7 +344,6 @@ describe("getUpdatedQuotas", () => {
   });
 
   it("should return the correct updated quotas", async () => {
-    (retrieveActiveAgreement as Mock).mockResolvedValue(agreement);
     (mockReadModelService.getAllPurposes as Mock).mockResolvedValue([
       {
         consumerId,
@@ -392,6 +362,7 @@ describe("getUpdatedQuotas", () => {
     const result = await getUpdatedQuotas(
       eservice,
       consumerId,
+      descriptorId,
       mockReadModelService
     );
 
@@ -438,7 +409,6 @@ describe("getUpdatedQuotas", () => {
       ],
     };
 
-    (retrieveActiveAgreement as Mock).mockResolvedValue(agreement);
     (mockReadModelService.getAllPurposes as Mock).mockResolvedValue([]);
     (mockReadModelService.getTenantById as Mock).mockResolvedValue(
       tenantWithCertifiedAttributes
@@ -447,6 +417,7 @@ describe("getUpdatedQuotas", () => {
     const result = await getUpdatedQuotas(
       eserviceWithCertifiedAttributes,
       consumerId,
+      descriptorId,
       mockReadModelService
     );
 
@@ -459,33 +430,26 @@ describe("getUpdatedQuotas", () => {
   });
 
   it("should throw descriptorNotFound if the descriptor is not found", async () => {
-    const agreementWithInvalidDescriptor: Agreement = {
-      ...agreement,
-      descriptorId: "invalid-descriptor-id" as DescriptorId,
-    };
-    (retrieveActiveAgreement as Mock).mockResolvedValue(
-      agreementWithInvalidDescriptor
-    );
+    const invalidDescriptorId = "invalid-descriptor-id" as DescriptorId;
     (mockReadModelService.getAllPurposes as Mock).mockResolvedValue([]);
     (mockReadModelService.getTenantById as Mock).mockResolvedValue(tenant);
 
     await expect(
-      getUpdatedQuotas(eservice, consumerId, mockReadModelService)
-    ).rejects.toThrow(
-      descriptorNotFound(
-        eservice.id,
-        agreementWithInvalidDescriptor.descriptorId
+      getUpdatedQuotas(
+        eservice,
+        consumerId,
+        invalidDescriptorId,
+        mockReadModelService
       )
-    );
+    ).rejects.toThrow(descriptorNotFound(eservice.id, invalidDescriptorId));
   });
 
   it("should throw tenantNotFound if the tenant is not found", async () => {
-    (retrieveActiveAgreement as Mock).mockResolvedValue(agreement);
     (mockReadModelService.getAllPurposes as Mock).mockResolvedValue([]);
     (mockReadModelService.getTenantById as Mock).mockResolvedValue(undefined);
 
     await expect(
-      getUpdatedQuotas(eservice, consumerId, mockReadModelService)
+      getUpdatedQuotas(eservice, consumerId, descriptorId, mockReadModelService)
     ).rejects.toThrow(tenantNotFound(consumerId));
   });
 });

--- a/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
+++ b/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   Agreement,
+  AttributeId,
   EService,
   EServiceId,
   Purpose,
@@ -11,6 +12,8 @@ import {
   descriptorState,
   generateId,
   purposeVersionState,
+  tenantAttributeType,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import {
   getMockAgreement,
@@ -164,5 +167,80 @@ describe("getRemainingDailyCalls", () => {
     ).rejects.toThrowError(
       tenantIsNotTheConsumer(anotherConsumerId, undefined)
     );
+  });
+
+  it("should return remaining daily calls using base descriptor quota when the consumer agreement is suspended after certified attribute revocation", async () => {
+    const consumerId: TenantId = generateId();
+    const producerId: TenantId = generateId();
+    const eserviceId: EServiceId = generateId();
+    const certifiedAttributeId = unsafeBrandId<AttributeId>(generateId());
+
+    const descriptor = {
+      ...getMockDescriptor(descriptorState.published),
+      dailyCallsPerConsumer: 10,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttributeId,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 100,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+    const eservice: EService = getMockEService(eserviceId, producerId, [
+      descriptor,
+    ]);
+
+    const suspendedAgreement: Agreement = {
+      ...getMockAgreement(eservice.id, consumerId, agreementState.suspended),
+      descriptorId: descriptor.id,
+      producerId,
+    };
+
+    // Attribute has been revoked: revocationTimestamp is set
+    const consumerTenant = {
+      ...getMockTenant(consumerId),
+      attributes: [
+        {
+          id: certifiedAttributeId,
+          type: tenantAttributeType.CERTIFIED,
+          assignmentTimestamp: new Date(),
+          revocationTimestamp: new Date(),
+        },
+      ],
+    };
+
+    const consumerPurpose: Purpose = {
+      ...getMockPurpose([
+        {
+          ...getMockPurposeVersion(purposeVersionState.active),
+          dailyCalls: 11,
+        },
+      ]),
+      eserviceId: eservice.id,
+      consumerId,
+    };
+
+    await addOneTenant(consumerTenant);
+    await addOneEService(eservice);
+    await addOneAgreement(suspendedAgreement);
+    await addOnePurpose(consumerPurpose);
+
+    const result = await purposeService.getRemainingDailyCalls({
+      purposeId: consumerPurpose.id,
+      ctx: getMockContext({ authData: getMockAuthData(consumerId) }),
+    });
+
+    expect(result).toEqual({
+      remainingDailyCallsPerConsumer: 0,
+      remainingDailyCallsTotal: 989,
+    });
   });
 });


### PR DESCRIPTION
## Jira Issue
[PIN-9637](https://pagopa.atlassian.net/browse/PIN-9637)

## Context
`getUpdatedQuotas`, the function that calculates daily call quotas, was calling
`retrieveActiveAgreement` internally to find out which e-service descriptor the consumer
was bound to. This worked as long as the agreement was `active`, but caused a 500 error
when the agreement was `suspended`.

An agreement is automatically suspended when a required certified attribute is revoked from the
consumer tenant. After that state transition, calling `GET /purposes/{purposeId}/remainingDailyCalls`
returned a 500 Unexpected Error because `retrieveActiveAgreement` throws `agreementNotFound`
when the agreement is not exactly `active`, and moreover, that error was not mapped in
`getRemainingDailyCallsErrorMapper`.

The deeper issue was that `getUpdatedQuotas` was called from two places with different requirements:
- `isOverQuota`: runs during purpose activation/creation, where an active agreement is required
- `getRemainingDailyCalls`: a read-only informational operation, which should work even when the agreement is suspended

Having the agreement fetch inside `getUpdatedQuotas` made it impossible to satisfy both callers.

## Services Affected
- `purpose-process`

## Key Changes
- The agreement fetch has been moved out of `getUpdatedQuotas`. The function now receives
  `descriptorId: DescriptorId` as a parameter directly. It was the only piece of information
  it actually needed from the agreement.
- `isOverQuota` calls `retrieveActiveAgreement` (unchanged: quota enforcement requires an active
  agreement) and passes `agreement.descriptorId` to `getUpdatedQuotas`.
- `getRemainingDailyCalls` calls the new `retrieveActiveOrSuspendedAgreement` (accepts
  `active | suspended`) and passes `agreement.descriptorId` to `getUpdatedQuotas`.
- Added `retrieveActiveOrSuspendedAgreement` in `purposeService.ts`, which delegates to
  `readModelService.getActiveOrSuspendedAgreement` and throws `agreementNotFound` if no
  agreement is found.
- `getRemainingDailyCallsErrorMapper` now maps three previously unhandled errors:
  - `eserviceNotFound` → 404
  - `tenantIsNotTheDelegatedConsumer` → 403
  - `agreementNotFound` → 400


[PIN-9637]: https://pagopa.atlassian.net/browse/PIN-9637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ