### PR TITLE
fix: preserve attribute-level dailyCallsPerConsumer on template insta…

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -26030,6 +26030,8 @@ components:
           format: int32
           minimum: 1
           maximum: 1000000000
+        attributes:
+          $ref: "#/components/schemas/DescriptorAttributesSeed"
     UpdateEServiceDescriptorAgreementApprovalPolicySeed:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -26101,6 +26101,8 @@ components:
           maximum: 1000000000
         agreementApprovalPolicy:
           $ref: "#/components/schemas/AgreementApprovalPolicy"
+        attributes:
+          $ref: "#/components/schemas/DescriptorAttributesSeed"
     Mail:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -3091,6 +3091,8 @@ components:
           maximum: 1000000000
         agreementApprovalPolicy:
           $ref: "#/components/schemas/AgreementApprovalPolicy"
+        attributes:
+          $ref: "#/components/schemas/AttributesSeed"
     UpdateEServiceDescriptorQuotasSeed:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -3132,6 +3132,8 @@ components:
           format: int32
           minimum: 1
           maximum: 1000000000
+        attributes:
+          $ref: "#/components/schemas/AttributesSeed"
       required:
         - dailyCallsPerConsumer
         - dailyCallsTotal

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -2908,6 +2908,11 @@ export function catalogServiceBuilder(
 
       const eservice = await retrieveEService(eserviceId, readModelService);
 
+      assertEServiceNotTemplateInstance(
+        eservice.data.id,
+        eservice.data.templateId
+      );
+
       await assertRequesterIsDelegateProducerOrProducer(
         eservice.data.producerId,
         eserviceId,
@@ -2921,13 +2926,6 @@ export function catalogServiceBuilder(
       const newAttributes = updateEServiceDescriptorAttributeInAdd(
         eserviceId,
         descriptor,
-        seed
-      );
-
-      assertTemplateInstanceAttributeStructureUnchanged(
-        eserviceId,
-        eservice.data.templateId,
-        descriptor.attributes,
         seed
       );
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -184,6 +184,7 @@ import {
   assertValidDelegationFlags,
   assertDailyCallsForCertifiedAttributesOnly,
   assertAttributeDailyCallsConsistentWithTotal,
+  assertTemplateInstanceAttributeStructureUnchanged,
 } from "./validators.js";
 import type { ReadModelServiceSQL } from "./readModelServiceTypes.js";
 import {
@@ -2869,11 +2870,6 @@ export function catalogServiceBuilder(
 
       const eservice = await retrieveEService(eserviceId, readModelService);
 
-      assertEServiceNotTemplateInstance(
-        eservice.data.id,
-        eservice.data.templateId
-      );
-
       await assertRequesterIsDelegateProducerOrProducer(
         eservice.data.producerId,
         eserviceId,
@@ -2887,6 +2883,13 @@ export function catalogServiceBuilder(
       const newAttributes = updateEServiceDescriptorAttributeInAdd(
         eserviceId,
         descriptor,
+        seed
+      );
+
+      assertTemplateInstanceAttributeStructureUnchanged(
+        eserviceId,
+        eservice.data.templateId,
+        descriptor.attributes,
         seed
       );
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1605,19 +1605,16 @@ export function catalogServiceBuilder(
         );
       }
 
-      const updatedAttributes = seed.attributes
-        ? await parseAndCheckAttributes(
-            {
-              certified:
-                seed.attributes.certified ?? descriptor.attributes.certified,
-              declared:
-                seed.attributes.declared ?? descriptor.attributes.declared,
-              verified:
-                seed.attributes.verified ?? descriptor.attributes.verified,
-            },
-            readModelService
-          )
-        : descriptor.attributes;
+      let updatedAttributes = descriptor.attributes;
+
+      if (seed.attributes) {
+        const parsedAttributes = await parseAndCheckAttributes(
+          seed.attributes,
+          readModelService
+        );
+
+        updatedAttributes = parsedAttributes;
+      }
 
       assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
       assertAttributeDailyCallsConsistentWithTotal(
@@ -2125,11 +2122,13 @@ export function catalogServiceBuilder(
           readModelService
         );
 
-        assertDailyCallsForCertifiedAttributesOnly(parsedAttributes);
+        const updatedAttributes = parsedAttributes;
+
+        assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
 
         updatedDescriptor = {
           ...updatedDescriptor,
-          attributes: parsedAttributes,
+          attributes: updatedAttributes,
         };
       }
 
@@ -2203,11 +2202,13 @@ export function catalogServiceBuilder(
           readModelService
         );
 
-        assertDailyCallsForCertifiedAttributesOnly(parsedAttributes);
+        const updatedAttributes = parsedAttributes;
+
+        assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
 
         updatedDescriptor = {
           ...updatedDescriptor,
-          attributes: parsedAttributes,
+          attributes: updatedAttributes,
         };
       }
 
@@ -3127,15 +3128,14 @@ export function catalogServiceBuilder(
         readModelService
       );
 
-      const attributesWithPreservedDailyCalls =
-        preserveInstanceAttributeDailyCalls(
-          parsedAttributes,
-          descriptor.attributes
-        );
+      const updatedAttributes = retainCurrentCertifiedDailyCalls(
+        parsedAttributes,
+        descriptor.attributes
+      );
 
       const updatedDescriptor: Descriptor = {
         ...descriptor,
-        attributes: attributesWithPreservedDailyCalls,
+        attributes: updatedAttributes,
       };
 
       const updatedEService = replaceDescriptor(
@@ -4008,49 +4008,103 @@ const processDescriptorPublication = async (
   );
 };
 
-function buildCertifiedDailyCallsLookup(
-  certifiedGroups: EServiceAttribute[][]
-): Map<string, number> {
-  const lookup = new Map<string, number>();
-  for (const group of certifiedGroups) {
-    for (const attr of group) {
-      if (attr.dailyCallsPerConsumer !== undefined) {
-        lookup.set(attr.id, attr.dailyCallsPerConsumer);
-      }
-    }
-  }
-  return lookup;
-}
-
-function restoreCertifiedDailyCalls(
-  parsedGroups: EServiceAttribute[][],
-  dailyCallsLookup: Map<string, number>
-): EServiceAttribute[][] {
-  return parsedGroups.map((group) =>
-    group.map((attr) => {
-      const existingDailyCalls = dailyCallsLookup.get(attr.id);
-      return existingDailyCalls !== undefined
-        ? { ...attr, dailyCallsPerConsumer: existingDailyCalls }
-        : attr;
-    })
+function isMatchingCertifiedGroup(
+  incomingGroup: EServiceAttribute[],
+  currentGroup: EServiceAttribute[]
+): boolean {
+  return currentGroup.every((currentAttribute) =>
+    incomingGroup.some(
+      (incomingAttribute) => incomingAttribute.id === currentAttribute.id
+    )
   );
 }
 
-function preserveInstanceAttributeDailyCalls(
-  parsedAttributes: EserviceAttributes,
-  existingAttributes: EserviceAttributes
+function findMatchingCertifiedGroup(
+  incomingGroup: EServiceAttribute[],
+  currentGroups: EServiceAttribute[][],
+  usedCurrentGroupIndexes: Set<number>
+): EServiceAttribute[] | undefined {
+  for (const [groupIndex, currentGroup] of currentGroups.entries()) {
+    if (usedCurrentGroupIndexes.has(groupIndex)) {
+      continue;
+    }
+
+    if (!isMatchingCertifiedGroup(incomingGroup, currentGroup)) {
+      continue;
+    }
+
+    usedCurrentGroupIndexes.add(groupIndex);
+    return currentGroup;
+  }
+
+  return undefined;
+}
+
+function findCurrentCertifiedAttribute(
+  incomingAttribute: EServiceAttribute,
+  currentGroup: EServiceAttribute[] | undefined
+): EServiceAttribute | undefined {
+  return currentGroup?.find(
+    (currentAttribute) => currentAttribute.id === incomingAttribute.id
+  );
+}
+
+function retainCurrentDailyCallsPerConsumer(
+  incomingAttribute: EServiceAttribute,
+  currentAttribute: EServiceAttribute | undefined
+): EServiceAttribute {
+  const currentDailyCalls = currentAttribute?.dailyCallsPerConsumer;
+  if (currentDailyCalls === undefined) {
+    return incomingAttribute;
+  }
+
+  return {
+    ...incomingAttribute,
+    dailyCallsPerConsumer: currentDailyCalls,
+  };
+}
+
+function retainCurrentDailyCallsInCertifiedGroup(
+  incomingGroup: EServiceAttribute[],
+  currentGroup: EServiceAttribute[] | undefined
+): EServiceAttribute[] {
+  return incomingGroup.map((incomingAttribute) => {
+    const currentAttribute = findCurrentCertifiedAttribute(
+      incomingAttribute,
+      currentGroup
+    );
+
+    return retainCurrentDailyCallsPerConsumer(
+      incomingAttribute,
+      currentAttribute
+    );
+  });
+}
+
+function retainCurrentCertifiedDailyCalls(
+  incomingAttributes: EserviceAttributes,
+  currentAttributes: EserviceAttributes
 ): EserviceAttributes {
-  const certifiedLookup = buildCertifiedDailyCallsLookup(
-    existingAttributes.certified
+  const usedCurrentGroupIndexes = new Set<number>();
+  const updatedCertifiedAttributes = incomingAttributes.certified.map(
+    (incomingGroup) => {
+      const currentGroup = findMatchingCertifiedGroup(
+        incomingGroup,
+        currentAttributes.certified,
+        usedCurrentGroupIndexes
+      );
+
+      return retainCurrentDailyCallsInCertifiedGroup(
+        incomingGroup,
+        currentGroup
+      );
+    }
   );
 
   return {
-    certified: restoreCertifiedDailyCalls(
-      parsedAttributes.certified,
-      certifiedLookup
-    ),
-    declared: parsedAttributes.declared,
-    verified: parsedAttributes.verified,
+    certified: updatedCertifiedAttributes,
+    declared: incomingAttributes.declared,
+    verified: incomingAttributes.verified,
   };
 }
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -2111,10 +2111,6 @@ export function catalogServiceBuilder(
 
       assertDescriptorUpdatableAfterPublish(descriptor);
       assertConsistentDailyCalls(seed);
-      assertAttributeDailyCallsConsistentWithTotal(
-        descriptor.attributes,
-        seed.dailyCallsTotal
-      );
 
       let updatedDescriptor: Descriptor = {
         ...descriptor,
@@ -2186,10 +2182,6 @@ export function catalogServiceBuilder(
 
       assertDescriptorUpdatableAfterPublish(descriptor);
       assertConsistentDailyCalls(seed);
-      assertAttributeDailyCallsConsistentWithTotal(
-        descriptor.attributes,
-        seed.dailyCallsTotal
-      );
 
       let updatedDescriptor: Descriptor = {
         ...descriptor,
@@ -4014,41 +4006,49 @@ const processDescriptorPublication = async (
   );
 };
 
+function buildCertifiedDailyCallsLookup(
+  certifiedGroups: EServiceAttribute[][]
+): Map<string, number> {
+  const lookup = new Map<string, number>();
+  for (const group of certifiedGroups) {
+    for (const attr of group) {
+      if (attr.dailyCallsPerConsumer !== undefined) {
+        lookup.set(attr.id, attr.dailyCallsPerConsumer);
+      }
+    }
+  }
+  return lookup;
+}
+
+function restoreCertifiedDailyCalls(
+  parsedGroups: EServiceAttribute[][],
+  dailyCallsLookup: Map<string, number>
+): EServiceAttribute[][] {
+  return parsedGroups.map((group) =>
+    group.map((attr) => {
+      const existingDailyCalls = dailyCallsLookup.get(attr.id);
+      return existingDailyCalls !== undefined
+        ? { ...attr, dailyCallsPerConsumer: existingDailyCalls }
+        : attr;
+    })
+  );
+}
+
 function preserveInstanceAttributeDailyCalls(
   parsedAttributes: EserviceAttributes,
   existingAttributes: EserviceAttributes
 ): EserviceAttributes {
-  const mergeGroups = (
-    parsedGroups: EServiceAttribute[][],
-    existingGroups: EServiceAttribute[][]
-  ): EServiceAttribute[][] =>
-    parsedGroups.map((parsedGroup) =>
-      parsedGroup.map((parsedAttr) => {
-        const existingAttr = existingGroups
-          .flat()
-          .find((attr) => attr.id === parsedAttr.id);
-        return existingAttr?.dailyCallsPerConsumer !== undefined
-          ? {
-              ...parsedAttr,
-              dailyCallsPerConsumer: existingAttr.dailyCallsPerConsumer,
-            }
-          : parsedAttr;
-      })
-    );
+  const certifiedLookup = buildCertifiedDailyCallsLookup(
+    existingAttributes.certified
+  );
 
   return {
-    certified: mergeGroups(
+    certified: restoreCertifiedDailyCalls(
       parsedAttributes.certified,
-      existingAttributes.certified
+      certifiedLookup
     ),
-    declared: mergeGroups(
-      parsedAttributes.declared,
-      existingAttributes.declared
-    ),
-    verified: mergeGroups(
-      parsedAttributes.verified,
-      existingAttributes.verified
-    ),
+    declared: parsedAttributes.declared,
+    verified: parsedAttributes.verified,
   };
 }
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1595,12 +1595,33 @@ export function catalogServiceBuilder(
 
       assertConsistentDailyCalls(seed);
 
+      const updatedAttributes = seed.attributes
+        ? await parseAndCheckAttributes(
+            {
+              certified:
+                seed.attributes.certified ?? descriptor.attributes.certified,
+              declared:
+                seed.attributes.declared ?? descriptor.attributes.declared,
+              verified:
+                seed.attributes.verified ?? descriptor.attributes.verified,
+            },
+            readModelService
+          )
+        : descriptor.attributes;
+
+      assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
+      assertAttributeDailyCallsConsistentWithTotal(
+        updatedAttributes,
+        seed.dailyCallsTotal
+      );
+
       const updatedDescriptor: Descriptor = {
         ...descriptor,
         audience: seed.audience,
         dailyCallsPerConsumer: seed.dailyCallsPerConsumer,
         state: descriptorState.draft,
         dailyCallsTotal: seed.dailyCallsTotal,
+        attributes: updatedAttributes,
         agreementApprovalPolicy:
           apiAgreementApprovalPolicyToAgreementApprovalPolicy(
             seed.agreementApprovalPolicy

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -2126,16 +2126,17 @@ export function catalogServiceBuilder(
         );
 
         assertDailyCallsForCertifiedAttributesOnly(parsedAttributes);
-        assertAttributeDailyCallsConsistentWithTotal(
-          parsedAttributes,
-          seed.dailyCallsTotal
-        );
 
         updatedDescriptor = {
           ...updatedDescriptor,
           attributes: parsedAttributes,
         };
       }
+
+      assertAttributeDailyCallsConsistentWithTotal(
+        updatedDescriptor.attributes,
+        seed.dailyCallsTotal
+      );
 
       const updatedEService = replaceDescriptor(
         eservice.data,
@@ -2203,16 +2204,17 @@ export function catalogServiceBuilder(
         );
 
         assertDailyCallsForCertifiedAttributesOnly(parsedAttributes);
-        assertAttributeDailyCallsConsistentWithTotal(
-          parsedAttributes,
-          seed.dailyCallsTotal
-        );
 
         updatedDescriptor = {
           ...updatedDescriptor,
           attributes: parsedAttributes,
         };
       }
+
+      assertAttributeDailyCallsConsistentWithTotal(
+        updatedDescriptor.attributes,
+        seed.dailyCallsTotal
+      );
 
       const updatedEService = replaceDescriptor(
         eservice.data,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1596,6 +1596,15 @@ export function catalogServiceBuilder(
 
       assertConsistentDailyCalls(seed);
 
+      if (seed.attributes) {
+        assertTemplateInstanceAttributeStructureUnchanged(
+          eserviceId,
+          eservice.data.templateId,
+          descriptor.attributes,
+          seed.attributes
+        );
+      }
+
       const updatedAttributes = seed.attributes
         ? await parseAndCheckAttributes(
             {
@@ -2177,12 +2186,46 @@ export function catalogServiceBuilder(
 
       assertDescriptorUpdatableAfterPublish(descriptor);
       assertConsistentDailyCalls(seed);
+      assertAttributeDailyCallsConsistentWithTotal(
+        descriptor.attributes,
+        seed.dailyCallsTotal
+      );
 
-      const updatedEService = replaceDescriptor(eservice.data, {
+      let updatedDescriptor: Descriptor = {
         ...descriptor,
         dailyCallsPerConsumer: seed.dailyCallsPerConsumer,
         dailyCallsTotal: seed.dailyCallsTotal,
-      });
+      };
+
+      if (seed.attributes) {
+        assertTemplateInstanceAttributeStructureUnchanged(
+          eserviceId,
+          eservice.data.templateId,
+          descriptor.attributes,
+          seed.attributes
+        );
+
+        const parsedAttributes = await parseAndCheckAttributes(
+          seed.attributes,
+          readModelService
+        );
+
+        assertDailyCallsForCertifiedAttributesOnly(parsedAttributes);
+        assertAttributeDailyCallsConsistentWithTotal(
+          parsedAttributes,
+          seed.dailyCallsTotal
+        );
+
+        updatedDescriptor = {
+          ...updatedDescriptor,
+          attributes: parsedAttributes,
+        };
+      }
+
+      const updatedEService = replaceDescriptor(
+        eservice.data,
+        updatedDescriptor
+      );
 
       const event = toCreateEventEServiceDescriptorQuotasUpdated(
         eserviceId,
@@ -3085,9 +3128,20 @@ export function catalogServiceBuilder(
         return;
       }
 
+      const parsedAttributes = await parseAndCheckAttributes(
+        seed,
+        readModelService
+      );
+
+      const attributesWithPreservedDailyCalls =
+        preserveInstanceAttributeDailyCalls(
+          parsedAttributes,
+          descriptor.attributes
+        );
+
       const updatedDescriptor: Descriptor = {
         ...descriptor,
-        attributes: await parseAndCheckAttributes(seed, readModelService),
+        attributes: attributesWithPreservedDailyCalls,
       };
 
       const updatedEService = replaceDescriptor(
@@ -3959,6 +4013,44 @@ const processDescriptorPublication = async (
       : deprecateDescriptor(eservice.id, currentActiveDescriptor, logger)
   );
 };
+
+function preserveInstanceAttributeDailyCalls(
+  parsedAttributes: EserviceAttributes,
+  existingAttributes: EserviceAttributes
+): EserviceAttributes {
+  const mergeGroups = (
+    parsedGroups: EServiceAttribute[][],
+    existingGroups: EServiceAttribute[][]
+  ): EServiceAttribute[][] =>
+    parsedGroups.map((parsedGroup) =>
+      parsedGroup.map((parsedAttr) => {
+        const existingAttr = existingGroups
+          .flat()
+          .find((attr) => attr.id === parsedAttr.id);
+        return existingAttr?.dailyCallsPerConsumer !== undefined
+          ? {
+              ...parsedAttr,
+              dailyCallsPerConsumer: existingAttr.dailyCallsPerConsumer,
+            }
+          : parsedAttr;
+      })
+    );
+
+  return {
+    certified: mergeGroups(
+      parsedAttributes.certified,
+      existingAttributes.certified
+    ),
+    declared: mergeGroups(
+      parsedAttributes.declared,
+      existingAttributes.declared
+    ),
+    verified: mergeGroups(
+      parsedAttributes.verified,
+      existingAttributes.verified
+    ),
+  };
+}
 
 function updateEServiceDescriptorAttributeInAdd(
   eserviceId: EServiceId,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1605,16 +1605,9 @@ export function catalogServiceBuilder(
         );
       }
 
-      let updatedAttributes = descriptor.attributes;
-
-      if (seed.attributes) {
-        const parsedAttributes = await parseAndCheckAttributes(
-          seed.attributes,
-          readModelService
-        );
-
-        updatedAttributes = parsedAttributes;
-      }
+      const updatedAttributes = seed.attributes
+        ? await parseAndCheckAttributes(seed.attributes, readModelService)
+        : descriptor.attributes;
 
       assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
       assertAttributeDailyCallsConsistentWithTotal(
@@ -2109,28 +2102,19 @@ export function catalogServiceBuilder(
       assertDescriptorUpdatableAfterPublish(descriptor);
       assertConsistentDailyCalls(seed);
 
-      let updatedDescriptor: Descriptor = {
+      const updatedAttributes = seed.attributes
+        ? await parseAndCheckAttributes(seed.attributes, readModelService)
+        : descriptor.attributes;
+
+      assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
+
+      const updatedDescriptor: Descriptor = {
         ...descriptor,
         voucherLifespan: seed.voucherLifespan,
         dailyCallsPerConsumer: seed.dailyCallsPerConsumer,
         dailyCallsTotal: seed.dailyCallsTotal,
+        attributes: updatedAttributes,
       };
-
-      if (seed.attributes) {
-        const parsedAttributes = await parseAndCheckAttributes(
-          seed.attributes,
-          readModelService
-        );
-
-        const updatedAttributes = parsedAttributes;
-
-        assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
-
-        updatedDescriptor = {
-          ...updatedDescriptor,
-          attributes: updatedAttributes,
-        };
-      }
 
       assertAttributeDailyCallsConsistentWithTotal(
         updatedDescriptor.attributes,
@@ -2183,12 +2167,6 @@ export function catalogServiceBuilder(
       assertDescriptorUpdatableAfterPublish(descriptor);
       assertConsistentDailyCalls(seed);
 
-      let updatedDescriptor: Descriptor = {
-        ...descriptor,
-        dailyCallsPerConsumer: seed.dailyCallsPerConsumer,
-        dailyCallsTotal: seed.dailyCallsTotal,
-      };
-
       if (seed.attributes) {
         assertTemplateInstanceAttributeStructureUnchanged(
           eserviceId,
@@ -2196,21 +2174,20 @@ export function catalogServiceBuilder(
           descriptor.attributes,
           seed.attributes
         );
-
-        const parsedAttributes = await parseAndCheckAttributes(
-          seed.attributes,
-          readModelService
-        );
-
-        const updatedAttributes = parsedAttributes;
-
-        assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
-
-        updatedDescriptor = {
-          ...updatedDescriptor,
-          attributes: updatedAttributes,
-        };
       }
+
+      const updatedAttributes = seed.attributes
+        ? await parseAndCheckAttributes(seed.attributes, readModelService)
+        : descriptor.attributes;
+
+      assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
+
+      const updatedDescriptor: Descriptor = {
+        ...descriptor,
+        dailyCallsPerConsumer: seed.dailyCallsPerConsumer,
+        dailyCallsTotal: seed.dailyCallsTotal,
+        attributes: updatedAttributes,
+      };
 
       assertAttributeDailyCallsConsistentWithTotal(
         updatedDescriptor.attributes,
@@ -4006,83 +3983,89 @@ const processDescriptorPublication = async (
   );
 };
 
-function isMatchingCertifiedGroup(
-  incomingGroup: EServiceAttribute[],
-  currentGroup: EServiceAttribute[]
-): boolean {
-  return currentGroup.every((currentAttribute) =>
-    incomingGroup.some(
-      (incomingAttribute) => incomingAttribute.id === currentAttribute.id
-    )
-  );
-}
-
-function findMatchingCertifiedGroup(
-  incomingGroup: EServiceAttribute[],
-  currentGroups: EServiceAttribute[][],
-  usedCurrentGroupIndexes: Set<number>
-): EServiceAttribute[] | undefined {
-  for (const [groupIndex, currentGroup] of currentGroups.entries()) {
-    if (usedCurrentGroupIndexes.has(groupIndex)) {
-      continue;
-    }
-
-    if (!isMatchingCertifiedGroup(incomingGroup, currentGroup)) {
-      continue;
-    }
-
-    usedCurrentGroupIndexes.add(groupIndex);
-    return currentGroup;
-  }
-
-  return undefined;
-}
-
-function findCurrentCertifiedAttribute(
-  incomingAttribute: EServiceAttribute,
-  currentGroup: EServiceAttribute[] | undefined
-): EServiceAttribute | undefined {
-  return currentGroup?.find(
-    (currentAttribute) => currentAttribute.id === incomingAttribute.id
-  );
-}
-
-function retainCurrentDailyCallsPerConsumer(
-  incomingAttribute: EServiceAttribute,
-  currentAttribute: EServiceAttribute | undefined
-): EServiceAttribute {
-  const currentDailyCalls = currentAttribute?.dailyCallsPerConsumer;
-  if (currentDailyCalls === undefined) {
-    return incomingAttribute;
-  }
-
-  return {
-    ...incomingAttribute,
-    dailyCallsPerConsumer: currentDailyCalls,
-  };
-}
-
-function retainCurrentDailyCallsInCertifiedGroup(
-  incomingGroup: EServiceAttribute[],
-  currentGroup: EServiceAttribute[] | undefined
-): EServiceAttribute[] {
-  return incomingGroup.map((incomingAttribute) => {
-    const currentAttribute = findCurrentCertifiedAttribute(
-      incomingAttribute,
-      currentGroup
-    );
-
-    return retainCurrentDailyCallsPerConsumer(
-      incomingAttribute,
-      currentAttribute
-    );
-  });
-}
-
+/**
+ * Retains the existing `dailyCallsPerConsumer` value on the certified attribute.
+ * Used with template instances. This ensures that when a template updates and
+ * propagates its attributes to its instances, any custom threshold configured
+ * on the instance is preserved instead of being cleared.
+ */
 function retainCurrentCertifiedDailyCalls(
   incomingAttributes: EserviceAttributes,
   currentAttributes: EserviceAttributes
 ): EserviceAttributes {
+  function isMatchingCertifiedGroup(
+    incomingGroup: EServiceAttribute[],
+    currentGroup: EServiceAttribute[]
+  ): boolean {
+    return currentGroup.every((currentAttribute) =>
+      incomingGroup.some(
+        (incomingAttribute) => incomingAttribute.id === currentAttribute.id
+      )
+    );
+  }
+
+  function findMatchingCertifiedGroup(
+    incomingGroup: EServiceAttribute[],
+    currentGroups: EServiceAttribute[][],
+    usedCurrentGroupIndexes: Set<number>
+  ): EServiceAttribute[] | undefined {
+    for (const [groupIndex, currentGroup] of currentGroups.entries()) {
+      if (usedCurrentGroupIndexes.has(groupIndex)) {
+        continue;
+      }
+
+      if (!isMatchingCertifiedGroup(incomingGroup, currentGroup)) {
+        continue;
+      }
+
+      usedCurrentGroupIndexes.add(groupIndex);
+      return currentGroup;
+    }
+
+    return undefined;
+  }
+
+  function findCurrentCertifiedAttribute(
+    incomingAttribute: EServiceAttribute,
+    currentGroup: EServiceAttribute[] | undefined
+  ): EServiceAttribute | undefined {
+    return currentGroup?.find(
+      (currentAttribute) => currentAttribute.id === incomingAttribute.id
+    );
+  }
+
+  function retainCurrentDailyCallsPerConsumer(
+    incomingAttribute: EServiceAttribute,
+    currentAttribute: EServiceAttribute | undefined
+  ): EServiceAttribute {
+    const currentDailyCalls = currentAttribute?.dailyCallsPerConsumer;
+    if (currentDailyCalls === undefined) {
+      return incomingAttribute;
+    }
+
+    return {
+      ...incomingAttribute,
+      dailyCallsPerConsumer: currentDailyCalls,
+    };
+  }
+
+  function retainCurrentDailyCallsInCertifiedGroup(
+    incomingGroup: EServiceAttribute[],
+    currentGroup: EServiceAttribute[] | undefined
+  ): EServiceAttribute[] {
+    return incomingGroup.map((incomingAttribute) => {
+      const currentAttribute = findCurrentCertifiedAttribute(
+        incomingAttribute,
+        currentGroup
+      );
+
+      return retainCurrentDailyCallsPerConsumer(
+        incomingAttribute,
+        currentAttribute
+      );
+    });
+  }
+
   const usedCurrentGroupIndexes = new Set<number>();
   const updatedCertifiedAttributes = incomingAttributes.certified.map(
     (incomingGroup) => {

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -475,20 +475,18 @@ function assertAttributeGroupsUnchanged(
       throw templateInstanceNotAllowed(eserviceId, templateId);
     }
 
-    const hasChangedExplicitVerification = descriptorGroup.some(
-      (descriptorAttr) => {
-        const seedAttr = matchingSeedGroup.find(
-          (attr) => attr.id === descriptorAttr.id
-        );
-        return (
-          seedAttr?.explicitAttributeVerification !==
-          descriptorAttr.explicitAttributeVerification
-        );
-      }
-    );
+    for (const descriptorAttr of descriptorGroup) {
+      const seedAttr = matchingSeedGroup.find(
+        (attr) => attr.id === descriptorAttr.id
+      );
 
-    if (hasChangedExplicitVerification) {
-      throw templateInstanceNotAllowed(eserviceId, templateId);
+      if (
+        !seedAttr ||
+        seedAttr.explicitAttributeVerification !==
+          descriptorAttr.explicitAttributeVerification
+      ) {
+        throw templateInstanceNotAllowed(eserviceId, templateId);
+      }
     }
   }
 }

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -25,6 +25,7 @@ import {
   eserviceMode,
   operationForbidden,
   EServiceTemplateId,
+  type EServiceAttribute,
   type EserviceAttributes,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
@@ -417,6 +418,77 @@ export function assertDailyCallsForCertifiedAttributesOnly(
   for (const attribute of attributesToCheck) {
     if (attribute.dailyCallsPerConsumer !== undefined) {
       throw attributeDailyCallsNotAllowed(attribute.id);
+    }
+  }
+}
+
+export function assertTemplateInstanceAttributeStructureUnchanged(
+  eserviceId: EServiceId,
+  templateId: EServiceTemplateId | undefined,
+  descriptorAttributes: EserviceAttributes,
+  seedAttributes: catalogApi.AttributesSeed
+): void {
+  if (templateId === undefined) {
+    return;
+  }
+
+  assertAttributeGroupsUnchanged(
+    eserviceId,
+    templateId,
+    descriptorAttributes.certified,
+    seedAttributes.certified
+  );
+  assertAttributeGroupsUnchanged(
+    eserviceId,
+    templateId,
+    descriptorAttributes.declared,
+    seedAttributes.declared
+  );
+  assertAttributeGroupsUnchanged(
+    eserviceId,
+    templateId,
+    descriptorAttributes.verified,
+    seedAttributes.verified
+  );
+}
+
+function assertAttributeGroupsUnchanged(
+  eserviceId: EServiceId,
+  templateId: EServiceTemplateId,
+  descriptorGroups: EServiceAttribute[][],
+  seedGroups: catalogApi.AttributeSeed[][]
+): void {
+  if (descriptorGroups.length !== seedGroups.length) {
+    throw templateInstanceNotAllowed(eserviceId, templateId);
+  }
+
+  for (const descriptorGroup of descriptorGroups) {
+    const matchingSeedGroup = seedGroups.find(
+      (seedGroup) =>
+        seedGroup.length === descriptorGroup.length &&
+        descriptorGroup.every((descriptorAttr) =>
+          seedGroup.some((seedAttr) => seedAttr.id === descriptorAttr.id)
+        )
+    );
+
+    if (!matchingSeedGroup) {
+      throw templateInstanceNotAllowed(eserviceId, templateId);
+    }
+
+    const hasChangedExplicitVerification = descriptorGroup.some(
+      (descriptorAttr) => {
+        const seedAttr = matchingSeedGroup.find(
+          (attr) => attr.id === descriptorAttr.id
+        );
+        return (
+          seedAttr?.explicitAttributeVerification !==
+          descriptorAttr.explicitAttributeVerification
+        );
+      }
+    );
+
+    if (hasChangedExplicitVerification) {
+      throw templateInstanceNotAllowed(eserviceId, templateId);
     }
   }
 }

--- a/packages/catalog-process/test/integration/updateDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptor.test.ts
@@ -595,4 +595,52 @@ describe("update descriptor", () => {
       );
     }
   );
+
+  it("should throw inconsistentDailyCalls when lowering dailyCallsTotal below existing attribute dailyCallsPerConsumer without providing attributes", async () => {
+    const certifiedAttribute = getMockAttribute(attributeKind.certified);
+    await addOneAttribute(certifiedAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 500,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: 200,
+      dailyCallsTotal: 300,
+      // No attributes field — existing attributes must still be validated
+    };
+
+    await expect(
+      catalogService.updateDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(inconsistentDailyCalls());
+  });
 });

--- a/packages/catalog-process/test/integration/updateDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptor.test.ts
@@ -480,6 +480,198 @@ describe("update descriptor", () => {
       state: descriptorState.published,
       interface: mockDocument,
       publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+    const expectedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          voucherLifespan: 1000,
+          dailyCallsPerConsumer: 1,
+          dailyCallsTotal: 1000,
+          attributes: {
+            certified: [
+              [
+                {
+                  id: certifiedAttribute.id,
+                  explicitAttributeVerification: false,
+                },
+              ],
+            ],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+
+    const returnedEService = await catalogService.updateDescriptor(
+      eservice.id,
+      descriptor.id,
+      seed,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    const lastEvent = await readLastEserviceEvent(eservice.id);
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorQuotasUpdatedV2,
+      payload: lastEvent.data,
+    });
+
+    expect(writtenPayload).toEqual({
+      eservice: toEServiceV2(expectedEService),
+      descriptorId: descriptor.id,
+    });
+    expect(returnedEService).toEqual({
+      data: expectedEService,
+      metadata: { version: 1 },
+    });
+  });
+
+  it("should clear existing certified attribute dailyCallsPerConsumer when seed.attributes omits them", async () => {
+    const certifiedAttribute = getMockAttribute(attributeKind.certified);
+    await addOneAttribute(certifiedAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+    const expectedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          voucherLifespan: 1000,
+          dailyCallsPerConsumer: 1,
+          dailyCallsTotal: 1000,
+          attributes: {
+            certified: [
+              [
+                {
+                  id: certifiedAttribute.id,
+                  explicitAttributeVerification: false,
+                },
+              ],
+            ],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+
+    const returnedEService = await catalogService.updateDescriptor(
+      eservice.id,
+      descriptor.id,
+      seed,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    const lastEvent = await readLastEserviceEvent(eservice.id);
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorQuotasUpdatedV2,
+      payload: lastEvent.data,
+    });
+
+    expect(writtenPayload).toEqual({
+      eservice: toEServiceV2(expectedEService),
+      descriptorId: descriptor.id,
+    });
+    expect(returnedEService).toEqual({
+      data: expectedEService,
+      metadata: { version: 1 },
+    });
+  });
+
+  it("should throw inconsistentDailyCalls when a new certified attribute has dailyCallsPerConsumer greater than or equal to the descriptor dailyCallsTotal", async () => {
+    const certifiedAttribute = getMockAttribute(attributeKind.certified);
+    await addOneAttribute(certifiedAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
       dailyCallsTotal: 100,
       attributes: {
         certified: [],

--- a/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
@@ -726,65 +726,6 @@ describe("update descriptor", () => {
     );
   });
 
-  it("should throw templateInstanceNotAllowed when removing an attribute from a group on a template instance", async () => {
-    const templateId = unsafeBrandId<EServiceTemplateId>(generateId());
-
-    const mockDescriptor: Descriptor = {
-      ...getMockDescriptor(),
-      state: descriptorState.published,
-      dailyCallsTotal: 1000,
-      attributes: {
-        certified: [
-          [
-            {
-              id: mockCertifiedAttribute1.id,
-              explicitAttributeVerification: false,
-            },
-            {
-              id: mockCertifiedAttribute2.id,
-              explicitAttributeVerification: false,
-            },
-          ],
-        ],
-        verified: [],
-        declared: [],
-      },
-    };
-
-    const mockEService: EService = {
-      ...getMockEService(),
-      templateId,
-      descriptors: [mockDescriptor],
-    };
-
-    await addOneEService(mockEService);
-
-    const seed: catalogApi.AttributesSeed = {
-      certified: [
-        [
-          {
-            id: mockCertifiedAttribute1.id,
-            explicitAttributeVerification: false,
-          },
-          // mockCertifiedAttribute2 removed
-        ],
-      ],
-      verified: [],
-      declared: [],
-    };
-
-    await expect(
-      catalogService.updateDescriptorAttributes(
-        mockEService.id,
-        mockDescriptor.id,
-        seed,
-        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
-      )
-    ).rejects.toThrowError(
-      templateInstanceNotAllowed(mockEService.id, templateId)
-    );
-  });
-
   it("should write on event-store when adding new certified attribute with dailyCalls", async () => {
     const mockDescriptor: Descriptor = {
       ...getMockDescriptor(),

--- a/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
@@ -604,7 +604,7 @@ describe("update descriptor", () => {
     );
   });
 
-  it("should persist dailyCallsPerConsumer on a certified attribute of a published template instance", async () => {
+  it("should throw templateInstanceNotAllowed when updating dailyCallsPerConsumer on a certified attribute of a published template instance", async () => {
     const templateId = unsafeBrandId<EServiceTemplateId>(generateId());
     const dailyCallsPerConsumer = 500;
 
@@ -648,28 +648,16 @@ describe("update descriptor", () => {
       declared: [],
     };
 
-    const result = await catalogService.updateDescriptorAttributes(
-      mockEService.id,
-      mockDescriptor.id,
-      seed,
-      getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+    await expect(
+      catalogService.updateDescriptorAttributes(
+        mockEService.id,
+        mockDescriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      )
+    ).rejects.toThrowError(
+      templateInstanceNotAllowed(mockEService.id, templateId)
     );
-
-    expect(result).toBeDefined();
-
-    const updatedDescriptor = result.data.descriptors.find(
-      (d) => d.id === mockDescriptor.id
-    );
-
-    expect(updatedDescriptor).toBeDefined();
-    expect(updatedDescriptor!.attributes.certified).toHaveLength(1);
-    expect(updatedDescriptor!.attributes.certified[0]).toHaveLength(1);
-    expect(updatedDescriptor!.attributes.certified[0][0].id).toBe(
-      mockCertifiedAttribute1.id
-    );
-    expect(
-      updatedDescriptor!.attributes.certified[0][0].dailyCallsPerConsumer
-    ).toBe(dailyCallsPerConsumer);
   });
 
   it("should throw templateInstanceNotAllowed when changing explicitAttributeVerification on a template instance", async () => {

--- a/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
@@ -34,8 +34,8 @@ import {
   descriptorAttributeGroupSupersetMissingInAttributesSeed,
   notValidDescriptorState,
   unchangedAttributes,
-  templateInstanceNotAllowed,
   attributeDailyCallsNotAllowed,
+  templateInstanceNotAllowed,
 } from "../../src/model/domain/errors.js";
 import {
   addOneAttribute,
@@ -572,7 +572,7 @@ describe("update descriptor", () => {
       )
     );
   });
-  it("should throw templateInstanceNotAllowed if the templateId is defined", async () => {
+  it("should throw templateInstanceNotAllowed when adding new attributes on a template instance", async () => {
     const templateId = unsafeBrandId<EServiceTemplateId>(generateId());
     const mockDescriptor: Descriptor = {
       ...getMockDescriptor(),
@@ -592,11 +592,192 @@ describe("update descriptor", () => {
 
     await addOneEService(mockEService);
 
-    expect(
+    await expect(
       catalogService.updateDescriptorAttributes(
         mockEService.id,
         mockDescriptor.id,
         validMockDescriptorAttributeSeed,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      )
+    ).rejects.toThrowError(
+      templateInstanceNotAllowed(mockEService.id, templateId)
+    );
+  });
+
+  it("should persist dailyCallsPerConsumer on a certified attribute of a published template instance", async () => {
+    const templateId = unsafeBrandId<EServiceTemplateId>(generateId());
+    const dailyCallsPerConsumer = 500;
+
+    const mockDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      state: descriptorState.published,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: true,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+      templateId,
+      descriptors: [mockDescriptor],
+    };
+
+    await addOneEService(mockEService);
+
+    const seed: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedAttribute1.id,
+            explicitAttributeVerification: true,
+            dailyCallsPerConsumer,
+          },
+        ],
+      ],
+      verified: [],
+      declared: [],
+    };
+
+    const result = await catalogService.updateDescriptorAttributes(
+      mockEService.id,
+      mockDescriptor.id,
+      seed,
+      getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+    );
+
+    expect(result).toBeDefined();
+
+    const updatedDescriptor = result.data.descriptors.find(
+      (d) => d.id === mockDescriptor.id
+    );
+
+    expect(updatedDescriptor).toBeDefined();
+    expect(updatedDescriptor!.attributes.certified).toHaveLength(1);
+    expect(updatedDescriptor!.attributes.certified[0]).toHaveLength(1);
+    expect(updatedDescriptor!.attributes.certified[0][0].id).toBe(
+      mockCertifiedAttribute1.id
+    );
+    expect(
+      updatedDescriptor!.attributes.certified[0][0].dailyCallsPerConsumer
+    ).toBe(dailyCallsPerConsumer);
+  });
+
+  it("should throw templateInstanceNotAllowed when changing explicitAttributeVerification on a template instance", async () => {
+    const templateId = unsafeBrandId<EServiceTemplateId>(generateId());
+
+    const mockDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      state: descriptorState.published,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+      templateId,
+      descriptors: [mockDescriptor],
+    };
+
+    await addOneEService(mockEService);
+
+    const seed: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedAttribute1.id,
+            explicitAttributeVerification: true, // changed from false
+          },
+        ],
+      ],
+      verified: [],
+      declared: [],
+    };
+
+    await expect(
+      catalogService.updateDescriptorAttributes(
+        mockEService.id,
+        mockDescriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      )
+    ).rejects.toThrowError(
+      templateInstanceNotAllowed(mockEService.id, templateId)
+    );
+  });
+
+  it("should throw templateInstanceNotAllowed when removing an attribute from a group on a template instance", async () => {
+    const templateId = unsafeBrandId<EServiceTemplateId>(generateId());
+
+    const mockDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      state: descriptorState.published,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: false,
+            },
+            {
+              id: mockCertifiedAttribute2.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+      templateId,
+      descriptors: [mockDescriptor],
+    };
+
+    await addOneEService(mockEService);
+
+    const seed: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedAttribute1.id,
+            explicitAttributeVerification: false,
+          },
+          // mockCertifiedAttribute2 removed
+        ],
+      ],
+      verified: [],
+      declared: [],
+    };
+
+    await expect(
+      catalogService.updateDescriptorAttributes(
+        mockEService.id,
+        mockDescriptor.id,
+        seed,
         getMockContext({ authData: getMockAuthData(mockEService.producerId) })
       )
     ).rejects.toThrowError(

--- a/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
@@ -580,6 +580,103 @@ describe("update draft descriptor instance", () => {
     expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
   });
 
+  it("should clear existing certified attribute dailyCallsPerConsumer when seed.attributes omits them", async () => {
+    const template = getMockEServiceTemplate();
+
+    const certifiedAttributeId = unsafeBrandId<AttributeId>(generateId());
+    const certifiedAttribute: Attribute = {
+      name: "Certified attribute",
+      id: certifiedAttributeId,
+      kind: "Certified",
+      description: "A certified attribute",
+      creationTime: new Date(),
+    };
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttributeId,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      name: `${template.name} test`,
+      templateId: template.id,
+    };
+
+    await addOneEServiceTemplate(template);
+    await addOneAttribute(certifiedAttribute);
+    await addOneEService(eservice);
+
+    const seedWithAttributesWithoutDailyCalls: catalogApi.UpdateEServiceDescriptorTemplateInstanceSeed =
+      {
+        ...buildUpdateDescriptorSeed(descriptor),
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedAttributeId,
+                explicitAttributeVerification: false,
+              },
+            ],
+          ],
+          declared: [],
+          verified: [],
+        },
+      };
+
+    await catalogService.updateDraftDescriptorTemplateInstance(
+      eservice.id,
+      descriptor.id,
+      seedWithAttributesWithoutDailyCalls,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDraftDescriptorUpdatedV2,
+      payload: writtenEvent.data,
+    });
+
+    const expectedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          attributes: {
+            certified: [
+              [
+                {
+                  id: certifiedAttributeId,
+                  explicitAttributeVerification: false,
+                },
+              ],
+            ],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(expectedEService));
+  });
+
   it("should throw attributeDailyCallsNotAllowed when dailyCallsPerConsumer is set on declared attribute", async () => {
     const template = getMockEServiceTemplate();
 

--- a/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
@@ -21,6 +21,8 @@ import {
   operationForbidden,
   delegationState,
   delegationKind,
+  AttributeId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { expect, describe, it } from "vitest";
 import {
@@ -29,6 +31,7 @@ import {
   notValidDescriptorState,
   inconsistentDailyCalls,
   eServiceNotAnInstance,
+  attributeDailyCallsNotAllowed,
 } from "../../src/model/domain/errors.js";
 import {
   addOneEService,
@@ -378,5 +381,341 @@ describe("update draft descriptor instance", () => {
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
     ).rejects.toThrowError(eServiceNotAnInstance(eservice.id));
+  });
+
+  it("should update draft descriptor with attribute-level dailyCallsPerConsumer on certified attributes", async () => {
+    const template = getMockEServiceTemplate();
+
+    const certifiedAttributeId = unsafeBrandId<AttributeId>(generateId());
+    const certifiedAttribute: Attribute = {
+      name: "Certified attribute",
+      id: certifiedAttributeId,
+      kind: "Certified",
+      description: "A certified attribute",
+      creationTime: new Date(),
+    };
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttributeId,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      name: `${template.name} test`,
+      templateId: template.id,
+    };
+
+    await addOneEServiceTemplate(template);
+    await addOneAttribute(certifiedAttribute);
+    await addOneEService(eservice);
+
+    const attributesWithDailyCalls: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: certifiedAttributeId,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 500,
+          },
+        ],
+      ],
+      declared: [],
+      verified: [],
+    };
+
+    const expectedDescriptorSeed: catalogApi.UpdateEServiceDescriptorTemplateInstanceSeed =
+      {
+        ...buildUpdateDescriptorSeed(descriptor),
+        dailyCallsTotal: 1000,
+        attributes: attributesWithDailyCalls,
+      };
+
+    const updatedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          dailyCallsTotal: 1000,
+          attributes: {
+            certified: [
+              [
+                {
+                  id: certifiedAttributeId,
+                  explicitAttributeVerification: false,
+                  dailyCallsPerConsumer: 500,
+                },
+              ],
+            ],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+
+    await catalogService.updateDraftDescriptorTemplateInstance(
+      eservice.id,
+      descriptor.id,
+      expectedDescriptorSeed,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: eservice.id,
+      version: "1",
+      type: "EServiceDraftDescriptorUpdated",
+      event_version: 2,
+    });
+
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDraftDescriptorUpdatedV2,
+      payload: writtenEvent.data,
+    });
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
+  });
+
+  it("should preserve existing attributes when seed.attributes is not provided", async () => {
+    const template = getMockEServiceTemplate();
+
+    const certifiedAttributeId = unsafeBrandId<AttributeId>(generateId());
+    const certifiedAttribute: Attribute = {
+      name: "Certified attribute",
+      id: certifiedAttributeId,
+      kind: "Certified",
+      description: "A certified attribute",
+      creationTime: new Date(),
+    };
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttributeId,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      name: `${template.name} test`,
+      templateId: template.id,
+    };
+
+    await addOneEServiceTemplate(template);
+    await addOneAttribute(certifiedAttribute);
+    await addOneEService(eservice);
+
+    const seedWithoutAttributes: catalogApi.UpdateEServiceDescriptorTemplateInstanceSeed =
+      {
+        audience: descriptor.audience,
+        dailyCallsPerConsumer: descriptor.dailyCallsPerConsumer,
+        dailyCallsTotal: 2000,
+        agreementApprovalPolicy: "AUTOMATIC",
+      };
+
+    const updatedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          dailyCallsTotal: 2000,
+          attributes: {
+            certified: [
+              [
+                {
+                  id: certifiedAttributeId,
+                  explicitAttributeVerification: false,
+                  dailyCallsPerConsumer: 500,
+                },
+              ],
+            ],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+
+    await catalogService.updateDraftDescriptorTemplateInstance(
+      eservice.id,
+      descriptor.id,
+      seedWithoutAttributes,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDraftDescriptorUpdatedV2,
+      payload: writtenEvent.data,
+    });
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(updatedEService));
+  });
+
+  it("should throw attributeDailyCallsNotAllowed when dailyCallsPerConsumer is set on declared attribute", async () => {
+    const template = getMockEServiceTemplate();
+
+    const declaredAttributeId = unsafeBrandId<AttributeId>(generateId());
+    const declaredAttribute: Attribute = {
+      name: "Declared attribute",
+      id: declaredAttributeId,
+      kind: "Declared",
+      description: "A declared attribute",
+      creationTime: new Date(),
+    };
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [],
+        declared: [
+          [
+            {
+              id: declaredAttributeId,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        verified: [],
+      },
+    };
+
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      name: `${template.name} test`,
+      templateId: template.id,
+    };
+
+    await addOneEServiceTemplate(template);
+    await addOneAttribute(declaredAttribute);
+    await addOneEService(eservice);
+
+    const attributesWithDailyCallsOnDeclared: catalogApi.AttributesSeed = {
+      certified: [],
+      declared: [
+        [
+          {
+            id: declaredAttributeId,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 100,
+          },
+        ],
+      ],
+      verified: [],
+    };
+
+    await expect(
+      catalogService.updateDraftDescriptorTemplateInstance(
+        eservice.id,
+        descriptor.id,
+        {
+          ...buildUpdateDescriptorSeed(descriptor),
+          attributes: attributesWithDailyCallsOnDeclared,
+        },
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(attributeDailyCallsNotAllowed(declaredAttributeId));
+  });
+
+  it("should throw inconsistentDailyCalls when attribute dailyCallsPerConsumer exceeds dailyCallsTotal", async () => {
+    const template = getMockEServiceTemplate();
+
+    const certifiedAttributeId = unsafeBrandId<AttributeId>(generateId());
+    const certifiedAttribute: Attribute = {
+      name: "Certified attribute",
+      id: certifiedAttributeId,
+      kind: "Certified",
+      description: "A certified attribute",
+      creationTime: new Date(),
+    };
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 100,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttributeId,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      name: `${template.name} test`,
+      templateId: template.id,
+    };
+
+    await addOneEServiceTemplate(template);
+    await addOneAttribute(certifiedAttribute);
+    await addOneEService(eservice);
+
+    const attributesWithExceedingDailyCalls: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: certifiedAttributeId,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 500,
+          },
+        ],
+      ],
+      declared: [],
+      verified: [],
+    };
+
+    await expect(
+      catalogService.updateDraftDescriptorTemplateInstance(
+        eservice.id,
+        descriptor.id,
+        {
+          ...buildUpdateDescriptorSeed(descriptor),
+          dailyCallsTotal: 100,
+          attributes: attributesWithExceedingDailyCalls,
+        },
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(inconsistentDailyCalls());
   });
 });

--- a/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
@@ -478,6 +478,97 @@ describe("update descriptor", () => {
     );
   });
 
+  it("should clear existing certified attribute dailyCallsPerConsumer when seed.attributes omits them", async () => {
+    const certifiedAttribute = getMockAttribute(attributeKind.certified);
+
+    await addOneAttribute(certifiedAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      templateId: mockTemplate.id,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+    await addOneEServiceTemplate(mockTemplate);
+
+    const descriptorQuotasSeed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+      {
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedAttribute.id,
+                explicitAttributeVerification: false,
+              },
+            ],
+          ],
+          declared: [],
+          verified: [],
+        },
+      };
+
+    const returnedEService =
+      await catalogService.updateTemplateInstanceDescriptor(
+        eservice.id,
+        descriptor.id,
+        descriptorQuotasSeed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorQuotasUpdatedV2,
+      payload: writtenEvent.data,
+    });
+
+    const expectedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          attributes: {
+            certified: [
+              [
+                {
+                  id: certifiedAttribute.id,
+                  explicitAttributeVerification: false,
+                },
+              ],
+            ],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(expectedEService));
+    expect(returnedEService).toEqual(expectedEService);
+  });
+
   it("should throw templateInstanceNotAllowed when seed.attributes changes attribute structure", async () => {
     const mockCertifiedAttribute1 = getMockAttribute(attributeKind.certified);
     const mockCertifiedAttribute2 = getMockAttribute(attributeKind.certified);

--- a/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
@@ -678,4 +678,54 @@ describe("update descriptor", () => {
       attributeDailyCallsNotAllowed(mockDeclaredAttribute.id)
     );
   });
+
+  it("should throw inconsistentDailyCalls when lowering dailyCallsTotal below existing attribute dailyCallsPerConsumer without providing attributes", async () => {
+    const certifiedAttribute = getMockAttribute(attributeKind.certified);
+    await addOneAttribute(certifiedAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 500,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      templateId: mockTemplate.id,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+    await addOneEServiceTemplate(mockTemplate);
+
+    const seed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+      {
+        dailyCallsPerConsumer: 200,
+        dailyCallsTotal: 300,
+        // No attributes field — existing attributes must still be validated
+      };
+
+    await expect(
+      catalogService.updateTemplateInstanceDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(inconsistentDailyCalls());
+  });
 });

--- a/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
@@ -8,6 +8,7 @@ import {
   getMockEService,
   getMockDescriptor,
   getMockDocument,
+  getMockAttribute,
 } from "pagopa-interop-commons-test";
 import {
   Descriptor,
@@ -18,6 +19,7 @@ import {
   operationForbidden,
   delegationState,
   delegationKind,
+  attributeKind,
 } from "pagopa-interop-models";
 import { catalogApi } from "pagopa-interop-api-clients";
 import { expect, describe, it } from "vitest";
@@ -27,10 +29,13 @@ import {
   notValidDescriptorState,
   inconsistentDailyCalls,
   eServiceNotAnInstance,
+  templateInstanceNotAllowed,
+  attributeDailyCallsNotAllowed,
 } from "../../src/model/domain/errors.js";
 import {
   addOneEService,
   addOneEServiceTemplate,
+  addOneAttribute,
   catalogService,
   readLastEserviceEvent,
   addOneDelegation,
@@ -359,5 +364,318 @@ describe("update descriptor", () => {
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
     ).rejects.toThrowError(eServiceNotAnInstance(eservice.id));
+  });
+
+  it("should update dailyCallsPerConsumer on certified attributes of a published template instance descriptor", async () => {
+    const mockCertifiedAttribute1 = getMockAttribute(attributeKind.certified);
+    const mockCertifiedAttribute2 = getMockAttribute(attributeKind.certified);
+
+    await addOneAttribute(mockCertifiedAttribute1);
+    await addOneAttribute(mockCertifiedAttribute2);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: false,
+            },
+            {
+              id: mockCertifiedAttribute2.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      templateId: mockTemplate.id,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+    await addOneEServiceTemplate(mockTemplate);
+
+    const attributesSeed: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedAttribute1.id,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 500,
+          },
+          {
+            id: mockCertifiedAttribute2.id,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 300,
+          },
+        ],
+      ],
+      declared: [],
+      verified: [],
+    };
+
+    const descriptorQuotasSeed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+      {
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: attributesSeed,
+      };
+
+    const returnedEService =
+      await catalogService.updateTemplateInstanceDescriptor(
+        eservice.id,
+        descriptor.id,
+        descriptorQuotasSeed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: eservice.id,
+      version: "1",
+      type: "EServiceDescriptorQuotasUpdated",
+      event_version: 2,
+    });
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorQuotasUpdatedV2,
+      payload: writtenEvent.data,
+    });
+
+    const updatedDescriptor = writtenPayload.eservice?.descriptors[0];
+    const certifiedGroup = updatedDescriptor?.attributes?.certified[0]?.values;
+
+    const attr1 = certifiedGroup?.find(
+      (attr) => attr.id === mockCertifiedAttribute1.id
+    );
+    expect(attr1?.dailyCallsPerConsumer).toBe(500);
+
+    const attr2 = certifiedGroup?.find(
+      (attr) => attr.id === mockCertifiedAttribute2.id
+    );
+    expect(attr2?.dailyCallsPerConsumer).toBe(300);
+
+    expect(returnedEService.descriptors[0].attributes.certified[0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: mockCertifiedAttribute1.id,
+          dailyCallsPerConsumer: 500,
+        }),
+        expect.objectContaining({
+          id: mockCertifiedAttribute2.id,
+          dailyCallsPerConsumer: 300,
+        }),
+      ])
+    );
+  });
+
+  it("should throw templateInstanceNotAllowed when seed.attributes changes attribute structure", async () => {
+    const mockCertifiedAttribute1 = getMockAttribute(attributeKind.certified);
+    const mockCertifiedAttribute2 = getMockAttribute(attributeKind.certified);
+
+    await addOneAttribute(mockCertifiedAttribute1);
+    await addOneAttribute(mockCertifiedAttribute2);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      templateId: mockTemplate.id,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+    await addOneEServiceTemplate(mockTemplate);
+
+    const seedWithExtraAttribute: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedAttribute1.id,
+            explicitAttributeVerification: false,
+          },
+          {
+            id: mockCertifiedAttribute2.id,
+            explicitAttributeVerification: false,
+          },
+        ],
+      ],
+      declared: [],
+      verified: [],
+    };
+
+    const descriptorQuotasSeed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+      {
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: seedWithExtraAttribute,
+      };
+
+    expect(
+      catalogService.updateTemplateInstanceDescriptor(
+        eservice.id,
+        descriptor.id,
+        descriptorQuotasSeed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      templateInstanceNotAllowed(eservice.id, mockTemplate.id)
+    );
+  });
+
+  it("should throw inconsistentDailyCalls when attribute dailyCallsPerConsumer exceeds dailyCallsTotal", async () => {
+    const mockCertifiedAttribute1 = getMockAttribute(attributeKind.certified);
+
+    await addOneAttribute(mockCertifiedAttribute1);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      templateId: mockTemplate.id,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+    await addOneEServiceTemplate(mockTemplate);
+
+    const seedWithExcessiveDailyCalls: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedAttribute1.id,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 2000,
+          },
+        ],
+      ],
+      declared: [],
+      verified: [],
+    };
+
+    const descriptorQuotasSeed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+      {
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: seedWithExcessiveDailyCalls,
+      };
+
+    expect(
+      catalogService.updateTemplateInstanceDescriptor(
+        eservice.id,
+        descriptor.id,
+        descriptorQuotasSeed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(inconsistentDailyCalls());
+  });
+
+  it("should throw attributeDailyCallsNotAllowed when dailyCallsPerConsumer is set on a declared attribute", async () => {
+    const mockDeclaredAttribute = getMockAttribute(attributeKind.declared);
+
+    await addOneAttribute(mockDeclaredAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [],
+        declared: [
+          [
+            {
+              id: mockDeclaredAttribute.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      templateId: mockTemplate.id,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+    await addOneEServiceTemplate(mockTemplate);
+
+    const seedWithDailyCallsOnDeclared: catalogApi.AttributesSeed = {
+      certified: [],
+      declared: [
+        [
+          {
+            id: mockDeclaredAttribute.id,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 100,
+          },
+        ],
+      ],
+      verified: [],
+    };
+
+    const descriptorQuotasSeed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+      {
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: seedWithDailyCallsOnDeclared,
+      };
+
+    expect(
+      catalogService.updateTemplateInstanceDescriptor(
+        eservice.id,
+        descriptor.id,
+        descriptorQuotasSeed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      attributeDailyCallsNotAllowed(mockDeclaredAttribute.id)
+    );
   });
 });

--- a/packages/catalog-process/test/integration/updateTemplateInstanceDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateTemplateInstanceDescriptorAttributes.test.ts
@@ -434,4 +434,113 @@ describe("updateTemplateInstanceDescriptorAttributes", () => {
       )
     );
   });
+
+  it.each([descriptorState.published, descriptorState.suspended])(
+    "should preserve dailyCallsPerConsumer on existing attributes when template is edited",
+    async (descriptorState) => {
+      const dailyCallsAttr1 = 500;
+      const dailyCallsAttr2 = 300;
+
+      const mockDescriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: mockCertifiedAttribute1.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: dailyCallsAttr1,
+              },
+              {
+                id: mockCertifiedAttribute2.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: dailyCallsAttr2,
+              },
+            ],
+          ],
+          verified: validMockDescriptorVerifiedAttributes,
+          declared: [],
+        },
+      };
+
+      const mockEService: EService = {
+        ...getMockEService(),
+        descriptors: [mockDescriptor],
+      };
+
+      await addOneEService(mockEService);
+
+      const seedWithNewAttribute: catalogApi.AttributesSeed = {
+        certified: [
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: false,
+            },
+            {
+              id: mockCertifiedAttribute2.id,
+              explicitAttributeVerification: false,
+            },
+            {
+              id: mockCertifiedAttribute3.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        verified: [
+          [
+            ...validMockDescriptorVerifiedAttributes[0],
+            {
+              id: mockVerifiedAttribute3.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+          validMockDescriptorVerifiedAttributes[1],
+        ],
+        declared: [],
+      };
+
+      await catalogService.internalUpdateTemplateInstanceDescriptorAttributes(
+        mockEService.id,
+        mockDescriptor.id,
+        seedWithNewAttribute,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      );
+
+      const writtenEvent = await readLastEserviceEvent(mockEService.id);
+      expect(writtenEvent).toMatchObject({
+        stream_id: mockEService.id,
+        version: "1",
+        type: "EServiceDescriptorAttributesUpdatedByTemplateUpdate",
+        event_version: 2,
+      });
+
+      const writtenPayload = decodeProtobufPayload({
+        messageType: EServiceDescriptorAttributesUpdatedByTemplateUpdateV2,
+        payload: writtenEvent.data,
+      });
+
+      const updatedDescriptor = writtenPayload.eservice?.descriptors[0];
+
+      const certifiedGroup =
+        updatedDescriptor?.attributes?.certified[0]?.values;
+
+      const preservedAttr1 = certifiedGroup?.find(
+        (attr) => attr.id === mockCertifiedAttribute1.id
+      );
+      expect(preservedAttr1?.dailyCallsPerConsumer).toBe(dailyCallsAttr1);
+
+      const preservedAttr2 = certifiedGroup?.find(
+        (attr) => attr.id === mockCertifiedAttribute2.id
+      );
+      expect(preservedAttr2?.dailyCallsPerConsumer).toBe(dailyCallsAttr2);
+
+      const newAttribute = certifiedGroup?.find(
+        (attr) => attr.id === mockCertifiedAttribute3.id
+      );
+      expect(newAttribute?.dailyCallsPerConsumer).toBeUndefined();
+    }
+  );
 });

--- a/packages/catalog-process/test/integration/updateTemplateInstanceDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateTemplateInstanceDescriptorAttributes.test.ts
@@ -543,4 +543,153 @@ describe("updateTemplateInstanceDescriptorAttributes", () => {
       expect(newAttribute?.dailyCallsPerConsumer).toBeUndefined();
     }
   );
+
+  it.each([descriptorState.published, descriptorState.suspended])(
+    "should preserve distinct dailyCallsPerConsumer values when the same certified attribute id appears in multiple groups",
+    async (descriptorState) => {
+      const firstGroupAttr1DailyCalls = 100;
+      const firstGroupAttr2DailyCalls = 200;
+      const secondGroupAttr1DailyCalls = 900;
+      const secondGroupAttr2DailyCalls = 300;
+
+      const mockDescriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: mockCertifiedAttribute1.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: firstGroupAttr1DailyCalls,
+              },
+              {
+                id: mockCertifiedAttribute2.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: firstGroupAttr2DailyCalls,
+              },
+            ],
+            [
+              {
+                id: mockCertifiedAttribute1.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: secondGroupAttr1DailyCalls,
+              },
+              {
+                id: mockCertifiedAttribute2.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: secondGroupAttr2DailyCalls,
+              },
+            ],
+          ],
+          verified: [],
+          declared: [],
+        },
+      };
+
+      const mockEService: EService = {
+        ...getMockEService(),
+        descriptors: [mockDescriptor],
+      };
+
+      await addOneEService(mockEService);
+
+      const seedWithNewAttribute: catalogApi.AttributesSeed = {
+        certified: [
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: false,
+            },
+            {
+              id: mockCertifiedAttribute2.id,
+              explicitAttributeVerification: false,
+            },
+            {
+              id: mockCertifiedAttribute3.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: false,
+            },
+            {
+              id: mockCertifiedAttribute2.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      };
+
+      await catalogService.internalUpdateTemplateInstanceDescriptorAttributes(
+        mockEService.id,
+        mockDescriptor.id,
+        seedWithNewAttribute,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      );
+
+      const writtenEvent = await readLastEserviceEvent(mockEService.id);
+      expect(writtenEvent).toMatchObject({
+        stream_id: mockEService.id,
+        version: "1",
+        type: "EServiceDescriptorAttributesUpdatedByTemplateUpdate",
+        event_version: 2,
+      });
+
+      const writtenPayload = decodeProtobufPayload({
+        messageType: EServiceDescriptorAttributesUpdatedByTemplateUpdateV2,
+        payload: writtenEvent.data,
+      });
+
+      const expectedEService: EService = {
+        ...mockEService,
+        descriptors: [
+          {
+            ...mockDescriptor,
+            attributes: {
+              certified: [
+                [
+                  {
+                    id: mockCertifiedAttribute1.id,
+                    explicitAttributeVerification: false,
+                    dailyCallsPerConsumer: firstGroupAttr1DailyCalls,
+                  },
+                  {
+                    id: mockCertifiedAttribute2.id,
+                    explicitAttributeVerification: false,
+                    dailyCallsPerConsumer: firstGroupAttr2DailyCalls,
+                  },
+                  {
+                    id: mockCertifiedAttribute3.id,
+                    explicitAttributeVerification: false,
+                  },
+                ],
+                [
+                  {
+                    id: mockCertifiedAttribute1.id,
+                    explicitAttributeVerification: false,
+                    dailyCallsPerConsumer: secondGroupAttr1DailyCalls,
+                  },
+                  {
+                    id: mockCertifiedAttribute2.id,
+                    explicitAttributeVerification: false,
+                    dailyCallsPerConsumer: secondGroupAttr2DailyCalls,
+                  },
+                ],
+              ],
+              verified: [],
+              declared: [],
+            },
+          },
+        ],
+      };
+
+      expect(writtenPayload.eservice).toEqual(toEServiceV2(expectedEService));
+    }
+  );
 });


### PR DESCRIPTION
## Jira Issue
[PIN-9803](https://pagopa.atlassian.net/browse/PIN-9803), [PIN-9812](https://pagopa.atlassian.net/browse/PIN-9812)

## Context
- PIN-9803: after setting a differentiated threshold on a draft e-service instance, saving the draft, moving to the next step, going back, and then publishing, the value was lost. Attribute-level `dailyCallsPerConsumer` was not being persisted correctly across template-instance descriptor update flows.
- PIN-9812: updating a differentiated threshold on a published e-service instance failed with `TemplateId must be undefined`. The generic descriptor attribute update flow rejects template instances, and the template-instance quota update flow had no contract to receive attribute-level thresholds.
- Template propagation could also clear `dailyCallsPerConsumer` already configured on instances.

## Services Affected
- `catalog-process`
- `api-clients` (`catalogApi`)

## Key Changes
- Added `attributes` to the template-instance descriptor update seeds in the OpenAPI contract.
- Added `assertTemplateInstanceAttributeStructureUnchanged` to keep template-instance attribute structure immutable while allowing updates to `dailyCallsPerConsumer` on existing certified attributes.
- Updated `updateDraftDescriptorTemplateInstance` and `updateTemplateInstanceDescriptor` to parse `seed.attributes`, persist attribute-level thresholds, and validate them against `dailyCallsTotal`.
- Updated user-driven descriptor update flows so omitting `dailyCallsPerConsumer` inside `seed.attributes` clears the existing differentiated threshold instead of restoring it implicitly.
- Updated internal template propagation so template changes do not clear `dailyCallsPerConsumer` already configured on instances.
- Added group-aware matching when preserving certified attribute thresholds, so different groups keep their own values even when the same certified attribute id is reused across groups.
- Centralized default quota fallback values used when creating or upgrading template instances.

## Tests
- Added coverage for draft template-instance descriptor updates with attribute-level `dailyCallsPerConsumer`.
- Added coverage for published and suspended template-instance descriptor quota updates with attribute-level `dailyCallsPerConsumer`.
- Added regression coverage for preserving instance-specific `dailyCallsPerConsumer` during internal template propagation.
- Added regression coverage for clearing existing certified thresholds when `seed.attributes` omits `dailyCallsPerConsumer`.
- Added regression coverage for lowering `dailyCallsTotal` below existing certified thresholds when `attributes` is omitted.
- Added regression coverage for certified attributes reused across different groups.
- Added validation coverage for rejecting `dailyCallsPerConsumer` on declared and verified attributes.

[PIN-9803]: https://pagopa.atlassian.net/browse/PIN-9803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-9812]: https://pagopa.atlassian.net/browse/PIN-9812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ