### PR TITLE
fix: handle affectedDescriptor index 0 correctly in eservice M2M event test

### DIFF
--- a/packages/m2m-event-dispatcher/test/handleEServiceEvent.test.ts
+++ b/packages/m2m-event-dispatcher/test/handleEServiceEvent.test.ts
@@ -277,9 +277,10 @@ describe("handleEServiceEvent test", async () => {
                 descriptors
               );
 
-              const descriptorId = affectedDescriptor
-                ? eservice.descriptors.at(affectedDescriptor)!.id
-                : undefined;
+              const descriptorId =
+                affectedDescriptor !== undefined
+                  ? eservice.descriptors.at(affectedDescriptor)!.id
+                  : undefined;
 
               const message = {
                 ...getMockEventEnvelopeCommons(),


### PR DESCRIPTION
## Summary

- Fix falsy check on `affectedDescriptor` in `handleEServiceEvent.test.ts` that treated index `0` as `undefined`
- The truthiness check `affectedDescriptor ? ... : undefined` skipped descriptor index 0, causing the test to send events without `descriptorId` for descriptor-level events
- Changed to explicit `affectedDescriptor !== undefined` check