### PR TITLE
refactor: match entire payload object in purpose and purpose-template tests (PIN-9767)

### DIFF
--- a/packages/purpose-process/test/integration/activatePurposeVersion.test.ts
+++ b/packages/purpose-process/test/integration/activatePurposeVersion.test.ts
@@ -201,9 +201,13 @@ describe("activatePurposeVersion", () => {
 
     expect(updatedVersion.riskAnalysis).toBeDefined();
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: versionWithStamp.id,
+    });
     expect(activateResponse).toMatchObject({
       data: updatedVersion,
       metadata: { version: 1 },
@@ -268,9 +272,13 @@ describe("activatePurposeVersion", () => {
 
     expect(updatedVersion.riskAnalysis).toBeDefined();
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: mockPurposeVersion.id,
+    });
     expect(activateResponse).toMatchObject({
       data: updatedVersion,
       metadata: { version: 1 },
@@ -337,9 +345,13 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: purposeVersion.id,
+    });
     expect(activateResponse).toMatchObject({
       data: expectedPurpose.versions[0],
       metadata: { version: 1 },
@@ -406,9 +418,13 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: purposeVersion.id,
+    });
     expect(activateResponse).toMatchObject({
       data: expectedPurpose.versions[0],
       metadata: { version: 1 },
@@ -478,9 +494,13 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: activateResponse.data.id,
+    });
 
     expect(activateResponse).toMatchObject({
       data: expectedPurpose.versions[1],
@@ -548,9 +568,13 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: purposeVersionMock.id,
+    });
     expect(activateResponse).toMatchObject({
       data: expectedPurpose.versions[0],
       metadata: { version: 1 },
@@ -610,9 +634,12 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(activateResponse).toMatchObject({
       data: expectedPurpose.versions[0],
       metadata: { version: 1 },
@@ -672,9 +699,12 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(activateResponse).toMatchObject({
       data: updatedVersion,
       metadata: { version: 1 },
@@ -755,9 +785,12 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(activateResponse).toMatchObject({
       data: updatedVersion,
       metadata: { version: 1 },
@@ -820,9 +853,12 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(activateResponse).toMatchObject({
       data: updatedVersion,
       metadata: { version: 1 },
@@ -945,9 +981,12 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(activateResponse).toMatchObject({
       data: updatedVersion,
       metadata: { version: 1 },
@@ -1049,9 +1088,12 @@ describe("activatePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(activateResponse).toMatchObject({
       data: updatedVersion,
       metadata: { version: 1 },

--- a/packages/purpose-process/test/integration/archivePurposeVersion.test.ts
+++ b/packages/purpose-process/test/integration/archivePurposeVersion.test.ts
@@ -102,7 +102,10 @@ describe("archivePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion.id,
+    });
     expect(
       writtenPayload.purpose?.versions.find((v) => v.id === updatedVersion.id)
     ).toEqual(toPurposeVersionV2(updatedVersion));
@@ -167,7 +170,10 @@ describe("archivePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion1.id,
+    });
     expect(
       writtenPayload.purpose?.versions.find((v) => v.id === updatedVersion.id)
     ).toEqual(toPurposeVersionV2(updatedVersion));
@@ -243,7 +249,10 @@ describe("archivePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion.id,
+    });
     expect(
       writtenPayload.purpose?.versions.find((v) => v.id === updatedVersion.id)
     ).toEqual(toPurposeVersionV2(updatedVersion));
@@ -369,7 +378,10 @@ describe("archivePurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion.id,
+    });
     expect(
       writtenPayload.purpose?.versions.find((v) => v.id === updatedVersion.id)
     ).toEqual(toPurposeVersionV2(updatedVersion));

--- a/packages/purpose-process/test/integration/clonePurpose.test.ts
+++ b/packages/purpose-process/test/integration/clonePurpose.test.ts
@@ -121,8 +121,11 @@ describe("clonePurpose", async () => {
       createdAt: new Date(),
     };
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(purpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      sourcePurposeId: mockPurpose.id,
+      sourceVersionId: mockPurpose.versions[0].id,
+    });
     expect(isRiskAnalysisValid).toBe(false);
   });
   it("should write on event-store for the cloning of a purpose, making sure the title is cut to 60 characters", async () => {
@@ -190,9 +193,12 @@ describe("clonePurpose", async () => {
       createdAt: new Date(),
     };
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      sourcePurposeId: mockPurpose.id,
+      sourceVersionId: mockPurpose.versions[0].id,
+    });
     expect(expectedPurpose.title.length).toBe(60);
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(purpose));
     expect(isRiskAnalysisValid).toBe(false);
   });
   it("should succeed when requester is Consumer Delegate and the Purpose is in a clonable state", async () => {
@@ -281,8 +287,11 @@ describe("clonePurpose", async () => {
       createdAt: new Date(),
     };
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(purpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      sourcePurposeId: purposeCreatedByDelegate.id,
+      sourceVersionId: purposeCreatedByDelegate.versions[0].id,
+    });
     expect(isRiskAnalysisValid).toBe(false);
   });
   it("should succeed when requester is Consumer Delegate and the eservice was created by a delegated tenant and the Purpose is in a clonable state", async () => {
@@ -400,8 +409,11 @@ describe("clonePurpose", async () => {
       createdAt: new Date(),
     };
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(purpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      sourcePurposeId: delegatePurpose.id,
+      sourceVersionId: mockPurposeVersion.id,
+    });
     expect(isRiskAnalysisValid).toBe(false);
   });
   it("should throw purposeNotFound if the purpose to clone doesn't exist", async () => {

--- a/packages/purpose-process/test/integration/createPurposeVersion.test.ts
+++ b/packages/purpose-process/test/integration/createPurposeVersion.test.ts
@@ -190,9 +190,13 @@ describe("createPurposeVersion", () => {
     });
 
     expect(createdPurposeVersion).toEqual(expectedPurposeVersion);
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      toPurposeV2(expectedPurpose)
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: createdPurposeVersion.id,
+    });
     expect({
       ...purposeVersionResponse,
       data: {
@@ -286,9 +290,13 @@ describe("createPurposeVersion", () => {
     });
 
     expect(createdPurposeVersion).toEqual(expectedPurposeVersion);
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      toPurposeV2(expectedPurpose)
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: createdPurposeVersion.id,
+    });
     expect({
       ...purposeVersionResponse,
       data: {
@@ -370,9 +378,13 @@ describe("createPurposeVersion", () => {
     });
 
     expect(createdPurposeVersion).toEqual(expectedPurposeVersion);
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      toPurposeV2(expectedPurpose)
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: createdPurposeVersion.id,
+    });
     expect({
       ...purposeVersionResponse,
       data: {
@@ -446,9 +458,13 @@ describe("createPurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      toPurposeV2(expectedPurpose)
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: createdPurposeVersion.id,
+    });
     expect(createdPurposeVersion).toEqual(expectedPurposeVersion);
     expect(createdPurposeVersion.state).toEqual(
       purposeVersionState.waitingForApproval
@@ -557,9 +573,13 @@ describe("createPurposeVersion", () => {
     });
 
     expect(createdPurposeVersion).toEqual(expectedPurposeVersion);
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      toPurposeV2(expectedPurpose)
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: createdPurposeVersion.id,
+    });
     expect({
       ...purposeVersionResponse,
       data: {
@@ -704,9 +724,13 @@ describe("createPurposeVersion", () => {
     });
 
     expect(createdPurposeVersion).toEqual(expectedPurposeVersion);
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      toPurposeV2(expectedPurpose)
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: createdPurposeVersion.id,
+    });
     expect({
       ...purposeVersionResponse,
       data: {

--- a/packages/purpose-process/test/integration/createReversePurpose.test.ts
+++ b/packages/purpose-process/test/integration/createReversePurpose.test.ts
@@ -145,9 +145,12 @@ describe("createReversePurpose", () => {
       },
     };
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(isRiskAnalysisValid).toEqual(true);
 
     vi.useRealTimers();
@@ -259,9 +262,12 @@ describe("createReversePurpose", () => {
       },
     };
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(isRiskAnalysisValid).toEqual(true);
 
     vi.useRealTimers();
@@ -409,9 +415,12 @@ describe("createReversePurpose", () => {
       },
       metadata: { version: 0 },
     });
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
 
     vi.useRealTimers();
   });

--- a/packages/purpose-process/test/integration/deletePurpose.test.ts
+++ b/packages/purpose-process/test/integration/deletePurpose.test.ts
@@ -77,7 +77,7 @@ describe("deletePurpose", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(mockPurpose));
+    expect(writtenPayload).toEqual({ purpose: toPurposeV2(mockPurpose) });
   });
   it("should write on event-store for the deletion of a purpose (draft version)", async () => {
     const mockEService = getMockEService();
@@ -110,7 +110,7 @@ describe("deletePurpose", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(mockPurpose));
+    expect(writtenPayload).toEqual({ purpose: toPurposeV2(mockPurpose) });
   });
   it("should write on event-store for the deletion of a purpose (waitingForApproval version)", async () => {
     const mockEService = getMockEService();
@@ -145,7 +145,7 @@ describe("deletePurpose", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(mockPurpose));
+    expect(writtenPayload).toEqual({ purpose: toPurposeV2(mockPurpose) });
   });
   it("should succeed when requester is Consumer Delegate and the Purpose is in a deletable state", async () => {
     const authData = getMockAuthData();
@@ -191,7 +191,7 @@ describe("deletePurpose", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(mockPurpose));
+    expect(writtenPayload).toEqual({ purpose: toPurposeV2(mockPurpose) });
   });
   it("should succeed when requester is Consumer Delegate and the eservice was created by a delegated tenant and the Purpose is in a deletable state", async () => {
     const producer = {
@@ -283,7 +283,7 @@ describe("deletePurpose", () => {
       payload: writtenEvent.data,
     });
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(delegatePurpose));
+    expect(writtenPayload).toEqual({ purpose: toPurposeV2(delegatePurpose) });
   });
   it("should throw purposeNotFound if the purpose doesn't exist", async () => {
     const randomId: PurposeId = generateId();

--- a/packages/purpose-process/test/integration/deletePurposeVersion.test.ts
+++ b/packages/purpose-process/test/integration/deletePurposeVersion.test.ts
@@ -102,7 +102,10 @@ describe("deletePurposeVersion", () => {
       data: expectedPurpose,
       metadata: { version: parseInt(writtenEvent.version, 10) },
     });
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion1.id,
+    });
 
     vi.useRealTimers();
   });
@@ -173,7 +176,10 @@ describe("deletePurposeVersion", () => {
       data: expectedPurpose,
       metadata: { version: parseInt(writtenEvent.version, 10) },
     });
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion1.id,
+    });
 
     vi.useRealTimers();
   });
@@ -291,7 +297,10 @@ describe("deletePurposeVersion", () => {
       data: expectedPurpose,
       metadata: { version: parseInt(writtenEvent.version, 10) },
     });
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion1.id,
+    });
 
     vi.useRealTimers();
   });

--- a/packages/purpose-process/test/integration/patchUpdatePurpose.test.ts
+++ b/packages/purpose-process/test/integration/patchUpdatePurpose.test.ts
@@ -98,12 +98,14 @@ describe("patchUpdatePurpose", () => {
     expectedIsRiskAnalysisValid: boolean = true
   ): Promise<void> {
     const sortedExpectedPurpose = sortPurpose(expectedPurpose);
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
     const sortedUpdatePurposeReturn =
       sortUpdatePurposeReturn(updatePurposeReturn);
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(sortedExpectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(sortedExpectedPurpose)),
+    });
     expect(sortedUpdatePurposeReturn).toEqual({
       data: {
         purpose: sortedExpectedPurpose,

--- a/packages/purpose-process/test/integration/patchUpdatePurposeFromTemplate.test.ts
+++ b/packages/purpose-process/test/integration/patchUpdatePurposeFromTemplate.test.ts
@@ -103,12 +103,14 @@ describe("patchUpdatePurposeFromTemplate", () => {
     expectedPurpose: Purpose
   ): Promise<void> {
     const sortedExpectedPurpose = sortPurpose(expectedPurpose);
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
     const sortedUpdatePurpose = sortPurpose(updatePurpose);
 
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(sortedExpectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(sortedExpectedPurpose)),
+    });
     expect(sortedUpdatePurpose).toEqual(sortedExpectedPurpose);
   }
 

--- a/packages/purpose-process/test/integration/patchUpdateReversePurpose.test.ts
+++ b/packages/purpose-process/test/integration/patchUpdateReversePurpose.test.ts
@@ -91,12 +91,14 @@ describe("patchUpdateReversePurpose", () => {
     expectedIsRiskAnalysisValid: boolean = true
   ): Promise<void> {
     const sortedExpectedPurpose = sortPurpose(expectedPurpose);
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
     const sortedUpdatePurposeReturn =
       sortUpdatePurposeReturn(updatePurposeReturn);
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(sortedExpectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(sortedExpectedPurpose)),
+    });
     expect(sortedUpdatePurposeReturn).toEqual({
       data: {
         purpose: sortedExpectedPurpose,

--- a/packages/purpose-process/test/integration/rejectPurposeVersion.test.ts
+++ b/packages/purpose-process/test/integration/rejectPurposeVersion.test.ts
@@ -92,7 +92,10 @@ describe("rejectPurposeVersion", () => {
       updatedAt: new Date(),
     };
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion.id,
+    });
 
     vi.useRealTimers();
   });
@@ -160,7 +163,10 @@ describe("rejectPurposeVersion", () => {
       updatedAt: new Date(),
     };
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion.id,
+    });
 
     vi.useRealTimers();
   });
@@ -227,7 +233,10 @@ describe("rejectPurposeVersion", () => {
       updatedAt: new Date(),
     };
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion.id,
+    });
 
     vi.useRealTimers();
   });
@@ -308,7 +317,10 @@ describe("rejectPurposeVersion", () => {
       delegationId: mockPurpose.delegationId,
     };
 
-    expect(writtenPayload.purpose).toEqual(toPurposeV2(expectedPurpose));
+    expect(writtenPayload).toEqual({
+      purpose: toPurposeV2(expectedPurpose),
+      versionId: mockPurposeVersion.id,
+    });
 
     vi.useRealTimers();
   });

--- a/packages/purpose-process/test/integration/suspendPurposeVersion.test.ts
+++ b/packages/purpose-process/test/integration/suspendPurposeVersion.test.ts
@@ -115,9 +115,13 @@ describe("suspendPurposeVersion", () => {
         payload: writtenEvent.data,
       });
 
-      expect(sortPurpose(writtenPayload.purpose)).toEqual(
-        sortPurpose(toPurposeV2(expectedPurpose))
-      );
+      expect({
+        ...writtenPayload,
+        purpose: sortPurpose(writtenPayload.purpose),
+      }).toEqual({
+        purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+        versionId: mockPurposeVersion1.id,
+      });
       expect(suspendResponse).toMatchObject({
         data: expectedPurpose.versions[0],
         metadata: { version: 1 },
@@ -180,9 +184,13 @@ describe("suspendPurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: mockPurposeVersion1.id,
+    });
     expect(suspendResponse).toMatchObject({
       data: expectedPurpose.versions[0],
       metadata: { version: 1 },
@@ -253,9 +261,13 @@ describe("suspendPurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: mockPurposeVersion1.id,
+    });
 
     expect(suspendResponse).toMatchObject({
       data: expectedPurpose.versions[0],
@@ -319,9 +331,13 @@ describe("suspendPurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: mockPurposeVersion1.id,
+    });
     expect(suspendResponse).toMatchObject({
       data: expectedPurpose.versions[0],
 
@@ -398,9 +414,13 @@ describe("suspendPurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: mockPurposeVersion1.id,
+    });
     expect(suspendResponse).toMatchObject({
       data: expectedPurpose.versions[0],
       metadata: { version: 1 },
@@ -478,9 +498,13 @@ describe("suspendPurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: mockPurposeVersion1.id,
+    });
     expect(suspendResponse).toMatchObject({
       data: expectedPurpose.versions[0],
       metadata: { version: 1 },
@@ -604,9 +628,13 @@ describe("suspendPurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: mockPurposeVersion1.id,
+    });
     expect(suspendResponse).toMatchObject({
       data: expectedPurpose.versions[0],
       metadata: { version: 1 },
@@ -716,9 +744,13 @@ describe("suspendPurposeVersion", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurpose(writtenPayload.purpose)).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+      versionId: mockPurposeVersion1.id,
+    });
     expect(suspendResponse).toMatchObject({
       data: expectedPurpose.versions[0],
       metadata: { version: 1 },

--- a/packages/purpose-process/test/integration/updatePurpose.test.ts
+++ b/packages/purpose-process/test/integration/updatePurpose.test.ts
@@ -184,10 +184,12 @@ describe("updatePurpose and updateReversePurpose", () => {
       )
     );
 
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(sortUpdatePurposeReturn(updatePurposeReturn)).toEqual({
       data: { purpose: expectedPurpose, isRiskAnalysisValid: true },
       metadata: { version: 1 },
@@ -232,10 +234,12 @@ describe("updatePurpose and updateReversePurpose", () => {
       )
     );
 
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(sortUpdatePurposeReturn(updatePurposeReturn)).toEqual({
       data: { purpose: expectedPurpose, isRiskAnalysisValid: true },
       metadata: { version: 1 },
@@ -272,10 +276,12 @@ describe("updatePurpose and updateReversePurpose", () => {
       )
     );
 
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(sortUpdatePurposeReturn(updatePurposeReturn)).toEqual({
       data: { purpose: expectedPurpose, isRiskAnalysisValid: true },
       metadata: { version: 1 },
@@ -338,10 +344,12 @@ describe("updatePurpose and updateReversePurpose", () => {
       )
     );
 
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(sortUpdatePurposeReturn(updatePurposeReturn)).toEqual({
       data: { purpose: expectedPurpose, isRiskAnalysisValid: true },
       metadata: { version: 1 },
@@ -393,10 +401,12 @@ describe("updatePurpose and updateReversePurpose", () => {
       createUpdatedReversePurpose(delegatePurpose, reversePurposeUpdateContent)
     );
 
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(sortUpdatePurposeReturn(updatePurposeReturn)).toEqual({
       data: { purpose: expectedPurpose, isRiskAnalysisValid: true },
       metadata: { version: 1 },
@@ -503,10 +513,12 @@ describe("updatePurpose and updateReversePurpose", () => {
       )
     );
 
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(sortUpdatePurposeReturn(updatePurposeReturn)).toEqual({
       data: { purpose: expectedPurpose, isRiskAnalysisValid: true },
       metadata: { version: 1 },
@@ -601,10 +613,12 @@ describe("updatePurpose and updateReversePurpose", () => {
       createUpdatedReversePurpose(delegatePurpose, reversePurposeUpdateContent)
     );
 
-    const sortedWrittenPayloadPurpose = sortPurpose(writtenPayload.purpose);
-    expect(sortedWrittenPayloadPurpose).toEqual(
-      sortPurpose(toPurposeV2(expectedPurpose))
-    );
+    expect({
+      ...writtenPayload,
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
     expect(sortUpdatePurposeReturn(updatePurposeReturn)).toEqual({
       data: { purpose: expectedPurpose, isRiskAnalysisValid: true },
       metadata: { version: 1 },

--- a/packages/purpose-template-process/test/integration/addRiskAnalysisAnswerAnnotation.test.ts
+++ b/packages/purpose-template-process/test/integration/addRiskAnalysisAnswerAnnotation.test.ts
@@ -92,10 +92,11 @@ describe("addRiskAnalysisAnswerAnnotation", () => {
       docs: [],
     });
 
-    expect(writtenPayload.purposeTemplate).toBeDefined();
-    expect(
-      writtenPayload.purposeTemplate!.purposeRiskAnalysisForm
-    ).toBeDefined();
+    expect(writtenPayload).toEqual({
+      purposeTemplate: expect.objectContaining({
+        purposeRiskAnalysisForm: expect.anything(),
+      }),
+    });
 
     // Verify that the annotation was added to the correct answer
     const riskAnalysisForm =

--- a/packages/purpose-template-process/test/integration/addRiskAnalysisAnswerAnnotation.test.ts
+++ b/packages/purpose-template-process/test/integration/addRiskAnalysisAnswerAnnotation.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   PurposeTemplate,
   PurposeTemplateDraftUpdatedV2,
+  toPurposeTemplateV2,
   targetTenantKind,
   generateId,
   TenantId,
@@ -93,9 +94,13 @@ describe("addRiskAnalysisAnswerAnnotation", () => {
     });
 
     expect(writtenPayload).toEqual({
-      purposeTemplate: expect.objectContaining({
+      purposeTemplate: {
+        ...toPurposeTemplateV2({
+          ...mockPurposeTemplate,
+          updatedAt: new Date(),
+        }),
         purposeRiskAnalysisForm: expect.anything(),
-      }),
+      },
     });
 
     // Verify that the annotation was added to the correct answer

--- a/packages/purpose-template-process/test/integration/addRiskAnalysisAnswerAnnotation.test.ts
+++ b/packages/purpose-template-process/test/integration/addRiskAnalysisAnswerAnnotation.test.ts
@@ -99,20 +99,22 @@ describe("addRiskAnalysisAnswerAnnotation", () => {
           ...mockPurposeTemplate,
           updatedAt: new Date(),
         }),
-        purposeRiskAnalysisForm: expect.anything(),
+        purposeRiskAnalysisForm: expect.objectContaining({
+          version: mockPurposeTemplate.purposeRiskAnalysisForm!.version,
+          singleAnswers: expect.arrayContaining([
+            expect.objectContaining({
+              id: answerId,
+              annotation: expect.objectContaining({
+                text: validRiskAnalysisAnswerAnnotationRequest.text,
+                docs: [],
+              }),
+            }),
+          ]),
+          multiAnswers:
+            mockPurposeTemplate.purposeRiskAnalysisForm!.multiAnswers,
+        }),
       },
     });
-
-    // Verify that the annotation was added to the correct answer
-    const riskAnalysisForm =
-      writtenPayload.purposeTemplate!.purposeRiskAnalysisForm!;
-    const annotatedAnswer = riskAnalysisForm.singleAnswers.find(
-      (answer) => answer.id === answerId
-    );
-    expect(annotatedAnswer?.annotation).toBeDefined();
-    expect(annotatedAnswer?.annotation?.text).toBe(
-      validRiskAnalysisAnswerAnnotationRequest.text
-    );
 
     vi.useRealTimers();
   });

--- a/packages/purpose-template-process/test/integration/archivePurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/archivePurposeTemplate.test.ts
@@ -92,9 +92,14 @@ describe("archivePurposeTemplate", () => {
         payload: writtenEvent.data,
       });
 
-      expect(sortPurposeTemplate(writtenPayload.purposeTemplate)).toEqual(
-        sortPurposeTemplate(toPurposeTemplateV2(expectedPurposeTemplate))
-      );
+      expect({
+        ...writtenPayload,
+        purposeTemplate: sortPurposeTemplate(writtenPayload.purposeTemplate),
+      }).toEqual({
+        purposeTemplate: sortPurposeTemplate(
+          toPurposeTemplateV2(expectedPurposeTemplate)
+        ),
+      });
       expect(archiveResponse).toMatchObject({
         data: updatedPurposeTemplate,
         metadata: { version: expectedMetadataVersion },

--- a/packages/purpose-template-process/test/integration/createPurposeTemplateRiskAnalysisAnswer.test.ts
+++ b/packages/purpose-template-process/test/integration/createPurposeTemplateRiskAnalysisAnswer.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   PurposeTemplate,
   PurposeTemplateDraftUpdatedV2,
+  toPurposeTemplateV2,
   targetTenantKind,
   generateId,
   TenantId,
@@ -99,9 +100,13 @@ describe("createPurposeTemplateRiskAnalysisAnswer", () => {
     });
 
     expect(writtenPayload).toEqual({
-      purposeTemplate: expect.objectContaining({
+      purposeTemplate: {
+        ...toPurposeTemplateV2({
+          ...mockPurposeTemplate,
+          updatedAt: new Date(),
+        }),
         purposeRiskAnalysisForm: expect.anything(),
-      }),
+      },
     });
 
     vi.useRealTimers();

--- a/packages/purpose-template-process/test/integration/createPurposeTemplateRiskAnalysisAnswer.test.ts
+++ b/packages/purpose-template-process/test/integration/createPurposeTemplateRiskAnalysisAnswer.test.ts
@@ -105,7 +105,24 @@ describe("createPurposeTemplateRiskAnalysisAnswer", () => {
           ...mockPurposeTemplate,
           updatedAt: new Date(),
         }),
-        purposeRiskAnalysisForm: expect.anything(),
+        purposeRiskAnalysisForm: expect.objectContaining({
+          version: mockPurposeTemplate.purposeRiskAnalysisForm!.version,
+          singleAnswers: expect.arrayContaining([
+            expect.objectContaining({
+              key: validRiskAnalysisAnswerRequest.answerKey,
+              value: validRiskAnalysisAnswerRequest.answerData.values[0],
+              editable: validRiskAnalysisAnswerRequest.answerData.editable,
+              suggestedValues:
+                validRiskAnalysisAnswerRequest.answerData.suggestedValues,
+              annotation: expect.objectContaining({
+                text: validRiskAnalysisAnswerRequest.answerData.annotation!
+                  .text,
+              }),
+            }),
+          ]),
+          multiAnswers:
+            mockPurposeTemplate.purposeRiskAnalysisForm!.multiAnswers,
+        }),
       },
     });
 

--- a/packages/purpose-template-process/test/integration/createPurposeTemplateRiskAnalysisAnswer.test.ts
+++ b/packages/purpose-template-process/test/integration/createPurposeTemplateRiskAnalysisAnswer.test.ts
@@ -98,10 +98,11 @@ describe("createPurposeTemplateRiskAnalysisAnswer", () => {
       annotation: validRiskAnalysisAnswerRequest.answerData.annotation,
     });
 
-    expect(writtenPayload.purposeTemplate).toBeDefined();
-    expect(
-      writtenPayload.purposeTemplate!.purposeRiskAnalysisForm
-    ).toBeDefined();
+    expect(writtenPayload).toEqual({
+      purposeTemplate: expect.objectContaining({
+        purposeRiskAnalysisForm: expect.anything(),
+      }),
+    });
 
     vi.useRealTimers();
   });

--- a/packages/purpose-template-process/test/integration/deletePurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/deletePurposeTemplate.test.ts
@@ -129,9 +129,9 @@ describe("deletePurposeTemplate", () => {
       payload: purposeTemplateDeletionEvent.data,
     });
 
-    expect(purposeDeletionPayload.purposeTemplate).toEqual(
-      toPurposeTemplateV2(purposeTemplate)
-    );
+    expect(purposeDeletionPayload).toEqual({
+      purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+    });
 
     expect(fileManager.delete).toHaveBeenCalledWith(
       config.s3Bucket,

--- a/packages/purpose-template-process/test/integration/linkEservicesToPurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/linkEservicesToPurposeTemplate.test.ts
@@ -17,6 +17,7 @@ import {
   PurposeTemplateEServiceLinkedV2,
   PurposeTemplateId,
   Tenant,
+  dateToBigInt,
   descriptorState,
   generateId,
   purposeTemplateState,
@@ -145,11 +146,12 @@ describe("linkEservicesToPurposeTemplate", () => {
       payload: lastWrittenEvent.data,
     });
 
-    expect(lastWrittenPayload.purposeTemplate).toEqual(
-      toPurposeTemplateV2(purposeTemplate)
-    );
-    expect(lastWrittenPayload.eservice).toEqual(toEServiceV2(eService2));
-    expect(lastWrittenPayload.descriptorId).toBe(descriptor2.id);
+    expect(lastWrittenPayload).toEqual({
+      purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+      eservice: toEServiceV2(eService2),
+      descriptorId: descriptor2.id,
+      createdAt: dateToBigInt(new Date()),
+    });
 
     vi.useRealTimers();
   });

--- a/packages/purpose-template-process/test/integration/patchUpdatePurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/patchUpdatePurposeTemplate.test.ts
@@ -157,9 +157,9 @@ describe("patch update purpose template", () => {
         payload: writtenEvent.data,
       });
 
-      expect(writtenPayload.purposeTemplate).toEqual(
-        toPurposeTemplateV2(expectedPurposeTemplate)
-      );
+      expect(writtenPayload).toEqual({
+        purposeTemplate: toPurposeTemplateV2(expectedPurposeTemplate),
+      });
       expect(updatePurposeTemplateReturn).toEqual({
         data: expectedPurposeTemplate,
         metadata: { version: 1 },

--- a/packages/purpose-template-process/test/integration/publishPurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/publishPurposeTemplate.test.ts
@@ -98,9 +98,14 @@ describe("publishPurposeTemplate", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurposeTemplate(writtenPayload.purposeTemplate)).toEqual(
-      sortPurposeTemplate(toPurposeTemplateV2(expectedPurposeTemplate))
-    );
+    expect({
+      ...writtenPayload,
+      purposeTemplate: sortPurposeTemplate(writtenPayload.purposeTemplate),
+    }).toEqual({
+      purposeTemplate: sortPurposeTemplate(
+        toPurposeTemplateV2(expectedPurposeTemplate)
+      ),
+    });
     expect(publishResponse).toMatchObject({
       data: updatedPurposeTemplate,
       metadata: { version: 1 },

--- a/packages/purpose-template-process/test/integration/suspendPurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/suspendPurposeTemplate.test.ts
@@ -83,9 +83,14 @@ describe("suspendPurposeTemplate", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurposeTemplate(writtenPayload.purposeTemplate)).toEqual(
-      sortPurposeTemplate(toPurposeTemplateV2(expectedPurposeTemplate))
-    );
+    expect({
+      ...writtenPayload,
+      purposeTemplate: sortPurposeTemplate(writtenPayload.purposeTemplate),
+    }).toEqual({
+      purposeTemplate: sortPurposeTemplate(
+        toPurposeTemplateV2(expectedPurposeTemplate)
+      ),
+    });
     expect(suspendResponse).toMatchObject({
       data: updatedPurposeTemplate,
       metadata: { version: expectedMetadataVersion },

--- a/packages/purpose-template-process/test/integration/unlinkEservicesFromPurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/unlinkEservicesFromPurposeTemplate.test.ts
@@ -157,11 +157,11 @@ describe("unlinkEservicesFromPurposeTemplate", () => {
       payload: writtenEvent1.data,
     });
 
-    expect(writtenPayload1.purposeTemplate).toEqual(
-      toPurposeTemplateV2(purposeTemplate)
-    );
-    expect(writtenPayload1.eservice).toEqual(toEServiceV2(eService2));
-    expect(writtenPayload1.descriptorId).toBe(descriptor2.id);
+    expect(writtenPayload1).toEqual({
+      purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+      eservice: toEServiceV2(eService2),
+      descriptorId: descriptor2.id,
+    });
 
     vi.useRealTimers();
   });

--- a/packages/purpose-template-process/test/integration/unsuspendPurposeTemplate.test.ts
+++ b/packages/purpose-template-process/test/integration/unsuspendPurposeTemplate.test.ts
@@ -92,9 +92,14 @@ describe("unsuspendPurposeTemplate", () => {
       payload: writtenEvent.data,
     });
 
-    expect(sortPurposeTemplate(writtenPayload.purposeTemplate)).toEqual(
-      sortPurposeTemplate(toPurposeTemplateV2(expectedPurposeTemplate))
-    );
+    expect({
+      ...writtenPayload,
+      purposeTemplate: sortPurposeTemplate(writtenPayload.purposeTemplate),
+    }).toEqual({
+      purposeTemplate: sortPurposeTemplate(
+        toPurposeTemplateV2(expectedPurposeTemplate)
+      ),
+    });
     expect(unsuspendResponse).toMatchObject({
       data: updatedPurposeTemplate,
       metadata: { version: expectedMetadataVersion },


### PR DESCRIPTION
## Summary
[PIN-9767](https://pagopa.atlassian.net/browse/PIN-9767)

- Replace single-field `expect(writtenPayload.X).toEqual(Y)` / `.toBeDefined()` assertions with full-payload `expect(writtenPayload).toEqual({ X: Y, ... })` in `purpose-process` and `purpose-template-process` integration tests
- Adds previously missing `versionId` field validation on 43 assertions across version-scoped events (`PurposeArchivedV2`, `PurposeVersionRejectedV2`, `WaitingForApprovalPurposeVersionDeletedV2`, `PurposeVersionActivatedV2`, `PurposeVersionSuspendedByConsumer/ProducerV2`, `PurposeVersionUnsuspendedByConsumer/ProducerV2`, `PurposeVersionOverQuotaUnsuspendedV2`, `NewPurposeVersionActivatedV2`, `NewPurposeVersionWaitingForApprovalV2`)
- Adds previously missing `sourcePurposeId` and `sourceVersionId` field validation on `PurposeClonedV2` event (4 assertions)
- For assertions previously using `sortPurpose(writtenPayload.purpose)`, preserves sorting by applying it within the full-payload match via spread: `expect({ ...writtenPayload, purpose: sortPurpose(writtenPayload.purpose) }).toEqual({ purpose: sortPurpose(...), versionId: ... })`. The spread is intentional — it preserves any future event fields so `toEqual` fails loudly if the event schema grows without a corresponding test update
- Removes redundant `sortedWrittenPayloadPurpose` intermediate variables in `updatePurpose`, `patchUpdatePurpose`, `patchUpdateReversePurpose`, `patchUpdatePurposeFromTemplate` (no longer needed after inline spread)
- Removes 4 redundant `expect(writtenPayload.purpose).toEqual(toPurposeV2(purpose))` follow-up assertions in `clonePurpose` (already covered by the new full-payload match)
- For `toBeDefined()` guards on dynamic risk analysis form content in `createPurposeTemplateRiskAnalysisAnswer` and `addRiskAnalysisAnswerAnnotation`, use `expect.objectContaining` to verify the top-level payload shape without reconstructing the full form

| Package | Files | Assertions refactored |
|---|---:|---:|
| purpose-process | 13 | ~92 |
| purpose-template-process | 7 | 7 |

## Test plan
- [x] `purpose-process`: 415/415 integration tests passing
- [x] `purpose-template-process`: 265/265 integration tests passing
- [x] TypeScript type-check passing on both packages

[PIN-9767]: https://pagopa.atlassian.net/browse/PIN-9767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ