### PR TITLE
fix: increase Node.js heap limit in check-selfcare-diff Dockerfile

### DIFF
--- a/packages/check-selfcare-diff/Dockerfile
+++ b/packages/check-selfcare-diff/Dockerfile
@@ -29,6 +29,8 @@ COPY ./packages/api-clients /app/packages/api-clients
 COPY ./packages/readmodel /app/packages/readmodel
 COPY ./packages/readmodel-models /app/packages/readmodel-models
 
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 RUN pnpm build && \
   rm -rf /app/node_modules/.modules.yaml && \
   rm -rf /app/node_modules/.cache && \


### PR DESCRIPTION
## Summary

- Add `NODE_OPTIONS="--max-old-space-size=4096"` to the check-selfcare-diff Dockerfile
- The `api-clients` build crashes with exit code 134 (SIGABRT) because the default V8 heap limit (~1.5-2GB) is insufficient for Zodios client generation from OpenAPI specs
- Verified locally: build now completes successfully (8/8 packages)