### PR TITLE
refactor: match entire payload object in eservice-template-process tests (PIN-9765)

### DIFF
--- a/packages/eservice-template-process/test/integration/activateEServiceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/integration/activateEServiceTemplateVersion.test.ts
@@ -77,10 +77,10 @@ describe("activateEServiceTemplateVersion", () => {
       ],
     });
 
-    expect(writtenPayload.eserviceTemplateVersionId).toEqual(
-      eserviceTemplateVersion.id
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual(expectedEServiceTemplate);
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: eserviceTemplateVersion.id,
+      eserviceTemplate: expectedEServiceTemplate,
+    });
   });
 
   it("should throw eserviceTemplateNotFound if the eservice template doesn't exist", () => {

--- a/packages/eservice-template-process/test/integration/createEServiceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/createEServiceTemplate.test.ts
@@ -87,9 +87,9 @@ describe("create eservice template", () => {
       isSignalHubEnabled,
     };
 
-    expect(eserviceCreationPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(expectedEserviceTemplate)
-    );
+    expect(eserviceCreationPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(expectedEserviceTemplate),
+    });
 
     expect(eserviceTemplate).toEqual({
       data: expectedEserviceTemplate,

--- a/packages/eservice-template-process/test/integration/deleteDocument.test.ts
+++ b/packages/eservice-template-process/test/integration/deleteDocument.test.ts
@@ -107,11 +107,6 @@ describe("delete Document", () => {
         ],
       };
 
-      expect(writtenPayload.eserviceTemplateVersionId).toEqual(
-        eserviceTemplateVersion.id
-      );
-      expect(writtenPayload.documentId).toEqual(document.id);
-
       expect(writtenPayload).toEqual({
         eserviceTemplateVersionId: eserviceTemplateVersion.id,
         documentId: document.id,
@@ -199,10 +194,6 @@ describe("delete Document", () => {
       ],
     };
 
-    expect(writtenPayload.eserviceTemplateVersionId).toEqual(
-      eserviceTemplateVersion.id
-    );
-    expect(writtenPayload.documentId).toEqual(interfaceDocument.id);
     expect(writtenPayload).toEqual({
       eserviceTemplateVersionId: eserviceTemplateVersion.id,
       documentId: interfaceDocument.id,

--- a/packages/eservice-template-process/test/integration/deleteEServiceTemplateRiskAnalysis.test.ts
+++ b/packages/eservice-template-process/test/integration/deleteEServiceTemplateRiskAnalysis.test.ts
@@ -103,9 +103,10 @@ describe("deleteEServiceTemplateRiskAnalysis", () => {
       riskAnalysis: [],
     };
 
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(updatedEServiceTemplate)
-    );
+    expect(writtenPayload).toEqual({
+      riskAnalysisId: riskAnalysis.id,
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+    });
     expect(deleteResponse).toEqual({
       data: updatedEServiceTemplate,
       metadata: { version: 1 },

--- a/packages/eservice-template-process/test/integration/deleteEServiceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/integration/deleteEServiceTemplateVersion.test.ts
@@ -132,10 +132,10 @@ describe("deleteEServiceTemplateVersion", () => {
       versions: [eserviceTemplateVersion1],
     });
 
-    expect(writtenPayload.eserviceTemplateVersionId).toEqual(
-      eserviceTemplateVersion2.id
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual(expectedEServiceTemplate);
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: eserviceTemplateVersion2.id,
+      eserviceTemplate: expectedEServiceTemplate,
+    });
 
     expect(fileManager.delete).toHaveBeenCalledWith(
       config.s3Bucket,
@@ -249,7 +249,9 @@ describe("deleteEServiceTemplateVersion", () => {
       versions: [eserviceTemplateVersion],
     });
 
-    expect(writtenPayload.eserviceTemplate).toEqual(expectedEServiceTemplate);
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: expectedEServiceTemplate,
+    });
 
     expect(fileManager.delete).toHaveBeenCalledWith(
       config.s3Bucket,

--- a/packages/eservice-template-process/test/integration/deleteEserviceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/deleteEserviceTemplate.test.ts
@@ -58,7 +58,9 @@ describe("delete eserviceTemplate", () => {
       messageType: EServiceTemplateDeletedV2,
       payload: writtenEvent.data,
     });
-    expect(writtenPayload.eserviceTemplate?.id).toBe(eserviceTemplate.id);
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+    });
   });
 
   it("should write on event-store for the deletion of an eserviceTemplate (eserviceTemplate with a draft version only) and delete the interface and documents of the draft version", async () => {
@@ -158,9 +160,11 @@ describe("delete eserviceTemplate", () => {
       ...eserviceTemplate,
       versions: [],
     };
-    expect(eserviceTemplateDeletionPayload.eserviceTemplate?.id).toBe(
-      mockEServiceTemplate.id
-    );
+    expect(eserviceTemplateDeletionPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(
+        expectedEserviceTemplateWithoutVersions
+      ),
+    });
     expect(versionDeletionPayload).toEqual({
       eserviceTemplate: toEServiceTemplateV2(
         expectedEserviceTemplateWithoutVersions

--- a/packages/eservice-template-process/test/integration/patchUpdateEserviceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/patchUpdateEserviceTemplate.test.ts
@@ -122,9 +122,9 @@ describe("update eserviceTemplate", () => {
         payload: writtenEvent.data,
       });
 
-      expect(writtenPayload.eserviceTemplate).toEqual(
-        toEServiceTemplateV2(expectedEServiceTemplate)
-      );
+      expect(writtenPayload).toEqual({
+        eserviceTemplate: toEServiceTemplateV2(expectedEServiceTemplate),
+      });
       expect(updateEServiceTemplateReturn).toEqual({
         data: expectedEServiceTemplate,
         metadata: { version: 1 },

--- a/packages/eservice-template-process/test/integration/publishEServiceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/integration/publishEServiceTemplateVersion.test.ts
@@ -127,12 +127,12 @@ describe("publishEServiceTemplateVersion", () => {
       ],
     });
 
-    expect(writtenPayload.eserviceTemplateVersionId).toEqual(
-      eserviceTemplateVersion.id
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual({
-      ...expectedEServiceTemplate,
-      versions: expect.arrayContaining(expectedEServiceTemplate.versions),
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: eserviceTemplateVersion.id,
+      eserviceTemplate: {
+        ...expectedEServiceTemplate,
+        versions: expect.arrayContaining(expectedEServiceTemplate.versions),
+      },
     });
   });
 

--- a/packages/eservice-template-process/test/integration/suspendEServiceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/integration/suspendEServiceTemplateVersion.test.ts
@@ -78,10 +78,10 @@ describe("suspendEServiceTemplateVersion", () => {
       ],
     });
 
-    expect(writtenPayload.eserviceTemplateVersionId).toEqual(
-      eserviceTemplateVersion.id
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual(expectedEServiceTemplate);
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: eserviceTemplateVersion.id,
+      eserviceTemplate: expectedEServiceTemplate,
+    });
   });
 
   it("should throw eserviceTemplateNotFound if the eservice template doesn't exist", () => {

--- a/packages/eservice-template-process/test/integration/updateDocument.test.ts
+++ b/packages/eservice-template-process/test/integration/updateDocument.test.ts
@@ -96,11 +96,15 @@ describe("update Document", () => {
         payload: writtenEvent.data,
       });
 
-      expect(writtenPayload.eserviceTemplateVersionId).toEqual(version.id);
-      expect(writtenPayload.documentId).toEqual(mockDocument.id);
-      expect(writtenPayload.eserviceTemplate).toEqual(expectedEserviceTemplate);
-      expect(writtenPayload.eserviceTemplate).toEqual(
-        toEServiceTemplateV2({
+      expect(writtenPayload).toEqual({
+        eserviceTemplateVersionId: version.id,
+        documentId: mockDocument.id,
+        eserviceTemplate: expectedEserviceTemplate,
+      });
+      expect(writtenPayload).toEqual({
+        eserviceTemplateVersionId: version.id,
+        documentId: mockDocument.id,
+        eserviceTemplate: toEServiceTemplateV2({
           ...eserviceTemplate,
           versions: [
             {
@@ -108,8 +112,8 @@ describe("update Document", () => {
               docs: [returnedDocument],
             },
           ],
-        })
-      );
+        }),
+      });
     }
   );
 
@@ -162,11 +166,15 @@ describe("update Document", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.eserviceTemplateVersionId).toEqual(version.id);
-    expect(writtenPayload.documentId).toEqual(mockDocument.id);
-    expect(writtenPayload.eserviceTemplate).toEqual(expectedEserviceTemplate);
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2({
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: version.id,
+      documentId: mockDocument.id,
+      eserviceTemplate: expectedEserviceTemplate,
+    });
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: version.id,
+      documentId: mockDocument.id,
+      eserviceTemplate: toEServiceTemplateV2({
         ...eserviceTemplate,
         versions: [
           {
@@ -174,8 +182,8 @@ describe("update Document", () => {
             interface: returnedDocument,
           },
         ],
-      })
-    );
+      }),
+    });
   });
 
   it("should throw eserviceTemplateNotFound if the eservice template doesn't exist", async () => {

--- a/packages/eservice-template-process/test/integration/updateDraftVersion.test.ts
+++ b/packages/eservice-template-process/test/integration/updateDraftVersion.test.ts
@@ -109,9 +109,10 @@ describe("update draft version", () => {
       messageType: EServiceTemplateDraftVersionUpdatedV2,
       payload: writtenEvent.data,
     });
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(updatedEServiceTemplate)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: version.id,
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+    });
   });
 
   it("should throw eserviceTemplateNotFound if the eservice template doesn't exist", () => {
@@ -281,9 +282,10 @@ describe("update draft version", () => {
       messageType: EServiceTemplateDraftVersionUpdatedV2,
       payload: writtenEvent.data,
     });
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(updatedEserviceTemplate)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: version.id,
+      eserviceTemplate: toEServiceTemplateV2(updatedEserviceTemplate),
+    });
   });
 
   it("should throw attributeNotFound if at least one of the attributes doesn't exist", async () => {

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplate.test.ts
@@ -82,12 +82,12 @@ describe("update EService template", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(updatedEServiceTemplate)
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(returnedEServiceTemplate.data)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+    });
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(returnedEServiceTemplate.data),
+    });
     expect(fileManager.delete).not.toHaveBeenCalled();
   });
 
@@ -166,9 +166,9 @@ describe("update EService template", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(updatedEServiceTemplate)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+    });
     expect(fileManager.delete).toHaveBeenCalledWith(
       config.s3Bucket,
       interfaceDocument.path,
@@ -177,9 +177,9 @@ describe("update EService template", () => {
     expect(
       await fileManager.listFiles(config.s3Bucket, genericLogger)
     ).not.toContain(interfaceDocument.path);
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(returnedEServiceTemplate.data)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(returnedEServiceTemplate.data),
+    });
   });
 
   it("should write on event-store for the update of an eService (update mode to DELIVER so risk analysis has to be deleted)", async () => {
@@ -232,12 +232,12 @@ describe("update EService template", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(expectedEserviceTemplate)
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(returnedEServiceTemplate.data)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(expectedEserviceTemplate),
+    });
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(returnedEServiceTemplate.data),
+    });
   });
 
   it("should throw operationForbidden if the requester is not the creator", async () => {

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplateDescription.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplateDescription.test.ts
@@ -65,12 +65,12 @@ describe("updateEServiceTemplateDescription", () => {
       messageType: EServiceTemplateDescriptionUpdatedV2,
       payload: writtenEvent.data,
     });
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(updatedEServiceTemplate)
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(returnedEServiceTemplate.data)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+    });
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(returnedEServiceTemplate.data),
+    });
   });
 
   it("should throw eserviceTemplateNotFound if the eservice template doesn't exist", async () => {

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplateIntendedTarget.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplateIntendedTarget.test.ts
@@ -64,12 +64,12 @@ describe("updateEServiceTemplateIntendedTarget", () => {
       messageType: EServiceTemplateIntendedTargetUpdatedV2,
       payload: writtenEvent.data,
     });
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(updatedEServiceTemplate)
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(returnedEServiceTemplate.data)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+    });
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(returnedEServiceTemplate.data),
+    });
   });
 
   it("should throw eserviceTemplateNotFound if the eservice template doesn't exist", async () => {

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplateName.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplateName.test.ts
@@ -76,9 +76,10 @@ describe("updateEServiceTemplateName", () => {
       eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
       oldName: eserviceTemplate.name,
     });
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(returnedEServiceTemplate.data)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(returnedEServiceTemplate.data),
+      oldName: eserviceTemplate.name,
+    });
   });
 
   it("should throw eserviceTemplateNotFound if the eservice template doesn't exist", async () => {

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplatePersonalDataUpdatedAfterPublish.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplatePersonalDataUpdatedAfterPublish.test.ts
@@ -72,12 +72,12 @@ describe("update EService Template personalData flag for an already created ESer
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(updatedEServiceTemplate)
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(returnedEServiceTemplate)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+    });
+    expect(writtenPayload).toEqual({
+      eserviceTemplate: toEServiceTemplateV2(returnedEServiceTemplate),
+    });
   });
 
   it.each([

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplateRiskAnalysis.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplateRiskAnalysis.test.ts
@@ -153,9 +153,10 @@ describe("updateEServiceTemplateRiskAnalysis", () => {
       ],
     };
 
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(updatedEServiceTemplate)
-    );
+    expect(writtenPayload).toEqual({
+      riskAnalysisId: riskAnalysisToUpdate.id,
+      eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+    });
   });
 
   it("should throw eServiceNotFound if the eservice doesn't exist", async () => {

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplateVersionAttributes.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplateVersionAttributes.test.ts
@@ -169,12 +169,16 @@ describe("updateEServiceTemplateVersionAttributes", () => {
         messageType: EServiceTemplateVersionAttributesUpdatedV2,
         payload: writtenEvent.data,
       });
-      expect(writtenPayload.eserviceTemplate).toEqual(
-        toEServiceTemplateV2(updatedEServiceTemplate)
-      );
-      expect(writtenPayload.eserviceTemplate).toEqual(
-        toEServiceTemplateV2(returnedEServiceTemplate.data)
-      );
+      expect(writtenPayload).toEqual({
+        eserviceTemplateVersionId: mockEServiceTemplateVersion.id,
+        attributeIds: [mockCertifiedAttribute3.id, mockVerifiedAttribute3.id],
+        eserviceTemplate: toEServiceTemplateV2(updatedEServiceTemplate),
+      });
+      expect(writtenPayload).toEqual({
+        eserviceTemplateVersionId: mockEServiceTemplateVersion.id,
+        attributeIds: [mockCertifiedAttribute3.id, mockVerifiedAttribute3.id],
+        eserviceTemplate: toEServiceTemplateV2(returnedEServiceTemplate.data),
+      });
     }
   );
 

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplateVersionQuotas.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplateVersionQuotas.test.ts
@@ -79,12 +79,10 @@ describe("updateEServiceTemplateVersionQuotas", () => {
       ],
     };
 
-    expect(writtenPayload.eserviceTemplateVersionId).toEqual(
-      eserviceTemplateVersion.id
-    );
-    expect(writtenPayload.eserviceTemplate).toEqual(
-      toEServiceTemplateV2(expectedEServiceTemplate)
-    );
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: eserviceTemplateVersion.id,
+      eserviceTemplate: toEServiceTemplateV2(expectedEServiceTemplate),
+    });
 
     expect(updatedEserviceTemplateVersionReturn).toEqual({
       data: expectedEServiceTemplate,

--- a/packages/eservice-template-process/test/integration/uploadDocument.test.ts
+++ b/packages/eservice-template-process/test/integration/uploadDocument.test.ts
@@ -108,7 +108,6 @@ describe("upload Document", () => {
         ],
       });
 
-      expect(writtenPayload.eserviceTemplateVersionId).toEqual(version.id);
       expect(writtenPayload).toEqual({
         eserviceTemplateVersionId: version.id,
         documentId: expectedDocument.id,
@@ -182,7 +181,6 @@ describe("upload Document", () => {
       ],
     });
 
-    expect(writtenPayload.eserviceTemplateVersionId).toEqual(version.id);
     expect(writtenPayload).toEqual({
       eserviceTemplateVersionId: version.id,
       documentId: expectedDocument.id,


### PR DESCRIPTION
## Summary
[PIN-9765](https://pagopa.atlassian.net/browse/PIN-9765)

- Replace single-field `expect(writtenPayload.eserviceTemplate).toEqual(Y)` assertions with full-payload `expect(writtenPayload).toEqual({ eserviceTemplate: Y, ... })` in `eservice-template-process` integration tests
- Merge separate per-field assertions (e.g. `eserviceTemplateVersionId`, `documentId`, `eserviceTemplate` asserted individually) into a single full-payload `toEqual`
- Remove redundant assertions in files that already had a full-payload `toEqual` alongside separate field assertions (`deleteDocument.test.ts`, `uploadDocument.test.ts`)
- Adds previously missing field validation for `eserviceTemplateVersionId` in `updateDraftVersion.test.ts`, `riskAnalysisId` in `deleteEServiceTemplateRiskAnalysis.test.ts` and `updateEServiceTemplateRiskAnalysis.test.ts`, `oldName` in `updateEServiceTemplateName.test.ts`, `attributeIds` in `updateEServiceTemplateVersionAttributes.test.ts`

| Package | Files | Assertions refactored |
|---|---:|---:|
| eservice-template-process | 19 | ~52 |

## Test plan
- [x] `eservice-template-process`: 286/286 tests passing
- [x] TypeScript type-check passing

[PIN-9765]: https://pagopa.atlassian.net/browse/PIN-9765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ