### PR TITLE
refactor: match entire payload object in auth and notification-config tests (PIN-9768)

### DIFF
--- a/packages/authorization-process/test/integration/createApiClient.test.ts
+++ b/packages/authorization-process/test/integration/createApiClient.test.ts
@@ -74,7 +74,9 @@ describe("createConsumerClient", () => {
       description: clientSeed.description,
     };
 
-    expect(writtenPayload.client).toEqual(toClientV2(expectedClient));
+    expect(writtenPayload).toEqual({
+      client: toClientV2(expectedClient),
+    });
     expect(client).toEqual(expectedClient);
   });
 });

--- a/packages/authorization-process/test/integration/createConsumerClient.test.ts
+++ b/packages/authorization-process/test/integration/createConsumerClient.test.ts
@@ -73,7 +73,9 @@ describe("createConsumerClient", () => {
       description: clientSeed.description,
     };
 
-    expect(writtenPayload.client).toEqual(toClientV2(expectedClient));
+    expect(writtenPayload).toEqual({
+      client: toClientV2(expectedClient),
+    });
     expect(client.data).toEqual(expectedClient);
   });
 });

--- a/packages/authorization-process/test/integration/createKey.test.ts
+++ b/packages/authorization-process/test/integration/createKey.test.ts
@@ -148,7 +148,10 @@ describe("createKey", () => {
         },
       ],
     };
-    expect(writtenPayload.client).toEqual(toClientV2(expectedClient));
+    expect(writtenPayload).toEqual({
+      kid: calculateKid(createJWK({ pemKeyBase64: keySeed.key })),
+      client: toClientV2(expectedClient),
+    });
   });
   it("should throw clientNotFound if the client doesn't exist ", async () => {
     await addOneClient(getMockClient());

--- a/packages/authorization-process/test/integration/createProducerKeychain.test.ts
+++ b/packages/authorization-process/test/integration/createProducerKeychain.test.ts
@@ -71,8 +71,8 @@ describe("createProducerKeychain", () => {
       description: producerKeychain.data.description,
     };
 
-    expect(writtenPayload.producerKeychain).toEqual(
-      toProducerKeychainV2(expectedProducerKeychain)
-    );
+    expect(writtenPayload).toEqual({
+      producerKeychain: toProducerKeychainV2(expectedProducerKeychain),
+    });
   });
 });

--- a/packages/authorization-process/test/integration/createProducerKeychainKey.test.ts
+++ b/packages/authorization-process/test/integration/createProducerKeychainKey.test.ts
@@ -146,10 +146,10 @@ describe("createProducerKeychainKey", () => {
       ],
     };
 
-    expect(writtenPayload.producerKeychain).toEqual(
-      toProducerKeychainV2(expectedProducerKeychain)
-    );
-    expect(writtenPayload.kid).toEqual(writtenPayload.kid);
+    expect(writtenPayload).toEqual({
+      kid: calculateKid(createJWK({ pemKeyBase64: keySeed.key })),
+      producerKeychain: toProducerKeychainV2(expectedProducerKeychain),
+    });
   });
   it("should throw producerKeychainNotFound if the producer keychain doesn't exist ", async () => {
     await addOneProducerKeychain(getMockProducerKeychain());

--- a/packages/notification-config-process/test/integration/createTenantDefaultNotificationConfig.test.ts
+++ b/packages/notification-config-process/test/integration/createTenantDefaultNotificationConfig.test.ts
@@ -50,9 +50,11 @@ describe("createTenantNotificationConfig", () => {
       createdAt: new Date(),
     };
     expect(serviceReturnValue).toEqual(expectedTenantNotificationConfig);
-    expect(writtenPayload.tenantNotificationConfig).toEqual(
-      toTenantNotificationConfigV2(expectedTenantNotificationConfig)
-    );
+    expect(writtenPayload).toEqual({
+      tenantNotificationConfig: toTenantNotificationConfigV2(
+        expectedTenantNotificationConfig
+      ),
+    });
   });
 
   it("should throw tenantNotificationConfigAlreadyExists if a notification config already exists for that tenant", async () => {

--- a/packages/notification-config-process/test/integration/deleteTenantNotificationConfig.test.ts
+++ b/packages/notification-config-process/test/integration/deleteTenantNotificationConfig.test.ts
@@ -49,9 +49,11 @@ describe("deleteTenantNotificationConfig", () => {
       messageType: TenantNotificationConfigDeletedV2,
       payload: writtenEvent.data,
     });
-    expect(writtenPayload.tenantNotificationConfig).toEqual(
-      toTenantNotificationConfigV2(tenantNotificationConfig)
-    );
+    expect(writtenPayload).toEqual({
+      tenantNotificationConfig: toTenantNotificationConfigV2(
+        tenantNotificationConfig
+      ),
+    });
   });
 
   it("should throw tenantNotificationConfigNotFound if no notification config exists for the tenant", async () => {

--- a/packages/notification-config-process/test/integration/ensureUserNotificationConfigExistsWithRole.test.ts
+++ b/packages/notification-config-process/test/integration/ensureUserNotificationConfigExistsWithRole.test.ts
@@ -9,6 +9,7 @@ import {
   UserNotificationConfig,
   UserNotificationConfigCreatedV2,
   toUserNotificationConfigV2,
+  toUserRoleV2,
   TenantId,
   NotificationConfig,
   userRole,
@@ -113,9 +114,11 @@ describe("createUserNotificationConfig", () => {
       createdAt: new Date(),
     };
     expect(serviceReturnValue).toEqual(expectedUserNotificationConfig);
-    expect(writtenPayload.userNotificationConfig).toEqual(
-      toUserNotificationConfigV2(expectedUserNotificationConfig)
-    );
+    expect(writtenPayload).toEqual({
+      userNotificationConfig: toUserNotificationConfigV2(
+        expectedUserNotificationConfig
+      ),
+    });
   });
 
   it("should return existing config if a notification config already exists for that user with the same role, without writing on event-store", async () => {
@@ -176,9 +179,12 @@ describe("createUserNotificationConfig", () => {
       messageType: UserNotificationConfigRoleAddedV2,
       payload: writtenEvent.data,
     });
-    expect(writtenPayload.userNotificationConfig).toEqual(
-      toUserNotificationConfigV2(updatedUserNotificationConfig)
-    );
+    expect(writtenPayload).toEqual({
+      userNotificationConfig: toUserNotificationConfigV2(
+        updatedUserNotificationConfig
+      ),
+      userRole: toUserRoleV2(userRole.API_ROLE),
+    });
   });
 
   it("should create notification config with multiple roles at once", async () => {
@@ -215,9 +221,11 @@ describe("createUserNotificationConfig", () => {
       createdAt: new Date(),
     };
     expect(serviceReturnValue).toEqual(expectedUserNotificationConfig);
-    expect(writtenPayload.userNotificationConfig).toEqual(
-      toUserNotificationConfigV2(expectedUserNotificationConfig)
-    );
+    expect(writtenPayload).toEqual({
+      userNotificationConfig: toUserNotificationConfigV2(
+        expectedUserNotificationConfig
+      ),
+    });
   });
 
   it("should write two events when adding two missing roles to an existing config", async () => {
@@ -263,9 +271,12 @@ describe("createUserNotificationConfig", () => {
       messageType: UserNotificationConfigRoleAddedV2,
       payload: lastEvent.data,
     });
-    expect(lastEventPayload.userNotificationConfig).toEqual(
-      toUserNotificationConfigV2(expectedFinalUserNotificationConfig)
-    );
+    expect(lastEventPayload).toEqual({
+      userNotificationConfig: toUserNotificationConfigV2(
+        expectedFinalUserNotificationConfig
+      ),
+      userRole: toUserRoleV2(userRole.API_ROLE),
+    });
 
     // Read the previous event (version 1) - should be the first role addition
     const firstRoleEvent = await readNotificationConfigEventByVersion(
@@ -286,8 +297,11 @@ describe("createUserNotificationConfig", () => {
       userRoles: [userRole.SECURITY_ROLE, userRole.ADMIN_ROLE],
       updatedAt: new Date(),
     };
-    expect(firstRoleEventPayload.userNotificationConfig).toEqual(
-      toUserNotificationConfigV2(expectedAfterFirstRoleConfig)
-    );
+    expect(firstRoleEventPayload).toEqual({
+      userNotificationConfig: toUserNotificationConfigV2(
+        expectedAfterFirstRoleConfig
+      ),
+      userRole: toUserRoleV2(userRole.ADMIN_ROLE),
+    });
   });
 });

--- a/packages/notification-config-process/test/integration/removeUserNotificationConfigRole.test.ts
+++ b/packages/notification-config-process/test/integration/removeUserNotificationConfigRole.test.ts
@@ -9,6 +9,7 @@ import {
   UserNotificationConfig,
   UserNotificationConfigDeletedV2,
   toUserNotificationConfigV2,
+  toUserRoleV2,
   UserId,
   userRole,
   UserNotificationConfigRoleRemovedV2,
@@ -71,9 +72,11 @@ describe("removeUserNotificationConfigRole", () => {
       messageType: UserNotificationConfigDeletedV2,
       payload: writtenEvent.data,
     });
-    expect(writtenPayload.userNotificationConfig).toEqual(
-      toUserNotificationConfigV2(userNotificationConfig)
-    );
+    expect(writtenPayload).toEqual({
+      userNotificationConfig: toUserNotificationConfigV2(
+        userNotificationConfig
+      ),
+    });
   });
 
   it("should write on event-store for the removal of the role from the user's notification configuration when there are other roles", async () => {
@@ -94,13 +97,14 @@ describe("removeUserNotificationConfigRole", () => {
       messageType: UserNotificationConfigRoleRemovedV2,
       payload: writtenEvent.data,
     });
-    expect(writtenPayload.userNotificationConfig).toEqual(
-      toUserNotificationConfigV2({
+    expect(writtenPayload).toEqual({
+      userNotificationConfig: toUserNotificationConfigV2({
         ...userNotificationConfigWithTwoRoles,
         userRoles: [userRole.API_ROLE],
         updatedAt: new Date(),
-      })
-    );
+      }),
+      userRole: toUserRoleV2(userRole.SECURITY_ROLE),
+    });
   });
 
   it.each<[string, UserId, TenantId]>([

--- a/packages/notification-config-process/test/integration/updateTenantNotificationConfig.test.ts
+++ b/packages/notification-config-process/test/integration/updateTenantNotificationConfig.test.ts
@@ -65,9 +65,11 @@ describe("updateTenantNotificationConfig", () => {
       updatedAt: new Date(),
     };
     expect(serviceReturnValue).toEqual(expectedTenantNotificationConfig);
-    expect(writtenPayload.tenantNotificationConfig).toEqual(
-      toTenantNotificationConfigV2(expectedTenantNotificationConfig)
-    );
+    expect(writtenPayload).toEqual({
+      tenantNotificationConfig: toTenantNotificationConfigV2(
+        expectedTenantNotificationConfig
+      ),
+    });
   });
 
   it("should throw tenantNotificationConfigNotFound if no notification config exists for the tenant", async () => {

--- a/packages/notification-config-process/test/integration/updateUserNotificationConfig.test.ts
+++ b/packages/notification-config-process/test/integration/updateUserNotificationConfig.test.ts
@@ -150,9 +150,11 @@ describe("updateUserNotificationConfig", () => {
       updatedAt: new Date(),
     };
     expect(serviceReturnValue).toEqual(expectedUserNotificationConfig);
-    expect(writtenPayload.userNotificationConfig).toEqual(
-      toUserNotificationConfigV2(expectedUserNotificationConfig)
-    );
+    expect(writtenPayload).toEqual({
+      userNotificationConfig: toUserNotificationConfigV2(
+        expectedUserNotificationConfig
+      ),
+    });
   });
 
   it.each<[string, UserId, TenantId]>([


### PR DESCRIPTION
[PIN-9768](https://pagopa.atlassian.net/browse/PIN-9768)

## Summary
- Replace single-field `expect(writtenPayload.X).toEqual(Y)` assertions with full-payload `expect(writtenPayload).toEqual({ X: Y, ... })` in `authorization-process` and `notification-config-process` integration tests
- Adds previously missing `userRole` field validation on `UserNotificationConfigRoleAddedV2` and `UserNotificationConfigRoleRemovedV2` events (3 + 1 call sites)
- Fixes tautology bug in `createProducerKeychainKey.test.ts` where `expect(writtenPayload.kid).toEqual(writtenPayload.kid)` always passed — now asserts the deterministic value via `calculateKid(createJWK(...))`
- Replaces circular `kid: writtenPayload.kid` self-references in `createKey.test.ts` and `createProducerKeychainKey.test.ts` with deterministic `calculateKid(createJWK({ pemKeyBase64: keySeed.key }))` for full value verification

## Scope
| Package | Files | Assertions refactored |
|---|---:|---:|
| notification-config-process | 6 | 11 |
| authorization-process | 5 | 6 |

## Test plan
- [x] `notification-config-process`: 34/34 tests passing
- [x] `authorization-process`: 189/189 tests passing (full suite) + 28/28 on targeted files
- [x] TypeScript type-check passing on both packages