### PR TITLE
fix: block soap+bulk on descriptor create/update (PIN-9651)

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -62,7 +62,6 @@ import {
   AttributeKind,
   attributeKind,
   AsyncExchangeProperties,
-  technology,
 } from "pagopa-interop-models";
 import { match, P } from "ts-pattern";
 import { config } from "../config/config.js";
@@ -110,7 +109,6 @@ import {
   eServiceAsyncExchangeNotEnabled,
   descriptorAsyncExchangeNotConfigured,
   templateVersionMissingAsyncExchangeProperties,
-  asyncExchangeBulkNotAllowedForSoap,
 } from "../model/domain/errors.js";
 import { ApiGetEServicesFilters, Consumer } from "../model/domain/models.js";
 import {
@@ -711,13 +709,6 @@ async function innerAddDocumentToEserviceEvent(
 
     if (descriptor.asyncExchangeCallbackInterface !== undefined) {
       throw asyncExchangeCallbackInterfaceAlreadyExists(descriptor.id);
-    }
-
-    if (
-      eService.data.technology === technology.soap &&
-      descriptor.asyncExchangeProperties.bulk === true
-    ) {
-      throw asyncExchangeBulkNotAllowedForSoap(eService.data.id, descriptor.id);
     }
   }
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -193,6 +193,7 @@ import {
   assertUpdatedDescriptionDiffersFromCurrent,
   descriptorStatesNotAllowingInterfaceOperations,
   assertValidDelegationFlags,
+  assertAsyncExchangeBulkAllowedForDescriptor,
   assertAsyncExchangeReadyForPublication,
 } from "./validators.js";
 import type { ReadModelServiceSQL } from "./readModelServiceTypes.js";
@@ -1481,6 +1482,13 @@ export function catalogServiceBuilder(
               }
             : undefined,
       });
+
+      assertAsyncExchangeBulkAllowedForDescriptor(
+        eservice.data.technology,
+        newDescriptor.asyncExchangeProperties,
+        eservice.id,
+        newDescriptor.id
+      );
 
       const updatedEService: EService = {
         ...eservice.data,
@@ -4593,6 +4601,13 @@ async function updateDraftDescriptor(
         : descriptor.asyncExchangeProperties
       : descriptor.asyncExchangeProperties,
   };
+
+  assertAsyncExchangeBulkAllowedForDescriptor(
+    eservice.data.technology,
+    updatedDescriptor.asyncExchangeProperties,
+    eservice.id,
+    descriptor.id
+  );
 
   const updatedEService = replaceDescriptor(eservice.data, updatedDescriptor);
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1477,7 +1477,7 @@ export function catalogServiceBuilder(
       assertAsyncExchangeBulkAllowedForDescriptor(
         eservice.data.technology,
         newDescriptor.asyncExchangeProperties,
-        eservice.id,
+        eservice.data.id,
         newDescriptor.id
       );
 
@@ -1799,7 +1799,6 @@ export function catalogServiceBuilder(
         eservice.data.asyncExchange === true
       ) {
         assertAsyncExchangeReadyForPublication(
-          eservice.data.technology,
           descriptor,
           eserviceId,
           descriptorId
@@ -2931,7 +2930,6 @@ export function catalogServiceBuilder(
         eservice.data.asyncExchange === true
       ) {
         assertAsyncExchangeReadyForPublication(
-          eservice.data.technology,
           descriptor,
           eserviceId,
           descriptorId
@@ -4596,7 +4594,7 @@ async function updateDraftDescriptor(
   assertAsyncExchangeBulkAllowedForDescriptor(
     eservice.data.technology,
     updatedDescriptor.asyncExchangeProperties,
-    eservice.id,
+    eservice.data.id,
     descriptor.id
   );
 

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -13,6 +13,7 @@ import {
   validateRiskAnalysis,
 } from "pagopa-interop-commons";
 import {
+  AsyncExchangeProperties,
   Descriptor,
   DescriptorId,
   EService,
@@ -430,7 +431,7 @@ export function assertAsyncExchangeReadyForPublication(
 
 export function assertAsyncExchangeBulkAllowedForDescriptor(
   eserviceTechnology: Technology,
-  asyncExchangeProperties: Descriptor["asyncExchangeProperties"],
+  asyncExchangeProperties: AsyncExchangeProperties | undefined,
   eserviceId: EServiceId,
   descriptorId: DescriptorId
 ): void {

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -427,13 +427,6 @@ export function assertAsyncExchangeReadyForPublication(
   if (descriptor.asyncExchangeCallbackInterface === undefined) {
     throw missingAsyncExchangeCallbackInterface(eserviceId, descriptorId);
   }
-
-  assertAsyncExchangeBulkAllowedForDescriptor(
-    eserviceTechnology,
-    descriptor.asyncExchangeProperties,
-    eserviceId,
-    descriptorId
-  );
 }
 
 export function assertAsyncExchangeBulkAllowedForDescriptor(

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -428,9 +428,24 @@ export function assertAsyncExchangeReadyForPublication(
     throw missingAsyncExchangeCallbackInterface(eserviceId, descriptorId);
   }
 
+  assertAsyncExchangeBulkAllowedForDescriptor(
+    eserviceTechnology,
+    descriptor.asyncExchangeProperties,
+    eserviceId,
+    descriptorId
+  );
+}
+
+export function assertAsyncExchangeBulkAllowedForDescriptor(
+  eserviceTechnology: Technology,
+  asyncExchangeProperties: Descriptor["asyncExchangeProperties"],
+  eserviceId: EServiceId,
+  descriptorId: DescriptorId
+): void {
   if (
+    asyncExchangeProperties !== undefined &&
     eserviceTechnology === technology.soap &&
-    descriptor.asyncExchangeProperties.bulk === true
+    asyncExchangeProperties.bulk === true
   ) {
     throw asyncExchangeBulkNotAllowedForSoap(eserviceId, descriptorId);
   }

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -415,7 +415,6 @@ export function hasRoleToAccessInactiveDescriptors(
 }
 
 export function assertAsyncExchangeReadyForPublication(
-  eserviceTechnology: Technology,
   descriptor: Descriptor,
   eserviceId: EServiceId,
   descriptorId: DescriptorId

--- a/packages/catalog-process/test/integration/approveDelegatedEServiceDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/approveDelegatedEServiceDescriptor.test.ts
@@ -32,7 +32,6 @@ import {
   missingPersonalDataFlag,
   missingAsyncExchangeProperties,
   missingAsyncExchangeCallbackInterface,
-  asyncExchangeBulkNotAllowedForSoap,
 } from "../../src/model/domain/errors.js";
 import {
   addOneEService,
@@ -428,7 +427,7 @@ describe("publish descriptor (after delegator's approval)", () => {
     );
   });
 
-  it("should throw asyncExchangeBulkNotAllowedForSoap when approving with SOAP and asyncExchange bulk", async () => {
+  it("should not throw async exchange bulk errors when approving with SOAP and bulk enabled", async () => {
     const descriptor: Descriptor = {
       ...mockDescriptor,
       state: descriptorState.waitingForApproval,
@@ -458,9 +457,7 @@ describe("publish descriptor (after delegator's approval)", () => {
         descriptor.id,
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
-    ).rejects.toThrowError(
-      asyncExchangeBulkNotAllowedForSoap(eservice.id, descriptor.id)
-    );
+    ).resolves.toBeDefined();
   });
 
   it("should not throw async exchange errors when approving and all conditions are met", async () => {

--- a/packages/catalog-process/test/integration/createDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/createDescriptor.test.ts
@@ -24,6 +24,7 @@ import {
   delegationKind,
   EServiceTemplateId,
   unsafeBrandId,
+  technology,
 } from "pagopa-interop-models";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { catalogApi } from "pagopa-interop-api-clients";
@@ -599,6 +600,37 @@ describe("create descriptor", async () => {
     expect(protoDescriptor.asyncExchangeProperties?.confirmation).toBe(true);
     expect(protoDescriptor.asyncExchangeProperties?.bulk).toBe(true);
     expect(protoDescriptor.asyncExchangeProperties?.maxResultSet).toBe(1000);
+  });
+
+  it("should reject descriptor creation when technology is SOAP and async exchange bulk is true", async () => {
+    const eservice: EService = {
+      ...getMockEService(),
+      descriptors: [],
+      asyncExchange: true,
+      technology: technology.soap,
+    };
+    await addOneEService(eservice);
+
+    const descriptorSeed: catalogApi.EServiceDescriptorSeed = {
+      ...buildCreateDescriptorSeed(getMockDescriptor()),
+      asyncExchangeProperties: {
+        responseTime: 3600,
+        resourceAvailableTime: 7200,
+        confirmation: true,
+        bulk: true,
+        maxResultSet: 1000,
+      },
+    };
+
+    await expect(
+      catalogService.createDescriptor(
+        eservice.id,
+        descriptorSeed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toMatchObject({
+      code: "asyncExchangeBulkNotAllowedForSoap",
+    });
   });
 
   it("should ignore async exchange descriptor fields when flag ON but asyncExchange false", async () => {

--- a/packages/catalog-process/test/integration/publishDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/publishDescriptor.test.ts
@@ -44,7 +44,6 @@ import {
   missingPersonalDataFlag,
   missingAsyncExchangeProperties,
   missingAsyncExchangeCallbackInterface,
-  asyncExchangeBulkNotAllowedForSoap,
 } from "../../src/model/domain/errors.js";
 import {
   addOneEService,
@@ -824,42 +823,6 @@ describe("publish descriptor", () => {
     );
   });
 
-  it("should throw asyncExchangeBulkNotAllowedForSoap if technology is Soap and asyncExchange bulk is true", async () => {
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
-      state: descriptorState.draft,
-      interface: mockDocument,
-      asyncExchangeProperties: {
-        responseTime: 30,
-        resourceAvailableTime: 30,
-        confirmation: false,
-        bulk: true,
-        maxResultSet: 100,
-      },
-      asyncExchangeCallbackInterface: mockCallbackInterfaceDocument,
-    };
-
-    const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
-      personalData: false,
-      asyncExchange: true,
-      technology: technology.soap,
-    };
-
-    await addOneEService(eservice);
-
-    await expect(
-      catalogService.publishDescriptor(
-        eservice.id,
-        descriptor.id,
-        getMockContext({ authData: getMockAuthData(eservice.producerId) })
-      )
-    ).rejects.toThrowError(
-      asyncExchangeBulkNotAllowedForSoap(eservice.id, descriptor.id)
-    );
-  });
-
   it("should not throw when asyncExchange is true, technology is REST, and all required fields are set", async () => {
     const descriptor: Descriptor = {
       ...mockDescriptor,
@@ -953,7 +916,7 @@ describe("publish descriptor", () => {
     config.featureFlagAsyncExchange = true;
   });
 
-  it("should not throw asyncExchangeBulkNotAllowedForSoap when technology is REST and asyncExchange bulk is true", async () => {
+  it("should publish when technology is REST and asyncExchange bulk is true", async () => {
     const descriptor: Descriptor = {
       ...mockDescriptor,
       state: descriptorState.draft,

--- a/packages/catalog-process/test/integration/updateDraftDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDraftDescriptor.test.ts
@@ -22,6 +22,7 @@ import {
   operationForbidden,
   delegationState,
   delegationKind,
+  technology,
 } from "pagopa-interop-models";
 import { expect, describe, it, beforeEach } from "vitest";
 import {
@@ -31,6 +32,7 @@ import {
   inconsistentDailyCalls,
   attributeNotFound,
   templateInstanceNotAllowed,
+  asyncExchangeBulkNotAllowedForSoap,
 } from "../../src/model/domain/errors.js";
 import { config } from "../../src/config/config.js";
 import {
@@ -505,6 +507,42 @@ describe("updateDraftDescriptor", () => {
     expect(protoDescriptor.asyncExchangeProperties?.confirmation).toBe(true);
     expect(protoDescriptor.asyncExchangeProperties?.bulk).toBe(true);
     expect(protoDescriptor.asyncExchangeProperties?.maxResultSet).toBe(1000);
+  });
+
+  it("should reject descriptor update when technology is SOAP and async exchange bulk is true", async () => {
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      asyncExchange: true,
+      technology: technology.soap,
+    };
+    await addOneEService(eservice);
+
+    const updateSeed: catalogApi.UpdateEServiceDescriptorSeed = {
+      ...buildUpdateDescriptorSeed(descriptor),
+      asyncExchangeProperties: {
+        responseTime: 3600,
+        resourceAvailableTime: 7200,
+        confirmation: true,
+        bulk: true,
+        maxResultSet: 1000,
+      },
+    };
+
+    await expect(
+      catalogService.updateDraftDescriptor(
+        eservice.id,
+        descriptor.id,
+        updateSeed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      asyncExchangeBulkNotAllowedForSoap(eservice.id, descriptor.id)
+    );
   });
 
   it("should not update async exchange descriptor fields when flag ON but asyncExchange false", async () => {

--- a/packages/catalog-process/test/integration/uploadDocument.test.ts
+++ b/packages/catalog-process/test/integration/uploadDocument.test.ts
@@ -17,7 +17,6 @@ import {
   EServiceDescriptorAsyncExchangeCallbackInterfaceAddedV2,
   DescriptorState,
   featureFlagNotEnabled,
-  technology,
 } from "pagopa-interop-models";
 import { expect, describe, it, beforeEach, afterEach } from "vitest";
 import {
@@ -38,7 +37,6 @@ import {
   templateInstanceNotAllowed,
   checksumDuplicate,
   asyncExchangeCallbackInterfaceAlreadyExists,
-  asyncExchangeBulkNotAllowedForSoap,
 } from "../../src/model/domain/errors.js";
 import { config } from "../../src/config/config.js";
 import {
@@ -782,37 +780,6 @@ describe("upload Document", () => {
         )
       ).rejects.toThrowError(
         asyncExchangeCallbackInterfaceAlreadyExists(descriptor.id)
-      );
-    });
-
-    it("should throw asyncExchangeBulkNotAllowedForSoap when uploading async exchange callback interface with SOAP technology and bulk enabled", async () => {
-      const descriptor: Descriptor = {
-        ...getMockDescriptor(descriptorState.draft),
-        serverUrls: [],
-        asyncExchangeProperties: {
-          responseTime: 3600,
-          resourceAvailableTime: 3600,
-          confirmation: false,
-          bulk: true,
-          maxResultSet: 100,
-        },
-      };
-      const eservice: EService = {
-        ...mockEService,
-        asyncExchange: true,
-        technology: technology.soap,
-        descriptors: [descriptor],
-      };
-      await addOneEService(eservice);
-      expect(
-        catalogService.uploadDocument(
-          eservice.id,
-          descriptor.id,
-          buildAsyncExchangeCallbackInterfaceSeed(),
-          getMockContext({ authData: getMockAuthData(eservice.producerId) })
-        )
-      ).rejects.toThrowError(
-        asyncExchangeBulkNotAllowedForSoap(eservice.id, descriptor.id)
       );
     });
 

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -2446,7 +2446,7 @@ async function updateDraftEServiceTemplateVersion(
     updatedAsyncExchangeProperties?.bulk === true
   ) {
     throw asyncExchangeBulkNotAllowedForSoap(
-      eserviceTemplate.id,
+      eserviceTemplate.data.id,
       eserviceTemplateVersion.id
     );
   }

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -2459,6 +2459,17 @@ async function updateDraftEServiceTemplateVersion(
         .exhaustive()
     : eserviceTemplateVersion.asyncExchangeProperties;
 
+  if (
+    asyncExchangeEnabled &&
+    eserviceTemplate.data.technology === technology.soap &&
+    updatedAsyncExchangeProperties?.bulk === true
+  ) {
+    throw asyncExchangeBulkNotAllowedForSoap(
+      eserviceTemplate.id,
+      eserviceTemplateVersion.id
+    );
+  }
+
   const updatedVersion: EServiceTemplateVersion = {
     ...eserviceTemplateVersion,
     agreementApprovalPolicy: updatedAgreementApprovalPolicy,

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -552,15 +552,6 @@ export function eserviceTemplateServiceBuilder(
             eserviceTemplateVersionId
           );
         }
-        if (
-          eserviceTemplate.data.technology === technology.soap &&
-          eserviceTemplateVersion.asyncExchangeProperties.bulk === true
-        ) {
-          throw asyncExchangeBulkNotAllowedForSoap(
-            eserviceTemplateId,
-            eserviceTemplateVersionId
-          );
-        }
       }
 
       const publishedTemplate: EServiceTemplate = {
@@ -1680,16 +1671,6 @@ export function eserviceTemplateServiceBuilder(
 
         if (version.asyncExchangeCallbackInterface !== undefined) {
           throw asyncExchangeCallbackInterfaceAlreadyExists(version.id);
-        }
-
-        if (
-          eserviceTemplate.data.technology === technology.soap &&
-          version.asyncExchangeProperties.bulk === true
-        ) {
-          throw asyncExchangeBulkNotAllowedForSoap(
-            eserviceTemplate.data.id,
-            version.id
-          );
         }
       }
 

--- a/packages/eservice-template-process/test/integration/publishEServiceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/integration/publishEServiceTemplateVersion.test.ts
@@ -24,7 +24,6 @@ import {
   EServiceTemplateVersionId,
   eserviceMode,
   EServiceTemplateRiskAnalysis,
-  technology,
 } from "pagopa-interop-models";
 import { expect, describe, it, afterAll, vi, beforeAll } from "vitest";
 import {
@@ -36,7 +35,6 @@ import {
   notValidEServiceTemplateVersionState,
   riskAnalysisValidationFailed,
   missingAsyncExchangeProperties,
-  asyncExchangeBulkNotAllowedForSoap,
 } from "../../src/model/domain/errors.js";
 import {
   eserviceTemplateService,
@@ -483,46 +481,6 @@ describe("publishEServiceTemplateVersion", () => {
       )
     ).rejects.toThrowError(
       missingAsyncExchangeProperties(
-        eserviceTemplate.id,
-        eserviceTemplateVersion.id
-      )
-    );
-  });
-
-  it("should throw asyncExchangeBulkNotAllowedForSoap if technology is SOAP and bulk is true", async () => {
-    const eserviceTemplateVersion: EServiceTemplateVersion = {
-      ...getMockEServiceTemplateVersion(),
-      interface: getMockDocument(),
-      state: descriptorState.draft,
-      asyncExchangeProperties: {
-        responseTime: 3600,
-        resourceAvailableTime: 7200,
-        confirmation: true,
-        bulk: true,
-        maxResultSet: 1000,
-      },
-    };
-
-    const eserviceTemplate: EServiceTemplate = {
-      ...getMockEServiceTemplate(),
-      versions: [eserviceTemplateVersion],
-      asyncExchange: true,
-      personalData: false,
-      technology: technology.soap,
-    };
-
-    await addOneEServiceTemplate(eserviceTemplate);
-
-    await expect(
-      eserviceTemplateService.publishEServiceTemplateVersion(
-        eserviceTemplate.id,
-        eserviceTemplateVersion.id,
-        getMockContext({
-          authData: getMockAuthData(eserviceTemplate.creatorId),
-        })
-      )
-    ).rejects.toThrowError(
-      asyncExchangeBulkNotAllowedForSoap(
         eserviceTemplate.id,
         eserviceTemplateVersion.id
       )

--- a/packages/eservice-template-process/test/integration/updateDraftVersion.test.ts
+++ b/packages/eservice-template-process/test/integration/updateDraftVersion.test.ts
@@ -19,6 +19,7 @@ import {
   eserviceTemplateVersionState,
   operationForbidden,
   AttributeId,
+  technology,
 } from "pagopa-interop-models";
 import { expect, describe, it } from "vitest";
 import {
@@ -27,6 +28,7 @@ import {
   eserviceTemplateVersionNotFound,
   inconsistentDailyCalls,
   notValidEServiceTemplateVersionState,
+  asyncExchangeBulkNotAllowedForSoap,
 } from "../../src/model/domain/errors.js";
 import {
   addOneAttribute,
@@ -405,6 +407,44 @@ describe("update draft version", () => {
     });
     expect(writtenPayload.eserviceTemplate).toEqual(
       toEServiceTemplateV2(updatedEServiceTemplate)
+    );
+  });
+
+  it("should reject version update when technology is SOAP and async exchange bulk is true", async () => {
+    const version: EServiceTemplateVersion = {
+      ...mockVersion,
+      state: descriptorState.draft,
+    };
+    const eserviceTemplate: EServiceTemplate = {
+      ...mockEServiceTemplate,
+      asyncExchange: true,
+      technology: technology.soap,
+      versions: [version],
+    };
+    await addOneEServiceTemplate(eserviceTemplate);
+
+    const versionSeed: eserviceTemplateApi.UpdateEServiceTemplateVersionSeed = {
+      ...buildUpdateVersionSeed(version),
+      asyncExchangeProperties: {
+        responseTime: 3600,
+        resourceAvailableTime: 7200,
+        confirmation: true,
+        bulk: true,
+        maxResultSet: 1000,
+      },
+    };
+
+    await expect(
+      eserviceTemplateService.updateDraftTemplateVersion(
+        eserviceTemplate.id,
+        version.id,
+        versionSeed,
+        getMockContext({
+          authData: getMockAuthData(eserviceTemplate.creatorId),
+        })
+      )
+    ).rejects.toThrowError(
+      asyncExchangeBulkNotAllowedForSoap(eserviceTemplate.id, version.id)
     );
   });
 

--- a/packages/eservice-template-process/test/integration/uploadDocument.test.ts
+++ b/packages/eservice-template-process/test/integration/uploadDocument.test.ts
@@ -14,7 +14,6 @@ import {
   generateId,
   EServiceTemplateVersionId,
   featureFlagNotEnabled,
-  technology,
 } from "pagopa-interop-models";
 import { expect, describe, it } from "vitest";
 import {
@@ -35,7 +34,6 @@ import {
   eserviceTemplateAsyncExchangeNotEnabled,
   asyncExchangeCallbackInterfaceAlreadyExists,
   missingAsyncExchangeProperties,
-  asyncExchangeBulkNotAllowedForSoap,
 } from "../../src/model/domain/errors.js";
 import { config } from "../../src/config/config.js";
 import {
@@ -623,40 +621,6 @@ describe("upload Document", () => {
       )
     ).rejects.toThrowError(
       missingAsyncExchangeProperties(eserviceTemplate.id, version.id)
-    );
-  });
-
-  it("should throw asyncExchangeBulkNotAllowedForSoap when uploading asyncExchangeCallbackInterface with SOAP technology and bulk enabled", async () => {
-    const version: EServiceTemplateVersion = {
-      ...mockVersion,
-      state: eserviceTemplateVersionState.draft,
-      asyncExchangeProperties: {
-        responseTime: 3600,
-        resourceAvailableTime: 3600,
-        confirmation: false,
-        bulk: true,
-        maxResultSet: 100,
-      },
-    };
-    const eserviceTemplate: EServiceTemplate = {
-      ...mockEServiceTemplate,
-      asyncExchange: true,
-      technology: technology.soap,
-      versions: [version],
-    };
-    await addOneEServiceTemplate(eserviceTemplate);
-
-    await expect(
-      eserviceTemplateService.createEServiceTemplateDocument(
-        eserviceTemplate.id,
-        version.id,
-        buildAsyncExchangeCallbackInterfaceSeed(),
-        getMockContext({
-          authData: getMockAuthData(eserviceTemplate.creatorId),
-        })
-      )
-    ).rejects.toThrowError(
-      asyncExchangeBulkNotAllowedForSoap(eserviceTemplate.id, version.id)
     );
   });
 


### PR DESCRIPTION
## Issue
- [PIN-9651](https://pagopa.atlassian.net/browse/PIN-9651)

## Context / Why
- The `SOAP + asyncExchangeProperties.bulk=true` validation was being enforced too late in the flow.
- We want to reject that combination when the draft descriptor/version is created or updated, instead of waiting for later operations.

## Scope
- Add the validation to catalog draft descriptor creation.
- Add the validation to catalog draft descriptor update.
- Add the validation to e-service template draft version update.
- Remove the same validation from descriptor publication.
- Remove the same validation from async exchange callback interface upload.

## Key Changes
- The `asyncExchangeBulkNotAllowedForSoap` check now lives in the write paths that introduce or modify `asyncExchangeProperties`.
- Descriptor publication and async exchange callback interface upload no longer repeat the same validation.
- Regression tests were updated to cover the create/update rejection paths and to remove the obsolete publish/upload expectations.

## Testing / Validation
- [x] Type check
- [x] Integration tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated


[PIN-9651]: https://pagopa.atlassian.net/browse/PIN-9651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ