### PR TITLE
feat: add eservice_template_version_purpose_template read model table (PIN-9771)

### DIFF
--- a/docker/readmodel-db/purpose-template.sql
+++ b/docker/readmodel-db/purpose-template.sql
@@ -112,8 +112,18 @@ CREATE TABLE IF NOT EXISTS readmodel_purpose_template.purpose_template_risk_anal
   path VARCHAR NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   signed_at TIMESTAMP WITH TIME ZONE NOT NULL,
-  
+
   PRIMARY KEY (id),
-  
+
+  FOREIGN KEY (purpose_template_id, metadata_version) REFERENCES readmodel_purpose_template.purpose_template (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS readmodel_purpose_template.eservice_template_version_purpose_template (
+  metadata_version INTEGER NOT NULL,
+  purpose_template_id UUID NOT NULL REFERENCES readmodel_purpose_template.purpose_template (id) ON DELETE CASCADE,
+  eservice_template_id UUID NOT NULL,
+  eservice_template_version_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  PRIMARY KEY (purpose_template_id, eservice_template_id),
   FOREIGN KEY (purpose_template_id, metadata_version) REFERENCES readmodel_purpose_template.purpose_template (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
 );

--- a/packages/documents-generator/src/handler/handlePurposeTemplateMessageV2.ts
+++ b/packages/documents-generator/src/handler/handlePurposeTemplateMessageV2.ts
@@ -90,6 +90,8 @@ export async function handlePurposeTemplateMessageV2(
           "PurposeTemplateDraftDeleted",
           "PurposeTemplateDraftUpdated",
           "PurposeTemplateEServiceLinked",
+          "PurposeTemplateEServiceTemplateLinked",
+          "PurposeTemplateEServiceTemplateUnlinked",
           "PurposeTemplateEServiceUnlinked",
           "PurposeTemplateSuspended",
           "PurposeTemplateUnsuspended",

--- a/packages/documents-signer/src/handlers/handlePurposeTemplateDocument.ts
+++ b/packages/documents-signer/src/handlers/handlePurposeTemplateDocument.ts
@@ -120,6 +120,8 @@ export async function handlePurposeTemplateDocument(
           "PurposeTemplateDraftDeleted",
           "PurposeTemplateDraftUpdated",
           "PurposeTemplateEServiceLinked",
+          "PurposeTemplateEServiceTemplateLinked",
+          "PurposeTemplateEServiceTemplateUnlinked",
           "PurposeTemplateEServiceUnlinked",
           "PurposeTemplateSuspended",
           "PurposeTemplateUnsuspended",

--- a/packages/domains-analytics-writer/src/handlers/purpose-template/consumerServiceV2.ts
+++ b/packages/domains-analytics-writer/src/handlers/purpose-template/consumerServiceV2.ts
@@ -128,6 +128,11 @@ export async function handlePurposeTemplateMessageV2(
           >)
         );
       })
+      .with(
+        { type: "PurposeTemplateEServiceTemplateLinked" },
+        { type: "PurposeTemplateEServiceTemplateUnlinked" },
+        () => Promise.resolve()
+      )
       .exhaustive();
   }
 

--- a/packages/events-signer/src/handlers/handlePurposeTemplateMessageV2.ts
+++ b/packages/events-signer/src/handlers/handlePurposeTemplateMessageV2.ts
@@ -73,6 +73,8 @@ export const handlePurposeTemplateMessageV2 = async (
             "PurposeTemplateDraftDeleted",
             "PurposeTemplateDraftUpdated",
             "PurposeTemplateEServiceLinked",
+            "PurposeTemplateEServiceTemplateLinked",
+            "PurposeTemplateEServiceTemplateUnlinked",
             "PurposeTemplateEServiceUnlinked",
             "PurposeTemplateSuspended",
             "PurposeTemplateUnsuspended",

--- a/packages/events-signer/test/handlers/handlePurposeTemplateMessageV2.test.ts
+++ b/packages/events-signer/test/handlers/handlePurposeTemplateMessageV2.test.ts
@@ -7,7 +7,10 @@ import {
   generateId,
   PurposeTemplateAddedV2,
   PurposeTemplateArchivedV2,
+  PurposeTemplateEServiceTemplateLinkedV2,
+  PurposeTemplateEServiceTemplateUnlinkedV2,
   toPurposeTemplateV2,
+  toEServiceTemplateV2,
 } from "pagopa-interop-models";
 import {
   FileManager,
@@ -22,6 +25,7 @@ import {
   buildDynamoDBTables,
   deleteDynamoDBTables,
   getMockPurposeTemplate,
+  getMockEServiceTemplate,
 } from "pagopa-interop-commons-test";
 import { config } from "../../src/config/config.js";
 import { dynamoDBClient } from "../utils/utils.js";
@@ -158,6 +162,75 @@ describe("handlePurposeTemplateMessageV2 - Integration Test", () => {
       data: {
         purposeTemplate: toPurposeTemplateV2(mockTemplate),
       } as any,
+      log_date: new Date(),
+    };
+
+    const eventsWithTimestamp = [
+      { purposeTemplateV2: message, timestamp: new Date() },
+    ];
+
+    const safeStorageCreateFileSpy = vi.spyOn(safeStorageService, "createFile");
+
+    await handlePurposeTemplateMessageV2(
+      eventsWithTimestamp,
+      fileManager,
+      signatureService,
+      safeStorageService
+    );
+
+    expect(safeStorageCreateFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not process a PurposeTemplateEServiceTemplateLinked event", async () => {
+    const mockTemplate = getMockPurposeTemplate();
+    const mockEServiceTemplate = getMockEServiceTemplate();
+
+    const message: PurposeTemplateEventEnvelopeV2 = {
+      sequence_num: 1,
+      stream_id: mockTemplate.id,
+      version: 1,
+      event_version: 2,
+      type: "PurposeTemplateEServiceTemplateLinked",
+      data: {
+        purposeTemplate: toPurposeTemplateV2(mockTemplate),
+        eserviceTemplate: toEServiceTemplateV2(mockEServiceTemplate),
+        eserviceTemplateVersionId: mockEServiceTemplate.versions[0].id,
+        createdAt: BigInt(Date.now()),
+      } as PurposeTemplateEServiceTemplateLinkedV2,
+      log_date: new Date(),
+    };
+
+    const eventsWithTimestamp = [
+      { purposeTemplateV2: message, timestamp: new Date() },
+    ];
+
+    const safeStorageCreateFileSpy = vi.spyOn(safeStorageService, "createFile");
+
+    await handlePurposeTemplateMessageV2(
+      eventsWithTimestamp,
+      fileManager,
+      signatureService,
+      safeStorageService
+    );
+
+    expect(safeStorageCreateFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not process a PurposeTemplateEServiceTemplateUnlinked event", async () => {
+    const mockTemplate = getMockPurposeTemplate();
+    const mockEServiceTemplate = getMockEServiceTemplate();
+
+    const message: PurposeTemplateEventEnvelopeV2 = {
+      sequence_num: 1,
+      stream_id: mockTemplate.id,
+      version: 1,
+      event_version: 2,
+      type: "PurposeTemplateEServiceTemplateUnlinked",
+      data: {
+        purposeTemplate: toPurposeTemplateV2(mockTemplate),
+        eserviceTemplate: toEServiceTemplateV2(mockEServiceTemplate),
+        eserviceTemplateVersionId: mockEServiceTemplate.versions[0].id,
+      } as PurposeTemplateEServiceTemplateUnlinkedV2,
       log_date: new Date(),
     };
 

--- a/packages/m2m-event-dispatcher/src/handlers/handlePurposeTemplateEvent.ts
+++ b/packages/m2m-event-dispatcher/src/handlers/handlePurposeTemplateEvent.ts
@@ -26,6 +26,12 @@ export async function handlePurposeTemplateEvent(
       {
         type: "RiskAnalysisTemplateDocumentGenerated",
       },
+      {
+        type: "PurposeTemplateEServiceTemplateLinked",
+      },
+      {
+        type: "PurposeTemplateEServiceTemplateUnlinked",
+      },
       () => Promise.resolve(void 0)
     )
     .with(

--- a/packages/m2m-event-dispatcher/test/handlePurposeTemplateEvent.test.ts
+++ b/packages/m2m-event-dispatcher/test/handlePurposeTemplateEvent.test.ts
@@ -81,7 +81,14 @@ describe("handlePurposeTemplateEvent test", async () => {
                 })),
             ]
           )
-          .with("RiskAnalysisTemplateDocumentGenerated", async () => [])
+          .with(
+            P.union(
+              "RiskAnalysisTemplateDocumentGenerated",
+              "PurposeTemplateEServiceTemplateLinked",
+              "PurposeTemplateEServiceTemplateUnlinked"
+            ),
+            async () => []
+          )
           .exhaustive();
 
         for (const { state, expectedVisibility } of testCasesData) {

--- a/packages/models/proto/v2/purpose-template/events.proto
+++ b/packages/models/proto/v2/purpose-template/events.proto
@@ -4,6 +4,7 @@ package purpose.template.v2;
 
 import "v2/purpose-template/purpose-template.proto";
 import "v2/eservice/eservice.proto";
+import "v2/eservice-template/eservice-template.proto";
 
 message PurposeTemplateAddedV2 {
   PurposeTemplateV2 purposeTemplate = 1;
@@ -68,4 +69,17 @@ message RiskAnalysisTemplateDocumentGeneratedV2 {
 
 message RiskAnalysisTemplateSignedDocumentGeneratedV2 {
   PurposeTemplateV2 purposeTemplate = 1;
+}
+
+message PurposeTemplateEServiceTemplateLinkedV2 {
+  PurposeTemplateV2 purposeTemplate = 1;
+  eservice.template.v2.EServiceTemplateV2 eserviceTemplate = 2;
+  string eserviceTemplateVersionId = 3;
+  int64 createdAt = 4;
+}
+
+message PurposeTemplateEServiceTemplateUnlinkedV2 {
+  PurposeTemplateV2 purposeTemplate = 1;
+  eservice.template.v2.EServiceTemplateV2 eserviceTemplate = 2;
+  string eserviceTemplateVersionId = 3;
 }

--- a/packages/models/src/purpose-template/purposeTemplate.ts
+++ b/packages/models/src/purpose-template/purposeTemplate.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import {
   DescriptorId,
   EServiceId,
+  EServiceTemplateId,
+  EServiceTemplateVersionId,
   PurposeTemplateId,
   TenantId,
 } from "../brandedIds.js";
@@ -37,6 +39,16 @@ export const EServiceDescriptorPurposeTemplate = z.object({
 });
 export type EServiceDescriptorPurposeTemplate = z.infer<
   typeof EServiceDescriptorPurposeTemplate
+>;
+
+export const EServiceTemplateVersionPurposeTemplate = z.object({
+  purposeTemplateId: PurposeTemplateId,
+  eserviceTemplateId: EServiceTemplateId,
+  eserviceTemplateVersionId: EServiceTemplateVersionId,
+  createdAt: z.coerce.date(),
+});
+export type EServiceTemplateVersionPurposeTemplate = z.infer<
+  typeof EServiceTemplateVersionPurposeTemplate
 >;
 
 export const PurposeTemplate = z.object({

--- a/packages/models/src/purpose-template/purposeTemplateEvents.ts
+++ b/packages/models/src/purpose-template/purposeTemplateEvents.ts
@@ -9,6 +9,8 @@ import {
   PurposeTemplateDraftDeletedV2,
   PurposeTemplateDraftUpdatedV2,
   PurposeTemplateEServiceLinkedV2,
+  PurposeTemplateEServiceTemplateLinkedV2,
+  PurposeTemplateEServiceTemplateUnlinkedV2,
   PurposeTemplateEServiceUnlinkedV2,
   PurposeTemplatePublishedV2,
   PurposeTemplateSuspendedV2,
@@ -34,6 +36,16 @@ export const PurposeTemplateEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("PurposeTemplateEServiceUnlinked"),
     data: protobufDecoder(PurposeTemplateEServiceUnlinkedV2),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("PurposeTemplateEServiceTemplateLinked"),
+    data: protobufDecoder(PurposeTemplateEServiceTemplateLinkedV2),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("PurposeTemplateEServiceTemplateUnlinked"),
+    data: protobufDecoder(PurposeTemplateEServiceTemplateUnlinkedV2),
   }),
   z.object({
     event_version: z.literal(2),
@@ -105,6 +117,12 @@ export function purposeTemplateEventToBinaryDataV2(
     )
     .with({ type: "PurposeTemplateEServiceUnlinked" }, (e) =>
       PurposeTemplateEServiceUnlinkedV2.toBinary(e.data)
+    )
+    .with({ type: "PurposeTemplateEServiceTemplateLinked" }, (e) =>
+      PurposeTemplateEServiceTemplateLinkedV2.toBinary(e.data)
+    )
+    .with({ type: "PurposeTemplateEServiceTemplateUnlinked" }, (e) =>
+      PurposeTemplateEServiceTemplateUnlinkedV2.toBinary(e.data)
     )
     .with({ type: "PurposeTemplateDraftUpdated" }, (e) =>
       PurposeTemplateDraftUpdatedV2.toBinary(e.data)

--- a/packages/purpose-template-outbound-writer/src/converters/toOutboundEventV2.ts
+++ b/packages/purpose-template-outbound-writer/src/converters/toOutboundEventV2.ts
@@ -103,9 +103,9 @@ function toOutboundPurposeTemplateV2(
 
 export function toOutboundEventV2(
   message: PurposeTemplateEventEnvelopeV2
-): OutboundPurposeTemplateEvent {
+): OutboundPurposeTemplateEvent | undefined {
   return match(message)
-    .returnType<OutboundPurposeTemplateEvent>()
+    .returnType<OutboundPurposeTemplateEvent | undefined>()
     .with(
       { type: "PurposeTemplateAdded" },
       { type: "PurposeTemplateDraftUpdated" },
@@ -190,5 +190,10 @@ export function toOutboundEventV2(
       stream_id: msg.stream_id,
       timestamp: new Date().toISOString(),
     }))
+    .with(
+      { type: "PurposeTemplateEServiceTemplateLinked" },
+      { type: "PurposeTemplateEServiceTemplateUnlinked" },
+      () => undefined
+    )
     .exhaustive();
 }

--- a/packages/purpose-template-readmodel-writer-sql/src/consumerServiceV2.ts
+++ b/packages/purpose-template-readmodel-writer-sql/src/consumerServiceV2.ts
@@ -83,5 +83,10 @@ export async function handleMessageV2(
         }
       );
     })
+    .with(
+      { type: "PurposeTemplateEServiceTemplateLinked" },
+      { type: "PurposeTemplateEServiceTemplateUnlinked" },
+      () => Promise.resolve()
+    )
     .exhaustive();
 }

--- a/packages/purpose-template-readmodel-writer-sql/test/purposeTemplateReadModelWriter.integration.test.ts
+++ b/packages/purpose-template-readmodel-writer-sql/test/purposeTemplateReadModelWriter.integration.test.ts
@@ -2,6 +2,7 @@
 import {
   getMockDescriptor,
   getMockEService,
+  getMockEServiceTemplate,
   getMockPurposeTemplate,
   getMockRiskAnalysisTemplateAnswerAnnotation,
   getMockRiskAnalysisTemplateAnswerAnnotationDocument,
@@ -21,6 +22,8 @@ import {
   PurposeTemplateDraftDeletedV2,
   PurposeTemplateDraftUpdatedV2,
   PurposeTemplateEServiceLinkedV2,
+  PurposeTemplateEServiceTemplateLinkedV2,
+  PurposeTemplateEServiceTemplateUnlinkedV2,
   PurposeTemplateEServiceUnlinkedV2,
   PurposeTemplateEventEnvelope,
   PurposeTemplatePublishedV2,
@@ -31,6 +34,7 @@ import {
   RiskAnalysisTemplateAnswerAnnotationId,
   tenantKind,
   toEServiceV2,
+  toEServiceTemplateV2,
   toPurposeTemplateV2,
   WithMetadata,
 } from "pagopa-interop-models";
@@ -639,6 +643,73 @@ describe("Integration tests", async () => {
         data: updatedPurposeTemplate,
         metadata: { version: metadataVersion },
       });
+    });
+
+    it("PurposeTemplateEServiceTemplateLinked (no-op)", async () => {
+      const metadataVersion = 1;
+      const eserviceTemplate = getMockEServiceTemplate();
+
+      await purposeTemplateWriterService.upsertPurposeTemplate(
+        purposeTemplate,
+        0
+      );
+
+      const payload: PurposeTemplateEServiceTemplateLinkedV2 = {
+        purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+        eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+        eserviceTemplateVersionId: eserviceTemplate.versions[0].id,
+        createdAt: BigInt(Date.now()),
+      };
+      const message: PurposeTemplateEventEnvelope = {
+        sequence_num: 1,
+        stream_id: purposeTemplate.id,
+        version: metadataVersion,
+        type: "PurposeTemplateEServiceTemplateLinked",
+        event_version: 2,
+        data: payload,
+        log_date: new Date(),
+      };
+      await handleMessageV2(message, purposeTemplateWriterService);
+
+      const retrievedPurposeTemplate =
+        await purposeTemplateReadModelService.getPurposeTemplateById(
+          purposeTemplate.id
+        );
+
+      expect(retrievedPurposeTemplate?.data).toStrictEqual(purposeTemplate);
+    });
+
+    it("PurposeTemplateEServiceTemplateUnlinked (no-op)", async () => {
+      const metadataVersion = 1;
+      const eserviceTemplate = getMockEServiceTemplate();
+
+      await purposeTemplateWriterService.upsertPurposeTemplate(
+        purposeTemplate,
+        0
+      );
+
+      const payload: PurposeTemplateEServiceTemplateUnlinkedV2 = {
+        purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+        eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+        eserviceTemplateVersionId: eserviceTemplate.versions[0].id,
+      };
+      const message: PurposeTemplateEventEnvelope = {
+        sequence_num: 1,
+        stream_id: purposeTemplate.id,
+        version: metadataVersion,
+        type: "PurposeTemplateEServiceTemplateUnlinked",
+        event_version: 2,
+        data: payload,
+        log_date: new Date(),
+      };
+      await handleMessageV2(message, purposeTemplateWriterService);
+
+      const retrievedPurposeTemplate =
+        await purposeTemplateReadModelService.getPurposeTemplateById(
+          purposeTemplate.id
+        );
+
+      expect(retrievedPurposeTemplate?.data).toStrictEqual(purposeTemplate);
     });
   });
 });

--- a/packages/readmodel-models/src/drizzle/schema.ts
+++ b/packages/readmodel-models/src/drizzle/schema.ts
@@ -2286,3 +2286,37 @@ export const purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate =
       }),
     ]
   );
+
+export const eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate =
+  readmodelPurposeTemplate.table(
+    "eservice_template_version_purpose_template",
+    {
+      metadataVersion: integer("metadata_version").notNull(),
+      purposeTemplateId: uuid("purpose_template_id").notNull(),
+      eserviceTemplateId: uuid("eservice_template_id").notNull(),
+      eserviceTemplateVersionId: uuid("eservice_template_version_id").notNull(),
+      createdAt: timestamp("created_at", {
+        withTimezone: true,
+        mode: "string",
+      }).notNull(),
+    },
+    (table) => [
+      foreignKey({
+        columns: [table.purposeTemplateId],
+        foreignColumns: [purposeTemplateInReadmodelPurposeTemplate.id],
+        name: "eservice_tpl_ver_pt_purpose_template_id_fkey",
+      }).onDelete("cascade"),
+      foreignKey({
+        columns: [table.purposeTemplateId, table.metadataVersion],
+        foreignColumns: [
+          purposeTemplateInReadmodelPurposeTemplate.id,
+          purposeTemplateInReadmodelPurposeTemplate.metadataVersion,
+        ],
+        name: "eservice_tpl_ver_pt_purpose_template_id_metadata_fkey",
+      }),
+      primaryKey({
+        columns: [table.purposeTemplateId, table.eserviceTemplateId],
+        name: "eservice_template_version_purpose_template_pkey",
+      }),
+    ]
+  );

--- a/packages/readmodel-models/src/types.ts
+++ b/packages/readmodel-models/src/types.ts
@@ -39,6 +39,7 @@ import {
   purposeInReadmodelPurpose,
   purposeRiskAnalysisAnswerInReadmodelPurpose,
   purposeRiskAnalysisFormInReadmodelPurpose,
+  eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate,
   purposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate,
@@ -320,6 +321,9 @@ export type PurposeTemplateSQL = InferSelectModel<
 >;
 export type PurposeTemplateEServiceDescriptorSQL = InferSelectModel<
   typeof purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate
+>;
+export type EServiceTemplateVersionPurposeTemplateSQL = InferSelectModel<
+  typeof eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate
 >;
 export type PurposeTemplateRiskAnalysisFormSQL = InferSelectModel<
   typeof purposeTemplateRiskAnalysisFormInReadmodelPurposeTemplate


### PR DESCRIPTION
**Jira**: [PIN-9771](https://pagopa.atlassian.net/browse/PIN-9771)

## Summary

- Add `eservice_template_version_purpose_template` table to the purpose template read model schema
- DDL in `docker/readmodel-db/purpose-template.sql`, Drizzle definition in `schema.ts`, SQL type export in `types.ts`
- Table **not** added to `purposeTemplateChildTables` (deferred to WI6 to coordinate with writer exclusion rule)

[PIN-9771]: https://pagopa.atlassian.net/browse/PIN-9771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ