### PR TITLE
[PIN-9557] Fix purpose template archive when readmodel lags behind event store

### DIFF
--- a/packages/backend-for-frontend/test/api/purposeTemplateRouter/archivePurposeTemplate.test.ts
+++ b/packages/backend-for-frontend/test/api/purposeTemplateRouter/archivePurposeTemplate.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { generateId, PurposeTemplateId } from "pagopa-interop-models";
+import {
+  generateId,
+  Problem,
+  PurposeTemplateId,
+} from "pagopa-interop-models";
 import request from "supertest";
 import { generateToken } from "pagopa-interop-commons-test/src/mockedPayloadForToken.js";
 import { authRole } from "pagopa-interop-commons";
 import { appBasePath } from "../../../src/config/appBasePath.js";
 import { api, clients } from "../../vitest.api.setup.js";
+import { AxiosError, InternalAxiosRequestConfig } from "axios";
 
 describe("API POST /purposeTemplates/{purposeTemplateId}/archive", () => {
   const mockArchivedPurposeTemplateId = generateId<PurposeTemplateId>();
@@ -35,5 +40,39 @@ describe("API POST /purposeTemplates/{purposeTemplateId}/archive", () => {
     const token = generateToken(authRole.ADMIN_ROLE);
     const res = await makeRequest(token, "invalid" as PurposeTemplateId);
     expect(res.status).toBe(400);
+  });
+
+  it("Should return 500 when the downstream archive endpoint returns an unexpected error", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const downstreamProblem: Problem = {
+      type: "about:blank",
+      title: "Unexpected error",
+      status: 500,
+      detail: "Unexpected error",
+      correlationId: "test-correlation-id",
+      errors: [{ code: "015-9991", detail: "Unexpected error" }],
+    };
+
+    clients.purposeTemplateProcessClient.archivePurposeTemplate = vi
+      .fn()
+      .mockRejectedValue(
+        new AxiosError("Unexpected error", "500", undefined, undefined, {
+          status: 500,
+          data: downstreamProblem,
+          statusText: "Internal Server Error",
+          config: {} as InternalAxiosRequestConfig,
+          headers: {},
+        })
+      );
+
+    const res = await makeRequest(token, mockArchivedPurposeTemplateId);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({
+      title: downstreamProblem.title,
+      status: downstreamProblem.status,
+      detail: downstreamProblem.detail,
+      errors: [{ code: "008-9991", detail: downstreamProblem.detail }],
+    });
   });
 });

--- a/packages/backend-for-frontend/test/api/purposeTemplateRouter/archivePurposeTemplate.test.ts
+++ b/packages/backend-for-frontend/test/api/purposeTemplateRouter/archivePurposeTemplate.test.ts
@@ -1,9 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  generateId,
-  Problem,
-  PurposeTemplateId,
-} from "pagopa-interop-models";
+import { generateId, Problem, PurposeTemplateId } from "pagopa-interop-models";
 import request from "supertest";
 import { generateToken } from "pagopa-interop-commons-test/src/mockedPayloadForToken.js";
 import { authRole } from "pagopa-interop-commons";

--- a/packages/commons/src/repositories/EventRepository.ts
+++ b/packages/commons/src/repositories/EventRepository.ts
@@ -123,12 +123,34 @@ async function internalCreateEvents<T extends Event>(
   }
 }
 
+async function internalGetLatestVersion(
+  db: DB,
+  streamId: string
+): Promise<number | undefined> {
+  const dbRecord = await db.oneOrNone(sql.getLatestEventVersion, {
+    stream_id: streamId,
+  });
+  const decodedDBRecord = z
+    .object({ version: z.coerce.number() })
+    .nullish()
+    .safeParse(dbRecord);
+
+  if (!decodedDBRecord.success) {
+    throw genericInternalError(
+      `Error retrieving latest version for stream ${streamId}: ${decodedDBRecord.error.message}`
+    );
+  }
+
+  return decodedDBRecord.data?.version;
+}
+
 export const eventRepository = <T extends Event>(
   db: DB,
   toBinaryData: (event: T) => Uint8Array
 ): {
   createEvent: (createEvent: CreateEvent<T>) => Promise<CreatedEvent>;
   createEvents: (createEvents: Array<CreateEvent<T>>) => Promise<CreatedEvents>;
+  getLatestVersion: (streamId: string) => Promise<number | undefined>;
 } => ({
   async createEvent(createEvent: CreateEvent<T>): Promise<CreatedEvent> {
     return await internalCreateEvent(db, toBinaryData, createEvent);
@@ -137,6 +159,9 @@ export const eventRepository = <T extends Event>(
     createEvents: Array<CreateEvent<T>>
   ): Promise<CreatedEvents> {
     return await internalCreateEvents(db, toBinaryData, createEvents);
+  },
+  async getLatestVersion(streamId: string): Promise<number | undefined> {
+    return await internalGetLatestVersion(db, streamId);
   },
 });
 

--- a/packages/commons/src/repositories/sql/getLatestEventVersion.sql
+++ b/packages/commons/src/repositories/sql/getLatestEventVersion.sql
@@ -1,0 +1,6 @@
+SELECT "version"
+FROM "events"
+WHERE
+    stream_id = $(stream_id)
+ORDER BY "version" DESC
+LIMIT 1

--- a/packages/commons/src/repositories/sql/index.ts
+++ b/packages/commons/src/repositories/sql/index.ts
@@ -24,3 +24,4 @@ function sql(file: string): pgPromise.QueryFile {
 
 export const insertEvent = sql("insertEvent.sql");
 export const checkEventVersionExists = sql("checkEventVersionExists.sql");
+export const getLatestEventVersion = sql("getLatestEventVersion.sql");

--- a/packages/purpose-template-process/src/services/purposeTemplateService.ts
+++ b/packages/purpose-template-process/src/services/purposeTemplateService.ts
@@ -20,6 +20,7 @@ import {
   EServiceDescriptorPurposeTemplate,
   EServiceId,
   generateId,
+  genericInternalError,
   ListResult,
   PurposeTemplate,
   PurposeTemplateEvent,
@@ -1808,10 +1809,22 @@ export function purposeTemplateServiceBuilder(
         updatedAt: new Date(),
       };
 
+      const latestStreamVersion = await repository.getLatestVersion(id);
+
+      if (latestStreamVersion === undefined) {
+        throw genericInternalError(
+          `Cannot archive purpose template ${id}: no event stream found`
+        );
+      }
+
+      logger.info(
+        `Archiving purpose template ${id} from state ${purposeTemplate.data.state} using event stream version ${latestStreamVersion} and readmodel version ${purposeTemplate.metadata.version}`
+      );
+
       const createdEvent = await repository.createEvent(
         toCreateEventPurposeTemplateArchived({
           purposeTemplate: updatedPurposeTemplate,
-          version: purposeTemplate.metadata.version,
+          version: latestStreamVersion,
           correlationId,
         })
       );

--- a/packages/purpose-template-process/test/integration/archivePurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/archivePurposeTemplate.test.ts
@@ -4,7 +4,9 @@ import {
   getMockAuthData,
   getMockCompleteRiskAnalysisFormTemplate,
   getMockContext,
+  getMockContextInternal,
   getMockPurposeTemplate,
+  getMockRiskAnalysisTemplateSignedDocument,
   sortPurposeTemplate,
 } from "pagopa-interop-commons-test";
 import {
@@ -101,6 +103,37 @@ describe("archivePurposeTemplate", () => {
       });
     }
   );
+
+  it("should archive a purpose template even if the event-store version is ahead of the readmodel version", async () => {
+    const metadataVersion = 2;
+    await addOnePurposeTemplate(
+      { ...purposeTemplate, state: purposeTemplateState.suspended },
+      metadataVersion
+    );
+
+    await purposeTemplateService.internalAddRiskAnalysisTemplateSignedDocumentMetadata(
+      purposeTemplate.id,
+      getMockRiskAnalysisTemplateSignedDocument(undefined, purposeTemplate.id),
+      getMockContextInternal({})
+    );
+
+    const archiveResponse = await purposeTemplateService.archivePurposeTemplate(
+      purposeTemplate.id,
+      getMockContext({ authData: getMockAuthData(creatorId) })
+    );
+
+    const writtenEvent = await readLastPurposeTemplateEvent(purposeTemplate.id);
+
+    expect(writtenEvent).toMatchObject({
+      stream_id: purposeTemplate.id,
+      version: String(metadataVersion + 2),
+      type: "PurposeTemplateArchived",
+      event_version: 2,
+    });
+    expect(archiveResponse.metadata).toEqual({
+      version: metadataVersion + 2,
+    });
+  });
 
   it("should throw purposeTemplateNotFound if the caller is not the creator of the purpose template", async () => {
     await addOnePurposeTemplate(purposeTemplate);


### PR DESCRIPTION
## Summary

This change fixes a failure in `archivePurposeTemplate` when the purpose template readmodel is behind the event store.

Before this change, the archive command used `purposeTemplate.metadata.version` from the readmodel when appending the `PurposeTemplateArchived` event.
If another event had already been appended on the same stream but the readmodel had not caught up yet, the archive command failed with a generic `500`.

The fix keeps validation on the readmodel, but uses the latest stream version from the event store when writing the archive event.

## How to reproduce the bug

1. Start local infrastructure together with:
   - `purpose-template-process`
   - `purpose-template-readmodel-writer-sql`
   - `backend-for-frontend`

2. Create a purpose template.

3. Publish the purpose template.

4. Suspend the purpose template.

5. Wait until `GET /purposeTemplates/{id}` returns `SUSPENDED`.

6. Stop `purpose-template-readmodel-writer-sql`.

7. Call:
   `POST /internal/purposeTemplates/{id}/riskAnalysisDocument/signed`

8. Call `GET /purposeTemplates/{id}` again.
   The purpose template still appears as `SUSPENDED` because the readmodel writer is stopped.

9. Call:
   `POST /purposeTemplates/{id}/archive`

10. The archive fails with:
   - `015-9991` on `purpose-template-process`
   - `008-9991` on `backend-for-frontend`

## Root cause

The internal signed risk analysis document endpoint appends a new event on the same purpose template stream.
With the readmodel writer stopped, the readmodel version remains stale while the event store version advances.
The archive command was using the stale readmodel version, so event append failed.

## Changes

- Added an event repository helper to retrieve the latest stream version from the event store.
- Updated `archivePurposeTemplate` to use the latest event store version when appending `PurposeTemplateArchived`.
- Added an integration regression test for the stale readmodel scenario.
- Added a BFF API test covering the downstream unexpected error path.

## Verification

- `packages/purpose-template-process`
  - `pnpm exec vitest run test/integration/archivePurposeTemplate.test.ts --config vitest.integration.config.ts`
- `packages/backend-for-frontend`
  - `pnpm exec vitest run test/api/purposeTemplateRouter/archivePurposeTemplate.test.ts --config vitest.api.config.ts`