### PR TITLE
refactor: match entire payload object in tenant and attribute-registry tests (PIN-9766)

### DIFF
--- a/packages/attribute-registry-process/test/integration/createCertifiedAttribute.test.ts
+++ b/packages/attribute-registry-process/test/integration/createCertifiedAttribute.test.ts
@@ -78,7 +78,9 @@ describe("certified attribute creation", () => {
       creationTime: new Date(writtenPayload.attribute!.creationTime),
       origin: getTenantOneCertifierFeature(tenant).certifierId,
     };
-    expect(writtenPayload.attribute).toEqual(toAttributeV1(expectedAttribute));
+    expect(writtenPayload).toEqual({
+      attribute: toAttributeV1(expectedAttribute),
+    });
     expect(createAttributeResponse).toEqual({
       data: expectedAttribute,
       metadata: { version: 0 },

--- a/packages/attribute-registry-process/test/integration/createDeclaredAttribute.test.ts
+++ b/packages/attribute-registry-process/test/integration/createDeclaredAttribute.test.ts
@@ -77,12 +77,12 @@ describe("declared attribute creation", () => {
         creationTime: new Date(writtenPayload.attribute!.creationTime),
       };
 
-      expect(writtenPayload.attribute).toEqual(
-        toAttributeV1(expectedAttribute)
-      );
-      expect(writtenPayload.attribute).toEqual(
-        toAttributeV1(createDeclaredAttributeResponse.data)
-      );
+      expect(writtenPayload).toEqual({
+        attribute: toAttributeV1(expectedAttribute),
+      });
+      expect(writtenPayload).toEqual({
+        attribute: toAttributeV1(createDeclaredAttributeResponse.data),
+      });
       expect(createDeclaredAttributeResponse).toEqual({
         data: expectedAttribute,
         metadata: {

--- a/packages/attribute-registry-process/test/integration/createInternalCertifiedAttribute.test.ts
+++ b/packages/attribute-registry-process/test/integration/createInternalCertifiedAttribute.test.ts
@@ -72,8 +72,10 @@ describe("certified attribute internal creation", () => {
       creationTime: new Date(writtenPayload.attribute!.creationTime),
       origin: getTenantOneCertifierFeature(tenant).certifierId,
     };
-    expect(writtenPayload.attribute).toEqual(toAttributeV1(expectedAttribute));
-    expect(writtenPayload.attribute).toEqual(toAttributeV1(attribute));
+    expect(writtenPayload).toEqual({
+      attribute: toAttributeV1(expectedAttribute),
+    });
+    expect(writtenPayload).toEqual({ attribute: toAttributeV1(attribute) });
   });
   it("should write 2 attribute with different name and origin but same code, case insensitive", async () => {
     const attributeCode = "123456ab";

--- a/packages/attribute-registry-process/test/integration/createVerifiedAttribute.test.ts
+++ b/packages/attribute-registry-process/test/integration/createVerifiedAttribute.test.ts
@@ -76,12 +76,12 @@ describe("verified attribute creation", () => {
         creationTime: new Date(writtenPayload.attribute!.creationTime),
       };
 
-      expect(writtenPayload.attribute).toEqual(
-        toAttributeV1(expectedAttribute)
-      );
-      expect(writtenPayload.attribute).toEqual(
-        toAttributeV1(createVerifiedAttributeResponse.data)
-      );
+      expect(writtenPayload).toEqual({
+        attribute: toAttributeV1(expectedAttribute),
+      });
+      expect(writtenPayload).toEqual({
+        attribute: toAttributeV1(createVerifiedAttributeResponse.data),
+      });
       expect(createVerifiedAttributeResponse).toEqual({
         data: expectedAttribute,
         metadata: {

--- a/packages/tenant-process/test/integration/addCertifiedAttribute.test.ts
+++ b/packages/tenant-process/test/integration/addCertifiedAttribute.test.ts
@@ -115,7 +115,10 @@ describe("addCertifiedAttribute", async () => {
       kind: fromTenantKindV2(writtenPayload.tenant!.kind!),
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: tenantAttributeSeed.id,
+      tenant: toTenantV2(updatedTenant),
+    });
     expect(addCertifiedAttributeReponse).toEqual({
       data: updatedTenant,
       metadata: { version: 1 },
@@ -241,7 +244,10 @@ describe("addCertifiedAttribute", async () => {
       kind: fromTenantKindV2(writtenPayload.tenant!.kind!),
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: tenantAttributeSeed.id,
+      tenant: toTenantV2(updatedTenant),
+    });
     expect(addCertifiedAttributeReponse).toEqual({
       data: updatedTenant,
       metadata: { version: 1 },

--- a/packages/tenant-process/test/integration/addCertifierId.test.ts
+++ b/packages/tenant-process/test/integration/addCertifierId.test.ts
@@ -77,7 +77,9 @@ describe("addCertifierId", async () => {
       updatedAt: new Date(),
     };
 
-    expect(writtenPayload.tenant).toEqual(toTenantV2(expectedTenant));
+    expect(writtenPayload).toEqual({
+      tenant: toTenantV2(expectedTenant),
+    });
     expect(returnedTenant).toEqual(expectedTenant);
   });
   it("Should throw tenantNotFound when tenant doesn't exist", async () => {

--- a/packages/tenant-process/test/integration/addTenantMail.test.ts
+++ b/packages/tenant-process/test/integration/addTenantMail.test.ts
@@ -33,6 +33,10 @@ describe("addTenantMail", async () => {
     address: "testMail@test.it",
     description: "mail description",
   };
+  const expectedMailId = crypto
+    .createHash("sha256")
+    .update(mailSeed.address)
+    .digest("hex");
 
   beforeAll(async () => {
     vi.useFakeTimers();
@@ -78,13 +82,16 @@ describe("addTenantMail", async () => {
       mails: [
         {
           ...mailSeed,
-          id: writtenPayload.mailId,
+          id: expectedMailId,
           createdAt: new Date(),
         },
       ],
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      mailId: expectedMailId,
+      tenant: toTenantV2(updatedTenant),
+    });
   });
   it("Should correctly add the mail if address doesn't already exists as the last mail of that kind in the tenant", async () => {
     const mockTenant: Tenant = {
@@ -134,13 +141,16 @@ describe("addTenantMail", async () => {
       mails: [
         {
           ...mailSeed,
-          id: writtenPayload.mailId,
+          id: expectedMailId,
           createdAt: new Date(),
         },
       ],
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      mailId: expectedMailId,
+      tenant: toTenantV2(updatedTenant),
+    });
   });
   it("Should correctly add email by cleaning the address from unwanted characters", async () => {
     const mockTenant: Tenant = getMockTenant();
@@ -181,13 +191,16 @@ describe("addTenantMail", async () => {
       mails: [
         {
           ...mailSeed,
-          id: writtenPayload.mailId,
+          id: expectedMailId,
           createdAt: new Date(),
         },
       ],
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      mailId: expectedMailId,
+      tenant: toTenantV2(updatedTenant),
+    });
   });
   it("Should throw tenantNotFound if the tenant doesn't exists", async () => {
     const mockTenant: Tenant = getMockTenant();

--- a/packages/tenant-process/test/integration/deleteTenantMailById.test.ts
+++ b/packages/tenant-process/test/integration/deleteTenantMailById.test.ts
@@ -92,7 +92,10 @@ describe("deleteTenantMailById", async () => {
       ],
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      mailId,
+      tenant: toTenantV2(updatedTenant),
+    });
   });
   it("Should throw tenantNotFound if the tenant doesn't exists", async () => {
     await addOneTenant(getMockTenant());

--- a/packages/tenant-process/test/integration/internalAssignCertifiedAttribute.test.ts
+++ b/packages/tenant-process/test/integration/internalAssignCertifiedAttribute.test.ts
@@ -88,7 +88,10 @@ describe("internalAssignCertifiedAttributes", async () => {
       kind: fromTenantKindV2(writtenPayload.tenant!.kind!),
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: certifiedAttribute.id,
+      tenant: toTenantV2(updatedTenant),
+    });
   });
   it("Should re-assign the attribute if it was revoked", async () => {
     const tenantWithCertifiedAttribute: Tenant = {
@@ -144,7 +147,10 @@ describe("internalAssignCertifiedAttributes", async () => {
       kind: fromTenantKindV2(writtenPayload.tenant!.kind!),
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: certifiedAttribute.id,
+      tenant: toTenantV2(updatedTenant),
+    });
   });
   it("Should throw certifiedAttributeAlreadyAssigned if the attribute was already assigned", async () => {
     const tenantAlreadyAssigned: Tenant = {

--- a/packages/tenant-process/test/integration/internalRevokeCertifiedAttribute.test.ts
+++ b/packages/tenant-process/test/integration/internalRevokeCertifiedAttribute.test.ts
@@ -108,7 +108,10 @@ describe("testInternalRevokeCertifiedAttribute", async () => {
       kind: fromTenantKindV2(writtenPayload.tenant!.kind!),
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: mockAttribute.id,
+      tenant: toTenantV2(updatedTenant),
+    });
   });
   it("should throw tenantNotFoundByExternalId if the target tenant doesn't exist", async () => {
     const mockAttribute = getMockAttribute();

--- a/packages/tenant-process/test/integration/internalUpsertTenant.test.ts
+++ b/packages/tenant-process/test/integration/internalUpsertTenant.test.ts
@@ -109,7 +109,10 @@ describe("internalUpsertTenant", async () => {
       ],
     };
 
-    expect(writtenPayload.tenant).toEqual(toTenantV2(expectedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: attribute1.id,
+      tenant: toTenantV2(expectedTenant),
+    });
     expect(returnedTenant.data).toEqual(expectedTenant);
     expect(returnedTenant.metadata.version).toBe(1);
   });
@@ -205,9 +208,12 @@ describe("internalUpsertTenant", async () => {
     };
 
     const tenantV2 = toTenantV2(expectedTenant);
-    expect(writtenPayload.tenant).toEqual({
-      ...tenantV2,
-      attributes: expect.arrayContaining(tenantV2.attributes),
+    expect(writtenPayload).toEqual({
+      attributeId: attribute2.id,
+      tenant: {
+        ...tenantV2,
+        attributes: expect.arrayContaining(tenantV2.attributes),
+      },
     });
     expect(sortTenant(returnedTenant.data)).toEqual(sortTenant(expectedTenant));
     expect(returnedTenant.metadata.version).toBe(2);

--- a/packages/tenant-process/test/integration/m2mRevokeCertifiedAttribute.test.ts
+++ b/packages/tenant-process/test/integration/m2mRevokeCertifiedAttribute.test.ts
@@ -98,7 +98,10 @@ describe("m2mRevokeCertifiedAttribute", () => {
       ],
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: mockAttribute.id,
+      tenant: toTenantV2(updatedTenant),
+    });
   });
   it("should throw tenantNotFound if the requester tenant doesn't exist", async () => {
     const certifierId = generateId();

--- a/packages/tenant-process/test/integration/m2mUpsertTenant.test.ts
+++ b/packages/tenant-process/test/integration/m2mUpsertTenant.test.ts
@@ -134,7 +134,10 @@ describe("m2mUpsertTenant", async () => {
       ],
     };
 
-    expect(writtenPayload.tenant).toEqual(toTenantV2(expectedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: attribute.id,
+      tenant: toTenantV2(expectedTenant),
+    });
 
     const writtenEvent2 = await readEventByStreamIdAndVersion(
       mockTenant.id,
@@ -278,7 +281,10 @@ describe("m2mUpsertTenant", async () => {
       ],
     };
 
-    expect(writtenPayload.tenant).toEqual(toTenantV2(expectedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: attribute2.id,
+      tenant: toTenantV2(expectedTenant),
+    });
     expect(returnedTenant).toEqual(expectedTenant);
   });
   it("Should throw certifiedAttributeAlreadyAssigned if the attribute was already assigned", async () => {

--- a/packages/tenant-process/test/integration/m2mUpsertTenant.test.ts
+++ b/packages/tenant-process/test/integration/m2mUpsertTenant.test.ts
@@ -179,7 +179,10 @@ describe("m2mUpsertTenant", async () => {
       ],
     };
 
-    expect(writtenPayload2.tenant).toEqual(toTenantV2(expectedTenant2));
+    expect(writtenPayload2).toEqual({
+      attributeId: attribute2.id,
+      tenant: toTenantV2(expectedTenant2),
+    });
     expect(returnedTenant).toEqual(expectedTenant2);
   });
 

--- a/packages/tenant-process/test/integration/maintenanceTenantDelete.test.ts
+++ b/packages/tenant-process/test/integration/maintenanceTenantDelete.test.ts
@@ -43,7 +43,10 @@ describe("maintenanceTenantDelete", async () => {
     const writtenPayload: MaintenanceTenantDeletedV2 | undefined =
       protobufDecoder(MaintenanceTenantDeletedV2).parse(writtenEvent.data);
 
-    expect(writtenPayload.tenant).toEqual(toTenantV2(mockTenant));
+    expect(writtenPayload).toEqual({
+      tenantId: mockTenant.id,
+      tenant: toTenantV2(mockTenant),
+    });
   });
   it("Should throw tenantNotFound when the tenant doesn't exists", async () => {
     const mockTenant = getMockTenant();

--- a/packages/tenant-process/test/integration/maintenanceTenantUpdate.test.ts
+++ b/packages/tenant-process/test/integration/maintenanceTenantUpdate.test.ts
@@ -67,7 +67,9 @@ describe("maintenanceTenantUpdate", async () => {
       selfcareInstitutionType: tenantUpdate.selfcareInstitutionType,
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedMockTenant));
+    expect(writtenPayload).toEqual({
+      tenant: toTenantV2(updatedMockTenant),
+    });
   });
   it("Should throw tenantNotFound when the tenant doesn't exists", async () => {
     const mockTenant = getMockTenant();

--- a/packages/tenant-process/test/integration/revokeCertifiedAttributeById.test.ts
+++ b/packages/tenant-process/test/integration/revokeCertifiedAttributeById.test.ts
@@ -114,7 +114,10 @@ describe("revokeCertifiedAttributeById", async () => {
       kind: fromTenantKindV2(writtenPayload.tenant!.kind!),
       updatedAt: new Date(),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId: attribute.id,
+      tenant: toTenantV2(updatedTenant),
+    });
 
     expect(revokeCertifiedAttributeByIdResponse).toEqual({
       data: updatedTenant,

--- a/packages/tenant-process/test/integration/selfcareUpsertTenant.test.ts
+++ b/packages/tenant-process/test/integration/selfcareUpsertTenant.test.ts
@@ -79,7 +79,9 @@ describe("selfcareUpsertTenant", async () => {
       updatedAt: new Date(),
     };
 
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      tenant: toTenantV2(updatedTenant),
+    });
   });
   it.each([
     { origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER, type: "PA" },
@@ -133,7 +135,9 @@ describe("selfcareUpsertTenant", async () => {
         mails: [],
       };
 
-      expect(writtenPayload.tenant).toEqual(toTenantV2(expectedTenant));
+      expect(writtenPayload).toEqual({
+        tenant: toTenantV2(expectedTenant),
+      });
     }
   );
   it("should throw operation forbidden if role isn't internal and the requester is another tenant", async () => {

--- a/packages/tenant-process/test/integration/updateTenantDelegatedFeatures.test.ts
+++ b/packages/tenant-process/test/integration/updateTenantDelegatedFeatures.test.ts
@@ -90,7 +90,9 @@ describe("updateTenantDelegatedFeatures", async () => {
         updatedAt: new Date(),
       };
 
-      expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+      expect(writtenPayload).toEqual({
+        tenant: toTenantV2(updatedTenant),
+      });
     }
   );
 
@@ -145,7 +147,9 @@ describe("updateTenantDelegatedFeatures", async () => {
         updatedAt: new Date(),
       };
 
-      expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+      expect(writtenPayload).toEqual({
+        tenant: toTenantV2(updatedTenant),
+      });
     }
   );
 
@@ -200,7 +204,9 @@ describe("updateTenantDelegatedFeatures", async () => {
         updatedAt: new Date(),
       };
 
-      expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+      expect(writtenPayload).toEqual({
+        tenant: toTenantV2(updatedTenant),
+      });
     }
   );
 
@@ -255,7 +261,9 @@ describe("updateTenantDelegatedFeatures", async () => {
         updatedAt: new Date(),
       };
 
-      expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+      expect(writtenPayload).toEqual({
+        tenant: toTenantV2(updatedTenant),
+      });
     }
   );
 
@@ -329,7 +337,9 @@ describe("updateTenantDelegatedFeatures", async () => {
         updatedAt: new Date(),
       };
 
-      expect(lastUpdatedPayload.tenant).toEqual(toTenantV2(updatedTenant));
+      expect(lastUpdatedPayload).toEqual({
+        tenant: toTenantV2(updatedTenant),
+      });
     }
   );
 
@@ -403,7 +413,9 @@ describe("updateTenantDelegatedFeatures", async () => {
         updatedAt: new Date(),
       };
 
-      expect(lastUpdatedPayload.tenant).toEqual(toTenantV2(updatedTenant));
+      expect(lastUpdatedPayload).toEqual({
+        tenant: toTenantV2(updatedTenant),
+      });
     }
   );
 

--- a/packages/tenant-process/test/integration/updateTenantVerifiedAttribute.test.ts
+++ b/packages/tenant-process/test/integration/updateTenantVerifiedAttribute.test.ts
@@ -106,7 +106,10 @@ describe("updateTenantVerifiedAttribute", async () => {
       updatedAt: new Date(Number(writtenPayload.tenant?.updatedAt)),
     };
 
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId,
+      tenant: toTenantV2(updatedTenant),
+    });
     expect(returnedTenant).toEqual(updatedTenant);
   });
   it("should throw tenantNotFound when tenant doesn't exist", async () => {

--- a/packages/tenant-process/test/integration/updateVerifiedAttributeExtensionDate.test.ts
+++ b/packages/tenant-process/test/integration/updateVerifiedAttributeExtensionDate.test.ts
@@ -101,7 +101,10 @@ describe("updateVerifiedAttributeExtensionDate", async () => {
       ],
       updatedAt: new Date(Number(writtenPayload.tenant?.updatedAt)),
     };
-    expect(writtenPayload.tenant).toEqual(toTenantV2(updatedTenant));
+    expect(writtenPayload).toEqual({
+      attributeId,
+      tenant: toTenantV2(updatedTenant),
+    });
     expect(returnedTenant).toEqual(updatedTenant);
   });
   it("should throw tenantNotFound when tenant doesn't exist", async () => {


### PR DESCRIPTION
## Summary
[PIN-9766](https://pagopa.atlassian.net/browse/PIN-9766)

- Replace single-field `expect(writtenPayload.X).toEqual(Y)` assertions with full-payload `expect(writtenPayload).toEqual({ X: Y, ... })` in `tenant-process` and `attribute-registry-process` integration tests
- Adds previously missing `attributeId` field validation on 13 assertions across certified/verified attribute events (`TenantCertifiedAttributeAssignedV2`, `TenantCertifiedAttributeRevokedV2`, `TenantVerifiedAttributeExtensionUpdatedV2`, `TenantVerifiedAttributeExpirationUpdatedV2`)
- Adds previously missing `tenantId` field validation on `MaintenanceTenantDeletedV2` event
- Adds previously missing `mailId` field validation on `TenantMailAddedV2` and `TenantMailDeletedV2` events (4 assertions)
- Replaces circular `mailId: writtenPayload.mailId` self-references in `addTenantMail.test.ts` with deterministic `crypto.createHash("sha256").update(mailSeed.address).digest("hex")` for full value verification

| Package | Files | Assertions refactored |
|---|---:|---:|
| tenant-process | 16 | 28 |
| attribute-registry-process | 4 | 7 |

## Test plan
- [x] `attribute-registry-process`: 35/35 tests passing
- [x] `tenant-process`: 164/164 tests passing
- [x] TypeScript type-check passing on both packages (pre-existing TS error in `tenantService.ts:1268` unrelated to this change)

[PIN-9766]: https://pagopa.atlassian.net/browse/PIN-9766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ