### PR TITLE
PIN-9250: change error thrown when client with unexpected kind is ret…

### DIFF
--- a/packages/m2m-gateway-v3/src/model/errors.ts
+++ b/packages/m2m-gateway-v3/src/model/errors.ts
@@ -66,6 +66,7 @@ const errorCodes = {
   dpopProofJtiAlreadyUsed: "0044",
   dpopTokenBindingFailed: "0045",
   purposeVersionDocumentNotReady: "0046",
+  clientNotFound: "0047",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -265,6 +266,16 @@ export function unexpectedClientKind(
     detail: `Unexpected client kind "${client.kind}" for client ${client.id}`,
     code: "unexpectedClientKind",
     title: "Unexpected client kind",
+  });
+}
+
+export function clientNotFound(
+  client: authorizationApi.Client
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Client ${client.id} not found`,
+    code: "clientNotFound",
+    title: "Client not found",
   });
 }
 

--- a/packages/m2m-gateway-v3/src/routers/clientRouter.ts
+++ b/packages/m2m-gateway-v3/src/routers/clientRouter.ts
@@ -12,6 +12,7 @@ import { emptyErrorMapper, unsafeBrandId } from "pagopa-interop-models";
 import { makeApiProblem } from "../model/errors.js";
 import { ClientService } from "../services/clientService.js";
 import { fromM2MGatewayAppContext } from "../utils/context.js";
+import { getClientErrorMapper } from "../utils/errorMappers.js";
 
 const { M2M_ROLE, M2M_ADMIN_ROLE } = authRole;
 
@@ -72,7 +73,7 @@ const clientRouter = (
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
-          emptyErrorMapper,
+          getClientErrorMapper,
           ctx,
           `Error retrieving client with id ${req.params.clientId}`
         );

--- a/packages/m2m-gateway-v3/src/services/clientService.ts
+++ b/packages/m2m-gateway-v3/src/services/clientService.ts
@@ -4,7 +4,7 @@ import { authorizationApi, m2mGatewayApiV3 } from "pagopa-interop-api-clients";
 import { match } from "ts-pattern";
 import { PagoPAInteropBeClients } from "../clients/clientsProvider.js";
 import { M2MGatewayAppContext } from "../utils/context.js";
-import { clientAdminIdNotFound } from "../model/errors.js";
+import { clientAdminIdNotFound, clientNotFound } from "../model/errors.js";
 import { WithMaybeMetadata } from "../clients/zodiosWithMetadataPatch.js";
 import {
   isPolledVersionAtLeastResponseVersion,
@@ -90,7 +90,9 @@ export function clientServiceBuilder(clients: PagoPAInteropBeClients) {
       logger.info(`Retrieving client with id ${clientId}`);
 
       const client = await retrieveClientById(clientId, headers);
-
+      if (client.data.kind === authorizationApi.ClientKind.Values.API) {
+        throw clientNotFound(client.data);
+      }
       return toM2MGatewayApiConsumerClient(client.data);
     },
     async getClients(

--- a/packages/m2m-gateway-v3/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway-v3/src/utils/errorMappers.ts
@@ -318,3 +318,8 @@ export const getRemainingDailyCallsErrorMapper = (
   match(error.code)
     .with("purposeNotFound", () => HTTP_STATUS_NOT_FOUND)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const getClientErrorMapper = (error: ApiError<ErrorCodes>): number =>
+  match(error.code)
+    .with("clientNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/m2m-gateway-v3/test/api/clients/getClient.test.ts
+++ b/packages/m2m-gateway-v3/test/api/clients/getClient.test.ts
@@ -12,7 +12,7 @@ import { authorizationApi } from "pagopa-interop-api-clients";
 import { generateId } from "pagopa-interop-models";
 import { api, mockClientService } from "../../vitest.api.setup.js";
 import { appBasePath } from "../../../src/config/appBasePath.js";
-import { unexpectedClientKind } from "../../../src/model/errors.js";
+import { clientNotFound } from "../../../src/model/errors.js";
 import { toM2MGatewayApiConsumerClient } from "../../../src/api/clientApiConverter.js";
 
 describe("GET /clients/:clientId route test", () => {
@@ -107,15 +107,13 @@ describe("GET /clients/:clientId route test", () => {
     }
   );
 
-  it("Should return 500 in case of unexpectedClientKind error", async () => {
+  it("Should return 404 in case of clientNotFound error", async () => {
     mockClientService.getClient = vi
       .fn()
-      .mockRejectedValue(
-        unexpectedClientKind(getMockedApiConsumerFullClient())
-      );
+      .mockRejectedValue(clientNotFound(getMockedApiConsumerFullClient()));
     const token = generateToken(authRole.M2M_ADMIN_ROLE);
     const res = await makeRequest(token);
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/m2m-gateway-v3/test/integration/clients/getClient.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/clients/getClient.test.ts
@@ -12,7 +12,7 @@ import {
   mockInteropBeClients,
 } from "../../integrationUtils.js";
 import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
-import { unexpectedClientKind } from "../../../src/model/errors.js";
+import { clientNotFound } from "../../../src/model/errors.js";
 import { getMockM2MAdminAppContext } from "../../mockUtils.js";
 
 describe("getClient", () => {
@@ -84,7 +84,7 @@ describe("getClient", () => {
     });
   });
 
-  it("Should throw unexpectedClientKind in case the returned client has an unexpected kind", async () => {
+  it("Should throw clientNotFound in case the returned client is not an E-Service Client", async () => {
     const mockResponse = {
       ...mockPartialClientFromProcess,
       data: {
@@ -100,7 +100,7 @@ describe("getClient", () => {
         unsafeBrandId(mockPartialClientFromProcess.data.id),
         getMockM2MAdminAppContext()
       )
-    ).rejects.toThrowError(unexpectedClientKind(mockResponse.data));
+    ).rejects.toThrowError(clientNotFound(mockResponse.data));
 
     const mockResponsFull = {
       ...mockFullClientFromProcess,
@@ -117,6 +117,6 @@ describe("getClient", () => {
         unsafeBrandId(mockFullClientFromProcess.data.id),
         getMockM2MAdminAppContext()
       )
-    ).rejects.toThrowError(unexpectedClientKind(mockResponsFull.data));
+    ).rejects.toThrowError(clientNotFound(mockResponsFull.data));
   });
 });

--- a/packages/m2m-gateway/src/services/clientService.ts
+++ b/packages/m2m-gateway/src/services/clientService.ts
@@ -80,6 +80,7 @@ export function clientServiceBuilder(clients: PagoPAInteropBeClients) {
       logger.info(`Retrieving client with id ${clientId}`);
 
       const client = await retrieveClientById(clientId, headers);
+
       if (client.data.kind === authorizationApi.ClientKind.Values.API) {
         throw clientNotFound(client.data);
       }


### PR DESCRIPTION
connected to this pr: [PR-3050](https://github.com/pagopa/interop-be-monorepo/pull/3050)

for [PIN-9250](https://pagopa.atlassian.net/browse/PIN-9250)


This pull request updates the error handling for the client retrieval route in the M2M Gateway V3 service. 

The main change is introducing a specific error mapper for client-related errors, ensuring that the `unexpectedClientKind` error is triggered only when the clientKind is actually unexpected and in case the client kind is API now returns a 404 Not Found status instead of a generic 500 Internal Server Error. This improves the accuracy and clarity of API responses for client errors.

Error handling improvements:

* Added `getClientErrorMapper` to `packages/m2m-gateway/src/utils/errorMappers.ts`, mapping `clientNotFound` errors to HTTP 404 Not Found.
* Updated `clientRouter` in `packages/m2m-gateway/src/routers/clientRouter.ts` to use `getClientErrorMapper` instead of `emptyErrorMapper` for client error responses. 

Testing updates:

* Modified `GET /clients/:clientId` route tests in `packages/m2m-gateway-v3/test/api/clients/getClient.test.ts` to expect a 404 status for `clientNotFound` errors, reflecting the new error handling. 

[PIN-9250]: https://pagopa.atlassian.net/browse/PIN-9250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ