### PR TITLE
refactor: replace delete + toMatchObject with toEqual in agreement-process tests (PIN-5587)

### DIFF
--- a/packages/agreement-process/test/integration/activateAgreement.test.ts
+++ b/packages/agreement-process/test/integration/activateAgreement.test.ts
@@ -344,15 +344,15 @@ describe("activate agreement", () => {
           suspendedByProducer: false,
           suspendedByConsumer: false,
           suspendedByPlatform: false, // when the agreement is Activated this is uptated to false
+          // The contract document is populated by a separate event, so we
+          // don't assert on its specific shape here
+          contract: actualAgreementActivated.contract,
         };
-        delete (expectedActivatedAgreement as Partial<Agreement>).contract;
 
-        expect(actualAgreementActivated).toMatchObject(
-          expectedActivatedAgreement
-        );
+        expect(actualAgreementActivated).toEqual(expectedActivatedAgreement);
 
         await testRelatedAgreementsArchiviation(relatedAgreements);
-        expect(activateAgreementReturnValue).toMatchObject({
+        expect(activateAgreementReturnValue).toEqual({
           data: expectedActivatedAgreement,
           metadata: { version: 1 },
         });
@@ -458,10 +458,12 @@ describe("activate agreement", () => {
         ...agreement,
         state: agreementState.missingCertifiedAttributes,
         suspendedByPlatform: true,
+        // The contract document is populated by a separate event, so we
+        // don't assert on its specific shape here
+        contract: actualAgreement.contract,
       };
-      delete (expectedAgreement as Partial<Agreement>).contract;
 
-      expect(sortAgreement(actualAgreement)).toMatchObject(
+      expect(sortAgreement(actualAgreement)).toEqual(
         sortAgreement(expectedAgreement)
       );
     });

--- a/packages/agreement-process/test/integration/cloneAgreement.test.ts
+++ b/packages/agreement-process/test/integration/cloneAgreement.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable functional/immutable-data */
-/* eslint-disable fp/no-delete */
 import { FileManagerError, genericLogger } from "pagopa-interop-commons";
 import {
   addSomeRandomDelegations,
@@ -71,6 +70,34 @@ describe("clone agreement", () => {
   afterAll(() => {
     vi.useRealTimers();
   });
+
+  // See agreementService.cloneAgreement for the fields overridden during clone.
+  const buildExpectedClonedAgreement = ({
+    source,
+    newAgreementId,
+    sourceConsumerDocuments,
+    clonedConsumerDocuments,
+  }: {
+    source: Parameters<typeof toAgreementV2>[0];
+    newAgreementId: AgreementId;
+    sourceConsumerDocuments: AgreementDocument[];
+    clonedConsumerDocuments: AgreementV2["consumerDocuments"] | undefined;
+  }): AgreementV2 =>
+    toAgreementV2({
+      ...source,
+      id: newAgreementId,
+      verifiedAttributes: [],
+      certifiedAttributes: [],
+      declaredAttributes: [],
+      state: agreementState.draft,
+      createdAt: TEST_EXECUTION_DATE,
+      consumerDocuments: sourceConsumerDocuments.map((doc, i) => ({
+        ...doc,
+        id: unsafeBrandId(clonedConsumerDocuments?.[i].id as string),
+        path: clonedConsumerDocuments?.[i].path as string,
+      })),
+      stamps: {},
+    });
 
   it("should succeed when requester is Consumer and the Agreement is in a clonable state", async () => {
     const authData = getMockAuthData();
@@ -166,36 +193,14 @@ describe("clone agreement", () => {
 
     const agreementClonedAgreement = agreementClonedEventPayload.agreement;
 
-    const expectedAgreementCloned: AgreementV2 = toAgreementV2({
-      id: newAgreementId,
-      eserviceId: agreementToBeCloned.eserviceId,
-      descriptorId: agreementToBeCloned.descriptorId,
-      producerId: agreementToBeCloned.producerId,
-      consumerId: agreementToBeCloned.consumerId,
-      consumerNotes: agreementToBeCloned.consumerNotes,
-      verifiedAttributes: [],
-      certifiedAttributes: [],
-      declaredAttributes: [],
-      state: agreementState.draft,
-      createdAt: TEST_EXECUTION_DATE,
-      consumerDocuments: agreementConsumerDocuments.map<AgreementDocument>(
-        (doc, i) => ({
-          ...doc,
-          id: unsafeBrandId(
-            agreementClonedAgreement?.consumerDocuments[i].id as string
-          ),
-          path: agreementClonedAgreement?.consumerDocuments[i].path as string,
-        })
-      ),
-      stamps: {},
+    const expectedAgreementCloned = buildExpectedClonedAgreement({
+      source: agreementToBeCloned,
+      newAgreementId,
+      sourceConsumerDocuments: agreementConsumerDocuments,
+      clonedConsumerDocuments: agreementClonedAgreement?.consumerDocuments,
     });
-    delete expectedAgreementCloned.suspendedAt;
-    delete expectedAgreementCloned.updatedAt;
-    delete expectedAgreementCloned.contract;
-    delete expectedAgreementCloned.signedContract;
-    expectedAgreementCloned.stamps = {};
 
-    expect(agreementClonedEventPayload).toMatchObject({
+    expect(agreementClonedEventPayload).toEqual({
       agreement: expectedAgreementCloned,
     });
     expect(agreementClonedEventPayload).toEqual({
@@ -315,36 +320,14 @@ describe("clone agreement", () => {
 
     const agreementClonedAgreement = agreementClonedEventPayload.agreement;
 
-    const expectedAgreementCloned: AgreementV2 = toAgreementV2({
-      id: newAgreementId,
-      eserviceId: agreementToBeCloned.eserviceId,
-      descriptorId: agreementToBeCloned.descriptorId,
-      producerId: agreementToBeCloned.producerId,
-      consumerId: agreementToBeCloned.consumerId,
-      consumerNotes: agreementToBeCloned.consumerNotes,
-      verifiedAttributes: [],
-      certifiedAttributes: [],
-      declaredAttributes: [],
-      state: agreementState.draft,
-      createdAt: TEST_EXECUTION_DATE,
-      consumerDocuments: agreementConsumerDocuments.map<AgreementDocument>(
-        (doc, i) => ({
-          ...doc,
-          id: unsafeBrandId(
-            agreementClonedAgreement?.consumerDocuments[i].id as string
-          ),
-          path: agreementClonedAgreement?.consumerDocuments[i].path as string,
-        })
-      ),
-      stamps: {},
+    const expectedAgreementCloned = buildExpectedClonedAgreement({
+      source: agreementToBeCloned,
+      newAgreementId,
+      sourceConsumerDocuments: agreementConsumerDocuments,
+      clonedConsumerDocuments: agreementClonedAgreement?.consumerDocuments,
     });
-    delete expectedAgreementCloned.suspendedAt;
-    delete expectedAgreementCloned.updatedAt;
-    delete expectedAgreementCloned.contract;
-    delete expectedAgreementCloned.signedContract;
-    expectedAgreementCloned.stamps = {};
 
-    expect(agreementClonedEventPayload).toMatchObject({
+    expect(agreementClonedEventPayload).toEqual({
       agreement: expectedAgreementCloned,
     });
     expect(agreementClonedEventPayload).toEqual({

--- a/packages/agreement-process/test/integration/rejectAgreement.test.ts
+++ b/packages/agreement-process/test/integration/rejectAgreement.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable fp/no-delete */
 /* eslint-disable functional/immutable-data */
 import {
   decodeProtobufPayload,
@@ -251,16 +250,15 @@ describe("reject agreement", () => {
         payload: agreementEvent.data,
       }).agreement;
 
-      /* We must delete some properties because the rejection
-    sets them to undefined thus and the protobuf
-    serialization strips them from the payload */
-      delete agreement.suspendedByConsumer;
-      delete agreement.suspendedByProducer;
-      delete agreement.suspendedByPlatform;
       const expectedAgreementRejected: Agreement = {
         ...agreement,
         state: agreementState.rejected,
         rejectionReason: "Rejected by producer due to test reasons",
+        // The rejection sets these suspension flags to undefined, and the
+        // protobuf serialization strips them from the payload
+        suspendedByConsumer: undefined,
+        suspendedByProducer: undefined,
+        suspendedByPlatform: undefined,
         // Keeps only not revoked attributes that are matching in descriptor and tenant
         verifiedAttributes: [
           { id: tenantVerifiedAttribute.id },
@@ -278,7 +276,7 @@ describe("reject agreement", () => {
         },
       };
 
-      expect(sortAgreementAttributes(actualAgreementRejected)).toMatchObject(
+      expect(sortAgreementAttributes(actualAgreementRejected)).toEqual(
         sortAgreementAttributes(toAgreementV2(expectedAgreementRejected))
       );
       expect(sortAgreement(rejectAgreementReponse)).toEqual({


### PR DESCRIPTION
## Jira Issue
[PIN-5587](https://pagopa.atlassian.net/browse/PIN-5587)

## Context
Some integration tests in `agreement-process` use the anti-pattern `delete expected.field` + `toMatchObject(expected)` to work around protobuf serialization stripping `undefined` fields from the decoded payload. The `delete` physically removes the key from the expected object so that `toMatchObject` does not check it, because `toMatchObject({x: undefined})` against a payload where `x` is missing does not match.

This PR replaces that anti-pattern with `toEqual`, which treats missing keys and `undefined` values as equivalent during comparison — making the tests clearer and removing the need for `delete`.

## Changes

### `cloneAgreement.test.ts`
- Removed 8 `delete` statements across the two happy-path test cases.
- Extracted the duplicated expected-agreement construction into a local `buildExpectedClonedAgreement` helper inside the `describe` block.
- Replaced `toMatchObject` with `toEqual`.
- **Note**: the previous `delete + toMatchObject` was silently skipping the assertion on `contract`, `signedContract`, `suspendedAt`, `updatedAt`, `rejectionReason`, `suspendedByConsumer/Producer/Platform`, which the clone service actually inherits from the source agreement (see `agreementService.cloneAgreement` — it spreads `...agreementToBeCloned.data`). The expected object is now constructed by mirroring the service's behaviour (`...agreementToBeCloned` + the same set of overrides), so the test now **also asserts that the clone correctly inherits those fields from the source**, which was previously uncovered.
- Removed `/* eslint-disable fp/no-delete */` (no longer needed).

### `rejectAgreement.test.ts`
- Removed 3 `delete` statements that were mutating the input mock `agreement`.
- The suspension flags (`suspendedByConsumer/Producer/Platform`) are now explicitly set to `undefined` in the expected object, which is the correct semantic after rejection (the protobuf payload strips them).
- Replaced `toMatchObject` with `toEqual`.
- Removed `/* eslint-disable fp/no-delete */` (no longer needed).

### `activateAgreement.test.ts`
- Removed 2 `delete (expected as Partial<Agreement>).contract` statements.
- Since the `contract` document is populated by a **separate event** and its shape is not the responsibility of the activation assertion, the expected object now sets `contract: actualAgreementActivated.contract` (equivalent semantic to the previous "do not assert on contract" behaviour, but compatible with `toEqual`).
- Replaced `toMatchObject` with `toEqual`.

## Out of scope
`purposeReadmodelWriter.integration.test.ts` also contains `delete` statements on a test field, but paired with `toStrictEqual` (not `toMatchObject`). `toStrictEqual` distinguishes between a missing key and `undefined`, so the `delete` there is a deliberate semantic choice, not the anti-pattern targeted by this ticket. Left unchanged.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm check` (tsc) passes
- [x] `pnpm test:api` — 403/403 pass
- [x] `pnpm test:integration` — 329/329 pass

[PIN-5587]: https://pagopa.atlassian.net/browse/PIN-5587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ