### PR TITLE
Add archive agreement endpoint to m2m gateway v3 (PIN-9702)

### DIFF
--- a/collections/m2m gateway-v3/agreements/Archive Agreement.bru
+++ b/collections/m2m gateway-v3/agreements/Archive Agreement.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Archive agreement
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{host-m2m-gw-v3}}/agreements/:agreementId/archive
+  body: none
+  auth: none
+}
+
+params:path {
+  agreementId: {{agreementId}}
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M-ADMIN}}
+  DPoP: {{DPOP-PROOF}}
+}

--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -317,10 +317,13 @@ const agreementRouter = (
       try {
         validateAuthorization(ctx, [ADMIN_ROLE]);
 
-        const agreement = await agreementService.archiveAgreement(
-          unsafeBrandId(req.params.agreementId),
-          ctx
-        );
+        const { data: agreement, metadata } =
+          await agreementService.archiveAgreement(
+            unsafeBrandId(req.params.agreementId),
+            ctx
+          );
+
+        setMetadataVersionHeader(res, metadata);
         return res
           .status(200)
           .send(

--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -1358,7 +1358,7 @@ export function agreementServiceBuilder(
     async archiveAgreement(
       agreementId: AgreementId,
       { authData, correlationId, logger }: WithLogger<AppContext<UIAuthData>>
-    ): Promise<Agreement> {
+    ): Promise<WithMetadata<Agreement>> {
       logger.info(`Archiving agreement ${agreementId}`);
 
       const agreement = await retrieveAgreement(agreementId, readModelService);
@@ -1391,7 +1391,7 @@ export function agreementServiceBuilder(
         },
       };
 
-      await repository.createEvent(
+      const { newVersion } = await repository.createEvent(
         toCreateEventAgreementArchivedByConsumer(
           updatedAgreement,
           agreement.metadata.version,
@@ -1399,7 +1399,12 @@ export function agreementServiceBuilder(
         )
       );
 
-      return updatedAgreement;
+      return {
+        data: updatedAgreement,
+        metadata: {
+          version: newVersion,
+        },
+      };
     },
     async internalArchiveAgreementAfterDelegationRevocation(
       agreementId: AgreementId,

--- a/packages/agreement-process/test/api/archiveAgreement.test.ts
+++ b/packages/agreement-process/test/api/archiveAgreement.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   AgreementId,
   DelegationId,
+  WithMetadata,
   agreementState,
   generateId,
 } from "pagopa-interop-models";
@@ -25,11 +26,15 @@ describe("API POST /agreements/{agreementId}/archive test", () => {
   const apiResponse = agreementApi.Agreement.parse(
     agreementToApiAgreement(mockAgreement)
   );
+  const serviceResponse: WithMetadata<typeof mockAgreement> = {
+    data: mockAgreement,
+    metadata: { version: 1 },
+  };
 
   beforeEach(() => {
     agreementService.archiveAgreement = vi
       .fn()
-      .mockResolvedValue(mockAgreement);
+      .mockResolvedValue(serviceResponse);
   });
 
   const makeRequest = async (
@@ -46,6 +51,7 @@ describe("API POST /agreements/{agreementId}/archive test", () => {
     const res = await makeRequest(token);
     expect(res.status).toBe(200);
     expect(res.body).toEqual(apiResponse);
+    expect(res.headers["x-metadata-version"]).toBe("1");
   });
 
   it.each(

--- a/packages/agreement-process/test/integration/archiveAgreement.test.ts
+++ b/packages/agreement-process/test/integration/archiveAgreement.test.ts
@@ -57,7 +57,7 @@ describe("archive agreement", () => {
       agreement.id,
       getMockContext({ authData })
     );
-    const agreementId = returnedAgreement.id;
+    const agreementId = returnedAgreement.data.id;
 
     expect(agreementId).toBeDefined();
     const actualAgreementData = await readLastAgreementEvent(agreementId);
@@ -95,8 +95,10 @@ describe("archive agreement", () => {
     );
 
     expect(sortAgreementV2(actualAgreement)).toEqual(
-      sortAgreementV2(toAgreementV2(returnedAgreement))
+      sortAgreementV2(toAgreementV2(returnedAgreement.data))
     );
+
+    expect(returnedAgreement.metadata).toEqual({ version: 1 });
 
     vi.useRealTimers();
   });
@@ -130,7 +132,7 @@ describe("archive agreement", () => {
       getMockContext({ authData })
     );
 
-    const agreementId = returnedAgreement.id;
+    const agreementId = returnedAgreement.data.id;
 
     expect(agreementId).toBeDefined();
 
@@ -170,8 +172,10 @@ describe("archive agreement", () => {
     );
 
     expect(sortAgreementV2(actualAgreement)).toEqual(
-      sortAgreementV2(toAgreementV2(returnedAgreement))
+      sortAgreementV2(toAgreementV2(returnedAgreement.data))
     );
+
+    expect(returnedAgreement.metadata).toEqual({ version: 1 });
 
     vi.useRealTimers();
   });

--- a/packages/api-clients/open-api/agreementApi.yml
+++ b/packages/api-clients/open-api/agreementApi.yml
@@ -432,6 +432,9 @@ paths:
       responses:
         "200":
           description: Agreement archived.
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
           content:
             application/json:
               schema:

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -421,8 +421,6 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
-        "409":
-          $ref: "#/components/responses/Conflict"
         "429":
           $ref: "#/components/responses/TooManyRequests"
   /agreements/{agreementId}/submit:

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -379,6 +379,52 @@ paths:
           $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+  /agreements/{agreementId}/archive:
+    parameters:
+      - schema:
+          $ref: "#/components/schemas/AgreementId"
+        name: agreementId
+        description: The ID of the Agreement to archive
+        in: path
+        required: true
+    post:
+      tags:
+        - agreements
+      summary: Archive an Agreement in Active or Suspended state
+      description: |
+        Archive an Agreement that is in Active or Suspended state, transitioning it to Archived state.
+        The Archived state is not reversible.
+      operationId: archiveAgreement
+      responses:
+        "200":
+          description: Agreement archived
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agreement"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
   /agreements/{agreementId}/submit:
     parameters:
       - schema:

--- a/packages/m2m-gateway-v3/src/routers/agreementRouter.ts
+++ b/packages/m2m-gateway-v3/src/routers/agreementRouter.ts
@@ -15,6 +15,7 @@ import { AgreementService } from "../services/agreementService.js";
 import { fromM2MGatewayAppContext } from "../utils/context.js";
 import {
   approveAgreementErrorMapper,
+  archiveAgreementErrorMapper,
   downloadAgreementConsumerContractErrorMapper,
   unsuspendAgreementErrorMapper,
 } from "../utils/errorMappers.js";
@@ -231,6 +232,26 @@ const agreementRouter = (
           unsuspendAgreementErrorMapper,
           ctx,
           `Error unsuspending agreement with id ${req.params.agreementId}`
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
+    .post("/agreements/:agreementId/archive", async (req, res) => {
+      const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+      try {
+        validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+        const agreement = await agreementService.archiveAgreement(
+          unsafeBrandId(req.params.agreementId),
+          ctx
+        );
+
+        return res.status(200).send(m2mGatewayApiV3.Agreement.parse(agreement));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          archiveAgreementErrorMapper,
+          ctx,
+          `Error archiving agreement with id ${req.params.agreementId}`
         );
         return res.status(errorRes.status).send(errorRes);
       }

--- a/packages/m2m-gateway-v3/src/services/agreementService.ts
+++ b/packages/m2m-gateway-v3/src/services/agreementService.ts
@@ -339,6 +339,27 @@ export function agreementServiceBuilder(
         headers
       );
     },
+    async archiveAgreement(
+      agreementId: AgreementId,
+      { logger, headers }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.Agreement> {
+      logger.info(`Archiving agreement with id ${agreementId}`);
+
+      const response = await clients.agreementProcessClient.archiveAgreement(
+        undefined,
+        {
+          params: { agreementId },
+          headers,
+        }
+      );
+
+      const polledResource = await pollAgreement(response, headers);
+
+      return toM2MGatewayApiAgreementWithDelegationId(
+        polledResource.data,
+        headers
+      );
+    },
     async upgradeAgreement(
       agreementId: AgreementId,
       { logger, headers }: WithLogger<M2MGatewayAppContext>

--- a/packages/m2m-gateway-v3/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway-v3/src/utils/errorMappers.ts
@@ -4,7 +4,16 @@ import { ApiError, CommonErrorCodes } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { ErrorCodes as M2MGatewayErrorCodes } from "../model/errors.js";
 
-type ErrorCodes = M2MGatewayErrorCodes | CommonErrorCodes;
+type AgreementProcessErrorCodes =
+  | "agreementNotFound"
+  | "agreementNotInExpectedState"
+  | "tenantIsNotTheConsumer"
+  | "tenantIsNotTheDelegateConsumer";
+
+type ErrorCodes =
+  | M2MGatewayErrorCodes
+  | CommonErrorCodes
+  | AgreementProcessErrorCodes;
 
 const {
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -26,6 +35,19 @@ export const unsuspendAgreementErrorMapper = (
 ): number =>
   match(error.code)
     .with("agreementNotInSuspendedState", () => HTTP_STATUS_CONFLICT)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const archiveAgreementErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("agreementNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("agreementNotInExpectedState", () => HTTP_STATUS_BAD_REQUEST)
+    .with(
+      "tenantIsNotTheConsumer",
+      "tenantIsNotTheDelegateConsumer",
+      () => HTTP_STATUS_FORBIDDEN
+    )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
 export const getAttributeErrorMapper = (error: ApiError<ErrorCodes>): number =>

--- a/packages/m2m-gateway-v3/test/api/agreements/archiveAgreement.test.ts
+++ b/packages/m2m-gateway-v3/test/api/agreements/archiveAgreement.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  generateToken,
+  getMockDPoPProof,
+  getMockedApiAgreement,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  ApiError,
+  generateId,
+  pollingMaxRetriesExceeded,
+  TenantId,
+} from "pagopa-interop-models";
+import { api, mockAgreementService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { toM2MGatewayApiAgreement } from "../../../src/api/agreementApiConverter.js";
+import { config } from "../../../src/config/config.js";
+
+describe("POST /agreements/:agreementId/archive router test", () => {
+  const mockApiAgreement = getMockedApiAgreement();
+
+  const mockM2MAgreementResponse: m2mGatewayApiV3.Agreement =
+    toM2MGatewayApiAgreement(mockApiAgreement, generateId());
+
+  const makeRequest = async (
+    token: string,
+    agreementId: string = mockApiAgreement.id
+  ) =>
+    request(api)
+      .post(`${appBasePath}/agreements/${agreementId}/archive`)
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 and perform service calls for user with role %s",
+    async (role) => {
+      mockAgreementService.archiveAgreement = vi
+        .fn()
+        .mockResolvedValue(mockM2MAgreementResponse);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockM2MAgreementResponse);
+    }
+  );
+
+  it("Should return 400 for incorrect value for agreement id", async () => {
+    mockAgreementService.archiveAgreement = vi
+      .fn()
+      .mockResolvedValue(mockM2MAgreementResponse);
+
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, "INVALID ID");
+    expect(res.status).toBe(400);
+  });
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, generateId());
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockAgreementService.archiveAgreement = vi.fn().mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(500);
+  });
+
+  it.each([
+    {
+      error: new ApiError({
+        code: "agreementNotFound",
+        title: "Agreement not found",
+        detail: "Agreement not found",
+      }),
+      status: 404,
+    },
+    {
+      error: new ApiError({
+        code: "agreementNotInExpectedState",
+        title: "Agreement not in expected state",
+        detail: "Agreement not in expected state",
+      }),
+      status: 400,
+    },
+    {
+      error: new ApiError({
+        code: "tenantIsNotTheConsumer",
+        title: "Tenant is not the consumer",
+        detail: "Tenant is not the consumer",
+      }),
+      status: 403,
+    },
+    {
+      error: new ApiError({
+        code: "tenantIsNotTheDelegateConsumer",
+        title: "Tenant is not the delegate consumer",
+        detail: `Tenant ${generateId<TenantId>()} is not the delegate consumer`,
+      }),
+      status: 403,
+    },
+  ])("Should return $status for mapped process errors", async ({ error, status }) => {
+    mockAgreementService.archiveAgreement = vi.fn().mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(status);
+  });
+
+  it.each([
+    { ...mockM2MAgreementResponse, state: "INVALID_STATE" },
+    { ...mockM2MAgreementResponse, invalidParam: "invalidValue" },
+    { ...mockM2MAgreementResponse, createdAt: undefined },
+  ])(
+    "Should return 500 when API model parsing fails for response",
+    async (resp) => {
+      mockAgreementService.archiveAgreement = vi
+        .fn()
+        .mockResolvedValueOnce(resp);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(500);
+    }
+  );
+});

--- a/packages/m2m-gateway-v3/test/api/agreements/archiveAgreement.test.ts
+++ b/packages/m2m-gateway-v3/test/api/agreements/archiveAgreement.test.ts
@@ -115,13 +115,16 @@ describe("POST /agreements/:agreementId/archive router test", () => {
       }),
       status: 403,
     },
-  ])("Should return $status for mapped process errors", async ({ error, status }) => {
-    mockAgreementService.archiveAgreement = vi.fn().mockRejectedValue(error);
-    const token = generateToken(authRole.M2M_ADMIN_ROLE);
-    const res = await makeRequest(token);
+  ])(
+    "Should return $status for mapped process errors",
+    async ({ error, status }) => {
+      mockAgreementService.archiveAgreement = vi.fn().mockRejectedValue(error);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token);
 
-    expect(res.status).toBe(status);
-  });
+      expect(res.status).toBe(status);
+    }
+  );
 
   it.each([
     { ...mockM2MAgreementResponse, state: "INVALID_STATE" },


### PR DESCRIPTION
## Summary
- add `POST /agreements/{agreementId}/archive` to the m2m gateway v3 OpenAPI contract and Bruno collection
- expose the archive route in `m2m-gateway-v3` with read-after-write polling, aligned with other agreement mutations
- update `agreement-process` archive responses to return metadata version headers needed by polling
- add API and integration test coverage for the new archive flow and mapped error handling

## Testing
- Not run (not requested)