### PR TITLE
feat: add e-service templates link endpoint to purpose template process (PIN-9832)

### DIFF
--- a/collections/purpose-template/Link EService Templates to Purpose Template.bru
+++ b/collections/purpose-template/Link EService Templates to Purpose Template.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Link EService Templates to Purpose Template
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{host-purpose-template}}/purposeTemplates/:purposeTemplateId/linkEserviceTemplates
+  body: json
+  auth: none
+}
+
+params:path {
+  purposeTemplateId: {{purposeTemplateId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}
+
+body:json {
+  {
+    "eserviceTemplateIds": [
+      "{{eserviceTemplateId}}"
+    ]
+  }
+}
+
+vars:post-response {
+  linkedEServiceTemplateVersion1: res.body[0]
+}

--- a/packages/api-clients/open-api/purposeTemplateApi.yml
+++ b/packages/api-clients/open-api/purposeTemplateApi.yml
@@ -437,6 +437,72 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /purposeTemplates/{id}/linkEserviceTemplates:
+    parameters:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - purposeTemplate
+      summary: Link E-Service Templates to Purpose Template
+      operationId: linkEServiceTemplatesToPurposeTemplate
+      description: Link E-Service Templates to a purpose template (in Draft or Active state)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                eserviceTemplateIds:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  minItems: 1
+              required:
+                - eserviceTemplateIds
+        required: true
+      responses:
+        "200":
+          description: E-Service Templates linked to purpose template
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EServiceTemplateVersionPurposeTemplate"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Purpose Template Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /purposeTemplates/{id}/unlinkEservices:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"

--- a/packages/purpose-template-process/src/errors/purposeTemplateValidationErrors.ts
+++ b/packages/purpose-template-process/src/errors/purposeTemplateValidationErrors.ts
@@ -3,6 +3,8 @@ import {
   EService,
   EServiceDescriptorPurposeTemplate,
   EServiceId,
+  EServiceTemplate,
+  EServiceTemplateId,
   InternalError,
   PurposeTemplate,
   PurposeTemplateId,
@@ -18,7 +20,15 @@ type PurposeTemplateValidationIssueCode =
   | "invalidDescriptorState"
   | "unexpectedUnassociationEServiceError"
   | "purposeTemplateEServicePersonalDataFlagMismatch"
-  | "invalidDescriptorStateForPublicationError";
+  | "invalidDescriptorStateForPublicationError"
+  | "eserviceIsInstanceOfEServiceTemplate"
+  | "unexpectedEServiceTemplateError"
+  | "eserviceTemplateNotFound"
+  | "unexpectedAssociationEServiceTemplateError"
+  | "eserviceTemplateAlreadyAssociated"
+  | "missingEServiceTemplateVersion"
+  | "invalidEServiceTemplateVersionState"
+  | "purposeTemplateEServiceTemplatePersonalDataFlagMismatch";
 
 export class PurposeTemplateValidationIssue extends InternalError<PurposeTemplateValidationIssueCode> {
   constructor({
@@ -149,6 +159,86 @@ export function purposeTemplateEServicePersonalDataFlagMismatch(
   return new PurposeTemplateValidationIssue({
     code: "purposeTemplateEServicePersonalDataFlagMismatch",
     detail: `EService ${eservice.id} personal data flag (${eservice.personalData}) does not match purpose template ${purposeTemplate.id} personal data flag (${purposeTemplate.handlesPersonalData}).`,
+  });
+}
+
+export function eserviceIsInstanceOfEServiceTemplateError(
+  eserviceId: EServiceId,
+  eserviceTemplateId: EServiceTemplateId
+): PurposeTemplateValidationIssue {
+  return new PurposeTemplateValidationIssue({
+    code: "eserviceIsInstanceOfEServiceTemplate",
+    detail: `EService ${eserviceId} is an instance of e-service template ${eserviceTemplateId} and cannot be linked directly to a purpose template. Link the e-service template instead.`,
+  });
+}
+
+export function unexpectedEServiceTemplateError(
+  reason: string,
+  eserviceTemplateId: EServiceTemplateId
+): PurposeTemplateValidationIssue {
+  return new PurposeTemplateValidationIssue({
+    code: "unexpectedEServiceTemplateError",
+    detail: `Unexpected error: ${reason} for e-service template ${eserviceTemplateId}`,
+  });
+}
+
+export function eserviceTemplateNotFound(
+  eserviceTemplateId: EServiceTemplateId
+): PurposeTemplateValidationIssue {
+  return new PurposeTemplateValidationIssue({
+    code: "eserviceTemplateNotFound",
+    detail: `E-service template ${eserviceTemplateId} not found`,
+  });
+}
+
+export function unexpectedAssociationEServiceTemplateError(
+  reason: string,
+  eserviceTemplateId: EServiceTemplateId
+): PurposeTemplateValidationIssue {
+  return new PurposeTemplateValidationIssue({
+    code: "unexpectedAssociationEServiceTemplateError",
+    detail: `Missing expected association for e-service template ${eserviceTemplateId}: ${reason}`,
+  });
+}
+
+export function eserviceTemplateAlreadyAssociatedError(
+  eserviceTemplateId: EServiceTemplateId,
+  purposeTemplateId: PurposeTemplateId
+): PurposeTemplateValidationIssue {
+  return new PurposeTemplateValidationIssue({
+    code: "eserviceTemplateAlreadyAssociated",
+    detail: `E-service template ${eserviceTemplateId} is already associated with purpose template ${purposeTemplateId}`,
+  });
+}
+
+export function missingEServiceTemplateVersionError(
+  eserviceTemplateId: EServiceTemplateId
+): PurposeTemplateValidationIssue {
+  return new PurposeTemplateValidationIssue({
+    code: "missingEServiceTemplateVersion",
+    detail: `E-service template ${eserviceTemplateId} has no versions.`,
+  });
+}
+
+export function invalidEServiceTemplateVersionStateError(
+  eserviceTemplateId: EServiceTemplateId,
+  expectedStates: string[]
+): PurposeTemplateValidationIssue {
+  return new PurposeTemplateValidationIssue({
+    code: "invalidEServiceTemplateVersionState",
+    detail: `E-service template ${eserviceTemplateId} has no valid versions. Expected ${expectedStates.join(
+      ", "
+    )}.`,
+  });
+}
+
+export function purposeTemplateEServiceTemplatePersonalDataFlagMismatch(
+  eserviceTemplate: EServiceTemplate,
+  purposeTemplate: PurposeTemplate
+): PurposeTemplateValidationIssue {
+  return new PurposeTemplateValidationIssue({
+    code: "purposeTemplateEServiceTemplatePersonalDataFlagMismatch",
+    detail: `E-service template ${eserviceTemplate.id} personal data flag (${eserviceTemplate.personalData}) does not match purpose template ${purposeTemplate.id} personal data flag (${purposeTemplate.handlesPersonalData}).`,
   });
 }
 

--- a/packages/purpose-template-process/src/index.ts
+++ b/packages/purpose-template-process/src/index.ts
@@ -1,6 +1,7 @@
 import { initDB, initFileManager, startServer } from "pagopa-interop-commons";
 import {
   catalogReadModelServiceBuilder,
+  eserviceTemplateReadModelServiceBuilder,
   makeDrizzleConnection,
   purposeTemplateReadModelServiceBuilder,
 } from "pagopa-interop-readmodel";
@@ -12,12 +13,15 @@ import { purposeTemplateServiceBuilder } from "./services/purposeTemplateService
 const readModelDB = makeDrizzleConnection(config);
 const fileManager = initFileManager(config);
 const catalogReadModelServiceSQL = catalogReadModelServiceBuilder(readModelDB);
+const eserviceTemplateReadModelServiceSQL =
+  eserviceTemplateReadModelServiceBuilder(readModelDB);
 const purposeTemplateReadModelServiceSQL =
   purposeTemplateReadModelServiceBuilder(readModelDB);
 
 const readModelServiceSQL = readModelServiceBuilderSQL({
   readModelDB,
   catalogReadModelServiceSQL,
+  eserviceTemplateReadModelServiceSQL,
   purposeTemplateReadModelServiceSQL,
 });
 

--- a/packages/purpose-template-process/src/model/domain/errors.ts
+++ b/packages/purpose-template-process/src/model/domain/errors.ts
@@ -2,6 +2,7 @@ import { RiskAnalysisTemplateValidationIssue } from "pagopa-interop-commons";
 import {
   ApiError,
   EServiceId,
+  EServiceTemplateId,
   makeApiProblemBuilder,
   PurposeTemplateId,
   PurposeTemplateState,
@@ -42,6 +43,9 @@ const errorCodes = {
   missingRiskAnalysisFormTemplate: "0026",
   eServiceDescriptorPurposeTemplateNotFound: "0027",
   invalidFreeOfChargeReason: "0028",
+  associationEServiceTemplatesForPurposeTemplateFailed: "0029",
+  associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists: "0030",
+  tooManyEServiceTemplatesForPurposeTemplate: "0031",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -220,6 +224,42 @@ export function tooManyEServicesForPurposeTemplate(
     detail: `Too many e-services provided. Maximum allowed: ${maxCount}, provided: ${actualCount}`,
     code: "tooManyEServicesForPurposeTemplate",
     title: "Too Many E-Services for Purpose Template",
+  });
+}
+
+export function associationEServiceTemplatesForPurposeTemplateFailed(
+  reasons: PurposeTemplateValidationIssue[],
+  eserviceTemplateIds: EServiceTemplateId[],
+  purposeTemplateId: PurposeTemplateId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Association of e-service templates to purpose template failed. Reasons: ${reasons} EserviceTemplates: ${eserviceTemplateIds} Purpose template: ${purposeTemplateId}`,
+    code: "associationEServiceTemplatesForPurposeTemplateFailed",
+    title: "Association of e-service templates to purpose template failed",
+  });
+}
+
+export function associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists(
+  reasons: PurposeTemplateValidationIssue[],
+  eserviceTemplateIds: EServiceTemplateId[],
+  purposeTemplateId: PurposeTemplateId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Association between e-service templates and purpose template failed. Reasons: ${reasons} EserviceTemplates: ${eserviceTemplateIds} Purpose template: ${purposeTemplateId}`,
+    code: "associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists",
+    title:
+      "Association between e-service template and purpose template already exists",
+  });
+}
+
+export function tooManyEServiceTemplatesForPurposeTemplate(
+  actualCount: number,
+  maxCount: number
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Too many e-service templates provided. Maximum allowed: ${maxCount}, provided: ${actualCount}`,
+    code: "tooManyEServiceTemplatesForPurposeTemplate",
+    title: "Too Many E-Service Templates for Purpose Template",
   });
 }
 

--- a/packages/purpose-template-process/src/model/domain/toEvent.ts
+++ b/packages/purpose-template-process/src/model/domain/toEvent.ts
@@ -4,8 +4,11 @@ import {
   dateToBigInt,
   EService,
   EServiceDescriptorPurposeTemplate,
+  EServiceTemplate,
+  EServiceTemplateVersionPurposeTemplate,
   PurposeTemplate,
   PurposeTemplateEventV2,
+  toEServiceTemplateV2,
   toEServiceV2,
   RiskAnalysisTemplateAnswerAnnotationDocumentId,
   toPurposeTemplateV2,
@@ -48,6 +51,30 @@ export function toCreateEventPurposeTemplateEServiceLinked(
         eservice: toEServiceV2(eservice),
         descriptorId: eServiceDescriptorPurposeTemplate.descriptorId,
         createdAt: dateToBigInt(eServiceDescriptorPurposeTemplate.createdAt),
+      },
+    },
+  };
+}
+
+export function toCreateEventPurposeTemplateEServiceTemplateLinked(
+  link: EServiceTemplateVersionPurposeTemplate,
+  purposeTemplate: PurposeTemplate,
+  eserviceTemplate: EServiceTemplate,
+  correlationId: CorrelationId,
+  version: number
+): CreateEvent<PurposeTemplateEventV2> {
+  return {
+    streamId: link.purposeTemplateId,
+    version,
+    correlationId,
+    event: {
+      type: "PurposeTemplateEServiceTemplateLinked",
+      event_version: 2,
+      data: {
+        purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+        eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+        eserviceTemplateVersionId: link.eserviceTemplateVersionId,
+        createdAt: dateToBigInt(link.createdAt),
       },
     },
   };

--- a/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
+++ b/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
@@ -14,6 +14,7 @@ import {
 import {
   emptyErrorMapper,
   EServiceId,
+  EServiceTemplateId,
   RiskAnalysisMultiAnswerId,
   RiskAnalysisSingleAnswerId,
   RiskAnalysisTemplateDocument,
@@ -37,6 +38,7 @@ import {
   getPurposeTemplatesErrorMapper,
   getRiskAnalysisTemplateAnswerAnnotationDocumentErrorMapper,
   linkEservicesToPurposeTemplateErrorMapper,
+  linkEServiceTemplatesToPurposeTemplateErrorMapper,
   suspendPurposeTemplateErrorMapper,
   unlinkEServicesFromPurposeTemplateErrorMapper,
   updatePurposeTemplateErrorMapper,
@@ -460,6 +462,40 @@ const purposeTemplateRouter = (
         const errorRes = makeApiProblem(
           error,
           linkEservicesToPurposeTemplateErrorMapper,
+          ctx
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
+    .post("/purposeTemplates/:id/linkEserviceTemplates", async (req, res) => {
+      const ctx = fromAppContext(req.ctx);
+      try {
+        validateAuthorization(ctx, [ADMIN_ROLE, M2M_ADMIN_ROLE]);
+
+        const links =
+          await purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+            unsafeBrandId(req.params.id),
+            req.body.eserviceTemplateIds.map(unsafeBrandId<EServiceTemplateId>),
+            ctx
+          );
+
+        if (links.length !== 0) {
+          setMetadataVersionHeader(res, links[0].metadata);
+        }
+
+        return res
+          .status(200)
+          .send(
+            links.map((link) =>
+              eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate(
+                link.data
+              )
+            )
+          );
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          linkEServiceTemplatesToPurposeTemplateErrorMapper,
           ctx
         );
         return res.status(errorRes.status).send(errorRes);

--- a/packages/purpose-template-process/src/services/purposeTemplateService.ts
+++ b/packages/purpose-template-process/src/services/purposeTemplateService.ts
@@ -19,6 +19,9 @@ import {
   EService,
   EServiceDescriptorPurposeTemplate,
   EServiceId,
+  EServiceTemplate,
+  EServiceTemplateId,
+  EServiceTemplateVersionId,
   EServiceTemplateVersionPurposeTemplate,
   generateId,
   ListResult,
@@ -48,6 +51,7 @@ import {
 import { match } from "ts-pattern";
 import {
   associationEServicesForPurposeTemplateFailed,
+  associationEServiceTemplatesForPurposeTemplateFailed,
   disassociationEServicesFromPurposeTemplateFailed,
   eServiceDescriptorPurposeTemplateNotFound,
   invalidAssociatedEServiceForPublication,
@@ -70,6 +74,7 @@ import {
   toCreateEventPurposeTemplateDraftDeleted,
   toCreateEventPurposeTemplateDraftUpdated,
   toCreateEventPurposeTemplateEServiceLinked,
+  toCreateEventPurposeTemplateEServiceTemplateLinked,
   toCreateEventPurposeTemplateEServiceUnlinked,
   toCreateEventPurposeTemplatePublished,
   toCreateEventPurposeTemplateSuspended,
@@ -98,6 +103,7 @@ import {
   assertConsistentFreeOfCharge,
   assertDocumentsLimitsNotReached,
   assertEServiceIdsCountIsBelowThreshold,
+  assertEServiceTemplateIdsCountIsBelowThreshold,
   assertPurposeTemplateHasRiskAnalysisForm,
   assertPurposeTemplateIsDraft,
   assertPurposeTemplateStateIsValid,
@@ -111,6 +117,7 @@ import {
   validateAssociatedEserviceForPublication,
   validateEservicesAssociations,
   validateEservicesDisassociations,
+  validateEServiceTemplatesAssociations,
   validateRiskAnalysisAnswerAnnotationOrThrow,
   validateRiskAnalysisAnswerOrThrow,
   validateRiskAnalysisTemplateOrThrow,
@@ -843,6 +850,28 @@ export function purposeTemplateServiceBuilder(
     );
   }
 
+  function linkValidationResultsToEServiceTemplateVersionPurposeTemplates(
+    validationResults: Array<{
+      eserviceTemplate: EServiceTemplate;
+      eserviceTemplateVersionId: EServiceTemplateVersionId;
+    }>,
+    purposeTemplateId: PurposeTemplateId,
+    creationTimestamp: Date,
+    createdEvents: Awaited<ReturnType<typeof repository.createEvents>>
+  ): Array<WithMetadata<EServiceTemplateVersionPurposeTemplate>> {
+    return validationResults.map((validationResult) => ({
+      data: {
+        purposeTemplateId,
+        eserviceTemplateId: validationResult.eserviceTemplate.id,
+        eserviceTemplateVersionId: validationResult.eserviceTemplateVersionId,
+        createdAt: creationTimestamp,
+      },
+      metadata: {
+        version: createdEvents.latestNewVersions.get(purposeTemplateId) ?? 0,
+      },
+    }));
+  }
+
   return {
     async createPurposeTemplate(
       seed: purposeTemplateApi.PurposeTemplateSeed,
@@ -1161,6 +1190,81 @@ export function purposeTemplateServiceBuilder(
       const createdEvents = await repository.createEvents(createEvents);
 
       return linkOrUnlinkValidationResultsToEServiceDescriptorsPurposeTemplate(
+        validationResult.value,
+        purposeTemplateId,
+        creationTimestamp,
+        createdEvents
+      );
+    },
+    async linkEServiceTemplatesToPurposeTemplate(
+      purposeTemplateId: PurposeTemplateId,
+      eserviceTemplateIds: EServiceTemplateId[],
+      {
+        authData,
+        logger,
+        correlationId,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
+    ): Promise<Array<WithMetadata<EServiceTemplateVersionPurposeTemplate>>> {
+      logger.info(
+        `Linking e-service templates ${eserviceTemplateIds} to purpose template ${purposeTemplateId}`
+      );
+
+      assertEServiceTemplateIdsCountIsBelowThreshold(
+        eserviceTemplateIds.length
+      );
+
+      const purposeTemplate = await retrievePurposeTemplate(
+        purposeTemplateId,
+        readModelService
+      );
+
+      assertPurposeTemplateStateIsValid(purposeTemplate.data, [
+        purposeTemplateState.draft,
+        purposeTemplateState.published,
+      ]);
+
+      assertRequesterIsCreator(
+        purposeTemplateId,
+        purposeTemplate.data.creatorId,
+        authData
+      );
+
+      const validationResult = await validateEServiceTemplatesAssociations(
+        eserviceTemplateIds,
+        purposeTemplate.data,
+        readModelService
+      );
+
+      if (validationResult.type === "invalid") {
+        throw associationEServiceTemplatesForPurposeTemplateFailed(
+          validationResult.issues,
+          eserviceTemplateIds,
+          purposeTemplateId
+        );
+      }
+
+      const creationTimestamp = new Date();
+
+      const createEvents = validationResult.value.map((pair, index) => {
+        const link: EServiceTemplateVersionPurposeTemplate = {
+          purposeTemplateId,
+          eserviceTemplateId: pair.eserviceTemplate.id,
+          eserviceTemplateVersionId: pair.eserviceTemplateVersionId,
+          createdAt: creationTimestamp,
+        };
+        const version = purposeTemplate.metadata.version + index;
+        return toCreateEventPurposeTemplateEServiceTemplateLinked(
+          link,
+          purposeTemplate.data,
+          pair.eserviceTemplate,
+          correlationId,
+          version
+        );
+      });
+
+      const createdEvents = await repository.createEvents(createEvents);
+
+      return linkValidationResultsToEServiceTemplateVersionPurposeTemplates(
         validationResult.value,
         purposeTemplateId,
         creationTimestamp,

--- a/packages/purpose-template-process/src/services/readModelServiceSQL.ts
+++ b/packages/purpose-template-process/src/services/readModelServiceSQL.ts
@@ -26,6 +26,8 @@ import {
   EService,
   EServiceDescriptorPurposeTemplate,
   EServiceId,
+  EServiceTemplate,
+  EServiceTemplateId,
   EServiceTemplateVersionPurposeTemplate,
   genericInternalError,
   ListResult,
@@ -48,6 +50,7 @@ import {
   aggregatePurposeTemplateEServiceDescriptor,
   aggregatePurposeTemplateEServiceDescriptorArray,
   CatalogReadModelService,
+  EServiceTemplateReadModelService,
   PurposeTemplateReadModelService,
   toPurposeTemplateAggregatorArray,
   toRiskAnalysisTemplateAnswerAnnotationDocument,
@@ -202,15 +205,43 @@ const getPurposeTemplatesFilters = (
 export function readModelServiceBuilderSQL({
   readModelDB,
   catalogReadModelServiceSQL,
+  eserviceTemplateReadModelServiceSQL,
   purposeTemplateReadModelServiceSQL,
 }: {
   readModelDB: DrizzleReturnType;
   catalogReadModelServiceSQL: CatalogReadModelService;
+  eserviceTemplateReadModelServiceSQL: EServiceTemplateReadModelService;
   purposeTemplateReadModelServiceSQL: PurposeTemplateReadModelService;
 }) {
   return {
     async getEServiceById(id: EServiceId): Promise<EService | undefined> {
       return (await catalogReadModelServiceSQL.getEServiceById(id))?.data;
+    },
+    async getEServiceTemplateById(
+      id: EServiceTemplateId
+    ): Promise<EServiceTemplate | undefined> {
+      return (
+        await eserviceTemplateReadModelServiceSQL.getEServiceTemplateById(id)
+      )?.data;
+    },
+    async getEServiceTemplateVersionPurposeTemplateByPurposeTemplateIdAndEServiceTemplateId(
+      purposeTemplateId: PurposeTemplateId,
+      eserviceTemplateId: EServiceTemplateId
+    ): Promise<EServiceTemplateVersionPurposeTemplate | undefined> {
+      const rows =
+        await purposeTemplateReadModelServiceSQL.getEServiceTemplateVersionPurposeTemplatesByFilter(
+          and(
+            eq(
+              eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate.purposeTemplateId,
+              purposeTemplateId
+            ),
+            eq(
+              eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate.eserviceTemplateId,
+              eserviceTemplateId
+            )
+          )
+        );
+      return rows.at(0)?.data;
     },
     async getPurposeTemplatesByTitle(
       title: string

--- a/packages/purpose-template-process/src/services/validators.ts
+++ b/packages/purpose-template-process/src/services/validators.ts
@@ -20,6 +20,11 @@ import {
   EService,
   EServiceDescriptorPurposeTemplate,
   EServiceId,
+  EServiceTemplate,
+  EServiceTemplateId,
+  EServiceTemplateVersionId,
+  EServiceTemplateVersionState,
+  eserviceTemplateVersionState,
   PurposeTemplate,
   PurposeTemplateId,
   purposeTemplateState,
@@ -37,17 +42,25 @@ import { match } from "ts-pattern";
 import { config } from "../config/config.js";
 import {
   eserviceAlreadyAssociatedError,
+  eserviceIsInstanceOfEServiceTemplateError,
   eserviceNotAssociatedError,
   eserviceNotFound,
+  eserviceTemplateAlreadyAssociatedError,
+  eserviceTemplateNotFound,
   invalidDescriptorStateError,
   invalidDescriptorStateForPublicationError,
+  invalidEServiceTemplateVersionStateError,
   invalidPurposeTemplateResult,
   missingDescriptorError,
+  missingEServiceTemplateVersionError,
   purposeTemplateEServicePersonalDataFlagMismatch,
+  purposeTemplateEServiceTemplatePersonalDataFlagMismatch,
   PurposeTemplateValidationIssue,
   PurposeTemplateValidationResult,
   unexpectedAssociationEServiceError,
+  unexpectedAssociationEServiceTemplateError,
   unexpectedEServiceError,
+  unexpectedEServiceTemplateError,
   unexpectedUnassociationEServiceError,
   validPurposeTemplateResult,
 } from "../errors/purposeTemplateValidationErrors.js";
@@ -59,7 +72,9 @@ import {
   annotationDocumentLimitExceeded,
   associationBetweenEServiceAndPurposeTemplateAlreadyExists,
   associationBetweenEServiceAndPurposeTemplateDoesNotExist,
+  associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists,
   associationEServicesForPurposeTemplateFailed,
+  associationEServiceTemplatesForPurposeTemplateFailed,
   conflictDocumentPrettyNameDuplicate,
   conflictDuplicatedDocument,
   disassociationEServicesFromPurposeTemplateFailed,
@@ -73,6 +88,7 @@ import {
   riskAnalysisTemplateAnswerNotFound,
   riskAnalysisTemplateValidationFailed,
   tooManyEServicesForPurposeTemplate,
+  tooManyEServiceTemplatesForPurposeTemplate,
   purposeTemplateNotFound,
 } from "../model/domain/errors.js";
 import { ReadModelServiceSQL } from "./readModelServiceSQL.js";
@@ -96,6 +112,9 @@ export const ALLOWED_DESCRIPTOR_STATES_FOR_PURPOSE_TEMPLATE_ESERVICE_DISASSOCIAT
     descriptorState.deprecated,
     descriptorState.archived,
   ];
+
+export const ALLOWED_ESERVICE_TEMPLATE_VERSION_STATES_FOR_PURPOSE_TEMPLATE_ASSOCIATION: EServiceTemplateVersionState[] =
+  [eserviceTemplateVersionState.published];
 
 export const isRequesterCreator = (
   creatorId: TenantId,
@@ -142,6 +161,17 @@ export const assertEServiceIdsCountIsBelowThreshold = (
   if (eserviceIdsSize > config.maxEServicesPerLinkRequest) {
     throw tooManyEServicesForPurposeTemplate(
       eserviceIdsSize,
+      config.maxEServicesPerLinkRequest
+    );
+  }
+};
+
+export const assertEServiceTemplateIdsCountIsBelowThreshold = (
+  eserviceTemplateIdsSize: number
+): void => {
+  if (eserviceTemplateIdsSize > config.maxEServicesPerLinkRequest) {
+    throw tooManyEServiceTemplatesForPurposeTemplate(
+      eserviceTemplateIdsSize,
       config.maxEServicesPerLinkRequest
     );
   }
@@ -785,8 +815,21 @@ export async function validateEservicesAssociations(
     );
   }
 
+  const {
+    validationIssues: instanceOfTemplateIssues,
+    validEservices: nonTemplateInstanceEservices,
+  } = excludeEServiceInstancesOfTemplates(validEservices);
+
+  if (instanceOfTemplateIssues.length > 0) {
+    throw associationEServicesForPurposeTemplateFailed(
+      instanceOfTemplateIssues,
+      eserviceIds,
+      purposeTemplate.id
+    );
+  }
+
   const associationValidationIssues = await validateEServiceAssociations(
-    validEservices,
+    nonTemplateInstanceEservices,
     purposeTemplate.id,
     readModelService
   );
@@ -802,13 +845,46 @@ export async function validateEservicesAssociations(
   const {
     validationIssues: descriptorValidationIssues,
     validEServiceDescriptorPairs,
-  } = validateEServiceDescriptorsToAssociate(validEservices);
+  } = validateEServiceDescriptorsToAssociate(nonTemplateInstanceEservices);
 
   if (descriptorValidationIssues.length > 0) {
     return invalidPurposeTemplateResult(descriptorValidationIssues);
   }
 
   return validPurposeTemplateResult(validEServiceDescriptorPairs);
+}
+
+/**
+ * Filter out e-services that are instances of an e-service template.
+ * Link to a purpose template is not allowed for template-derived instances:
+ * the link must target the originating e-service template instead.
+ *
+ * Applied only in the association (link) flow, NOT in disassociation (unlink),
+ * to avoid blocking the unlink of entries that predate this validation.
+ */
+export function excludeEServiceInstancesOfTemplates(eservices: EService[]): {
+  validationIssues: PurposeTemplateValidationIssue[];
+  validEservices: EService[];
+} {
+  const validationIssues: PurposeTemplateValidationIssue[] = [];
+  const validEservices: EService[] = [];
+
+  eservices.forEach((eservice) => {
+    if (eservice.templateId !== undefined) {
+      // eslint-disable-next-line functional/immutable-data
+      validationIssues.push(
+        eserviceIsInstanceOfEServiceTemplateError(
+          eservice.id,
+          eservice.templateId
+        )
+      );
+      return;
+    }
+    // eslint-disable-next-line functional/immutable-data
+    validEservices.push(eservice);
+  });
+
+  return { validationIssues, validEservices };
 }
 
 export async function validateEservicesDisassociations(
@@ -864,6 +940,226 @@ export async function validateEservicesDisassociations(
   }
 
   return validPurposeTemplateResult(validEServiceDescriptorPairs);
+}
+
+/**
+ * Validate the existence of e-service templates by their ids.
+ * For each eservice template:
+ * - Promise.fulfilled: return error if not found, or mismatch on the personalData flag
+ * - Promise.rejected: return a validation issue
+ * Finally, return the valid e-service templates and the validation issues.
+ */
+async function validateEServiceTemplateExistence(
+  eserviceTemplateIds: EServiceTemplateId[],
+  purposeTemplate: PurposeTemplate,
+  readModelService: ReadModelServiceSQL
+): Promise<{
+  validationIssues: PurposeTemplateValidationIssue[];
+  validEServiceTemplates: EServiceTemplate[];
+}> {
+  const results = await Promise.allSettled(
+    eserviceTemplateIds.map(
+      async (id) => await readModelService.getEServiceTemplateById(id)
+    )
+  );
+
+  return results.reduce(
+    (acc, result, index) =>
+      match(result)
+        .with({ status: "fulfilled" }, (res) => {
+          if (!res.value) {
+            return {
+              ...acc,
+              validationIssues: [
+                ...acc.validationIssues,
+                eserviceTemplateNotFound(eserviceTemplateIds[index]),
+              ],
+            };
+          }
+
+          if (res.value.personalData !== purposeTemplate.handlesPersonalData) {
+            return {
+              ...acc,
+              validationIssues: [
+                ...acc.validationIssues,
+                purposeTemplateEServiceTemplatePersonalDataFlagMismatch(
+                  res.value,
+                  purposeTemplate
+                ),
+              ],
+            };
+          }
+
+          return {
+            ...acc,
+            validEServiceTemplates: [...acc.validEServiceTemplates, res.value],
+          };
+        })
+        .with({ status: "rejected" }, (res) => ({
+          ...acc,
+          validationIssues: [
+            ...acc.validationIssues,
+            unexpectedEServiceTemplateError(
+              res.reason.message,
+              eserviceTemplateIds[index]
+            ),
+          ],
+        }))
+        .exhaustive(),
+    {
+      validationIssues: new Array<PurposeTemplateValidationIssue>(),
+      validEServiceTemplates: new Array<EServiceTemplate>(),
+    }
+  );
+}
+
+/**
+ * For each valid e-service template, verify there's no pre-existing association
+ * with the given purpose template.
+ */
+async function validateEServiceTemplateAssociations(
+  validEServiceTemplates: EServiceTemplate[],
+  purposeTemplateId: PurposeTemplateId,
+  readModelService: ReadModelServiceSQL
+): Promise<PurposeTemplateValidationIssue[]> {
+  const associationResults = await Promise.allSettled(
+    validEServiceTemplates.map(
+      async (eserviceTemplate) =>
+        await readModelService.getEServiceTemplateVersionPurposeTemplateByPurposeTemplateIdAndEServiceTemplateId(
+          purposeTemplateId,
+          eserviceTemplate.id
+        )
+    )
+  );
+
+  return associationResults.flatMap((result, index) => {
+    if (result.status === "rejected") {
+      throw unexpectedAssociationEServiceTemplateError(
+        result.reason.message,
+        validEServiceTemplates[index].id
+      );
+    }
+
+    if (result.status === "fulfilled" && result.value !== undefined) {
+      return [
+        eserviceTemplateAlreadyAssociatedError(
+          validEServiceTemplates[index].id,
+          purposeTemplateId
+        ),
+      ];
+    }
+    return [];
+  });
+}
+
+/**
+ * For each e-service template, find the first version in an allowed state (Published).
+ * Return `{eserviceTemplate, eserviceTemplateVersionId}` pairs for the valid ones, and
+ * validation issues for templates without any acceptable version.
+ */
+function validateEServiceTemplateVersionsToAssociate(
+  validEServiceTemplates: EServiceTemplate[]
+): {
+  validationIssues: PurposeTemplateValidationIssue[];
+  validEServiceTemplateVersionPairs: Array<{
+    eserviceTemplate: EServiceTemplate;
+    eserviceTemplateVersionId: EServiceTemplateVersionId;
+  }>;
+} {
+  const validationIssues: PurposeTemplateValidationIssue[] = [];
+  const validEServiceTemplateVersionPairs: Array<{
+    eserviceTemplate: EServiceTemplate;
+    eserviceTemplateVersionId: EServiceTemplateVersionId;
+  }> = [];
+
+  validEServiceTemplates.forEach((eserviceTemplate) => {
+    if (!eserviceTemplate.versions || eserviceTemplate.versions.length === 0) {
+      // eslint-disable-next-line functional/immutable-data
+      validationIssues.push(
+        missingEServiceTemplateVersionError(eserviceTemplate.id)
+      );
+      return;
+    }
+
+    const validVersion = eserviceTemplate.versions.find((version) =>
+      ALLOWED_ESERVICE_TEMPLATE_VERSION_STATES_FOR_PURPOSE_TEMPLATE_ASSOCIATION.includes(
+        version.state
+      )
+    );
+
+    if (!validVersion) {
+      // eslint-disable-next-line functional/immutable-data
+      validationIssues.push(
+        invalidEServiceTemplateVersionStateError(
+          eserviceTemplate.id,
+          ALLOWED_ESERVICE_TEMPLATE_VERSION_STATES_FOR_PURPOSE_TEMPLATE_ASSOCIATION
+        )
+      );
+      return;
+    }
+
+    // eslint-disable-next-line functional/immutable-data
+    validEServiceTemplateVersionPairs.push({
+      eserviceTemplate,
+      eserviceTemplateVersionId: validVersion.id,
+    });
+  });
+
+  return { validationIssues, validEServiceTemplateVersionPairs };
+}
+
+export async function validateEServiceTemplatesAssociations(
+  eserviceTemplateIds: EServiceTemplateId[],
+  purposeTemplate: PurposeTemplate,
+  readModelService: ReadModelServiceSQL
+): Promise<
+  PurposeTemplateValidationResult<
+    Array<{
+      eserviceTemplate: EServiceTemplate;
+      eserviceTemplateVersionId: EServiceTemplateVersionId;
+    }>
+  >
+> {
+  const { validationIssues, validEServiceTemplates } =
+    await validateEServiceTemplateExistence(
+      eserviceTemplateIds,
+      purposeTemplate,
+      readModelService
+    );
+
+  if (validationIssues.length > 0) {
+    throw associationEServiceTemplatesForPurposeTemplateFailed(
+      validationIssues,
+      eserviceTemplateIds,
+      purposeTemplate.id
+    );
+  }
+
+  const associationValidationIssues =
+    await validateEServiceTemplateAssociations(
+      validEServiceTemplates,
+      purposeTemplate.id,
+      readModelService
+    );
+
+  if (associationValidationIssues.length > 0) {
+    throw associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists(
+      associationValidationIssues,
+      eserviceTemplateIds,
+      purposeTemplate.id
+    );
+  }
+
+  const {
+    validationIssues: versionValidationIssues,
+    validEServiceTemplateVersionPairs,
+  } = validateEServiceTemplateVersionsToAssociate(validEServiceTemplates);
+
+  if (versionValidationIssues.length > 0) {
+    return invalidPurposeTemplateResult(versionValidationIssues);
+  }
+
+  return validPurposeTemplateResult(validEServiceTemplateVersionPairs);
 }
 
 export function hasRoleToAccessDraftPurposeTemplates(

--- a/packages/purpose-template-process/src/utilities/errorMappers.ts
+++ b/packages/purpose-template-process/src/utilities/errorMappers.ts
@@ -84,6 +84,24 @@ export const linkEservicesToPurposeTemplateErrorMapper = (
     .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
+export const linkEServiceTemplatesToPurposeTemplateErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "associationEServiceTemplatesForPurposeTemplateFailed",
+      "tooManyEServiceTemplatesForPurposeTemplate",
+      () => HTTP_STATUS_BAD_REQUEST
+    )
+    .with("purposeTemplateNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with(
+      "associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists",
+      "purposeTemplateNotInExpectedStates",
+      () => HTTP_STATUS_CONFLICT
+    )
+    .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
 export const unlinkEServicesFromPurposeTemplateErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>

--- a/packages/purpose-template-process/test/api/linkEServiceTemplatesToPurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/api/linkEServiceTemplatesToPurposeTemplate.test.ts
@@ -1,0 +1,213 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { generateToken } from "pagopa-interop-commons-test";
+import {
+  EServiceTemplateId,
+  EServiceTemplateVersionId,
+  EServiceTemplateVersionPurposeTemplate,
+  generateId,
+  PurposeTemplateId,
+  purposeTemplateState,
+  WithMetadata,
+} from "pagopa-interop-models";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { purposeTemplateApi } from "pagopa-interop-api-clients";
+import { api, purposeTemplateService } from "../vitest.api.setup.js";
+import { eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate } from "../../src/model/domain/apiConverter.js";
+import {
+  associationEServiceTemplatesForPurposeTemplateFailed,
+  associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists,
+  tooManyEServiceTemplatesForPurposeTemplate,
+  purposeTemplateNotFound,
+  purposeTemplateNotInExpectedStates,
+} from "../../src/model/domain/errors.js";
+import { eserviceTemplateNotFound } from "../../src/errors/purposeTemplateValidationErrors.js";
+
+describe("API POST /purposeTemplates/:id/linkEserviceTemplates", () => {
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+
+  const purposeTemplateId: PurposeTemplateId = generateId<PurposeTemplateId>();
+  const eserviceTemplateIds: EServiceTemplateId[] = [
+    generateId<EServiceTemplateId>(),
+    generateId<EServiceTemplateId>(),
+  ];
+
+  const mockLinks: Array<WithMetadata<EServiceTemplateVersionPurposeTemplate>> =
+    [
+      {
+        data: {
+          purposeTemplateId,
+          eserviceTemplateId: eserviceTemplateIds[0],
+          eserviceTemplateVersionId: generateId<EServiceTemplateVersionId>(),
+          createdAt: new Date(),
+        },
+        metadata: { version: 1 },
+      },
+      {
+        data: {
+          purposeTemplateId,
+          eserviceTemplateId: eserviceTemplateIds[1],
+          eserviceTemplateVersionId: generateId<EServiceTemplateVersionId>(),
+          createdAt: new Date(),
+        },
+        metadata: { version: 1 },
+      },
+    ];
+
+  const validLinkRequest: purposeTemplateApi.linkEServiceTemplatesToPurposeTemplate_Body =
+    {
+      eserviceTemplateIds,
+    };
+
+  beforeEach(() => {
+    purposeTemplateService.linkEServiceTemplatesToPurposeTemplate = vi
+      .fn()
+      .mockResolvedValue(mockLinks);
+  });
+
+  const makeRequest = async (
+    token: string,
+    purposeTemplateId: string,
+    linkRequest: purposeTemplateApi.linkEServiceTemplatesToPurposeTemplate_Body
+  ) =>
+    request(api)
+      .post(`/purposeTemplates/${purposeTemplateId}/linkEserviceTemplates`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send(linkRequest);
+
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token, purposeTemplateId, validLinkRequest);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(
+        mockLinks.map((link) =>
+          eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate(
+            link.data
+          )
+        )
+      );
+      expect(
+        purposeTemplateService.linkEServiceTemplatesToPurposeTemplate
+      ).toHaveBeenCalledWith(
+        purposeTemplateId,
+        eserviceTemplateIds,
+        expect.any(Object)
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, purposeTemplateId, validLinkRequest);
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 400 when eserviceTemplateIds is empty", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const invalidRequest = { eserviceTemplateIds: [] };
+    const res = await makeRequest(token, purposeTemplateId, invalidRequest);
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 when eserviceTemplateIds contains invalid UUID", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const invalidRequest = { eserviceTemplateIds: ["invalid-uuid"] };
+    const res = await makeRequest(token, purposeTemplateId, invalidRequest);
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 when eserviceTemplateIds is not an array", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const invalidRequest = { eserviceTemplateIds: "not-an-array" };
+    const res = await makeRequest(
+      token,
+      purposeTemplateId,
+      invalidRequest as unknown as purposeTemplateApi.linkEServiceTemplatesToPurposeTemplate_Body
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 when eserviceTemplateIds is missing", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const invalidRequest = {};
+    const res = await makeRequest(
+      token,
+      purposeTemplateId,
+      invalidRequest as unknown as purposeTemplateApi.linkEServiceTemplatesToPurposeTemplate_Body
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 when purposeTemplateId is invalid UUID", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, "invalid-uuid", validLinkRequest);
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 500 when service throws an error", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    purposeTemplateService.linkEServiceTemplatesToPurposeTemplate = vi
+      .fn()
+      .mockRejectedValue(new Error("Service error"));
+
+    const res = await makeRequest(token, purposeTemplateId, validLinkRequest);
+    expect(res.status).toBe(500);
+  });
+
+  it.each([
+    {
+      error: tooManyEServiceTemplatesForPurposeTemplate(
+        eserviceTemplateIds.length,
+        10
+      ),
+      expectedStatus: 400,
+    },
+    {
+      error: associationEServiceTemplatesForPurposeTemplateFailed(
+        [eserviceTemplateNotFound(eserviceTemplateIds[0])],
+        eserviceTemplateIds,
+        purposeTemplateId
+      ),
+      expectedStatus: 400,
+    },
+    {
+      error: purposeTemplateNotFound(purposeTemplateId),
+      expectedStatus: 404,
+    },
+    {
+      error: associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists(
+        [],
+        eserviceTemplateIds,
+        purposeTemplateId
+      ),
+      expectedStatus: 409,
+    },
+    {
+      error: purposeTemplateNotInExpectedStates(
+        purposeTemplateId,
+        purposeTemplateState.suspended,
+        [purposeTemplateState.draft, purposeTemplateState.published]
+      ),
+      expectedStatus: 409,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate = vi
+        .fn()
+        .mockRejectedValue(error);
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, purposeTemplateId, validLinkRequest);
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+});

--- a/packages/purpose-template-process/test/integration/linkEServiceTemplatesToPurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/linkEServiceTemplatesToPurposeTemplate.test.ts
@@ -1,0 +1,365 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {
+  decodeProtobufPayload,
+  getMockAuthData,
+  getMockContext,
+  getMockEServiceTemplate,
+  getMockEServiceTemplateVersion,
+  getMockPurposeTemplate,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import {
+  EServiceTemplate,
+  EServiceTemplateVersion,
+  EServiceTemplateVersionPurposeTemplate,
+  PurposeTemplate,
+  PurposeTemplateEServiceTemplateLinkedV2,
+  PurposeTemplateId,
+  Tenant,
+  eserviceTemplateVersionState,
+  generateId,
+  purposeTemplateState,
+  toEServiceTemplateV2,
+  toPurposeTemplateV2,
+} from "pagopa-interop-models";
+import { describe, expect, it, vi } from "vitest";
+import { config } from "../../src/config/config.js";
+import {
+  eserviceTemplateAlreadyAssociatedError,
+  eserviceTemplateNotFound,
+  invalidEServiceTemplateVersionStateError,
+  missingEServiceTemplateVersionError,
+  purposeTemplateEServiceTemplatePersonalDataFlagMismatch,
+} from "../../src/errors/purposeTemplateValidationErrors.js";
+import {
+  associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists,
+  associationEServiceTemplatesForPurposeTemplateFailed,
+  purposeTemplateNotFound,
+  purposeTemplateNotInExpectedStates,
+  tooManyEServiceTemplatesForPurposeTemplate,
+} from "../../src/model/domain/errors.js";
+import { ALLOWED_ESERVICE_TEMPLATE_VERSION_STATES_FOR_PURPOSE_TEMPLATE_ASSOCIATION } from "../../src/services/validators.js";
+import {
+  addOneEServiceTemplate,
+  addOneEServiceTemplateVersionPurposeTemplate,
+  addOnePurposeTemplate,
+  addOneTenant,
+  purposeTemplateService,
+  readLastPurposeTemplateEvent,
+} from "../integrationUtils.js";
+
+describe("linkEServiceTemplatesToPurposeTemplate", () => {
+  const tenant: Tenant = getMockTenant();
+
+  const makeTemplate = (
+    versionState: EServiceTemplateVersion["state"] = eserviceTemplateVersionState.published,
+    personalData: boolean | undefined = false
+  ): EServiceTemplate => {
+    const version: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      state: versionState,
+    };
+    return {
+      ...getMockEServiceTemplate(),
+      creatorId: tenant.id,
+      personalData,
+      versions: [version],
+    };
+  };
+
+  const purposeTemplate: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    creatorId: tenant.id,
+    state: purposeTemplateState.draft,
+    handlesPersonalData: false,
+  };
+
+  it("should write on event-store for linking e-service templates to purpose template", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date());
+
+    const template1 = makeTemplate();
+    const template2 = makeTemplate();
+
+    await addOneTenant(tenant);
+    await addOnePurposeTemplate(purposeTemplate);
+    await addOneEServiceTemplate(template1);
+    await addOneEServiceTemplate(template2);
+
+    const linkResponse =
+      await purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        purposeTemplate.id,
+        [template1.id, template2.id],
+        getMockContext({ authData: getMockAuthData(tenant.id) })
+      );
+
+    expect(linkResponse).toHaveLength(2);
+    expect(linkResponse[0]).toMatchObject({
+      data: {
+        purposeTemplateId: purposeTemplate.id,
+        eserviceTemplateId: template1.id,
+        eserviceTemplateVersionId: template1.versions[0].id,
+        createdAt: new Date(),
+      },
+      metadata: { version: 2 },
+    });
+    expect(linkResponse[1]).toMatchObject({
+      data: {
+        purposeTemplateId: purposeTemplate.id,
+        eserviceTemplateId: template2.id,
+        eserviceTemplateVersionId: template2.versions[0].id,
+        createdAt: new Date(),
+      },
+      metadata: { version: 2 },
+    });
+
+    const lastEvent = await readLastPurposeTemplateEvent(purposeTemplate.id);
+    expect(lastEvent.type).toBe("PurposeTemplateEServiceTemplateLinked");
+    expect(lastEvent).toMatchObject({
+      stream_id: purposeTemplate.id,
+      version: "2",
+      event_version: 2,
+    });
+
+    const eventPayload = decodeProtobufPayload({
+      messageType: PurposeTemplateEServiceTemplateLinkedV2,
+      payload: lastEvent.data,
+    });
+    expect(eventPayload.purposeTemplate).toEqual(
+      toPurposeTemplateV2(purposeTemplate)
+    );
+    expect(eventPayload.eserviceTemplate).toEqual(
+      toEServiceTemplateV2(template2)
+    );
+    expect(eventPayload.eserviceTemplateVersionId).toBe(
+      template2.versions[0].id
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("should throw purposeTemplateNotFound if the purpose template does not exist", async () => {
+    const notExistingId = generateId<PurposeTemplateId>();
+    const template = makeTemplate();
+    await addOneEServiceTemplate(template);
+
+    await expect(
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        notExistingId,
+        [template.id],
+        getMockContext({ authData: getMockAuthData(tenant.id) })
+      )
+    ).rejects.toThrowError(purposeTemplateNotFound(notExistingId));
+  });
+
+  it("should throw purposeTemplateNotInExpectedStates for a Suspended purpose template", async () => {
+    const suspended: PurposeTemplate = {
+      ...purposeTemplate,
+      id: generateId<PurposeTemplateId>(),
+      state: purposeTemplateState.suspended,
+    };
+    const template = makeTemplate();
+    await addOnePurposeTemplate(suspended);
+    await addOneEServiceTemplate(template);
+
+    await expect(
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        suspended.id,
+        [template.id],
+        getMockContext({ authData: getMockAuthData(tenant.id) })
+      )
+    ).rejects.toThrowError(
+      purposeTemplateNotInExpectedStates(
+        suspended.id,
+        purposeTemplateState.suspended,
+        [purposeTemplateState.draft, purposeTemplateState.published]
+      )
+    );
+  });
+
+  it("should throw purposeTemplateNotFound when requester is not the creator", async () => {
+    const otherPurposeTemplate: PurposeTemplate = {
+      ...purposeTemplate,
+      id: generateId<PurposeTemplateId>(),
+    };
+    const template = makeTemplate();
+    await addOnePurposeTemplate(otherPurposeTemplate);
+    await addOneEServiceTemplate(template);
+
+    const nonCreator = generateId<Tenant["id"]>();
+
+    await expect(
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        otherPurposeTemplate.id,
+        [template.id],
+        getMockContext({ authData: getMockAuthData(nonCreator) })
+      )
+    ).rejects.toThrowError(purposeTemplateNotFound(otherPurposeTemplate.id));
+  });
+
+  it("should throw associationEServiceTemplatesForPurposeTemplateFailed when template does not exist", async () => {
+    const pt: PurposeTemplate = {
+      ...purposeTemplate,
+      id: generateId<PurposeTemplateId>(),
+    };
+    await addOnePurposeTemplate(pt);
+
+    const missingId = generateId<EServiceTemplate["id"]>();
+
+    await expect(
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        pt.id,
+        [missingId],
+        getMockContext({ authData: getMockAuthData(tenant.id) })
+      )
+    ).rejects.toThrowError(
+      associationEServiceTemplatesForPurposeTemplateFailed(
+        [eserviceTemplateNotFound(missingId)],
+        [missingId],
+        pt.id
+      )
+    );
+  });
+
+  it("should throw associationEServiceTemplatesForPurposeTemplateFailed on personalData mismatch", async () => {
+    const pt: PurposeTemplate = {
+      ...purposeTemplate,
+      id: generateId<PurposeTemplateId>(),
+      handlesPersonalData: true,
+    };
+    const template = makeTemplate(
+      eserviceTemplateVersionState.published,
+      false
+    );
+    await addOnePurposeTemplate(pt);
+    await addOneEServiceTemplate(template);
+
+    await expect(
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        pt.id,
+        [template.id],
+        getMockContext({ authData: getMockAuthData(tenant.id) })
+      )
+    ).rejects.toThrowError(
+      associationEServiceTemplatesForPurposeTemplateFailed(
+        [purposeTemplateEServiceTemplatePersonalDataFlagMismatch(template, pt)],
+        [template.id],
+        pt.id
+      )
+    );
+  });
+
+  it("should return invalid result when template has no versions", async () => {
+    const pt: PurposeTemplate = {
+      ...purposeTemplate,
+      id: generateId<PurposeTemplateId>(),
+    };
+    const template: EServiceTemplate = {
+      ...makeTemplate(),
+      versions: [],
+    };
+    await addOnePurposeTemplate(pt);
+    await addOneEServiceTemplate(template);
+
+    await expect(
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        pt.id,
+        [template.id],
+        getMockContext({ authData: getMockAuthData(tenant.id) })
+      )
+    ).rejects.toThrowError(
+      associationEServiceTemplatesForPurposeTemplateFailed(
+        [missingEServiceTemplateVersionError(template.id)],
+        [template.id],
+        pt.id
+      )
+    );
+  });
+
+  it("should return invalid result when template has only Draft versions", async () => {
+    const pt: PurposeTemplate = {
+      ...purposeTemplate,
+      id: generateId<PurposeTemplateId>(),
+    };
+    const template = makeTemplate(eserviceTemplateVersionState.draft);
+    await addOnePurposeTemplate(pt);
+    await addOneEServiceTemplate(template);
+
+    await expect(
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        pt.id,
+        [template.id],
+        getMockContext({ authData: getMockAuthData(tenant.id) })
+      )
+    ).rejects.toThrowError(
+      associationEServiceTemplatesForPurposeTemplateFailed(
+        [
+          invalidEServiceTemplateVersionStateError(
+            template.id,
+            ALLOWED_ESERVICE_TEMPLATE_VERSION_STATES_FOR_PURPOSE_TEMPLATE_ASSOCIATION
+          ),
+        ],
+        [template.id],
+        pt.id
+      )
+    );
+  });
+
+  it("should throw associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists when already linked", async () => {
+    const pt: PurposeTemplate = {
+      ...purposeTemplate,
+      id: generateId<PurposeTemplateId>(),
+    };
+    const template = makeTemplate();
+    await addOnePurposeTemplate(pt);
+    await addOneEServiceTemplate(template);
+
+    const existingLink: EServiceTemplateVersionPurposeTemplate = {
+      purposeTemplateId: pt.id,
+      eserviceTemplateId: template.id,
+      eserviceTemplateVersionId: template.versions[0].id,
+      createdAt: new Date(),
+    };
+    await addOneEServiceTemplateVersionPurposeTemplate(existingLink);
+
+    await expect(
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        pt.id,
+        [template.id],
+        getMockContext({ authData: getMockAuthData(tenant.id) })
+      )
+    ).rejects.toThrowError(
+      associationBetweenEServiceTemplateAndPurposeTemplateAlreadyExists(
+        [eserviceTemplateAlreadyAssociatedError(template.id, pt.id)],
+        [template.id],
+        pt.id
+      )
+    );
+  });
+
+  it("should throw tooManyEServiceTemplatesForPurposeTemplate when exceeding limit", async () => {
+    const pt: PurposeTemplate = {
+      ...purposeTemplate,
+      id: generateId<PurposeTemplateId>(),
+    };
+    await addOnePurposeTemplate(pt);
+
+    const tooMany = Array.from(
+      { length: config.maxEServicesPerLinkRequest + 1 },
+      () => generateId<EServiceTemplate["id"]>()
+    );
+
+    await expect(
+      purposeTemplateService.linkEServiceTemplatesToPurposeTemplate(
+        pt.id,
+        tooMany,
+        getMockContext({ authData: getMockAuthData(tenant.id) })
+      )
+    ).rejects.toThrowError(
+      tooManyEServiceTemplatesForPurposeTemplate(
+        tooMany.length,
+        config.maxEServicesPerLinkRequest
+      )
+    );
+  });
+});

--- a/packages/purpose-template-process/test/integration/linkEservicesToPurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/linkEservicesToPurposeTemplate.test.ts
@@ -28,6 +28,7 @@ import { describe, expect, it, vi } from "vitest";
 import { config } from "../../src/config/config.js";
 import {
   eserviceAlreadyAssociatedError,
+  eserviceIsInstanceOfEServiceTemplateError,
   eserviceNotFound,
   invalidDescriptorStateError,
   missingDescriptorError,
@@ -507,6 +508,40 @@ describe("linkEservicesToPurposeTemplate", () => {
       associationBetweenEServiceAndPurposeTemplateAlreadyExists(
         [eserviceAlreadyAssociatedError(eService1.id, purposeTemplate.id)],
         [eService1.id],
+        purposeTemplate.id
+      )
+    );
+  });
+
+  it("should throw associationEServicesForPurposeTemplateFailed when the eservice is an instance of an e-service template", async () => {
+    const templateOrigin = generateId<EService["templateId"] & string>();
+    const eserviceInstance: EService = {
+      ...eService1,
+      id: generateId<EServiceId>(),
+      templateId: templateOrigin,
+    };
+
+    await addOneTenant(tenant);
+    await addOnePurposeTemplate(purposeTemplate);
+    await addOneEService(eserviceInstance);
+
+    await expect(
+      purposeTemplateService.linkEservicesToPurposeTemplate(
+        purposeTemplate.id,
+        [eserviceInstance.id],
+        getMockContext({
+          authData: getMockAuthData(tenant.id),
+        })
+      )
+    ).rejects.toThrowError(
+      associationEServicesForPurposeTemplateFailed(
+        [
+          eserviceIsInstanceOfEServiceTemplateError(
+            eserviceInstance.id,
+            templateOrigin
+          ),
+        ],
+        [eserviceInstance.id],
         purposeTemplate.id
       )
     );

--- a/packages/purpose-template-process/test/integrationUtils.ts
+++ b/packages/purpose-template-process/test/integrationUtils.ts
@@ -23,6 +23,7 @@ import {
 } from "pagopa-interop-models";
 import {
   catalogReadModelServiceBuilder,
+  eserviceTemplateReadModelServiceBuilder,
   purposeTemplateReadModelServiceBuilder,
 } from "pagopa-interop-readmodel";
 import {
@@ -52,12 +53,16 @@ afterEach(cleanup);
 
 const catalogReadModelServiceSQL = catalogReadModelServiceBuilder(readModelDB);
 
+const eserviceTemplateReadModelServiceSQL =
+  eserviceTemplateReadModelServiceBuilder(readModelDB);
+
 const purposeTemplateReadModelServiceSQL =
   purposeTemplateReadModelServiceBuilder(readModelDB);
 
 export const readModelService = readModelServiceBuilderSQL({
   readModelDB,
   catalogReadModelServiceSQL,
+  eserviceTemplateReadModelServiceSQL,
   purposeTemplateReadModelServiceSQL,
 });
 

--- a/packages/readmodel/src/purpose-template/purposeTemplateReadModelService.ts
+++ b/packages/readmodel/src/purpose-template/purposeTemplateReadModelService.ts
@@ -1,6 +1,7 @@
 import { eq, SQL } from "drizzle-orm";
 import {
   EServiceDescriptorPurposeTemplate,
+  EServiceTemplateVersionPurposeTemplate,
   genericInternalError,
   PurposeTemplate,
   PurposeTemplateId,
@@ -10,6 +11,7 @@ import {
 } from "pagopa-interop-models";
 import {
   DrizzleReturnType,
+  eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate,
   purposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate,
@@ -218,6 +220,30 @@ export function purposeTemplateReadModelServiceBuilder(db: DrizzleReturnType) {
           purposeTemplateId: unsafeBrandId(row.purposeTemplateId),
           eserviceId: unsafeBrandId(row.eserviceId),
           descriptorId: unsafeBrandId(row.descriptorId),
+          createdAt: stringToDate(row.createdAt),
+        },
+        metadata: { version: row.metadataVersion },
+      }));
+    },
+    async getEServiceTemplateVersionPurposeTemplatesByFilter(
+      filter: SQL | undefined
+    ): Promise<Array<WithMetadata<EServiceTemplateVersionPurposeTemplate>>> {
+      if (filter === undefined) {
+        throw genericInternalError("Filter cannot be undefined");
+      }
+
+      const queryResult = await db
+        .select()
+        .from(eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate)
+        .where(filter);
+
+      return queryResult.map((row) => ({
+        data: {
+          purposeTemplateId: unsafeBrandId(row.purposeTemplateId),
+          eserviceTemplateId: unsafeBrandId(row.eserviceTemplateId),
+          eserviceTemplateVersionId: unsafeBrandId(
+            row.eserviceTemplateVersionId
+          ),
           createdAt: stringToDate(row.createdAt),
         },
         metadata: { version: row.metadataVersion },


### PR DESCRIPTION
**Jira**: [PIN-9832](https://pagopa.atlassian.net/browse/PIN-9832)

## Summary

- Add `POST /purposeTemplates/{id}/linkEserviceTemplates` endpoint in `purpose-template-process`, mirroring the existing `/linkEservices` flow for the new link between purpose templates and e-service templates (PIN-8621). Emits the `PurposeTemplateEServiceTemplateLinkedV2` event already defined in WI1
- Domain validations: existence of the e-service template, `personalData` coherence with the purpose template, at least one version in `Published` state, no pre-existing association, creator ownership, purpose template state in `Draft` or `Published`. Three new error codes (`0029`-`0031`) plus eight new validation issues with the corresponding factories
- Introduces the e-service template read-model primitive `getEServiceTemplateVersionPurposeTemplatesByFilter` (with `filter !== undefined` guard, deferred from WI3) and wires `eserviceTemplateReadModelServiceSQL` into the process read-model builder

## Note

As part of this WI, the link flow toward concrete e-services (`POST /linkEservices`) now rejects any e-service that is an instance of an e-service template (`eservice.templateId !== undefined`), surfacing the new `eserviceIsInstanceOfEServiceTemplateError` validation issue. The check is applied in the link orchestrator `validateEservicesAssociations` only; `validateEservicesDisassociations` is left untouched so previously created links of template-derived e-services remain unlink-able.

[PIN-9832]: https://pagopa.atlassian.net/browse/PIN-9832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ