### PR TITLE
feat: extend maintenance route to manage tenant features (PIN-9707)

### DIFF
--- a/packages/api-clients/open-api/tenantApi.yml
+++ b/packages/api-clients/open-api/tenantApi.yml
@@ -1062,7 +1062,10 @@ paths:
         - tenant
       summary: Updates a tenant
       operationId: maintenanceTenantUpdate
-      description: Updates the specified tenant by its ID
+      description: >-
+        Updates the specified tenant by its ID.
+        Optional fields (e.g. features) are merged with the existing tenant:
+        if provided, they overwrite the current value; if omitted, the current value is preserved.
       responses:
         "204":
           description: Tenant Updated

--- a/packages/api-clients/open-api/tenantApi.yml
+++ b/packages/api-clients/open-api/tenantApi.yml
@@ -1806,6 +1806,10 @@ components:
           $ref: "#/components/schemas/TenantUnitType"
         selfcareInstitutionType:
           type: string
+        features:
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantFeature"
       required:
         - selfcareId
         - externalId

--- a/packages/m2m-event-dispatcher/test/utils.ts
+++ b/packages/m2m-event-dispatcher/test/utils.ts
@@ -1,4 +1,3 @@
-import { randomInt } from "crypto";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import { setupTestContainersVitest } from "pagopa-interop-commons-test";
 import {
@@ -66,9 +65,11 @@ export const testReadModelService = readModelServiceBuilderSQL({
   catalogReadModelServiceSQL: catalogReadModelServiceBuilder(readModelDB),
 });
 
+let mockEventVersionCounter = 0;
+
 export const getMockEventEnvelopeCommons = () => ({
   sequence_num: 1,
-  version: randomInt(1, 1000),
+  version: ++mockEventVersionCounter,
   event_version: 2,
   log_date: new Date(),
 });

--- a/packages/tenant-process/src/model/domain/apiConverter.ts
+++ b/packages/tenant-process/src/model/domain/apiConverter.ts
@@ -15,7 +15,8 @@ import {
   tenantFeatureType,
 } from "pagopa-interop-models";
 import { tenantApi } from "pagopa-interop-api-clients";
-import { match } from "ts-pattern";
+import { match, P } from "ts-pattern";
+import { invalidTenantFeature } from "./errors.js";
 
 function toApiTenantKind(input: TenantKind): tenantApi.TenantKind {
   return match<TenantKind, tenantApi.TenantKind>(input)
@@ -140,6 +141,27 @@ export function toApiTenant(tenant: Tenant): tenantApi.Tenant {
     onboardedAt: tenant.onboardedAt?.toJSON(),
     subUnitType: tenant.subUnitType,
   };
+}
+
+export function fromApiTenantFeature(
+  input: tenantApi.TenantFeature
+): TenantFeature {
+  return match<tenantApi.TenantFeature, TenantFeature>(input)
+    .with({ certifier: P.not(P.nullish) }, ({ certifier }) => ({
+      type: tenantFeatureType.persistentCertifier,
+      certifierId: certifier.certifierId,
+    }))
+    .with({ delegatedProducer: P.not(P.nullish) }, ({ delegatedProducer }) => ({
+      type: tenantFeatureType.delegatedProducer,
+      availabilityTimestamp: new Date(delegatedProducer.availabilityTimestamp),
+    }))
+    .with({ delegatedConsumer: P.not(P.nullish) }, ({ delegatedConsumer }) => ({
+      type: tenantFeatureType.delegatedConsumer,
+      availabilityTimestamp: new Date(delegatedConsumer.availabilityTimestamp),
+    }))
+    .otherwise(() => {
+      throw invalidTenantFeature();
+    });
 }
 
 export function apiTenantFeatureTypeToTenantFeatureType(

--- a/packages/tenant-process/src/model/domain/errors.ts
+++ b/packages/tenant-process/src/model/domain/errors.ts
@@ -38,6 +38,7 @@ const errorCodes = {
   descriptorNotFoundInEservice: "0028",
   delegationNotFound: "0029",
   operationRestrictedToDelegate: "0030",
+  invalidTenantFeature: "0031",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -322,5 +323,13 @@ export function operationRestrictedToDelegate(): ApiError<ErrorCodes> {
     detail: "Not allowed to add declared attribute",
     code: "operationRestrictedToDelegate",
     title: "Not allowed to add declared attribute",
+  });
+}
+
+export function invalidTenantFeature(): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: "Tenant feature variant could not be determined",
+    code: "invalidTenantFeature",
+    title: "Invalid tenant feature",
   });
 }

--- a/packages/tenant-process/src/services/tenantService.ts
+++ b/packages/tenant-process/src/services/tenantService.ts
@@ -93,6 +93,7 @@ import {
   verifiedAttributeSelfVerificationNotAllowed,
 } from "../model/domain/errors.js";
 import { ApiGetTenantsFilters } from "../model/domain/models.js";
+import { fromApiTenantFeature } from "../model/domain/apiConverter.js";
 import {
   assertOrganizationIsInAttributeVerifiers,
   assertValidExpirationDate,
@@ -1256,13 +1257,15 @@ export function tenantServiceBuilder(
 
       const tenant = await retrieveTenant(tenantId, readModelService);
 
+      const { features: apiFeatures, ...restTenantUpdate } = tenantUpdate;
+
       const convertedTenantUpdate = {
-        ...tenantUpdate,
-        mails: tenantUpdate.mails.map((mail) => ({
+        ...restTenantUpdate,
+        mails: restTenantUpdate.mails.map((mail) => ({
           ...mail,
           createdAt: new Date(mail.createdAt),
         })),
-        onboardedAt: new Date(tenantUpdate.onboardedAt),
+        onboardedAt: new Date(restTenantUpdate.onboardedAt),
       };
 
       const updatedTenant: Tenant = {
@@ -1270,6 +1273,9 @@ export function tenantServiceBuilder(
         ...convertedTenantUpdate,
         subUnitType: convertedTenantUpdate.subUnitType,
         selfcareInstitutionType: convertedTenantUpdate.selfcareInstitutionType,
+        ...(apiFeatures !== undefined && {
+          features: apiFeatures.map(fromApiTenantFeature),
+        }),
         updatedAt: new Date(),
       };
 

--- a/packages/tenant-process/src/utilities/errorMappers.ts
+++ b/packages/tenant-process/src/utilities/errorMappers.ts
@@ -149,6 +149,7 @@ export const maintenanceTenantUpdatedErrorMapper = (
 ): number =>
   match(error.code)
     .with("tenantNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("invalidTenantFeature", () => HTTP_STATUS_BAD_REQUEST)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
 export const verifyVerifiedAttributeErrorMapper = (

--- a/packages/tenant-process/test/integration/maintenanceTenantUpdate.test.ts
+++ b/packages/tenant-process/test/integration/maintenanceTenantUpdate.test.ts
@@ -61,6 +61,7 @@ describe("maintenanceTenantUpdate", async () => {
     const updatedMockTenant: Tenant = {
       ...mockTenant,
       ...tenantUpdate,
+      features: mockTenant.features,
       mails: tenantUpdate.mails.map((mail) => ({
         ...mail,
         createdAt: new Date(mail.createdAt),

--- a/packages/tenant-process/test/integration/maintenanceTenantUpdate.test.ts
+++ b/packages/tenant-process/test/integration/maintenanceTenantUpdate.test.ts
@@ -2,7 +2,9 @@
 import {
   MaintenanceTenantUpdatedV2,
   Tenant,
+  TenantFeature,
   protobufDecoder,
+  tenantFeatureType,
   toTenantV2,
 } from "pagopa-interop-models";
 import { describe, it, expect, beforeAll, vi, afterAll } from "vitest";
@@ -83,5 +85,149 @@ describe("maintenanceTenantUpdate", async () => {
         getMockContextMaintenance({})
       )
     ).rejects.toThrowError(tenantNotFound(mockTenant.id));
+  });
+
+  it("should preserve existing features when 'features' is omitted from the update", async () => {
+    const existingFeatures: TenantFeature[] = [
+      {
+        type: tenantFeatureType.delegatedConsumer,
+        availabilityTimestamp: new Date(),
+      },
+    ];
+    const mockTenant: Tenant = {
+      ...getMockTenant(),
+      features: existingFeatures,
+    };
+    await addOneTenant(mockTenant);
+
+    const tenantUpdate = getMockMaintenanceTenantUpdate();
+    await tenantService.maintenanceTenantUpdate(
+      {
+        tenantId: mockTenant.id,
+        tenantUpdate,
+        version: 0,
+      },
+      getMockContextMaintenance({})
+    );
+
+    const writtenEvent = await readLastEventByStreamId(
+      mockTenant.id,
+      "tenant",
+      postgresDB
+    );
+    const writtenPayload = protobufDecoder(MaintenanceTenantUpdatedV2).parse(
+      writtenEvent.data
+    );
+
+    expect(writtenPayload.tenant?.features).toEqual(
+      toTenantV2({ ...mockTenant, features: existingFeatures }).features
+    );
+  });
+
+  it("should remove features when 'features' is set to empty array (GSP cleanup case)", async () => {
+    const mockTenant: Tenant = {
+      ...getMockTenant(),
+      features: [
+        {
+          type: tenantFeatureType.delegatedProducer,
+          availabilityTimestamp: new Date(),
+        },
+        {
+          type: tenantFeatureType.delegatedConsumer,
+          availabilityTimestamp: new Date(),
+        },
+      ],
+    };
+    await addOneTenant(mockTenant);
+
+    const tenantUpdate = {
+      ...getMockMaintenanceTenantUpdate(),
+      features: [],
+    };
+    await tenantService.maintenanceTenantUpdate(
+      {
+        tenantId: mockTenant.id,
+        tenantUpdate,
+        version: 0,
+      },
+      getMockContextMaintenance({})
+    );
+
+    const writtenEvent = await readLastEventByStreamId(
+      mockTenant.id,
+      "tenant",
+      postgresDB
+    );
+    const writtenPayload = protobufDecoder(MaintenanceTenantUpdatedV2).parse(
+      writtenEvent.data
+    );
+
+    expect(writtenPayload.tenant?.features).toEqual([]);
+  });
+
+  it("should replace features when a new list is provided (round-trip for all variants)", async () => {
+    const mockTenant: Tenant = {
+      ...getMockTenant(),
+      features: [
+        {
+          type: tenantFeatureType.delegatedProducer,
+          availabilityTimestamp: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+    };
+    await addOneTenant(mockTenant);
+
+    const newAvailabilityTimestamp = new Date("2026-04-13T10:00:00Z");
+    const tenantUpdate = {
+      ...getMockMaintenanceTenantUpdate(),
+      features: [
+        { certifier: { certifierId: "test-certifier-id" } },
+        {
+          delegatedProducer: {
+            availabilityTimestamp: newAvailabilityTimestamp.toISOString(),
+          },
+        },
+        {
+          delegatedConsumer: {
+            availabilityTimestamp: newAvailabilityTimestamp.toISOString(),
+          },
+        },
+      ],
+    };
+    await tenantService.maintenanceTenantUpdate(
+      {
+        tenantId: mockTenant.id,
+        tenantUpdate,
+        version: 0,
+      },
+      getMockContextMaintenance({})
+    );
+
+    const writtenEvent = await readLastEventByStreamId(
+      mockTenant.id,
+      "tenant",
+      postgresDB
+    );
+    const writtenPayload = protobufDecoder(MaintenanceTenantUpdatedV2).parse(
+      writtenEvent.data
+    );
+
+    const expectedFeatures: TenantFeature[] = [
+      {
+        type: tenantFeatureType.persistentCertifier,
+        certifierId: "test-certifier-id",
+      },
+      {
+        type: tenantFeatureType.delegatedProducer,
+        availabilityTimestamp: newAvailabilityTimestamp,
+      },
+      {
+        type: tenantFeatureType.delegatedConsumer,
+        availabilityTimestamp: newAvailabilityTimestamp,
+      },
+    ];
+    expect(writtenPayload.tenant?.features).toEqual(
+      toTenantV2({ ...mockTenant, features: expectedFeatures }).features
+    );
   });
 });


### PR DESCRIPTION
## Jira Issue
[PIN-9707](https://pagopa.atlassian.net/browse/PIN-9707)

## Context
The maintenance route `POST /maintenance/tenants/:tenantId` needs to be extended to support modifying the `features` section of a tenant.

This extension is required to **clean up non-PA tenants** (e.g. GSP) that have enabled delegation availability in collaudo and produzione environments, before the introduction of the new check based on the \"Pubbliche Amministrazioni\" certified attribute (PIN-9684).

Without this extension it's not possible to remove `DelegatedProducer` / `DelegatedConsumer` features from those tenants because:
- The standard API `POST /tenants/delegatedFeatures/update` now requires the PA certified attribute (would block the operation on GSPs)
- The only viable path is the maintenance route, which today does not support modifying the `features` field

## Services Affected
- `tenant-process`

## Key Changes
- Added optional `features` field to `MaintenanceTenantUpdate` schema in `tenantApi.yml`
- Added `fromApiTenantFeature` converter (API → model) in `apiConverter.ts` using exhaustive `ts-pattern` matching
- Added new domain error `invalidTenantFeature` (code `0031`) used as defensive fallback when no feature variant matches
- `invalidTenantFeature` mapped to `400 Bad Request` in `maintenanceTenantUpdatedErrorMapper`
- `maintenanceTenantUpdate` service now applies the converted features to the updated tenant when present
- Added integration tests for: features omitted (preserves existing), features = `[]` (cleanup case), features replaced with all variants (round-trip)

[PIN-9707]: https://pagopa.atlassian.net/browse/PIN-9707