### PR TITLE
feat: add e-service templates retrieval endpoint to purpose template process (PIN-9772)

### DIFF
--- a/collections/purpose-template/Get Purpose Template EService Templates.bru
+++ b/collections/purpose-template/Get Purpose Template EService Templates.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Get Purpose Template EService Templates
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{host-purpose-template}}/purposeTemplates/:purposeTemplateId/eserviceTemplates
+  body: none
+  auth: none
+}
+
+params:path {
+  purposeTemplateId: {{purposeTemplateId}}
+}
+
+params:query {
+  offset: 0
+  limit: 10
+  ~eserviceTemplateName: test
+  ~creatorIds: ["{{tenantId}}"]
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}

--- a/docker/readmodel-db/purpose-template.sql
+++ b/docker/readmodel-db/purpose-template.sql
@@ -112,8 +112,18 @@ CREATE TABLE IF NOT EXISTS readmodel_purpose_template.purpose_template_risk_anal
   path VARCHAR NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   signed_at TIMESTAMP WITH TIME ZONE NOT NULL,
-  
+
   PRIMARY KEY (id),
-  
+
+  FOREIGN KEY (purpose_template_id, metadata_version) REFERENCES readmodel_purpose_template.purpose_template (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS readmodel_purpose_template.eservice_template_version_purpose_template (
+  metadata_version INTEGER NOT NULL,
+  purpose_template_id UUID NOT NULL REFERENCES readmodel_purpose_template.purpose_template (id) ON DELETE CASCADE,
+  eservice_template_id UUID NOT NULL,
+  eservice_template_version_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  PRIMARY KEY (purpose_template_id, eservice_template_id),
   FOREIGN KEY (purpose_template_id, metadata_version) REFERENCES readmodel_purpose_template.purpose_template (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
 );

--- a/packages/api-clients/open-api/purposeTemplateApi.yml
+++ b/packages/api-clients/open-api/purposeTemplateApi.yml
@@ -561,6 +561,70 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /purposeTemplates/{id}/eserviceTemplates:
+    parameters:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: creatorIds
+        description: comma separated sequence of e-service template creator IDs
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+          default: []
+        explode: false
+      - in: query
+        name: eserviceTemplateName
+        description: filter linked e-service templates by name
+        schema:
+          type: string
+      - in: query
+        name: offset
+        required: true
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+      - in: query
+        name: limit
+        required: true
+        schema:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 50
+    get:
+      tags:
+        - purposeTemplate
+      summary: Get Purpose Template E-Service Templates
+      operationId: getPurposeTemplateEServiceTemplates
+      description: Retrieve e-service templates linked to a purpose template
+      responses:
+        "200":
+          description: Purpose Template E-Service Templates retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceTemplateVersionsPurposeTemplate"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Purpose Template Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /purposeTemplates/{id}/eservices/{eserviceId}:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"
@@ -1696,6 +1760,41 @@ components:
         - purposeTemplateId
         - eserviceId
         - descriptorId
+        - createdAt
+    EServiceTemplateVersionsPurposeTemplate:
+      type: object
+      additionalProperties: false
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/EServiceTemplateVersionPurposeTemplate"
+        totalCount:
+          type: integer
+          format: int32
+      required:
+        - results
+        - totalCount
+    EServiceTemplateVersionPurposeTemplate:
+      type: object
+      additionalProperties: false
+      properties:
+        purposeTemplateId:
+          type: string
+          format: uuid
+        eserviceTemplateId:
+          type: string
+          format: uuid
+        eserviceTemplateVersionId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - purposeTemplateId
+        - eserviceTemplateId
+        - eserviceTemplateVersionId
         - createdAt
     RiskAnalysisFormTemplate:
       type: object

--- a/packages/documents-generator/src/handler/handlePurposeTemplateMessageV2.ts
+++ b/packages/documents-generator/src/handler/handlePurposeTemplateMessageV2.ts
@@ -90,6 +90,8 @@ export async function handlePurposeTemplateMessageV2(
           "PurposeTemplateDraftDeleted",
           "PurposeTemplateDraftUpdated",
           "PurposeTemplateEServiceLinked",
+          "PurposeTemplateEServiceTemplateLinked",
+          "PurposeTemplateEServiceTemplateUnlinked",
           "PurposeTemplateEServiceUnlinked",
           "PurposeTemplateSuspended",
           "PurposeTemplateUnsuspended",

--- a/packages/documents-signer/src/handlers/handlePurposeTemplateDocument.ts
+++ b/packages/documents-signer/src/handlers/handlePurposeTemplateDocument.ts
@@ -120,6 +120,8 @@ export async function handlePurposeTemplateDocument(
           "PurposeTemplateDraftDeleted",
           "PurposeTemplateDraftUpdated",
           "PurposeTemplateEServiceLinked",
+          "PurposeTemplateEServiceTemplateLinked",
+          "PurposeTemplateEServiceTemplateUnlinked",
           "PurposeTemplateEServiceUnlinked",
           "PurposeTemplateSuspended",
           "PurposeTemplateUnsuspended",

--- a/packages/domains-analytics-writer/src/handlers/purpose-template/consumerServiceV2.ts
+++ b/packages/domains-analytics-writer/src/handlers/purpose-template/consumerServiceV2.ts
@@ -128,6 +128,11 @@ export async function handlePurposeTemplateMessageV2(
           >)
         );
       })
+      .with(
+        { type: "PurposeTemplateEServiceTemplateLinked" },
+        { type: "PurposeTemplateEServiceTemplateUnlinked" },
+        () => Promise.resolve()
+      )
       .exhaustive();
   }
 

--- a/packages/events-signer/src/handlers/handlePurposeTemplateMessageV2.ts
+++ b/packages/events-signer/src/handlers/handlePurposeTemplateMessageV2.ts
@@ -73,6 +73,8 @@ export const handlePurposeTemplateMessageV2 = async (
             "PurposeTemplateDraftDeleted",
             "PurposeTemplateDraftUpdated",
             "PurposeTemplateEServiceLinked",
+            "PurposeTemplateEServiceTemplateLinked",
+            "PurposeTemplateEServiceTemplateUnlinked",
             "PurposeTemplateEServiceUnlinked",
             "PurposeTemplateSuspended",
             "PurposeTemplateUnsuspended",

--- a/packages/events-signer/test/handlers/handlePurposeTemplateMessageV2.test.ts
+++ b/packages/events-signer/test/handlers/handlePurposeTemplateMessageV2.test.ts
@@ -7,7 +7,10 @@ import {
   generateId,
   PurposeTemplateAddedV2,
   PurposeTemplateArchivedV2,
+  PurposeTemplateEServiceTemplateLinkedV2,
+  PurposeTemplateEServiceTemplateUnlinkedV2,
   toPurposeTemplateV2,
+  toEServiceTemplateV2,
 } from "pagopa-interop-models";
 import {
   FileManager,
@@ -22,6 +25,7 @@ import {
   buildDynamoDBTables,
   deleteDynamoDBTables,
   getMockPurposeTemplate,
+  getMockEServiceTemplate,
 } from "pagopa-interop-commons-test";
 import { config } from "../../src/config/config.js";
 import { dynamoDBClient } from "../utils/utils.js";
@@ -158,6 +162,75 @@ describe("handlePurposeTemplateMessageV2 - Integration Test", () => {
       data: {
         purposeTemplate: toPurposeTemplateV2(mockTemplate),
       } as any,
+      log_date: new Date(),
+    };
+
+    const eventsWithTimestamp = [
+      { purposeTemplateV2: message, timestamp: new Date() },
+    ];
+
+    const safeStorageCreateFileSpy = vi.spyOn(safeStorageService, "createFile");
+
+    await handlePurposeTemplateMessageV2(
+      eventsWithTimestamp,
+      fileManager,
+      signatureService,
+      safeStorageService
+    );
+
+    expect(safeStorageCreateFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not process a PurposeTemplateEServiceTemplateLinked event", async () => {
+    const mockTemplate = getMockPurposeTemplate();
+    const mockEServiceTemplate = getMockEServiceTemplate();
+
+    const message: PurposeTemplateEventEnvelopeV2 = {
+      sequence_num: 1,
+      stream_id: mockTemplate.id,
+      version: 1,
+      event_version: 2,
+      type: "PurposeTemplateEServiceTemplateLinked",
+      data: {
+        purposeTemplate: toPurposeTemplateV2(mockTemplate),
+        eserviceTemplate: toEServiceTemplateV2(mockEServiceTemplate),
+        eserviceTemplateVersionId: mockEServiceTemplate.versions[0].id,
+        createdAt: BigInt(Date.now()),
+      } as PurposeTemplateEServiceTemplateLinkedV2,
+      log_date: new Date(),
+    };
+
+    const eventsWithTimestamp = [
+      { purposeTemplateV2: message, timestamp: new Date() },
+    ];
+
+    const safeStorageCreateFileSpy = vi.spyOn(safeStorageService, "createFile");
+
+    await handlePurposeTemplateMessageV2(
+      eventsWithTimestamp,
+      fileManager,
+      signatureService,
+      safeStorageService
+    );
+
+    expect(safeStorageCreateFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not process a PurposeTemplateEServiceTemplateUnlinked event", async () => {
+    const mockTemplate = getMockPurposeTemplate();
+    const mockEServiceTemplate = getMockEServiceTemplate();
+
+    const message: PurposeTemplateEventEnvelopeV2 = {
+      sequence_num: 1,
+      stream_id: mockTemplate.id,
+      version: 1,
+      event_version: 2,
+      type: "PurposeTemplateEServiceTemplateUnlinked",
+      data: {
+        purposeTemplate: toPurposeTemplateV2(mockTemplate),
+        eserviceTemplate: toEServiceTemplateV2(mockEServiceTemplate),
+        eserviceTemplateVersionId: mockEServiceTemplate.versions[0].id,
+      } as PurposeTemplateEServiceTemplateUnlinkedV2,
       log_date: new Date(),
     };
 

--- a/packages/m2m-event-dispatcher/src/handlers/handlePurposeTemplateEvent.ts
+++ b/packages/m2m-event-dispatcher/src/handlers/handlePurposeTemplateEvent.ts
@@ -26,6 +26,12 @@ export async function handlePurposeTemplateEvent(
       {
         type: "RiskAnalysisTemplateDocumentGenerated",
       },
+      {
+        type: "PurposeTemplateEServiceTemplateLinked",
+      },
+      {
+        type: "PurposeTemplateEServiceTemplateUnlinked",
+      },
       () => Promise.resolve(void 0)
     )
     .with(

--- a/packages/m2m-event-dispatcher/test/handlePurposeTemplateEvent.test.ts
+++ b/packages/m2m-event-dispatcher/test/handlePurposeTemplateEvent.test.ts
@@ -81,7 +81,14 @@ describe("handlePurposeTemplateEvent test", async () => {
                 })),
             ]
           )
-          .with("RiskAnalysisTemplateDocumentGenerated", async () => [])
+          .with(
+            P.union(
+              "RiskAnalysisTemplateDocumentGenerated",
+              "PurposeTemplateEServiceTemplateLinked",
+              "PurposeTemplateEServiceTemplateUnlinked"
+            ),
+            async () => []
+          )
           .exhaustive();
 
         for (const { state, expectedVisibility } of testCasesData) {

--- a/packages/models/proto/v2/purpose-template/events.proto
+++ b/packages/models/proto/v2/purpose-template/events.proto
@@ -4,6 +4,7 @@ package purpose.template.v2;
 
 import "v2/purpose-template/purpose-template.proto";
 import "v2/eservice/eservice.proto";
+import "v2/eservice-template/eservice-template.proto";
 
 message PurposeTemplateAddedV2 {
   PurposeTemplateV2 purposeTemplate = 1;
@@ -68,4 +69,17 @@ message RiskAnalysisTemplateDocumentGeneratedV2 {
 
 message RiskAnalysisTemplateSignedDocumentGeneratedV2 {
   PurposeTemplateV2 purposeTemplate = 1;
+}
+
+message PurposeTemplateEServiceTemplateLinkedV2 {
+  PurposeTemplateV2 purposeTemplate = 1;
+  eservice.template.v2.EServiceTemplateV2 eserviceTemplate = 2;
+  string eserviceTemplateVersionId = 3;
+  int64 createdAt = 4;
+}
+
+message PurposeTemplateEServiceTemplateUnlinkedV2 {
+  PurposeTemplateV2 purposeTemplate = 1;
+  eservice.template.v2.EServiceTemplateV2 eserviceTemplate = 2;
+  string eserviceTemplateVersionId = 3;
 }

--- a/packages/models/src/purpose-template/purposeTemplate.ts
+++ b/packages/models/src/purpose-template/purposeTemplate.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import {
   DescriptorId,
   EServiceId,
+  EServiceTemplateId,
+  EServiceTemplateVersionId,
   PurposeTemplateId,
   TenantId,
 } from "../brandedIds.js";
@@ -37,6 +39,16 @@ export const EServiceDescriptorPurposeTemplate = z.object({
 });
 export type EServiceDescriptorPurposeTemplate = z.infer<
   typeof EServiceDescriptorPurposeTemplate
+>;
+
+export const EServiceTemplateVersionPurposeTemplate = z.object({
+  purposeTemplateId: PurposeTemplateId,
+  eserviceTemplateId: EServiceTemplateId,
+  eserviceTemplateVersionId: EServiceTemplateVersionId,
+  createdAt: z.coerce.date(),
+});
+export type EServiceTemplateVersionPurposeTemplate = z.infer<
+  typeof EServiceTemplateVersionPurposeTemplate
 >;
 
 export const PurposeTemplate = z.object({

--- a/packages/models/src/purpose-template/purposeTemplateEvents.ts
+++ b/packages/models/src/purpose-template/purposeTemplateEvents.ts
@@ -9,6 +9,8 @@ import {
   PurposeTemplateDraftDeletedV2,
   PurposeTemplateDraftUpdatedV2,
   PurposeTemplateEServiceLinkedV2,
+  PurposeTemplateEServiceTemplateLinkedV2,
+  PurposeTemplateEServiceTemplateUnlinkedV2,
   PurposeTemplateEServiceUnlinkedV2,
   PurposeTemplatePublishedV2,
   PurposeTemplateSuspendedV2,
@@ -34,6 +36,16 @@ export const PurposeTemplateEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("PurposeTemplateEServiceUnlinked"),
     data: protobufDecoder(PurposeTemplateEServiceUnlinkedV2),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("PurposeTemplateEServiceTemplateLinked"),
+    data: protobufDecoder(PurposeTemplateEServiceTemplateLinkedV2),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("PurposeTemplateEServiceTemplateUnlinked"),
+    data: protobufDecoder(PurposeTemplateEServiceTemplateUnlinkedV2),
   }),
   z.object({
     event_version: z.literal(2),
@@ -105,6 +117,12 @@ export function purposeTemplateEventToBinaryDataV2(
     )
     .with({ type: "PurposeTemplateEServiceUnlinked" }, (e) =>
       PurposeTemplateEServiceUnlinkedV2.toBinary(e.data)
+    )
+    .with({ type: "PurposeTemplateEServiceTemplateLinked" }, (e) =>
+      PurposeTemplateEServiceTemplateLinkedV2.toBinary(e.data)
+    )
+    .with({ type: "PurposeTemplateEServiceTemplateUnlinked" }, (e) =>
+      PurposeTemplateEServiceTemplateUnlinkedV2.toBinary(e.data)
     )
     .with({ type: "PurposeTemplateDraftUpdated" }, (e) =>
       PurposeTemplateDraftUpdatedV2.toBinary(e.data)

--- a/packages/purpose-template-outbound-writer/src/converters/toOutboundEventV2.ts
+++ b/packages/purpose-template-outbound-writer/src/converters/toOutboundEventV2.ts
@@ -103,9 +103,9 @@ function toOutboundPurposeTemplateV2(
 
 export function toOutboundEventV2(
   message: PurposeTemplateEventEnvelopeV2
-): OutboundPurposeTemplateEvent {
+): OutboundPurposeTemplateEvent | undefined {
   return match(message)
-    .returnType<OutboundPurposeTemplateEvent>()
+    .returnType<OutboundPurposeTemplateEvent | undefined>()
     .with(
       { type: "PurposeTemplateAdded" },
       { type: "PurposeTemplateDraftUpdated" },
@@ -190,5 +190,10 @@ export function toOutboundEventV2(
       stream_id: msg.stream_id,
       timestamp: new Date().toISOString(),
     }))
+    .with(
+      { type: "PurposeTemplateEServiceTemplateLinked" },
+      { type: "PurposeTemplateEServiceTemplateUnlinked" },
+      () => undefined
+    )
     .exhaustive();
 }

--- a/packages/purpose-template-process/src/model/domain/apiConverter.ts
+++ b/packages/purpose-template-process/src/model/domain/apiConverter.ts
@@ -5,6 +5,7 @@ import {
 } from "pagopa-interop-commons";
 import {
   EServiceDescriptorPurposeTemplate,
+  EServiceTemplateVersionPurposeTemplate,
   PurposeTemplate,
   purposeTemplateState,
   PurposeTemplateState,
@@ -202,6 +203,14 @@ export const eserviceDescriptorPurposeTemplateToApiEServiceDescriptorPurposeTemp
   ): purposeTemplateApi.EServiceDescriptorPurposeTemplate => ({
     ...eserviceDescriptorPurposeTemplate,
     createdAt: eserviceDescriptorPurposeTemplate.createdAt.toJSON(),
+  });
+
+export const eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate =
+  (
+    eserviceTemplateVersionPurposeTemplate: EServiceTemplateVersionPurposeTemplate
+  ): purposeTemplateApi.EServiceTemplateVersionPurposeTemplate => ({
+    ...eserviceTemplateVersionPurposeTemplate,
+    createdAt: eserviceTemplateVersionPurposeTemplate.createdAt.toJSON(),
   });
 
 export const annotationDocumentToApiAnnotationDocument = (

--- a/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
+++ b/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
@@ -33,6 +33,7 @@ import {
   deleteRiskAnalysisTemplateAnswerAnnotationErrorMapper,
   getPurposeTemplateErrorMapper,
   getPurposeTemplateEServiceDescriptorsErrorMapper,
+  getPurposeTemplateEServiceTemplatesErrorMapper,
   getPurposeTemplatesErrorMapper,
   getRiskAnalysisTemplateAnswerAnnotationDocumentErrorMapper,
   linkEservicesToPurposeTemplateErrorMapper,
@@ -54,6 +55,7 @@ import {
   annotationDocumentToApiAnnotationDocumentWithAnswerId,
   apiPurposeTemplateStateToPurposeTemplateState,
   eserviceDescriptorPurposeTemplateToApiEServiceDescriptorPurposeTemplate,
+  eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate,
   purposeTemplateAnswerAnnotationToApiPurposeTemplateAnswerAnnotation,
   purposeTemplateToApiPurposeTemplate,
   riskAnalysisAnswerToApiRiskAnalysisAnswer,
@@ -342,6 +344,47 @@ const purposeTemplateRouter = (
         const errorRes = makeApiProblem(
           error,
           getPurposeTemplateEServiceDescriptorsErrorMapper,
+          ctx
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
+    .get("/purposeTemplates/:id/eserviceTemplates", async (req, res) => {
+      const ctx = fromAppContext(req.ctx);
+      try {
+        validateAuthorization(ctx, [
+          ADMIN_ROLE,
+          API_ROLE,
+          M2M_ADMIN_ROLE,
+          M2M_ROLE,
+          SECURITY_ROLE,
+          SUPPORT_ROLE,
+        ]);
+
+        const { creatorIds, eserviceTemplateName, offset, limit } = req.query;
+        const { results, totalCount } =
+          await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+            {
+              purposeTemplateId: unsafeBrandId(req.params.id),
+              creatorIds: creatorIds?.map(unsafeBrandId<TenantId>),
+              eserviceTemplateName,
+            },
+            { offset, limit },
+            ctx
+          );
+
+        return res.status(200).send(
+          purposeTemplateApi.EServiceTemplateVersionsPurposeTemplate.parse({
+            results: results.map(
+              eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate
+            ),
+            totalCount,
+          })
+        );
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          getPurposeTemplateEServiceTemplatesErrorMapper,
           ctx
         );
         return res.status(errorRes.status).send(errorRes);

--- a/packages/purpose-template-process/src/services/purposeTemplateService.ts
+++ b/packages/purpose-template-process/src/services/purposeTemplateService.ts
@@ -19,6 +19,7 @@ import {
   EService,
   EServiceDescriptorPurposeTemplate,
   EServiceId,
+  EServiceTemplateVersionPurposeTemplate,
   generateId,
   ListResult,
   PurposeTemplate,
@@ -84,6 +85,7 @@ import {
 import { purposeTemplateToApiPurposeTemplateSeed } from "../model/domain/apiConverter.js";
 import {
   GetPurposeTemplateEServiceDescriptorsFilters,
+  GetPurposeTemplateEServiceTemplatesFilters,
   GetPurposeTemplatesFilters,
   ReadModelServiceSQL,
 } from "./readModelServiceSQL.js";
@@ -1028,6 +1030,35 @@ export function purposeTemplateServiceBuilder(
       );
 
       return await readModelService.getPurposeTemplateEServiceDescriptors(
+        filters,
+        {
+          offset,
+          limit,
+        }
+      );
+    },
+    async getPurposeTemplateEServiceTemplates(
+      filters: GetPurposeTemplateEServiceTemplatesFilters,
+      { offset, limit }: { offset: number; limit: number },
+      {
+        authData,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAuthData | M2MAdminAuthData>>
+    ): Promise<ListResult<EServiceTemplateVersionPurposeTemplate>> {
+      const { purposeTemplateId } = filters;
+
+      logger.info(
+        `Retrieving e-service templates linked to purpose template ${purposeTemplateId} with filters: ${JSON.stringify(
+          filters
+        )}`
+      );
+
+      applyVisibilityToPurposeTemplate(
+        await retrievePurposeTemplate(purposeTemplateId, readModelService),
+        authData
+      );
+
+      return await readModelService.getPurposeTemplateEServiceTemplates(
         filters,
         {
           offset,

--- a/packages/purpose-template-process/src/services/readModelServiceSQL.ts
+++ b/packages/purpose-template-process/src/services/readModelServiceSQL.ts
@@ -26,6 +26,7 @@ import {
   EService,
   EServiceDescriptorPurposeTemplate,
   EServiceId,
+  EServiceTemplateVersionPurposeTemplate,
   genericInternalError,
   ListResult,
   PurposeTemplate,
@@ -42,6 +43,7 @@ import {
   WithMetadata,
 } from "pagopa-interop-models";
 import {
+  aggregateEServiceTemplateVersionPurposeTemplateArray,
   aggregatePurposeTemplateArray,
   aggregatePurposeTemplateEServiceDescriptor,
   aggregatePurposeTemplateEServiceDescriptorArray,
@@ -54,6 +56,8 @@ import {
   DrizzleReturnType,
   eserviceDescriptorInReadmodelCatalog,
   eserviceInReadmodelCatalog,
+  eserviceTemplateInReadmodelEserviceTemplate,
+  eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate,
   purposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate,
@@ -82,6 +86,12 @@ export type GetPurposeTemplateEServiceDescriptorsFilters = {
   purposeTemplateId: PurposeTemplateId;
   producerIds: TenantId[];
   eserviceName?: string;
+};
+
+export type GetPurposeTemplateEServiceTemplatesFilters = {
+  purposeTemplateId: PurposeTemplateId;
+  creatorIds: TenantId[];
+  eserviceTemplateName?: string;
 };
 
 const getPurposeTemplatesFilters = (
@@ -542,6 +552,62 @@ export function readModelServiceBuilderSQL({
         purposeTemplateEServiceDescriptors.map(
           (eserviceDescriptor) => eserviceDescriptor.data
         ),
+        queryResult[0]?.totalCount
+      );
+    },
+    async getPurposeTemplateEServiceTemplates(
+      filters: GetPurposeTemplateEServiceTemplatesFilters,
+      { limit, offset }: { limit: number; offset: number }
+    ): Promise<ListResult<EServiceTemplateVersionPurposeTemplate>> {
+      const { purposeTemplateId, creatorIds, eserviceTemplateName } = filters;
+
+      const queryResult = await readModelDB
+        .select(
+          withTotalCount(
+            getTableColumns(
+              eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate
+            )
+          )
+        )
+        .from(eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate)
+        .innerJoin(
+          eserviceTemplateInReadmodelEserviceTemplate,
+          eq(
+            eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate.eserviceTemplateId,
+            eserviceTemplateInReadmodelEserviceTemplate.id
+          )
+        )
+        .where(
+          and(
+            eq(
+              eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate.purposeTemplateId,
+              purposeTemplateId
+            ),
+            creatorIds.length > 0
+              ? inArray(
+                  eserviceTemplateInReadmodelEserviceTemplate.creatorId,
+                  creatorIds
+                )
+              : undefined,
+            eserviceTemplateName
+              ? ilikeEscaped(
+                  eserviceTemplateInReadmodelEserviceTemplate.name,
+                  `%${escapeSqlLike(eserviceTemplateName)}%`
+                )
+              : undefined
+          )
+        )
+        .orderBy(
+          eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate.createdAt
+        )
+        .limit(limit)
+        .offset(offset);
+
+      const eserviceTemplateVersionPurposeTemplates =
+        aggregateEServiceTemplateVersionPurposeTemplateArray(queryResult);
+
+      return createListResult(
+        eserviceTemplateVersionPurposeTemplates.map((row) => row.data),
         queryResult[0]?.totalCount
       );
     },

--- a/packages/purpose-template-process/src/utilities/errorMappers.ts
+++ b/packages/purpose-template-process/src/utilities/errorMappers.ts
@@ -46,6 +46,10 @@ export const getPurposeTemplateEServiceDescriptorsErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number => commonPurposeTemplatesErrorMapper(error);
 
+export const getPurposeTemplateEServiceTemplatesErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number => commonPurposeTemplatesErrorMapper(error);
+
 export const getPurposeTemplateEServiceDescriptorErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>

--- a/packages/purpose-template-process/test/api/getPurposeTemplateEServiceTemplates.test.ts
+++ b/packages/purpose-template-process/test/api/getPurposeTemplateEServiceTemplates.test.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { generateToken } from "pagopa-interop-commons-test";
+import {
+  EServiceTemplateVersionPurposeTemplate,
+  generateId,
+  ListResult,
+  PurposeTemplateId,
+} from "pagopa-interop-models";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { purposeTemplateApi } from "pagopa-interop-api-clients";
+import request from "supertest";
+import { authRole, AuthRole } from "pagopa-interop-commons";
+import { api, purposeTemplateService } from "../vitest.api.setup.js";
+import { eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate } from "../../src/model/domain/apiConverter.js";
+import { purposeTemplateNotFound } from "../../src/model/domain/errors.js";
+
+describe("API GET /purposeTemplates/:id/eserviceTemplates", () => {
+  const purposeTemplateId = generateId<PurposeTemplateId>();
+  const link1: EServiceTemplateVersionPurposeTemplate = {
+    purposeTemplateId,
+    eserviceTemplateId: generateId(),
+    eserviceTemplateVersionId: generateId(),
+    createdAt: new Date(),
+  };
+  const link2: EServiceTemplateVersionPurposeTemplate = {
+    purposeTemplateId,
+    eserviceTemplateId: generateId(),
+    eserviceTemplateVersionId: generateId(),
+    createdAt: new Date(),
+  };
+  const link3: EServiceTemplateVersionPurposeTemplate = {
+    purposeTemplateId,
+    eserviceTemplateId: generateId(),
+    eserviceTemplateVersionId: generateId(),
+    createdAt: new Date(),
+  };
+
+  const defaultQuery = {
+    eserviceTemplateName: "Test E-Service Template",
+    creatorIds: `${generateId()},${generateId()}`,
+    offset: 0,
+    limit: 10,
+  };
+
+  const eserviceTemplateVersionPurposeTemplates: ListResult<EServiceTemplateVersionPurposeTemplate> =
+    {
+      results: [link1, link2, link3],
+      totalCount: 3,
+    };
+
+  const apiResponse =
+    purposeTemplateApi.EServiceTemplateVersionsPurposeTemplate.parse({
+      results: eserviceTemplateVersionPurposeTemplates.results.map(
+        eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate
+      ),
+      totalCount: eserviceTemplateVersionPurposeTemplates.totalCount,
+    });
+
+  beforeEach(() => {
+    purposeTemplateService.getPurposeTemplateEServiceTemplates = vi
+      .fn()
+      .mockResolvedValue(eserviceTemplateVersionPurposeTemplates);
+  });
+
+  const makeRequest = async (
+    token: string,
+    purposeTemplateId: PurposeTemplateId = generateId(),
+    query: typeof defaultQuery = defaultQuery
+  ) =>
+    request(api)
+      .get(`/purposeTemplates/${purposeTemplateId}/eserviceTemplates`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .query(query);
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.API_ROLE,
+    authRole.SECURITY_ROLE,
+    authRole.M2M_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+    authRole.SUPPORT_ROLE,
+  ];
+
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(apiResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 404 when purpose template is not found", async () => {
+    const error = purposeTemplateNotFound(generateId());
+    purposeTemplateService.getPurposeTemplateEServiceTemplates = vi
+      .fn()
+      .mockRejectedValue(error);
+
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(404);
+  });
+
+  it.each([
+    { query: {} },
+    { query: { offset: 0 } },
+    { query: { limit: 10 } },
+    { query: { offset: -1, limit: 10 } },
+    { query: { offset: 0, limit: -2 } },
+    { query: { offset: 0, limit: 55 } },
+    { query: { offset: "invalid", limit: 10 } },
+    { query: { offset: 0, limit: "invalid" } },
+    { query: { ...defaultQuery, eserviceTemplateName: [1, 2, 3] } },
+    { query: { ...defaultQuery, creatorIds: `${generateId()},invalid` } },
+  ])("Should return 400 if passed invalid data: %s", async ({ query }) => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      purposeTemplateId,
+      query as typeof defaultQuery
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/purpose-template-process/test/integration/getPurposeTemplateEServiceTemplates.test.ts
+++ b/packages/purpose-template-process/test/integration/getPurposeTemplateEServiceTemplates.test.ts
@@ -1,0 +1,225 @@
+import {
+  getMockAuthData,
+  getMockContext,
+  getMockEServiceTemplate,
+  getMockEServiceTemplateVersion,
+  getMockPurposeTemplate,
+} from "pagopa-interop-commons-test";
+import {
+  EServiceTemplate,
+  EServiceTemplateVersionPurposeTemplate,
+  generateId,
+  PurposeTemplate,
+  PurposeTemplateId,
+  purposeTemplateState,
+  TenantId,
+} from "pagopa-interop-models";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  addOneEServiceTemplate,
+  addOneEServiceTemplateVersionPurposeTemplate,
+  addOnePurposeTemplate,
+  purposeTemplateService,
+} from "../integrationUtils.js";
+import { purposeTemplateNotFound } from "../../src/model/domain/errors.js";
+
+describe("getPurposeTemplateEServiceTemplates", async () => {
+  const creatorId = generateId<TenantId>();
+
+  const eserviceTemplate1: EServiceTemplate = {
+    ...getMockEServiceTemplate(),
+    name: "Test e-service template 1",
+    versions: [getMockEServiceTemplateVersion()],
+  };
+  const eserviceTemplate2: EServiceTemplate = {
+    ...getMockEServiceTemplate(),
+    name: "Test e-service template 2",
+    versions: [getMockEServiceTemplateVersion()],
+  };
+
+  const purposeTemplate1: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    purposeTitle: "Published Purpose Template 1 - test",
+    state: purposeTemplateState.published,
+    creatorId,
+  };
+  const purposeTemplate2: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    purposeTitle: "Published Purpose Template 2 - test",
+    state: purposeTemplateState.published,
+    creatorId,
+  };
+  const purposeTemplate3: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    purposeTitle: "Published Purpose Template 3 - test",
+    state: purposeTemplateState.published,
+    creatorId,
+  };
+
+  const link1: EServiceTemplateVersionPurposeTemplate = {
+    purposeTemplateId: purposeTemplate1.id,
+    eserviceTemplateId: eserviceTemplate1.id,
+    eserviceTemplateVersionId: eserviceTemplate1.versions[0].id,
+    createdAt: new Date(),
+  };
+  const link2: EServiceTemplateVersionPurposeTemplate = {
+    purposeTemplateId: purposeTemplate1.id,
+    eserviceTemplateId: eserviceTemplate2.id,
+    eserviceTemplateVersionId: eserviceTemplate2.versions[0].id,
+    createdAt: new Date(),
+  };
+  const link3: EServiceTemplateVersionPurposeTemplate = {
+    purposeTemplateId: purposeTemplate2.id,
+    eserviceTemplateId: eserviceTemplate1.id,
+    eserviceTemplateVersionId: eserviceTemplate1.versions[0].id,
+    createdAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    await addOneEServiceTemplate(eserviceTemplate1);
+    await addOneEServiceTemplate(eserviceTemplate2);
+
+    await addOnePurposeTemplate(purposeTemplate1);
+    await addOnePurposeTemplate(purposeTemplate2);
+    await addOnePurposeTemplate(purposeTemplate3);
+
+    await addOneEServiceTemplateVersionPurposeTemplate(link1);
+    await addOneEServiceTemplateVersionPurposeTemplate(link2);
+    await addOneEServiceTemplateVersionPurposeTemplate(link3);
+  });
+
+  it("should get all the linked purpose template e-service templates if they exist", async () => {
+    const result =
+      await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        {
+          purposeTemplateId: purposeTemplate1.id,
+          creatorIds: [],
+        },
+        { offset: 0, limit: 50 },
+        getMockContext({ authData: getMockAuthData(generateId<TenantId>()) })
+      );
+
+    expect(result).toEqual({
+      results: [link1, link2],
+      totalCount: 2,
+    });
+  });
+
+  it("should get the linked purpose template e-service templates (pagination: offset)", async () => {
+    const result =
+      await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        {
+          purposeTemplateId: purposeTemplate1.id,
+          creatorIds: [],
+        },
+        { offset: 1, limit: 50 },
+        getMockContext({ authData: getMockAuthData(generateId<TenantId>()) })
+      );
+
+    expect(result).toEqual({
+      totalCount: 2,
+      results: [link2],
+    });
+  });
+
+  it("should get the linked purpose template e-service templates (pagination: limit)", async () => {
+    const result =
+      await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        {
+          purposeTemplateId: purposeTemplate1.id,
+          creatorIds: [],
+        },
+        { offset: 0, limit: 1 },
+        getMockContext({ authData: getMockAuthData(generateId<TenantId>()) })
+      );
+
+    expect(result).toEqual({
+      totalCount: 2,
+      results: [link1],
+    });
+  });
+
+  it("should get the linked purpose template e-service templates (filter: creatorIds)", async () => {
+    const result =
+      await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        {
+          purposeTemplateId: purposeTemplate1.id,
+          creatorIds: [eserviceTemplate2.creatorId],
+        },
+        { offset: 0, limit: 50 },
+        getMockContext({ authData: getMockAuthData(generateId<TenantId>()) })
+      );
+
+    expect(result).toEqual({
+      totalCount: 1,
+      results: [link2],
+    });
+  });
+
+  it("should get the linked purpose template e-service templates (filter: eserviceTemplateName)", async () => {
+    const result =
+      await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        {
+          purposeTemplateId: purposeTemplate1.id,
+          eserviceTemplateName: "E-SERVICE TEMPLATE 2",
+          creatorIds: [],
+        },
+        { offset: 0, limit: 50 },
+        getMockContext({ authData: getMockAuthData(generateId<TenantId>()) })
+      );
+
+    expect(result).toEqual({
+      totalCount: 1,
+      results: [link2],
+    });
+  });
+
+  it("should not get the linked purpose template e-service templates if they don't exist", async () => {
+    const result =
+      await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        {
+          purposeTemplateId: purposeTemplate3.id,
+          creatorIds: [],
+        },
+        { offset: 0, limit: 50 },
+        getMockContext({ authData: getMockAuthData(generateId<TenantId>()) })
+      );
+
+    expect(result).toEqual({
+      totalCount: 0,
+      results: [],
+    });
+  });
+
+  it("should throw purposeTemplateNotFound if the purpose template doesn't exist", async () => {
+    const notExistingId = generateId<PurposeTemplateId>();
+
+    await expect(
+      purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        {
+          purposeTemplateId: notExistingId,
+          creatorIds: [],
+        },
+        { offset: 0, limit: 50 },
+        getMockContext({ authData: getMockAuthData(generateId<TenantId>()) })
+      )
+    ).rejects.toThrowError(purposeTemplateNotFound(notExistingId));
+  });
+
+  it("should throw purposeTemplateNotFound if the requester is not the creator and the purpose template is in draft state", async () => {
+    const purposeTemplateDraft = getMockPurposeTemplate();
+    await addOnePurposeTemplate(purposeTemplateDraft);
+
+    const requesterId = generateId<TenantId>();
+    await expect(
+      purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        {
+          purposeTemplateId: purposeTemplateDraft.id,
+          creatorIds: [],
+        },
+        { offset: 0, limit: 50 },
+        getMockContext({ authData: getMockAuthData(requesterId) })
+      )
+    ).rejects.toThrowError(purposeTemplateNotFound(purposeTemplateDraft.id));
+  });
+});

--- a/packages/purpose-template-process/test/integrationUtils.ts
+++ b/packages/purpose-template-process/test/integrationUtils.ts
@@ -11,6 +11,8 @@ import {
 import {
   EService,
   EServiceDescriptorPurposeTemplate,
+  EServiceTemplate,
+  EServiceTemplateVersionPurposeTemplate,
   ListResult,
   PurposeTemplate,
   PurposeTemplateEvent,
@@ -25,6 +27,8 @@ import {
 } from "pagopa-interop-readmodel";
 import {
   upsertEService,
+  upsertEServiceTemplate,
+  upsertEServiceTemplateVersionPurposeTemplate,
   upsertPurposeTemplate,
   upsertPurposeTemplateEServiceDescriptor,
   upsertTenant,
@@ -125,6 +129,22 @@ export const addOnePurposeTemplateEServiceDescriptor = async (
 
 export const addOneEService = async (eservice: EService): Promise<void> => {
   await upsertEService(readModelDB, eservice, 0);
+};
+
+export const addOneEServiceTemplate = async (
+  eserviceTemplate: EServiceTemplate
+): Promise<void> => {
+  await upsertEServiceTemplate(readModelDB, eserviceTemplate, 0);
+};
+
+export const addOneEServiceTemplateVersionPurposeTemplate = async (
+  eserviceTemplateVersionPurposeTemplate: EServiceTemplateVersionPurposeTemplate
+): Promise<void> => {
+  await upsertEServiceTemplateVersionPurposeTemplate(
+    readModelDB,
+    eserviceTemplateVersionPurposeTemplate,
+    0
+  );
 };
 
 export const addOneTenant = async (tenant: Tenant): Promise<void> => {

--- a/packages/purpose-template-readmodel-writer-sql/src/consumerServiceV2.ts
+++ b/packages/purpose-template-readmodel-writer-sql/src/consumerServiceV2.ts
@@ -83,5 +83,10 @@ export async function handleMessageV2(
         }
       );
     })
+    .with(
+      { type: "PurposeTemplateEServiceTemplateLinked" },
+      { type: "PurposeTemplateEServiceTemplateUnlinked" },
+      () => Promise.resolve()
+    )
     .exhaustive();
 }

--- a/packages/purpose-template-readmodel-writer-sql/test/purposeTemplateReadModelWriter.integration.test.ts
+++ b/packages/purpose-template-readmodel-writer-sql/test/purposeTemplateReadModelWriter.integration.test.ts
@@ -2,6 +2,7 @@
 import {
   getMockDescriptor,
   getMockEService,
+  getMockEServiceTemplate,
   getMockPurposeTemplate,
   getMockRiskAnalysisTemplateAnswerAnnotation,
   getMockRiskAnalysisTemplateAnswerAnnotationDocument,
@@ -21,6 +22,8 @@ import {
   PurposeTemplateDraftDeletedV2,
   PurposeTemplateDraftUpdatedV2,
   PurposeTemplateEServiceLinkedV2,
+  PurposeTemplateEServiceTemplateLinkedV2,
+  PurposeTemplateEServiceTemplateUnlinkedV2,
   PurposeTemplateEServiceUnlinkedV2,
   PurposeTemplateEventEnvelope,
   PurposeTemplatePublishedV2,
@@ -31,6 +34,7 @@ import {
   RiskAnalysisTemplateAnswerAnnotationId,
   tenantKind,
   toEServiceV2,
+  toEServiceTemplateV2,
   toPurposeTemplateV2,
   WithMetadata,
 } from "pagopa-interop-models";
@@ -639,6 +643,73 @@ describe("Integration tests", async () => {
         data: updatedPurposeTemplate,
         metadata: { version: metadataVersion },
       });
+    });
+
+    it("PurposeTemplateEServiceTemplateLinked (no-op)", async () => {
+      const metadataVersion = 1;
+      const eserviceTemplate = getMockEServiceTemplate();
+
+      await purposeTemplateWriterService.upsertPurposeTemplate(
+        purposeTemplate,
+        0
+      );
+
+      const payload: PurposeTemplateEServiceTemplateLinkedV2 = {
+        purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+        eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+        eserviceTemplateVersionId: eserviceTemplate.versions[0].id,
+        createdAt: BigInt(Date.now()),
+      };
+      const message: PurposeTemplateEventEnvelope = {
+        sequence_num: 1,
+        stream_id: purposeTemplate.id,
+        version: metadataVersion,
+        type: "PurposeTemplateEServiceTemplateLinked",
+        event_version: 2,
+        data: payload,
+        log_date: new Date(),
+      };
+      await handleMessageV2(message, purposeTemplateWriterService);
+
+      const retrievedPurposeTemplate =
+        await purposeTemplateReadModelService.getPurposeTemplateById(
+          purposeTemplate.id
+        );
+
+      expect(retrievedPurposeTemplate?.data).toStrictEqual(purposeTemplate);
+    });
+
+    it("PurposeTemplateEServiceTemplateUnlinked (no-op)", async () => {
+      const metadataVersion = 1;
+      const eserviceTemplate = getMockEServiceTemplate();
+
+      await purposeTemplateWriterService.upsertPurposeTemplate(
+        purposeTemplate,
+        0
+      );
+
+      const payload: PurposeTemplateEServiceTemplateUnlinkedV2 = {
+        purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+        eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+        eserviceTemplateVersionId: eserviceTemplate.versions[0].id,
+      };
+      const message: PurposeTemplateEventEnvelope = {
+        sequence_num: 1,
+        stream_id: purposeTemplate.id,
+        version: metadataVersion,
+        type: "PurposeTemplateEServiceTemplateUnlinked",
+        event_version: 2,
+        data: payload,
+        log_date: new Date(),
+      };
+      await handleMessageV2(message, purposeTemplateWriterService);
+
+      const retrievedPurposeTemplate =
+        await purposeTemplateReadModelService.getPurposeTemplateById(
+          purposeTemplate.id
+        );
+
+      expect(retrievedPurposeTemplate?.data).toStrictEqual(purposeTemplate);
     });
   });
 });

--- a/packages/readmodel-models/src/drizzle/schema.ts
+++ b/packages/readmodel-models/src/drizzle/schema.ts
@@ -2286,3 +2286,37 @@ export const purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate =
       }),
     ]
   );
+
+export const eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate =
+  readmodelPurposeTemplate.table(
+    "eservice_template_version_purpose_template",
+    {
+      metadataVersion: integer("metadata_version").notNull(),
+      purposeTemplateId: uuid("purpose_template_id").notNull(),
+      eserviceTemplateId: uuid("eservice_template_id").notNull(),
+      eserviceTemplateVersionId: uuid("eservice_template_version_id").notNull(),
+      createdAt: timestamp("created_at", {
+        withTimezone: true,
+        mode: "string",
+      }).notNull(),
+    },
+    (table) => [
+      foreignKey({
+        columns: [table.purposeTemplateId],
+        foreignColumns: [purposeTemplateInReadmodelPurposeTemplate.id],
+        name: "eservice_tpl_ver_pt_purpose_template_id_fkey",
+      }).onDelete("cascade"),
+      foreignKey({
+        columns: [table.purposeTemplateId, table.metadataVersion],
+        foreignColumns: [
+          purposeTemplateInReadmodelPurposeTemplate.id,
+          purposeTemplateInReadmodelPurposeTemplate.metadataVersion,
+        ],
+        name: "eservice_tpl_ver_pt_purpose_template_id_metadata_fkey",
+      }),
+      primaryKey({
+        columns: [table.purposeTemplateId, table.eserviceTemplateId],
+        name: "eservice_template_version_purpose_template_pkey",
+      }),
+    ]
+  );

--- a/packages/readmodel-models/src/types.ts
+++ b/packages/readmodel-models/src/types.ts
@@ -39,6 +39,7 @@ import {
   purposeInReadmodelPurpose,
   purposeRiskAnalysisAnswerInReadmodelPurpose,
   purposeRiskAnalysisFormInReadmodelPurpose,
+  eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate,
   purposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate,
@@ -320,6 +321,9 @@ export type PurposeTemplateSQL = InferSelectModel<
 >;
 export type PurposeTemplateEServiceDescriptorSQL = InferSelectModel<
   typeof purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate
+>;
+export type EServiceTemplateVersionPurposeTemplateSQL = InferSelectModel<
+  typeof eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate
 >;
 export type PurposeTemplateRiskAnalysisFormSQL = InferSelectModel<
   typeof purposeTemplateRiskAnalysisFormInReadmodelPurposeTemplate

--- a/packages/readmodel/src/purpose-template/aggregators.ts
+++ b/packages/readmodel/src/purpose-template/aggregators.ts
@@ -1,5 +1,6 @@
 import {
   EServiceDescriptorPurposeTemplate,
+  EServiceTemplateVersionPurposeTemplate,
   PurposeTemplate,
   PurposeTemplateId,
   PurposeTemplateState,
@@ -22,6 +23,7 @@ import {
   WithMetadata,
 } from "pagopa-interop-models";
 import {
+  EServiceTemplateVersionPurposeTemplateSQL,
   PurposeTemplateEServiceDescriptorSQL,
   PurposeTemplateRiskAnalysisAnswerSQL,
   PurposeTemplateRiskAnalysisAnswerAnnotationSQL,
@@ -593,6 +595,35 @@ export const aggregatePurposeTemplateEServiceDescriptor = ({
     },
   };
 };
+
+export const aggregateEServiceTemplateVersionPurposeTemplateArray = (
+  rows: EServiceTemplateVersionPurposeTemplateSQL[]
+): Array<WithMetadata<EServiceTemplateVersionPurposeTemplate>> =>
+  rows.map(aggregateEServiceTemplateVersionPurposeTemplate);
+
+export const aggregateEServiceTemplateVersionPurposeTemplate = ({
+  purposeTemplateId,
+  eserviceTemplateId,
+  eserviceTemplateVersionId,
+  createdAt,
+  metadataVersion,
+  ...rest
+}: EServiceTemplateVersionPurposeTemplateSQL): WithMetadata<EServiceTemplateVersionPurposeTemplate> => {
+  void (rest satisfies Record<string, never>);
+
+  return {
+    data: {
+      purposeTemplateId: unsafeBrandId(purposeTemplateId),
+      eserviceTemplateId: unsafeBrandId(eserviceTemplateId),
+      eserviceTemplateVersionId: unsafeBrandId(eserviceTemplateVersionId),
+      createdAt: stringToDate(createdAt),
+    },
+    metadata: {
+      version: metadataVersion,
+    },
+  };
+};
+
 export const aggregateRiskAnalysisFormDocument = ({
   id,
   name,

--- a/packages/readmodel/src/testUtils.ts
+++ b/packages/readmodel/src/testUtils.ts
@@ -7,6 +7,7 @@ import {
   EService,
   EServiceDescriptorPurposeTemplate,
   EServiceTemplate,
+  EServiceTemplateVersionPurposeTemplate,
   ProducerJWKKey,
   ProducerKeychain,
   Purpose,
@@ -76,6 +77,7 @@ import {
   purposeTemplateRiskAnalysisAnswerInReadmodelPurposeTemplate,
   purposeTemplateRiskAnalysisFormInReadmodelPurposeTemplate,
   purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate,
+  eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate,
   purposeVersionStampInReadmodelPurpose,
   purposeTemplateChildTables,
   DrizzleTransactionType,
@@ -946,4 +948,24 @@ export const upsertPurposeTemplateEServiceDescriptor = async (
       .insert(purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate)
       .values(purposeTemplateEServiceDescriptorSQL);
   });
+};
+
+export const upsertEServiceTemplateVersionPurposeTemplate = async (
+  readModelDB: DrizzleReturnType,
+  eserviceTemplateVersionPurposeTemplate: EServiceTemplateVersionPurposeTemplate,
+  metadataVersion: number
+): Promise<void> => {
+  await readModelDB
+    .insert(eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate)
+    .values({
+      metadataVersion,
+      purposeTemplateId:
+        eserviceTemplateVersionPurposeTemplate.purposeTemplateId,
+      eserviceTemplateId:
+        eserviceTemplateVersionPurposeTemplate.eserviceTemplateId,
+      eserviceTemplateVersionId:
+        eserviceTemplateVersionPurposeTemplate.eserviceTemplateVersionId,
+      createdAt: eserviceTemplateVersionPurposeTemplate.createdAt.toISOString(),
+    })
+    .onConflictDoNothing();
 };


### PR DESCRIPTION
**Jira**: [PIN-9772](https://pagopa.atlassian.net/browse/PIN-9772)

## Summary

- Add `GET /purposeTemplates/{id}/eserviceTemplates` endpoint in `purpose-template-process`, mirroring the existing `/eservices` endpoint for the new link between purpose templates and e-service templates (PIN-8621)
- Support filters `creatorIds` and `eserviceTemplateName` (ILIKE case-insensitive) with offset/limit pagination and the same Draft visibility rules (`applyVisibilityToPurposeTemplate`) and authorized roles as the AS-IS retrieval
- Add the API converter, the aggregator in `packages/readmodel`, the new Bruno collection entry, and the OpenAPI schemas `EServiceTemplateVersionsPurposeTemplate` / `EServiceTemplateVersionPurposeTemplate`

## Note

The `upsertEServiceTemplateVersionPurposeTemplate` helper added to `packages/readmodel/src/testUtils.ts` uses a plain `onConflictDoNothing` insert instead of the AS-IS `transaction + checkMetadataVersion + delete-then-insert + splitter` pattern used by `upsertPurposeTemplateEServiceDescriptor`. This is intentional for this WI — the helper is only consumed by integration tests for a read-only endpoint — and will be upgraded in WI6 alongside the new `toEServiceTemplateVersionPurposeTemplateSQL` splitter and the `purposeTemplateChildTables` exclusion-rule update.

[PIN-9772]: https://pagopa.atlassian.net/browse/PIN-9772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ