### PR TITLE
refactor: improve hasCertifiedAttributeDailyCallsChanged readability (PIN-9654)

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -4003,29 +4003,35 @@ function hasCertifiedAttributeDailyCallsChanged(
   descriptor: Descriptor,
   seed: catalogApi.AttributesSeed
 ): boolean {
-  return descriptor.attributes.certified.some((descriptorAttributesGroup) => {
-    const seedAttrGroup = seed.certified.find((seedGroup) =>
-      descriptorAttributesGroup.every((descriptorAttribute) =>
-        seedGroup.some(
-          (seedAttribute) => seedAttribute.id === descriptorAttribute.id
-        )
+  const findMatchingSeedGroup = (
+    descriptorGroup: EServiceAttribute[],
+    seedGroups: catalogApi.Attribute[][]
+  ): catalogApi.Attribute[] | undefined =>
+    seedGroups.find((seedGroup) =>
+      descriptorGroup.every((descriptorAttr) =>
+        seedGroup.some((seedAttr) => seedAttr.id === descriptorAttr.id)
       )
     );
 
-    if (seedAttrGroup === undefined) {
+  const hasDailyCallsChangedInGroup = (
+    descriptorGroup: EServiceAttribute[],
+    seedGroup: catalogApi.Attribute[]
+  ): boolean =>
+    descriptorGroup.some((descriptorAttr) => {
+      const seedAttr = seedGroup.find((attr) => attr.id === descriptorAttr.id);
+      return (
+        seedAttr?.dailyCallsPerConsumer !== descriptorAttr.dailyCallsPerConsumer
+      );
+    });
+
+  return descriptor.attributes.certified.some((descriptorGroup) => {
+    const seedGroup = findMatchingSeedGroup(descriptorGroup, seed.certified);
+
+    if (seedGroup === undefined) {
       throw certifiedAttributeGroupNotFoundInSeed(eserviceId, descriptor.id);
     }
 
-    return descriptorAttributesGroup.some((descriptorAttribute) => {
-      const seedAttribute = seedAttrGroup.find(
-        (attribute) => attribute.id === descriptorAttribute.id
-      );
-
-      return (
-        seedAttribute?.dailyCallsPerConsumer !==
-        descriptorAttribute.dailyCallsPerConsumer
-      );
-    });
+    return hasDailyCallsChangedInGroup(descriptorGroup, seedGroup);
   });
 }
 


### PR DESCRIPTION
## Jira Issue
[PIN-9654](https://pagopa.atlassian.net/browse/PIN-9654)

## Context
- `hasCertifiedAttributeDailyCallsChanged` in `catalogService.ts` had 4 levels of nested callbacks, making the logic hard to follow.
- The refactor extracts two explicitly named helpers that separate the two responsibilities: finding the matching seed group and checking whether the daily calls value has changed.
- No behavior change.

## Services Affected
- `catalog-process`

## Key Changes
- Extracted two local helpers `findMatchingSeedGroup` and `hasDailyCallsChangedInGroup` inside `hasCertifiedAttributeDailyCallsChanged`
- The main function body goes from 4 nesting levels to 3 readable lines
- Shorter, semantically clear variable names

[PIN-9654]: https://pagopa.atlassian.net/browse/PIN-9654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ