### PR TITLE
fix: fix remaining daily calls 500 on suspended agreement (PIN-9637)

### DIFF
--- a/packages/purpose-process/src/utilities/errorMappers.ts
+++ b/packages/purpose-process/src/utilities/errorMappers.ts
@@ -329,6 +329,11 @@ export const getRemainingDailyCallsErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)
-    .with("purposeNotFound", () => HTTP_STATUS_NOT_FOUND)
-    .with("tenantIsNotTheConsumer", () => HTTP_STATUS_FORBIDDEN)
+    .with("purposeNotFound", "eserviceNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with(
+      "tenantIsNotTheConsumer",
+      "tenantIsNotTheDelegatedConsumer",
+      () => HTTP_STATUS_FORBIDDEN
+    )
+    .with("agreementNotFound", () => HTTP_STATUS_BAD_REQUEST)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/purpose-process/test/api/getRemainingDailyCalls.test.ts
+++ b/packages/purpose-process/test/api/getRemainingDailyCalls.test.ts
@@ -7,8 +7,11 @@ import request from "supertest";
 import { purposeApi } from "pagopa-interop-api-clients";
 import { api, purposeService } from "../vitest.api.setup.js";
 import {
+  agreementNotFound,
+  eserviceNotFound,
   purposeNotFound,
   tenantIsNotTheConsumer,
+  tenantIsNotTheDelegatedConsumer,
 } from "../../src/model/domain/errors.js";
 import { remainingDailyCallsToApiRemainingDailyCalls } from "../../src/model/domain/apiConverter.js";
 
@@ -79,6 +82,18 @@ describe("API GET /purposes/{purposeId}/remainingDailyCalls test", () => {
     {
       error: tenantIsNotTheConsumer(generateId(), undefined),
       expectedStatus: 403,
+    },
+    {
+      error: agreementNotFound(generateId(), generateId()),
+      expectedStatus: 400,
+    },
+    {
+      error: tenantIsNotTheDelegatedConsumer(generateId(), undefined),
+      expectedStatus: 403,
+    },
+    {
+      error: eserviceNotFound(generateId()),
+      expectedStatus: 404,
     },
   ])(
     "Should return $expectedStatus for $error.code",


### PR DESCRIPTION
## Jira Issue
[PIN-9637](https://pagopa.atlassian.net/browse/PIN-9637)

## Context
Calling `GET /purposes/{purposeId}/remainingDailyCalls` with a suspended agreement
returned a 500 error. The `agreementNotFound` error thrown by `retrieveActiveAgreement`
was not mapped in `getRemainingDailyCallsErrorMapper`.

## Services Affected
- `purpose-process`

## Key Changes
- `getRemainingDailyCallsErrorMapper` now maps previously unhandled errors:
  - `eserviceNotFound` → 404
  - `tenantIsNotTheDelegatedConsumer` → 403
  - `agreementNotFound` → 403 (suspended or missing agreement = Forbidden)

[PIN-9637]: https://pagopa.atlassian.net/browse/PIN-9637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ