### PR TITLE
fix: allow updating attribute dailyCallsPerConsumer on published template instances (PIN-9812)

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -184,6 +184,7 @@ import {
   assertValidDelegationFlags,
   assertDailyCallsForCertifiedAttributesOnly,
   assertAttributeDailyCallsConsistentWithTotal,
+  assertTemplateInstanceCannotAddAttributes,
 } from "./validators.js";
 import type { ReadModelServiceSQL } from "./readModelServiceTypes.js";
 
@@ -2844,11 +2845,6 @@ export function catalogServiceBuilder(
 
       const eservice = await retrieveEService(eserviceId, readModelService);
 
-      assertEServiceNotTemplateInstance(
-        eservice.data.id,
-        eservice.data.templateId
-      );
-
       await assertRequesterIsDelegateProducerOrProducer(
         eservice.data.producerId,
         eserviceId,
@@ -2863,6 +2859,12 @@ export function catalogServiceBuilder(
         eserviceId,
         descriptor,
         seed
+      );
+
+      assertTemplateInstanceCannotAddAttributes(
+        eserviceId,
+        eservice.data.templateId,
+        newAttributes
       );
 
       const hasDailyCallsChanged = hasCertifiedAttributeDailyCallsChanged(

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -421,6 +421,16 @@ export function assertDailyCallsForCertifiedAttributesOnly(
   }
 }
 
+export function assertTemplateInstanceCannotAddAttributes(
+  eserviceId: EServiceId,
+  templateId: EServiceTemplateId | undefined,
+  newAttributeIds: string[]
+): void {
+  if (templateId !== undefined && newAttributeIds.length > 0) {
+    throw templateInstanceNotAllowed(eserviceId, templateId);
+  }
+}
+
 export function assertAttributeDailyCallsConsistentWithTotal(
   attributes: EserviceAttributes,
   dailyCallsTotal: number

--- a/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
@@ -34,8 +34,8 @@ import {
   descriptorAttributeGroupSupersetMissingInAttributesSeed,
   notValidDescriptorState,
   unchangedAttributes,
-  templateInstanceNotAllowed,
   attributeDailyCallsNotAllowed,
+  templateInstanceNotAllowed,
 } from "../../src/model/domain/errors.js";
 import {
   addOneAttribute,
@@ -572,7 +572,7 @@ describe("update descriptor", () => {
       )
     );
   });
-  it("should throw templateInstanceNotAllowed if the templateId is defined", async () => {
+  it("should throw templateInstanceNotAllowed when adding new attributes on a template instance", async () => {
     const templateId = unsafeBrandId<EServiceTemplateId>(generateId());
     const mockDescriptor: Descriptor = {
       ...getMockDescriptor(),
@@ -592,7 +592,7 @@ describe("update descriptor", () => {
 
     await addOneEService(mockEService);
 
-    expect(
+    await expect(
       catalogService.updateDescriptorAttributes(
         mockEService.id,
         mockDescriptor.id,
@@ -602,6 +602,74 @@ describe("update descriptor", () => {
     ).rejects.toThrowError(
       templateInstanceNotAllowed(mockEService.id, templateId)
     );
+  });
+
+  it("should persist dailyCallsPerConsumer on a certified attribute of a published template instance", async () => {
+    const templateId = unsafeBrandId<EServiceTemplateId>(generateId());
+    const dailyCallsPerConsumer = 500;
+
+    const mockDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      state: descriptorState.published,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: true,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+      templateId,
+      descriptors: [mockDescriptor],
+    };
+
+    await addOneEService(mockEService);
+
+    const seed: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedAttribute1.id,
+            explicitAttributeVerification: true,
+            dailyCallsPerConsumer,
+          },
+        ],
+      ],
+      verified: [],
+      declared: [],
+    };
+
+    const result = await catalogService.updateDescriptorAttributes(
+      mockEService.id,
+      mockDescriptor.id,
+      seed,
+      getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+    );
+
+    expect(result).toBeDefined();
+
+    const updatedDescriptor = result.data.descriptors.find(
+      (d) => d.id === mockDescriptor.id
+    );
+
+    expect(updatedDescriptor).toBeDefined();
+    expect(updatedDescriptor!.attributes.certified).toHaveLength(1);
+    expect(updatedDescriptor!.attributes.certified[0]).toHaveLength(1);
+    expect(updatedDescriptor!.attributes.certified[0][0].id).toBe(
+      mockCertifiedAttribute1.id
+    );
+    expect(
+      updatedDescriptor!.attributes.certified[0][0].dailyCallsPerConsumer
+    ).toBe(dailyCallsPerConsumer);
   });
 
   it("should write on event-store when adding new certified attribute with dailyCalls", async () => {


### PR DESCRIPTION
## Jira Issue
[PIN-9812](https://pagopa.atlassian.net/browse/PIN-9812)

## Context
When editing differentiated thresholds (`dailyCallsPerConsumer`) on a published e-service instantiated from a template, the call to `updateDescriptorAttributes` was rejected with a 400 `TemplateId must be undefined` error. The method had an `assertEServiceNotTemplateInstance` guard that unconditionally blocked all template instances, but attribute-level thresholds need to be editable on template instances too.

Simply removing the guard would have been too permissive: the underlying `updateEServiceDescriptorAttributeInAdd` logic allows adding new attributes (superset), which must remain forbidden on template instances. A targeted validator was introduced instead.

## Note ⚠️

The correct long-term solution for this use case is a **dedicated endpoint** for template instances, following the existing pattern of the monorepo.
Every mutation allowed on a template instance already has its own route with a narrow seed that exposes only what is customizable (e.g. `POST /templates/eservices/:id/descriptors/:did/update` for descriptor-level quotas).
The same pattern should be applied to attribute-level thresholds, with a new **`POST /templates/eservices/:id/descriptors/:did/attributes/update`** endpoint`.
This PR works around the missing endpoint by patching the generic `updateDescriptorAttributes` with a targeted validator.

## Services Affected
- `catalog-process` — replaced the blanket `assertEServiceNotTemplateInstance` guard in `updateDescriptorAttributes` with a targeted `assertTemplateInstanceCannotAddAttributes` that only blocks adding new attributes, while allowing `dailyCallsPerConsumer` changes

## Key Changes
- `validators.ts`: new `assertTemplateInstanceCannotAddAttributes(eserviceId, templateId, newAttributes)` — throws `templateInstanceNotAllowed` only when a template instance tries to add attributes that were not already present
- `catalogService.ts`: `updateDescriptorAttributes` now calls `assertTemplateInstanceCannotAddAttributes` after `updateEServiceDescriptorAttributeInAdd`; removed the blanket `assertEServiceNotTemplateInstance` guard
- `updateDescriptorAttributes.test.ts`: renamed test to assert `templateInstanceNotAllowed` when adding new attributes on a template instance; kept the test verifying `dailyCallsPerConsumer` is correctly persisted on a certified attribute of a published template instance

[PIN-9812]: https://pagopa.atlassian.net/browse/PIN-9812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ