### PR TITLE
feature: e-service archiving work item 3 DELETE /eservices/{eServiceId}/descriptors/{descriptorId}/scheduleArchive (PIN-9862)

### DIFF
--- a/collections/bff/catalog/Cancel Eservice Descriptor Archiving.bru
+++ b/collections/bff/catalog/Cancel Eservice Descriptor Archiving.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Cancel Eservice Descriptor Archiving
+  type: http
+  seq: 43
+}
+
+delete {
+  url: {{host-bff}}/eservices/:eServiceId/descriptors/:descriptorId/scheduleArchive
+  body: none
+  auth: none
+}
+
+params:path {
+  eServiceId: {{eserviceId}}
+  descriptorId: {{descriptorId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+}

--- a/collections/catalog/Cancel Eservice Descriptor Archiving.bru
+++ b/collections/catalog/Cancel Eservice Descriptor Archiving.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Cancel Eservice Descriptor Archiving
+  type: http
+  seq: 38
+}
+
+delete {
+  url: {{host-catalog}}/eservices/:eserviceId/descriptors/:descriptorId/scheduleArchive
+  body: none
+  auth: none
+}
+
+params:path {
+  eserviceId: {{eserviceId}}
+  descriptorId: {{descriptorId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}

--- a/collections/m2m gateway-v3/eservices/Cancel eservice descriptor archiving.bru
+++ b/collections/m2m gateway-v3/eservices/Cancel eservice descriptor archiving.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Cancel eservice descriptor archiving
+  type: http
+  seq: 42
+}
+
+delete {
+  url: {{host-m2m-gw-v3}}/eservices/:eserviceId/descriptors/:descriptorId/scheduleArchive
+  body: none
+  auth: none
+}
+
+params:path {
+  eserviceId: {{eserviceId}}
+  descriptorId: {{descriptorId}}
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M-ADMIN}}
+  DPoP: {{DPOP-PROOF}}
+}

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -3973,6 +3973,50 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+    delete:
+      security:
+        - bearerAuth: []
+      tags:
+        - eservices
+      summary: Cancel the archiving process for an E-Service Descriptor
+      description: Cancel the archiving process for an E-Service Descriptor
+      operationId: cancelEServiceDescriptorArchiving
+      parameters:
+        - name: eServiceId
+          in: path
+          description: the eservice id
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: descriptorId
+          in: path
+          description: the descriptor Id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: E-Service Descriptor archiving canceled
+        "400":
+          description: Invalid input
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /templates/eservices/{eServiceId}/descriptors/{descriptorId}/update:
     post:
       security:

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -3865,6 +3865,21 @@ paths:
               schema:
                 $ref: "#/components/schemas/Problem"
   /eservices/{eServiceId}/descriptors/{descriptorId}/scheduleArchive:
+    parameters:
+      - name: eServiceId
+        in: path
+        description: the eservice id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: descriptorId
+        in: path
+        description: the descriptor Id
+        required: true
+        schema:
+          type: string
+          format: uuid
     post:
       security:
         - bearerAuth: []
@@ -3873,21 +3888,6 @@ paths:
       summary: Schedule the archiving process for an E-Service Descriptor
       description: Schedule the archiving process for an E-Service Descriptor
       operationId: scheduleArchiveEserviceDescriptor
-      parameters:
-        - name: eServiceId
-          in: path
-          description: the eservice id
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: descriptorId
-          in: path
-          description: the descriptor Id
-          required: true
-          schema:
-            type: string
-            format: uuid
       responses:
         "204":
           description: E-Service Descriptor scheduled for archiving
@@ -3981,21 +3981,6 @@ paths:
       summary: Cancel the archiving process for an E-Service Descriptor
       description: Cancel the archiving process for an E-Service Descriptor
       operationId: cancelEServiceDescriptorArchiving
-      parameters:
-        - name: eServiceId
-          in: path
-          description: the eservice id
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: descriptorId
-          in: path
-          description: the descriptor Id
-          required: true
-          schema:
-            type: string
-            format: uuid
       responses:
         "204":
           description: E-Service Descriptor archiving canceled

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -2788,6 +2788,59 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /eservices/{eServiceId}/descriptors/{descriptorId}/scheduleArchive:
+    parameters:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+      - name: eServiceId
+        in: path
+        description: the eservice id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: descriptorId
+        in: path
+        description: the descriptor Id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    delete:
+      security:
+        - bearerAuth: []
+      tags:
+        - process
+      summary: Cancel e-service descriptor archiving process
+      operationId: cancelEServiceDescriptorArchiving
+      description: Cancels the archiving process of the specified E-Service descriptor if it is in scheduled state
+      responses:
+        "200":
+          description: E-service descriptor archiving process canceled.
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EService"
+        "400":
+          description: Invalid input or e-service descriptor is not in scheduled state
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /maintenance/eservices/{eServiceId}/personalDataFlag:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -1235,6 +1235,42 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+    delete:
+      security:
+        - bearerAuth: []
+      tags:
+        - process
+      summary: Cancel e-service descriptor archiving process
+      operationId: cancelEServiceDescriptorArchiving
+      description: Cancels the archiving process of the specified E-Service descriptor if it is in scheduled state
+      responses:
+        "200":
+          description: E-service descriptor archiving process canceled.
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EService"
+        "400":
+          description: Invalid input or e-service descriptor is not in scheduled state
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /eservices/{eServiceId}/descriptors/{descriptorId}/agreementApprovalPolicy/update:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"
@@ -2772,59 +2808,6 @@ paths:
                 $ref: "#/components/schemas/EService"
         "400":
           description: Invalid input
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-        "404":
-          description: Not found
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-        "403":
-          description: Forbidden
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-  /eservices/{eServiceId}/descriptors/{descriptorId}/scheduleArchive:
-    parameters:
-      - $ref: "#/components/parameters/CorrelationIdHeader"
-      - name: eServiceId
-        in: path
-        description: the eservice id
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: descriptorId
-        in: path
-        description: the descriptor id
-        required: true
-        schema:
-          type: string
-          format: uuid
-    delete:
-      security:
-        - bearerAuth: []
-      tags:
-        - process
-      summary: Cancel e-service descriptor archiving process
-      operationId: cancelEServiceDescriptorArchiving
-      description: Cancels the archiving process of the specified E-Service descriptor if it is in scheduled state
-      responses:
-        "200":
-          description: E-service descriptor archiving process canceled.
-          headers:
-            X-Metadata-Version:
-              $ref: "#/components/headers/MetadataVersionHeader"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/EService"
-        "400":
-          description: Invalid input or e-service descriptor is not in scheduled state
           content:
             application/problem+json:
               schema:

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -1242,7 +1242,7 @@ paths:
         - process
       summary: Cancel e-service descriptor archiving process
       operationId: cancelEServiceDescriptorArchiving
-      description: Cancels the archiving process of the specified E-Service descriptor if it is in scheduled state
+      description: Cancels the archiving process of the specified E-Service descriptor if it is in archiving or archivingSuspended state
       responses:
         "200":
           description: E-service descriptor archiving process canceled.
@@ -1254,7 +1254,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/EService"
         "400":
-          description: Invalid input or e-service descriptor is not in scheduled state
+          description: Invalid input or e-service descriptor is not in archiving or archivingSuspended state
           content:
             application/problem+json:
               schema:

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -2800,7 +2800,7 @@ paths:
           format: uuid
       - name: descriptorId
         in: path
-        description: the descriptor Id
+        description: the descriptor id
         required: true
         schema:
           type: string

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -1259,14 +1259,20 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "404":
           description: Not found
           content:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
-        "403":
-          description: Forbidden
+        "409":
+          description: Conflict
           content:
             application/problem+json:
               schema:

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -3942,6 +3942,54 @@ paths:
           $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+    delete:
+      tags:
+        - eservices
+      summary: Cancel the archiving process for an E-Service Descriptor
+      description: Cancels an archiving of an E-Service Descriptor that is in Archiving or ArchivingSuspended state, transitioning it back to Deprecated or Suspended.
+      operationId: cancelEServiceDescriptorArchiving
+      parameters:
+        - name: eserviceId
+          in: path
+          description: The E-Service ID of the Descriptor
+          required: true
+          schema:
+            $ref: "#/components/schemas/EServiceId"
+        - name: descriptorId
+          in: path
+          description: The ID of the Descriptor to cancel archiving for
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Archiving process of an E-Service Descriptor canceled successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceDescriptor"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
   /eservices/{eserviceId}/riskAnalyses:
     parameters:
       - name: eserviceId

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -3894,26 +3894,26 @@ paths:
         "429":
           $ref: "#/components/responses/TooManyRequests"
   /eservices/{eserviceId}/descriptors/{descriptorId}/scheduleArchive:
+    parameters:
+      - name: eserviceId
+        in: path
+        description: The E-Service ID of the Descriptor
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceId"
+      - name: descriptorId
+        in: path
+        description: The ID of the Descriptor to schedule for archiving
+        required: true
+        schema:
+          type: string
+          format: uuid
     post:
       tags:
         - eservices
       summary: Schedule the archiving process for an E-Service Descriptor
-      description: Schedules an archiving of an E-Service Descriptor that is in Deprecated or Suspended state, transitioning it to Archiving or ArchivingSuspended (if state was Suspended), starting the grace period.        
+      description: Schedules an archiving of an E-Service Descriptor that is in Deprecated or Suspended state, transitioning it to Archiving or ArchivingSuspended (if state was Suspended), starting the grace period.
       operationId: scheduleArchiveEserviceDescriptor
-      parameters:
-        - name: eserviceId
-          in: path
-          description: The E-Service ID of the Descriptor
-          required: true
-          schema:
-            $ref: "#/components/schemas/EServiceId"
-        - name: descriptorId
-          in: path
-          description: The ID of the Descriptor to schedule for archiving
-          required: true
-          schema:
-            type: string
-            format: uuid
       responses:
         "200":
           description: Archiving process of an E-Service Descriptor scheduled successfully
@@ -3948,20 +3948,6 @@ paths:
       summary: Cancel the archiving process for an E-Service Descriptor
       description: Cancels an archiving of an E-Service Descriptor that is in Archiving or ArchivingSuspended state, transitioning it back to Deprecated or Suspended.
       operationId: cancelEServiceDescriptorArchiving
-      parameters:
-        - name: eserviceId
-          in: path
-          description: The E-Service ID of the Descriptor
-          required: true
-          schema:
-            $ref: "#/components/schemas/EServiceId"
-        - name: descriptorId
-          in: path
-          description: The ID of the Descriptor to cancel archiving for
-          required: true
-          schema:
-            type: string
-            format: uuid
       responses:
         "200":
           description: Archiving process of an E-Service Descriptor canceled successfully

--- a/packages/backend-for-frontend/src/routers/catalogRouter.ts
+++ b/packages/backend-for-frontend/src/routers/catalogRouter.ts
@@ -371,6 +371,28 @@ const catalogRouter = (
         }
       }
     )
+    .delete(
+      "/eservices/:eServiceId/descriptors/:descriptorId/scheduleArchive",
+      async (req, res) => {
+        const ctx = fromBffAppContext(req.ctx, req.headers);
+        try {
+          await catalogService.cancelEServiceDescriptorArchiving(
+            unsafeBrandId(req.params.eServiceId),
+            unsafeBrandId(req.params.descriptorId),
+            ctx
+          );
+          return res.status(204).send();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error canceling archiving for descriptor ${req.params.descriptorId} for eservice ${req.params.eServiceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
     .post(
       "/eservices/:eServiceId/descriptors/:descriptorId/agreementApprovalPolicy/update",
       async (req, res) => {

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -1396,7 +1396,7 @@ export function catalogServiceBuilder(
       { logger, headers }: WithLogger<BffAppContext>
     ): Promise<void> => {
       logger.info(
-        `Canceling archiving for descriptor ${descriptorId} of EService ${eServiceId}`
+        `Schedule interruption for descriptor ${descriptorId} of EService ${eServiceId}`
       );
       await catalogProcessClient.cancelEServiceDescriptorArchiving(undefined, {
         headers,

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -1389,6 +1389,23 @@ export function catalogServiceBuilder(
         }
       );
     },
+
+    cancelEServiceDescriptorArchiving: async (
+      eServiceId: EServiceId,
+      descriptorId: DescriptorId,
+      { logger, headers }: WithLogger<BffAppContext>
+    ): Promise<void> => {
+      logger.info(
+        `Canceling archiving for descriptor ${descriptorId} of EService ${eServiceId}`
+      );
+      await catalogProcessClient.cancelEServiceDescriptorArchiving(undefined, {
+        headers,
+        params: {
+          eServiceId,
+          descriptorId,
+        },
+      });
+    },
     updateAgreementApprovalPolicy: async (
       eServiceId: EServiceId,
       descriptorId: DescriptorId,

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -65,6 +65,7 @@ const errorCodes = {
   attributeDailyCallsNotAllowed: "0048",
   certifiedAttributeGroupNotFoundInSeed: "0049",
   eserviceInArchivingOrArchivedState: "0050",
+  descriptorArchivingNotCancelableByScope: "0051",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -578,5 +579,15 @@ export function eserviceInArchivingOrArchivedState(
     detail: `You can't create a new version, because the EService ${eserviceId} is in archiving or archived state`,
     code: "eserviceInArchivingOrArchivedState",
     title: "EService in archiving or archived state",
+  });
+}
+
+export function descriptorArchivingNotCancelableByScope(
+  descriptorId: DescriptorId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Descriptor ${descriptorId} archiving cannot be canceled because it was scheduled at eservice scope`,
+    code: "descriptorArchivingNotCancelableByScope",
+    title: "Descriptor archiving not cancelable by scope",
   });
 }

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -4,6 +4,7 @@ import {
   AttributeId,
   DelegationId,
   DescriptorId,
+  DescriptorState,
   EServiceDocumentId,
   EServiceId,
   EServiceTemplateId,
@@ -137,7 +138,7 @@ export function eServiceDocumentNotFound(
 
 export function notValidDescriptorState(
   descriptorId: DescriptorId,
-  descriptorStatus: string
+  descriptorStatus: DescriptorState
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Descriptor ${descriptorId} is in an invalid state ${descriptorStatus} for this operation`,

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -940,7 +940,7 @@ export const toCreateEventEServiceDescriptorArchivingDeleted = (
   streamId: eservice.id,
   version,
   event: {
-    type: "EServiceDescriptorArchiveScheduleCanceled",
+    type: "EServiceDescriptorArchivingCanceled",
     event_version: 2,
     data: {
       eservice: toEServiceV2(eservice),

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -931,6 +931,25 @@ export const toCreateEventEServiceDescriptorArchivingScheduled = (
   correlationId,
 });
 
+export const toCreateEventEServiceDescriptorArchivingDeleted = (
+  version: number,
+  eservice: EService,
+  descriptorId: DescriptorId,
+  correlationId: CorrelationId
+): CreateEvent<EServiceEvent> => ({
+  streamId: eservice.id,
+  version,
+  event: {
+    type: "EServiceDescriptorArchiveScheduleCanceled",
+    event_version: 2,
+    data: {
+      eservice: toEServiceV2(eservice),
+      descriptorId,
+    },
+  },
+  correlationId,
+});
+
 export const toCreateEventMaintenanceEServicePersonalDataFlagReset = (
   version: number,
   eservice: EService,

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -931,7 +931,7 @@ export const toCreateEventEServiceDescriptorArchivingScheduled = (
   correlationId,
 });
 
-export const toCreateEventEServiceDescriptorArchivingDeleted = (
+export const toCreateEventEServiceDescriptorArchivingCanceled = (
   version: number,
   eservice: EService,
   descriptorId: DescriptorId,

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -1599,6 +1599,40 @@ const eservicesRouter = (
       }
     )
     .delete(
+      "/eservices/:eServiceId/descriptors/:descriptorId/scheduleArchive",
+      async (req, res) => {
+        const ctx = fromAppContext(req.ctx);
+
+        try {
+          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
+
+          const updatedEService =
+            await catalogService.cancelEServiceDescriptorArchiving(
+              unsafeBrandId(req.params.eServiceId),
+              unsafeBrandId(req.params.descriptorId),
+              ctx
+            );
+
+          setMetadataVersionHeader(res, updatedEService.metadata);
+
+          return res
+            .status(200)
+            .send(
+              catalogApi.EService.parse(
+                eServiceToApiEService(updatedEService.data)
+              )
+            );
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            updateEserviceDescriptorArchivingStatusErrorMapper,
+            ctx
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .delete(
       "/maintenance/eservices/:eServiceId/personalDataFlag",
       async (req, res) => {
         const ctx = fromAppContext(req.ctx);

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -153,7 +153,7 @@ import {
   toCreateEventEServicePersonalDataFlagUpdatedByTemplateUpdate,
   toCreateEventEServiceInstanceLabelUpdated,
   toCreateEventEServiceDescriptorArchivingScheduled,
-  toCreateEventEServiceDescriptorArchivingDeleted,
+  toCreateEventEServiceDescriptorArchivingCanceled,
   toCreateEventMaintenanceEServicePersonalDataFlagReset,
 } from "../model/domain/toEvent.js";
 import {
@@ -3827,14 +3827,14 @@ export function catalogServiceBuilder(
       const eservice = await retrieveEService(eserviceId, readModelService);
       const descriptor = retrieveDescriptor(descriptorId, eservice);
 
+      assertRequesterIsProducer(eservice.data.producerId, authData);
+
       assertDescriptorCancelArchivable(descriptor, eservice.data);
 
       const newState =
         descriptor.state === descriptorState.archivingSuspended
           ? descriptorState.suspended
           : descriptorState.deprecated;
-
-      assertRequesterIsProducer(eservice.data.producerId, authData);
 
       const updatedDescriptor = updateDescriptorState(
         { ...descriptor, archivingSchedule: undefined },
@@ -3846,7 +3846,7 @@ export function catalogServiceBuilder(
         updatedDescriptor
       );
 
-      const event = toCreateEventEServiceDescriptorArchivingDeleted(
+      const event = toCreateEventEServiceDescriptorArchivingCanceled(
         eservice.metadata.version,
         updatedEService,
         descriptorId,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1601,10 +1601,7 @@ export function catalogServiceBuilder(
       const descriptor = retrieveDescriptor(descriptorId, eservice);
 
       if (descriptor.state !== descriptorState.draft) {
-        throw notValidDescriptorState(
-          descriptorId,
-          descriptor.state.toString()
-        );
+        throw notValidDescriptorState(descriptorId, descriptor.state);
       }
 
       assertConsistentDailyCalls(seed);
@@ -1662,10 +1659,7 @@ export function catalogServiceBuilder(
 
       const descriptor = retrieveDescriptor(descriptorId, eservice);
       if (descriptor.state !== descriptorState.draft) {
-        throw notValidDescriptorState(
-          descriptor.id,
-          descriptor.state.toString()
-        );
+        throw notValidDescriptorState(descriptor.id, descriptor.state);
       }
 
       if (descriptor.interface === undefined) {
@@ -1760,10 +1754,7 @@ export function catalogServiceBuilder(
         descriptor.state !== descriptorState.deprecated &&
         descriptor.state !== descriptorState.published
       ) {
-        throw notValidDescriptorState(
-          descriptorId,
-          descriptor.state.toString()
-        );
+        throw notValidDescriptorState(descriptorId, descriptor.state);
       }
 
       const updatedDescriptor = updateDescriptorState(
@@ -1814,10 +1805,7 @@ export function catalogServiceBuilder(
 
       const descriptor = retrieveDescriptor(descriptorId, eservice);
       if (descriptor.state !== descriptorState.suspended) {
-        throw notValidDescriptorState(
-          descriptorId,
-          descriptor.state.toString()
-        );
+        throw notValidDescriptorState(descriptorId, descriptor.state);
       }
 
       const updatedDescriptor = updateDescriptorState(
@@ -2797,10 +2785,7 @@ export function catalogServiceBuilder(
       const descriptor = retrieveDescriptor(descriptorId, eservice);
 
       if (descriptor.state !== descriptorState.waitingForApproval) {
-        throw notValidDescriptorState(
-          descriptor.id,
-          descriptor.state.toString()
-        );
+        throw notValidDescriptorState(descriptor.id, descriptor.state);
       }
 
       if (eservice.data.personalData === undefined) {
@@ -2847,10 +2832,7 @@ export function catalogServiceBuilder(
       const descriptor = retrieveDescriptor(descriptorId, eservice);
 
       if (descriptor.state !== descriptorState.waitingForApproval) {
-        throw notValidDescriptorState(
-          descriptor.id,
-          descriptor.state.toString()
-        );
+        throw notValidDescriptorState(descriptor.id, descriptor.state);
       }
 
       const newRejectionReason: DescriptorRejectionReason = {
@@ -3822,21 +3804,20 @@ export function catalogServiceBuilder(
 
       assertDescriptorArchivingIsNotEserviceScoped(descriptor);
 
-      assertDescriptorCancelArchivable(descriptor, eservice.data);
+      assertDescriptorCancelArchivable(descriptor, latestDescriptor);
 
-      const eserviceArchivingSchedule =
+      const updatedDescriptor =
         latestDescriptor.archivingSchedule?.scope === archivingScope.eservice
-          ? latestDescriptor.archivingSchedule
-          : undefined;
-
-      const updatedDescriptor = eserviceArchivingSchedule
-        ? { ...descriptor, archivingSchedule: eserviceArchivingSchedule }
-        : updateDescriptorState(
-            { ...descriptor, archivingSchedule: undefined },
-            descriptor.state === descriptorState.archivingSuspended
-              ? descriptorState.suspended
-              : descriptorState.deprecated
-          );
+          ? {
+              ...descriptor,
+              archivingSchedule: latestDescriptor.archivingSchedule,
+            }
+          : updateDescriptorState(
+              { ...descriptor, archivingSchedule: undefined },
+              descriptor.state === descriptorState.archivingSuspended
+                ? descriptorState.suspended
+                : descriptorState.deprecated
+            );
 
       const updatedEService = replaceDescriptor(
         eservice.data,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -3834,17 +3834,12 @@ export function catalogServiceBuilder(
           ? descriptorState.suspended
           : descriptorState.deprecated;
 
-      await assertRequesterIsDelegateProducerOrProducer(
-        eservice.data.producerId,
-        eservice.data.id,
-        authData,
-        readModelService
-      );
+      assertRequesterIsProducer(eservice.data.producerId, authData);
 
-      const updatedDescriptor: Descriptor = {
-        ...updateDescriptorState(descriptor, newState),
-        archivingSchedule: undefined,
-      };
+      const updatedDescriptor = updateDescriptorState(
+        { ...descriptor, archivingSchedule: undefined },
+        newState
+      );
 
       const updatedEService = replaceDescriptor(
         eservice.data,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -3823,8 +3823,13 @@ export function catalogServiceBuilder(
       {
         authData,
         correlationId,
+        logger,
       }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<WithMetadata<EService>> {
+      logger.info(
+        `Cancel archiving schedule for EService ${eserviceId} Descriptor ${descriptorId}`
+      );
+
       const eservice = await retrieveEService(eserviceId, readModelService);
       const descriptor = retrieveDescriptor(descriptorId, eservice);
       const latestDescriptor = getLatestDescriptor(eservice.data);
@@ -3836,7 +3841,7 @@ export function catalogServiceBuilder(
       assertDescriptorCancelArchivable(descriptor, eservice.data);
 
       const archivingSchedule =
-        latestDescriptor.archivingSchedule?.scope === "EService"
+        latestDescriptor.archivingSchedule?.scope === archivingScope.eservice
           ? latestDescriptor.archivingSchedule
           : undefined;
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -194,6 +194,7 @@ import {
   assertEserviceIsNotInArchivingOrArchivedState,
   assertDescriptorArchivable,
   assertDescriptorCancelArchivable,
+  assertDescriptorArchivingIsNotEserviceScoped,
 } from "./validators.js";
 import type { ReadModelServiceSQL } from "./readModelServiceTypes.js";
 import { calculateArchivableOn } from "../utilities/dateCalculator.js";
@@ -3826,10 +3827,18 @@ export function catalogServiceBuilder(
     ): Promise<WithMetadata<EService>> {
       const eservice = await retrieveEService(eserviceId, readModelService);
       const descriptor = retrieveDescriptor(descriptorId, eservice);
+      const latestDescriptor = getLatestDescriptor(eservice.data);
 
       assertRequesterIsProducer(eservice.data.producerId, authData);
 
+      assertDescriptorArchivingIsNotEserviceScoped(descriptor);
+
       assertDescriptorCancelArchivable(descriptor, eservice.data);
+
+      const archivingSchedule =
+        latestDescriptor.archivingSchedule?.scope === "EService"
+          ? latestDescriptor.archivingSchedule
+          : undefined;
 
       const newState =
         descriptor.state === descriptorState.archivingSuspended
@@ -3837,8 +3846,8 @@ export function catalogServiceBuilder(
           : descriptorState.deprecated;
 
       const updatedDescriptor = updateDescriptorState(
-        { ...descriptor, archivingSchedule: undefined },
-        newState
+        { ...descriptor, archivingSchedule },
+        archivingSchedule ? descriptor.state : newState
       );
 
       const updatedEService = replaceDescriptor(

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -153,6 +153,7 @@ import {
   toCreateEventEServicePersonalDataFlagUpdatedByTemplateUpdate,
   toCreateEventEServiceInstanceLabelUpdated,
   toCreateEventEServiceDescriptorArchivingScheduled,
+  toCreateEventEServiceDescriptorArchivingDeleted,
   toCreateEventMaintenanceEServicePersonalDataFlagReset,
 } from "../model/domain/toEvent.js";
 import {
@@ -377,6 +378,31 @@ const updateDescriptorState = (
       state: newState,
       deprecatedAt: new Date(),
     }))
+    .with(
+      [descriptorState.deprecated, descriptorState.archiving],
+      [descriptorState.published, descriptorState.archiving],
+      [descriptorState.suspended, descriptorState.archivingSuspended],
+      () => ({
+        ...descriptor,
+        state: newState,
+        archivingSchedule: {
+          ...calculateArchivableOn(
+            new Date(),
+            config.gracePeriodArchivingEService
+          ),
+          scope: scope ?? archivingScope.descriptor,
+        },
+      })
+    )
+    .with(
+      [descriptorState.archiving, descriptorState.deprecated],
+      [descriptorState.archivingSuspended, descriptorState.suspended],
+      () => ({
+        ...descriptor,
+        state: newState,
+        archivingSchedule: undefined,
+      })
+    )
     .otherwise(() => ({
       ...descriptor,
       state: newState,
@@ -3797,6 +3823,50 @@ export function catalogServiceBuilder(
       await repository.createEvent(event);
 
       return updatedEservice;
+    },
+    async cancelEServiceDescriptorArchiving(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      {
+        authData,
+        correlationId,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
+    ): Promise<WithMetadata<EService>> {
+      const eservice = await retrieveEService(eserviceId, readModelService);
+      const descriptor = retrieveDescriptor(descriptorId, eservice);
+
+      assertDescriptorInRequiredStates(descriptor, [
+        descriptorState.archiving,
+        descriptorState.archivingSuspended,
+      ]);
+      assertDescriptorIsNotLatestVersion(descriptor, eservice.data);
+
+      const newState =
+        descriptor.state === descriptorState.archivingSuspended
+          ? descriptorState.suspended
+          : descriptorState.deprecated;
+
+      const updatedEService =
+        await transitionEServiceDescriptorArchivingStateLogic(
+          eservice.data,
+          descriptor,
+          newState,
+          authData,
+          readModelService
+        );
+
+      const event = toCreateEventEServiceDescriptorArchivingDeleted(
+        eservice.metadata.version,
+        updatedEService,
+        descriptorId,
+        correlationId
+      );
+
+      const createdEvent = await repository.createEvent(event);
+      return {
+        data: updatedEService,
+        metadata: { version: createdEvent.newVersion },
+      };
     },
     async maintenanceResetEServicePersonalDataFlag(
       eserviceId: EServiceId,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -3827,7 +3827,7 @@ export function catalogServiceBuilder(
       const eservice = await retrieveEService(eserviceId, readModelService);
       const descriptor = retrieveDescriptor(descriptorId, eservice);
 
-      assertDescriptorCancelArchivable(descriptor);
+      assertDescriptorCancelArchivable(descriptor, eservice.data);
 
       const newState =
         descriptor.state === descriptorState.archivingSuspended

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -3840,20 +3840,19 @@ export function catalogServiceBuilder(
 
       assertDescriptorCancelArchivable(descriptor, eservice.data);
 
-      const archivingSchedule =
+      const eserviceArchivingSchedule =
         latestDescriptor.archivingSchedule?.scope === archivingScope.eservice
           ? latestDescriptor.archivingSchedule
           : undefined;
 
-      const newState =
-        descriptor.state === descriptorState.archivingSuspended
-          ? descriptorState.suspended
-          : descriptorState.deprecated;
-
-      const updatedDescriptor = updateDescriptorState(
-        { ...descriptor, archivingSchedule },
-        archivingSchedule ? descriptor.state : newState
-      );
+      const updatedDescriptor = eserviceArchivingSchedule
+        ? { ...descriptor, archivingSchedule: eserviceArchivingSchedule }
+        : updateDescriptorState(
+            { ...descriptor, archivingSchedule: undefined },
+            descriptor.state === descriptorState.archivingSuspended
+              ? descriptorState.suspended
+              : descriptorState.deprecated
+          );
 
       const updatedEService = replaceDescriptor(
         eservice.data,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -380,22 +380,6 @@ const updateDescriptorState = (
       state: newState,
       deprecatedAt: new Date(),
     }))
-    .with(
-      [descriptorState.deprecated, descriptorState.archiving],
-      [descriptorState.published, descriptorState.archiving],
-      [descriptorState.suspended, descriptorState.archivingSuspended],
-      () => ({
-        ...descriptor,
-        state: newState,
-        archivingSchedule: {
-          ...calculateArchivableOn(
-            new Date(),
-            config.gracePeriodArchivingEService
-          ),
-          scope: scope ?? archivingScope.descriptor,
-        },
-      })
-    )
     .otherwise(() => ({
       ...descriptor,
       state: newState,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -530,13 +530,13 @@ async function innerCreateEService(
   }: {
     seed: catalogApi.EServiceSeed;
     template:
-      | {
-          id: EServiceTemplateId;
-          versionId: EServiceTemplateVersionId;
-          attributes: EserviceAttributes;
-          riskAnalysis: RiskAnalysis[] | undefined;
-        }
-      | undefined;
+    | {
+      id: EServiceTemplateId;
+      versionId: EServiceTemplateVersionId;
+      attributes: EserviceAttributes;
+      riskAnalysis: RiskAnalysis[] | undefined;
+    }
+    | undefined;
     instanceLabel?: string | undefined;
   },
   readModelService: ReadModelServiceSQL,
@@ -721,24 +721,24 @@ async function innerAddDocumentToEserviceEvent(
 
   const event = isInterface
     ? toCreateEventEServiceInterfaceAdded(
-        eService.data.id,
-        eService.metadata.version,
-        {
-          descriptorId,
-          documentId: unsafeBrandId(documentSeed.documentId),
-          eservice: updatedEService,
-        },
-        ctx.correlationId
-      )
+      eService.data.id,
+      eService.metadata.version,
+      {
+        descriptorId,
+        documentId: unsafeBrandId(documentSeed.documentId),
+        eservice: updatedEService,
+      },
+      ctx.correlationId
+    )
     : toCreateEventEServiceDocumentAdded(
-        eService.metadata.version,
-        {
-          descriptorId,
-          documentId: unsafeBrandId(documentSeed.documentId),
-          eservice: updatedEService,
-        },
-        ctx.correlationId
-      );
+      eService.metadata.version,
+      {
+        descriptorId,
+        documentId: unsafeBrandId(documentSeed.documentId),
+        eservice: updatedEService,
+      },
+      ctx.correlationId
+    );
 
   return {
     eService: updatedEService,
@@ -1126,10 +1126,8 @@ export function catalogServiceBuilder(
       ctx: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<WithMetadata<Document>> {
       ctx.logger.info(
-        `Creating EService Document ${document.documentId.toString()} of kind ${
-          document.kind
-        }, name ${document.fileName}, path ${
-          document.filePath
+        `Creating EService Document ${document.documentId.toString()} of kind ${document.kind
+        }, name ${document.fileName}, path ${document.filePath
         } for EService ${eserviceId} and Descriptor ${descriptorId}`
       );
 
@@ -1208,37 +1206,37 @@ export function catalogServiceBuilder(
         descriptors: eservice.data.descriptors.map((d: Descriptor) =>
           d.id === descriptorId
             ? {
-                ...d,
-                interface:
-                  d.interface?.id === documentId ? undefined : d.interface,
-                serverUrls: isInterface ? [] : d.serverUrls,
-                docs: d.docs.filter((doc) => doc.id !== documentId),
-              }
+              ...d,
+              interface:
+                d.interface?.id === documentId ? undefined : d.interface,
+              serverUrls: isInterface ? [] : d.serverUrls,
+              docs: d.docs.filter((doc) => doc.id !== documentId),
+            }
             : d
         ),
       };
 
       const event = isInterface
         ? toCreateEventEServiceInterfaceDeleted(
-            eserviceId,
-            eservice.metadata.version,
-            {
-              descriptorId,
-              documentId,
-              eservice: newEservice,
-            },
-            correlationId
-          )
+          eserviceId,
+          eservice.metadata.version,
+          {
+            descriptorId,
+            documentId,
+            eservice: newEservice,
+          },
+          correlationId
+        )
         : toCreateEventEServiceDocumentDeleted(
-            eserviceId,
-            eservice.metadata.version,
-            {
-              descriptorId,
-              documentId,
-              eservice: newEservice,
-            },
-            correlationId
-          );
+          eserviceId,
+          eservice.metadata.version,
+          {
+            descriptorId,
+            documentId,
+            eservice: newEservice,
+          },
+          correlationId
+        );
 
       const createdEvent = await repository.createEvent(event);
 
@@ -1298,7 +1296,7 @@ export function catalogServiceBuilder(
           (d) =>
             d.id !== documentId &&
             d.prettyName.toLowerCase() ===
-              apiEServiceDescriptorDocumentUpdateSeed.prettyName.toLowerCase()
+            apiEServiceDescriptorDocumentUpdateSeed.prettyName.toLowerCase()
         )
       ) {
         throw documentPrettyNameDuplicate(
@@ -1317,37 +1315,37 @@ export function catalogServiceBuilder(
         descriptors: eservice.data.descriptors.map((d: Descriptor) =>
           d.id === descriptorId
             ? {
-                ...d,
-                interface: isInterface ? updatedDocument : d.interface,
-                docs: d.docs.map((doc) =>
-                  doc.id === documentId ? updatedDocument : doc
-                ),
-              }
+              ...d,
+              interface: isInterface ? updatedDocument : d.interface,
+              docs: d.docs.map((doc) =>
+                doc.id === documentId ? updatedDocument : doc
+              ),
+            }
             : d
         ),
       };
 
       const event = isInterface
         ? toCreateEventEServiceInterfaceUpdated(
-            eserviceId,
-            eservice.metadata.version,
-            {
-              descriptorId,
-              documentId,
-              eservice: newEservice,
-            },
-            correlationId
-          )
+          eserviceId,
+          eservice.metadata.version,
+          {
+            descriptorId,
+            documentId,
+            eservice: newEservice,
+          },
+          correlationId
+        )
         : toCreateEventEServiceDocumentUpdated(
-            eserviceId,
-            eservice.metadata.version,
-            {
-              descriptorId,
-              documentId,
-              eservice: newEservice,
-            },
-            correlationId
-          );
+          eserviceId,
+          eservice.metadata.version,
+          {
+            descriptorId,
+            documentId,
+            eservice: newEservice,
+          },
+          correlationId
+        );
 
       await repository.createEvent(event);
       return updatedDocument;
@@ -1944,9 +1942,9 @@ export function catalogServiceBuilder(
         eservice.data.name.length + suffix.length <= maxNameLength
           ? `${eservice.data.name}${suffix}`
           : `${eservice.data.name.slice(
-              0,
-              prefixLengthAllowance
-            )}${dots}${suffix}`;
+            0,
+            prefixLengthAllowance
+          )}${dots}${suffix}`;
 
       await assertEServiceNameAvailableForProducer(
         clonedEServiceName,
@@ -1965,26 +1963,26 @@ export function catalogServiceBuilder(
       const clonedInterfacePath =
         descriptor.interface !== undefined
           ? await fileManager.copy(
-              config.s3Bucket,
-              descriptor.interface.path,
-              config.eserviceDocumentsPath,
-              clonedInterfaceId,
-              descriptor.interface.name,
-              logger
-            )
+            config.s3Bucket,
+            descriptor.interface.path,
+            config.eserviceDocumentsPath,
+            clonedInterfaceId,
+            descriptor.interface.name,
+            logger
+          )
           : undefined;
 
       const clonedInterfaceDocument: Document | undefined =
         descriptor.interface !== undefined && clonedInterfacePath !== undefined
           ? {
-              id: clonedInterfaceId,
-              name: descriptor.interface.name,
-              contentType: descriptor.interface.contentType,
-              prettyName: descriptor.interface.prettyName,
-              path: clonedInterfacePath,
-              checksum: descriptor.interface.checksum,
-              uploadDate: new Date(),
-            }
+            id: clonedInterfaceId,
+            name: descriptor.interface.name,
+            contentType: descriptor.interface.contentType,
+            prettyName: descriptor.interface.prettyName,
+            path: clonedInterfacePath,
+            checksum: descriptor.interface.checksum,
+            uploadDate: new Date(),
+          }
           : undefined;
 
       const clonedDocuments = await Promise.all(
@@ -2611,15 +2609,15 @@ export function catalogServiceBuilder(
           ? undefined
           : isConsumerDelegable
             ? toCreateEventEServiceIsConsumerDelegableEnabled(
-                eservice.metadata.version,
-                updatedEservice,
-                correlationId
-              )
+              eservice.metadata.version,
+              updatedEservice,
+              correlationId
+            )
             : toCreateEventEServiceIsConsumerDelegableDisabled(
-                eservice.metadata.version,
-                updatedEservice,
-                correlationId
-              );
+              eservice.metadata.version,
+              updatedEservice,
+              correlationId
+            );
 
       const clientAccessEventVersion =
         eservice.metadata.version + (consumerDelegableEvent ? 1 : 0);
@@ -2629,15 +2627,15 @@ export function catalogServiceBuilder(
           ? undefined
           : isClientAccessDelegable
             ? toCreateEventEServiceIsClientAccessDelegableEnabled(
-                clientAccessEventVersion,
-                updatedEservice,
-                correlationId
-              )
+              clientAccessEventVersion,
+              updatedEservice,
+              correlationId
+            )
             : toCreateEventEServiceIsClientAccessDelegableDisabled(
-                clientAccessEventVersion,
-                updatedEservice,
-                correlationId
-              );
+              clientAccessEventVersion,
+              updatedEservice,
+              correlationId
+            );
 
       const events = [
         consumerDelegableEvent,
@@ -3625,8 +3623,8 @@ export function catalogServiceBuilder(
       const agreementApprovalPolicySeed =
         eserviceInstanceDescriptorSeed.agreementApprovalPolicy
           ? apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-              eserviceInstanceDescriptorSeed.agreementApprovalPolicy
-            )
+            eserviceInstanceDescriptorSeed.agreementApprovalPolicy
+          )
           : undefined;
 
       assertConsistentDailyCalls(eserviceInstanceDescriptorSeed);
@@ -3823,8 +3821,13 @@ export function catalogServiceBuilder(
       {
         authData,
         correlationId,
+        logger,
       }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<WithMetadata<EService>> {
+      logger.info(
+        `Cancel archiving schedule for EService ${eserviceId} Descriptor ${descriptorId}`
+      );
+
       const eservice = await retrieveEService(eserviceId, readModelService);
       const descriptor = retrieveDescriptor(descriptorId, eservice);
       const latestDescriptor = getLatestDescriptor(eservice.data);
@@ -3836,7 +3839,7 @@ export function catalogServiceBuilder(
       assertDescriptorCancelArchivable(descriptor, eservice.data);
 
       const archivingSchedule =
-        latestDescriptor.archivingSchedule?.scope === "EService"
+        latestDescriptor.archivingSchedule?.scope === archivingScope.eservice
           ? latestDescriptor.archivingSchedule
           : undefined;
 
@@ -3919,11 +3922,11 @@ async function createOpenApiInterfaceByTemplate(
   serverUrls: string[],
   eserviceInstanceInterfaceRestData:
     | {
-        contactEmail: string;
-        contactName: string;
-        contactUrl?: string;
-        termsAndConditionsUrl?: string;
-      }
+      contactEmail: string;
+      contactName: string;
+      contactUrl?: string;
+      termsAndConditionsUrl?: string;
+    }
     | undefined,
   bucket: string,
   fileManager: FileManager,
@@ -4290,13 +4293,13 @@ async function updateDraftEService(
   eserviceId: EServiceId,
   typeAndSeed:
     | {
-        type: "put";
-        seed: catalogApi.UpdateEServiceSeed;
-      }
+      type: "put";
+      seed: catalogApi.UpdateEServiceSeed;
+    }
     | {
-        type: "patch";
-        seed: catalogApi.PatchUpdateEServiceSeed;
-      },
+      type: "patch";
+      seed: catalogApi.PatchUpdateEServiceSeed;
+    },
   readModelService: ReadModelServiceSQL,
   fileManager: FileManager,
   repository: ReturnType<typeof eventRepository<EServiceEvent>>,
@@ -4366,9 +4369,9 @@ async function updateDraftEService(
   // - personalData flag is changed from true to false or vice versa
   const checkedRiskAnalysis =
     updatedMode === eserviceMode.deliver ||
-    (typeAndSeed.seed.personalData != null &&
-      eservice.data.personalData != null &&
-      typeAndSeed.seed.personalData !== eservice.data.personalData)
+      (typeAndSeed.seed.personalData != null &&
+        eservice.data.personalData != null &&
+        typeAndSeed.seed.personalData !== eservice.data.personalData)
       ? []
       : eservice.data.riskAnalysis;
 
@@ -4417,10 +4420,10 @@ async function updateDraftEService(
     riskAnalysis: checkedRiskAnalysis,
     descriptors: interfaceHasToBeDeleted
       ? eservice.data.descriptors.map((d) => ({
-          ...d,
-          interface: undefined,
-          serverUrls: [],
-        }))
+        ...d,
+        interface: undefined,
+        serverUrls: [],
+      }))
       : eservice.data.descriptors,
     isSignalHubEnabled: updatedIsSignalHubEnabled,
     isConsumerDelegable: updatedIsConsumerDelegable,
@@ -4493,13 +4496,13 @@ async function updateDraftDescriptor(
 
   const updatedAttributes = attributes
     ? await parseAndCheckAttributes(
-        {
-          certified: attributes.certified ?? descriptor.attributes.certified,
-          declared: attributes.declared ?? descriptor.attributes.declared,
-          verified: attributes.verified ?? descriptor.attributes.verified,
-        },
-        readModelService
-      )
+      {
+        certified: attributes.certified ?? descriptor.attributes.certified,
+        declared: attributes.declared ?? descriptor.attributes.declared,
+        verified: attributes.verified ?? descriptor.attributes.verified,
+      },
+      readModelService
+    )
     : descriptor.attributes;
 
   assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
@@ -4510,8 +4513,8 @@ async function updateDraftDescriptor(
 
   const updatedAgreementApprovalPolicy = agreementApprovalPolicy
     ? apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-        agreementApprovalPolicy
-      )
+      agreementApprovalPolicy
+    )
     : descriptor.agreementApprovalPolicy;
 
   const updatedDescriptor: Descriptor = {

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -530,13 +530,13 @@ async function innerCreateEService(
   }: {
     seed: catalogApi.EServiceSeed;
     template:
-    | {
-      id: EServiceTemplateId;
-      versionId: EServiceTemplateVersionId;
-      attributes: EserviceAttributes;
-      riskAnalysis: RiskAnalysis[] | undefined;
-    }
-    | undefined;
+      | {
+          id: EServiceTemplateId;
+          versionId: EServiceTemplateVersionId;
+          attributes: EserviceAttributes;
+          riskAnalysis: RiskAnalysis[] | undefined;
+        }
+      | undefined;
     instanceLabel?: string | undefined;
   },
   readModelService: ReadModelServiceSQL,
@@ -721,24 +721,24 @@ async function innerAddDocumentToEserviceEvent(
 
   const event = isInterface
     ? toCreateEventEServiceInterfaceAdded(
-      eService.data.id,
-      eService.metadata.version,
-      {
-        descriptorId,
-        documentId: unsafeBrandId(documentSeed.documentId),
-        eservice: updatedEService,
-      },
-      ctx.correlationId
-    )
+        eService.data.id,
+        eService.metadata.version,
+        {
+          descriptorId,
+          documentId: unsafeBrandId(documentSeed.documentId),
+          eservice: updatedEService,
+        },
+        ctx.correlationId
+      )
     : toCreateEventEServiceDocumentAdded(
-      eService.metadata.version,
-      {
-        descriptorId,
-        documentId: unsafeBrandId(documentSeed.documentId),
-        eservice: updatedEService,
-      },
-      ctx.correlationId
-    );
+        eService.metadata.version,
+        {
+          descriptorId,
+          documentId: unsafeBrandId(documentSeed.documentId),
+          eservice: updatedEService,
+        },
+        ctx.correlationId
+      );
 
   return {
     eService: updatedEService,
@@ -1126,8 +1126,10 @@ export function catalogServiceBuilder(
       ctx: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<WithMetadata<Document>> {
       ctx.logger.info(
-        `Creating EService Document ${document.documentId.toString()} of kind ${document.kind
-        }, name ${document.fileName}, path ${document.filePath
+        `Creating EService Document ${document.documentId.toString()} of kind ${
+          document.kind
+        }, name ${document.fileName}, path ${
+          document.filePath
         } for EService ${eserviceId} and Descriptor ${descriptorId}`
       );
 
@@ -1206,37 +1208,37 @@ export function catalogServiceBuilder(
         descriptors: eservice.data.descriptors.map((d: Descriptor) =>
           d.id === descriptorId
             ? {
-              ...d,
-              interface:
-                d.interface?.id === documentId ? undefined : d.interface,
-              serverUrls: isInterface ? [] : d.serverUrls,
-              docs: d.docs.filter((doc) => doc.id !== documentId),
-            }
+                ...d,
+                interface:
+                  d.interface?.id === documentId ? undefined : d.interface,
+                serverUrls: isInterface ? [] : d.serverUrls,
+                docs: d.docs.filter((doc) => doc.id !== documentId),
+              }
             : d
         ),
       };
 
       const event = isInterface
         ? toCreateEventEServiceInterfaceDeleted(
-          eserviceId,
-          eservice.metadata.version,
-          {
-            descriptorId,
-            documentId,
-            eservice: newEservice,
-          },
-          correlationId
-        )
+            eserviceId,
+            eservice.metadata.version,
+            {
+              descriptorId,
+              documentId,
+              eservice: newEservice,
+            },
+            correlationId
+          )
         : toCreateEventEServiceDocumentDeleted(
-          eserviceId,
-          eservice.metadata.version,
-          {
-            descriptorId,
-            documentId,
-            eservice: newEservice,
-          },
-          correlationId
-        );
+            eserviceId,
+            eservice.metadata.version,
+            {
+              descriptorId,
+              documentId,
+              eservice: newEservice,
+            },
+            correlationId
+          );
 
       const createdEvent = await repository.createEvent(event);
 
@@ -1296,7 +1298,7 @@ export function catalogServiceBuilder(
           (d) =>
             d.id !== documentId &&
             d.prettyName.toLowerCase() ===
-            apiEServiceDescriptorDocumentUpdateSeed.prettyName.toLowerCase()
+              apiEServiceDescriptorDocumentUpdateSeed.prettyName.toLowerCase()
         )
       ) {
         throw documentPrettyNameDuplicate(
@@ -1315,37 +1317,37 @@ export function catalogServiceBuilder(
         descriptors: eservice.data.descriptors.map((d: Descriptor) =>
           d.id === descriptorId
             ? {
-              ...d,
-              interface: isInterface ? updatedDocument : d.interface,
-              docs: d.docs.map((doc) =>
-                doc.id === documentId ? updatedDocument : doc
-              ),
-            }
+                ...d,
+                interface: isInterface ? updatedDocument : d.interface,
+                docs: d.docs.map((doc) =>
+                  doc.id === documentId ? updatedDocument : doc
+                ),
+              }
             : d
         ),
       };
 
       const event = isInterface
         ? toCreateEventEServiceInterfaceUpdated(
-          eserviceId,
-          eservice.metadata.version,
-          {
-            descriptorId,
-            documentId,
-            eservice: newEservice,
-          },
-          correlationId
-        )
+            eserviceId,
+            eservice.metadata.version,
+            {
+              descriptorId,
+              documentId,
+              eservice: newEservice,
+            },
+            correlationId
+          )
         : toCreateEventEServiceDocumentUpdated(
-          eserviceId,
-          eservice.metadata.version,
-          {
-            descriptorId,
-            documentId,
-            eservice: newEservice,
-          },
-          correlationId
-        );
+            eserviceId,
+            eservice.metadata.version,
+            {
+              descriptorId,
+              documentId,
+              eservice: newEservice,
+            },
+            correlationId
+          );
 
       await repository.createEvent(event);
       return updatedDocument;
@@ -1942,9 +1944,9 @@ export function catalogServiceBuilder(
         eservice.data.name.length + suffix.length <= maxNameLength
           ? `${eservice.data.name}${suffix}`
           : `${eservice.data.name.slice(
-            0,
-            prefixLengthAllowance
-          )}${dots}${suffix}`;
+              0,
+              prefixLengthAllowance
+            )}${dots}${suffix}`;
 
       await assertEServiceNameAvailableForProducer(
         clonedEServiceName,
@@ -1963,26 +1965,26 @@ export function catalogServiceBuilder(
       const clonedInterfacePath =
         descriptor.interface !== undefined
           ? await fileManager.copy(
-            config.s3Bucket,
-            descriptor.interface.path,
-            config.eserviceDocumentsPath,
-            clonedInterfaceId,
-            descriptor.interface.name,
-            logger
-          )
+              config.s3Bucket,
+              descriptor.interface.path,
+              config.eserviceDocumentsPath,
+              clonedInterfaceId,
+              descriptor.interface.name,
+              logger
+            )
           : undefined;
 
       const clonedInterfaceDocument: Document | undefined =
         descriptor.interface !== undefined && clonedInterfacePath !== undefined
           ? {
-            id: clonedInterfaceId,
-            name: descriptor.interface.name,
-            contentType: descriptor.interface.contentType,
-            prettyName: descriptor.interface.prettyName,
-            path: clonedInterfacePath,
-            checksum: descriptor.interface.checksum,
-            uploadDate: new Date(),
-          }
+              id: clonedInterfaceId,
+              name: descriptor.interface.name,
+              contentType: descriptor.interface.contentType,
+              prettyName: descriptor.interface.prettyName,
+              path: clonedInterfacePath,
+              checksum: descriptor.interface.checksum,
+              uploadDate: new Date(),
+            }
           : undefined;
 
       const clonedDocuments = await Promise.all(
@@ -2609,15 +2611,15 @@ export function catalogServiceBuilder(
           ? undefined
           : isConsumerDelegable
             ? toCreateEventEServiceIsConsumerDelegableEnabled(
-              eservice.metadata.version,
-              updatedEservice,
-              correlationId
-            )
+                eservice.metadata.version,
+                updatedEservice,
+                correlationId
+              )
             : toCreateEventEServiceIsConsumerDelegableDisabled(
-              eservice.metadata.version,
-              updatedEservice,
-              correlationId
-            );
+                eservice.metadata.version,
+                updatedEservice,
+                correlationId
+              );
 
       const clientAccessEventVersion =
         eservice.metadata.version + (consumerDelegableEvent ? 1 : 0);
@@ -2627,15 +2629,15 @@ export function catalogServiceBuilder(
           ? undefined
           : isClientAccessDelegable
             ? toCreateEventEServiceIsClientAccessDelegableEnabled(
-              clientAccessEventVersion,
-              updatedEservice,
-              correlationId
-            )
+                clientAccessEventVersion,
+                updatedEservice,
+                correlationId
+              )
             : toCreateEventEServiceIsClientAccessDelegableDisabled(
-              clientAccessEventVersion,
-              updatedEservice,
-              correlationId
-            );
+                clientAccessEventVersion,
+                updatedEservice,
+                correlationId
+              );
 
       const events = [
         consumerDelegableEvent,
@@ -3623,8 +3625,8 @@ export function catalogServiceBuilder(
       const agreementApprovalPolicySeed =
         eserviceInstanceDescriptorSeed.agreementApprovalPolicy
           ? apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-            eserviceInstanceDescriptorSeed.agreementApprovalPolicy
-          )
+              eserviceInstanceDescriptorSeed.agreementApprovalPolicy
+            )
           : undefined;
 
       assertConsistentDailyCalls(eserviceInstanceDescriptorSeed);
@@ -3821,13 +3823,8 @@ export function catalogServiceBuilder(
       {
         authData,
         correlationId,
-        logger,
       }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<WithMetadata<EService>> {
-      logger.info(
-        `Cancel archiving schedule for EService ${eserviceId} Descriptor ${descriptorId}`
-      );
-
       const eservice = await retrieveEService(eserviceId, readModelService);
       const descriptor = retrieveDescriptor(descriptorId, eservice);
       const latestDescriptor = getLatestDescriptor(eservice.data);
@@ -3839,7 +3836,7 @@ export function catalogServiceBuilder(
       assertDescriptorCancelArchivable(descriptor, eservice.data);
 
       const archivingSchedule =
-        latestDescriptor.archivingSchedule?.scope === archivingScope.eservice
+        latestDescriptor.archivingSchedule?.scope === "EService"
           ? latestDescriptor.archivingSchedule
           : undefined;
 
@@ -3922,11 +3919,11 @@ async function createOpenApiInterfaceByTemplate(
   serverUrls: string[],
   eserviceInstanceInterfaceRestData:
     | {
-      contactEmail: string;
-      contactName: string;
-      contactUrl?: string;
-      termsAndConditionsUrl?: string;
-    }
+        contactEmail: string;
+        contactName: string;
+        contactUrl?: string;
+        termsAndConditionsUrl?: string;
+      }
     | undefined,
   bucket: string,
   fileManager: FileManager,
@@ -4293,13 +4290,13 @@ async function updateDraftEService(
   eserviceId: EServiceId,
   typeAndSeed:
     | {
-      type: "put";
-      seed: catalogApi.UpdateEServiceSeed;
-    }
+        type: "put";
+        seed: catalogApi.UpdateEServiceSeed;
+      }
     | {
-      type: "patch";
-      seed: catalogApi.PatchUpdateEServiceSeed;
-    },
+        type: "patch";
+        seed: catalogApi.PatchUpdateEServiceSeed;
+      },
   readModelService: ReadModelServiceSQL,
   fileManager: FileManager,
   repository: ReturnType<typeof eventRepository<EServiceEvent>>,
@@ -4369,9 +4366,9 @@ async function updateDraftEService(
   // - personalData flag is changed from true to false or vice versa
   const checkedRiskAnalysis =
     updatedMode === eserviceMode.deliver ||
-      (typeAndSeed.seed.personalData != null &&
-        eservice.data.personalData != null &&
-        typeAndSeed.seed.personalData !== eservice.data.personalData)
+    (typeAndSeed.seed.personalData != null &&
+      eservice.data.personalData != null &&
+      typeAndSeed.seed.personalData !== eservice.data.personalData)
       ? []
       : eservice.data.riskAnalysis;
 
@@ -4420,10 +4417,10 @@ async function updateDraftEService(
     riskAnalysis: checkedRiskAnalysis,
     descriptors: interfaceHasToBeDeleted
       ? eservice.data.descriptors.map((d) => ({
-        ...d,
-        interface: undefined,
-        serverUrls: [],
-      }))
+          ...d,
+          interface: undefined,
+          serverUrls: [],
+        }))
       : eservice.data.descriptors,
     isSignalHubEnabled: updatedIsSignalHubEnabled,
     isConsumerDelegable: updatedIsConsumerDelegable,
@@ -4496,13 +4493,13 @@ async function updateDraftDescriptor(
 
   const updatedAttributes = attributes
     ? await parseAndCheckAttributes(
-      {
-        certified: attributes.certified ?? descriptor.attributes.certified,
-        declared: attributes.declared ?? descriptor.attributes.declared,
-        verified: attributes.verified ?? descriptor.attributes.verified,
-      },
-      readModelService
-    )
+        {
+          certified: attributes.certified ?? descriptor.attributes.certified,
+          declared: attributes.declared ?? descriptor.attributes.declared,
+          verified: attributes.verified ?? descriptor.attributes.verified,
+        },
+        readModelService
+      )
     : descriptor.attributes;
 
   assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
@@ -4513,8 +4510,8 @@ async function updateDraftDescriptor(
 
   const updatedAgreementApprovalPolicy = agreementApprovalPolicy
     ? apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-      agreementApprovalPolicy
-    )
+        agreementApprovalPolicy
+      )
     : descriptor.agreementApprovalPolicy;
 
   const updatedDescriptor: Descriptor = {

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -193,6 +193,7 @@ import {
   assertAttributeDailyCallsConsistentWithTotal,
   assertEserviceIsNotInArchivingOrArchivedState,
   assertDescriptorArchivable,
+  assertDescriptorCancelArchivable,
 } from "./validators.js";
 import type { ReadModelServiceSQL } from "./readModelServiceTypes.js";
 import { calculateArchivableOn } from "../utilities/dateCalculator.js";
@@ -392,15 +393,6 @@ const updateDescriptorState = (
           ),
           scope: scope ?? archivingScope.descriptor,
         },
-      })
-    )
-    .with(
-      [descriptorState.archiving, descriptorState.deprecated],
-      [descriptorState.archivingSuspended, descriptorState.suspended],
-      () => ({
-        ...descriptor,
-        state: newState,
-        archivingSchedule: undefined,
       })
     )
     .otherwise(() => ({
@@ -3835,25 +3827,29 @@ export function catalogServiceBuilder(
       const eservice = await retrieveEService(eserviceId, readModelService);
       const descriptor = retrieveDescriptor(descriptorId, eservice);
 
-      assertDescriptorInRequiredStates(descriptor, [
-        descriptorState.archiving,
-        descriptorState.archivingSuspended,
-      ]);
-      assertDescriptorIsNotLatestVersion(descriptor, eservice.data);
+      assertDescriptorCancelArchivable(descriptor);
 
       const newState =
         descriptor.state === descriptorState.archivingSuspended
           ? descriptorState.suspended
           : descriptorState.deprecated;
 
-      const updatedEService =
-        await transitionEServiceDescriptorArchivingStateLogic(
-          eservice.data,
-          descriptor,
-          newState,
-          authData,
-          readModelService
-        );
+      await assertRequesterIsDelegateProducerOrProducer(
+        eservice.data.producerId,
+        eservice.data.id,
+        authData,
+        readModelService
+      );
+
+      const updatedDescriptor: Descriptor = {
+        ...updateDescriptorState(descriptor, newState),
+        archivingSchedule: undefined,
+      };
+
+      const updatedEService = replaceDescriptor(
+        eservice.data,
+        updatedDescriptor
+      );
 
       const event = toCreateEventEServiceDescriptorArchivingDeleted(
         eservice.metadata.version,

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -521,12 +521,18 @@ export function assertEserviceIsNotInArchivingOrArchivedState(
   }
 }
 
-function isDescriptorCancelArchivable(descriptor: Descriptor): boolean {
+function isDescriptorCancelArchivable(
+  descriptor: Descriptor,
+  eservice: EService
+): boolean {
+  const latestDescriptor = getLatestDescriptor(eservice);
+  const isLatest = latestDescriptor?.id === descriptor.id;
+
   return match(descriptor.state)
     .with(
       descriptorState.archiving,
       descriptorState.archivingSuspended,
-      () => true
+      () => !isLatest
     )
     .with(
       descriptorState.draft,
@@ -540,8 +546,11 @@ function isDescriptorCancelArchivable(descriptor: Descriptor): boolean {
     .exhaustive();
 }
 
-export function assertDescriptorCancelArchivable(descriptor: Descriptor): void {
-  if (!isDescriptorCancelArchivable(descriptor)) {
+export function assertDescriptorCancelArchivable(
+  descriptor: Descriptor,
+  eservice: EService
+): void {
+  if (!isDescriptorCancelArchivable(descriptor, eservice)) {
     throw notValidDescriptorState(descriptor.id, descriptor.state.toString());
   }
 }

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -403,7 +403,7 @@ export function assertDescriptorUpdatableAfterPublish(
   descriptor: Descriptor
 ): void {
   if (!isDescriptorUpdatableAfterPublish(descriptor)) {
-    throw notValidDescriptorState(descriptor.id, descriptor.state.toString());
+    throw notValidDescriptorState(descriptor.id, descriptor.state);
   }
 }
 
@@ -487,7 +487,7 @@ export function assertDescriptorArchivable(
   eservice: EService
 ): void {
   if (!isDescriptorArchivable(descriptor, eservice)) {
-    throw notValidDescriptorState(descriptor.id, descriptor.state.toString());
+    throw notValidDescriptorState(descriptor.id, descriptor.state);
   }
 }
 
@@ -525,9 +525,8 @@ export function assertEserviceIsNotInArchivingOrArchivedState(
 
 function isDescriptorCancelArchivable(
   descriptor: Descriptor,
-  eservice: EService
+  latestDescriptor: Descriptor
 ): boolean {
-  const latestDescriptor = getLatestDescriptor(eservice);
   const isLatest = latestDescriptor.id === descriptor.id;
 
   return match(descriptor.state)
@@ -550,10 +549,10 @@ function isDescriptorCancelArchivable(
 
 export function assertDescriptorCancelArchivable(
   descriptor: Descriptor,
-  eservice: EService
+  latestDescriptor: Descriptor
 ): void {
-  if (!isDescriptorCancelArchivable(descriptor, eservice)) {
-    throw notValidDescriptorState(descriptor.id, descriptor.state.toString());
+  if (!isDescriptorCancelArchivable(descriptor, latestDescriptor)) {
+    throw notValidDescriptorState(descriptor.id, descriptor.state);
   }
 }
 

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -520,3 +520,61 @@ export function assertEserviceIsNotInArchivingOrArchivedState(
     throw eserviceInArchivingOrArchivedState(eservice.id);
   }
 }
+
+function isDescriptorArchivable(
+  descriptor: Descriptor,
+  eservice: EService
+): boolean {
+  const latestDescriptor = getLatestDescriptor(eservice);
+  const isLatest = latestDescriptor?.id === descriptor.id;
+
+  return match(descriptor.state)
+    .with(descriptorState.deprecated, () => true)
+    .with(descriptorState.suspended, () => !isLatest)
+    .with(
+      descriptorState.draft,
+      descriptorState.published,
+      descriptorState.waitingForApproval,
+      descriptorState.archived,
+      descriptorState.archiving,
+      descriptorState.archivingSuspended,
+      () => false
+    )
+    .exhaustive();
+}
+
+export function assertDescriptorArchivable(
+  descriptor: Descriptor,
+  eservice: EService
+): void {
+  if (!isDescriptorArchivable(descriptor, eservice)) {
+    throw notValidDescriptorState(descriptor.id, descriptor.state.toString());
+  }
+}
+
+function isDescriptorCancelArchivable(descriptor: Descriptor): boolean {
+  return match(descriptor.state)
+    .with(
+      descriptorState.archiving,
+      descriptorState.archivingSuspended,
+      () => true
+    )
+    .with(
+      descriptorState.draft,
+      descriptorState.published,
+      descriptorState.waitingForApproval,
+      descriptorState.archived,
+      descriptorState.deprecated,
+      descriptorState.suspended,
+      () => false
+    )
+    .exhaustive();
+}
+
+export function assertDescriptorCancelArchivable(
+  descriptor: Descriptor
+): void {
+  if (!isDescriptorCancelArchivable(descriptor)) {
+    throw notValidDescriptorState(descriptor.id, descriptor.state.toString());
+  }
+}

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -526,7 +526,7 @@ function isDescriptorCancelArchivable(
   eservice: EService
 ): boolean {
   const latestDescriptor = getLatestDescriptor(eservice);
-  const isLatest = latestDescriptor?.id === descriptor.id;
+  const isLatest = latestDescriptor.id === descriptor.id;
 
   return match(descriptor.state)
     .with(

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -521,37 +521,6 @@ export function assertEserviceIsNotInArchivingOrArchivedState(
   }
 }
 
-function isDescriptorArchivable(
-  descriptor: Descriptor,
-  eservice: EService
-): boolean {
-  const latestDescriptor = getLatestDescriptor(eservice);
-  const isLatest = latestDescriptor?.id === descriptor.id;
-
-  return match(descriptor.state)
-    .with(descriptorState.deprecated, () => true)
-    .with(descriptorState.suspended, () => !isLatest)
-    .with(
-      descriptorState.draft,
-      descriptorState.published,
-      descriptorState.waitingForApproval,
-      descriptorState.archived,
-      descriptorState.archiving,
-      descriptorState.archivingSuspended,
-      () => false
-    )
-    .exhaustive();
-}
-
-export function assertDescriptorArchivable(
-  descriptor: Descriptor,
-  eservice: EService
-): void {
-  if (!isDescriptorArchivable(descriptor, eservice)) {
-    throw notValidDescriptorState(descriptor.id, descriptor.state.toString());
-  }
-}
-
 function isDescriptorCancelArchivable(descriptor: Descriptor): boolean {
   return match(descriptor.state)
     .with(

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -19,6 +19,7 @@ import {
   Tenant,
   TenantId,
   TenantKind,
+  archivingScope,
   delegationKind,
   delegationState,
   descriptorState,
@@ -50,6 +51,7 @@ import {
   eserviceInDraftState,
   attributeDailyCallsNotAllowed,
   eserviceInArchivingOrArchivedState,
+  descriptorArchivingNotCancelableByScope,
 } from "../model/domain/errors.js";
 import type { ReadModelServiceSQL } from "./readModelServiceTypes.js";
 import { getLatestDescriptor } from "../utilities/versionGenerator.js";
@@ -552,5 +554,13 @@ export function assertDescriptorCancelArchivable(
 ): void {
   if (!isDescriptorCancelArchivable(descriptor, eservice)) {
     throw notValidDescriptorState(descriptor.id, descriptor.state.toString());
+  }
+}
+
+export function assertDescriptorArchivingIsNotEserviceScoped(
+  descriptor: Descriptor
+): void {
+  if (descriptor.archivingSchedule?.scope === archivingScope.eservice) {
+    throw descriptorArchivingNotCancelableByScope(descriptor.id);
   }
 }

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -571,9 +571,7 @@ function isDescriptorCancelArchivable(descriptor: Descriptor): boolean {
     .exhaustive();
 }
 
-export function assertDescriptorCancelArchivable(
-  descriptor: Descriptor
-): void {
+export function assertDescriptorCancelArchivable(descriptor: Descriptor): void {
   if (!isDescriptorCancelArchivable(descriptor)) {
     throw notValidDescriptorState(descriptor.id, descriptor.state.toString());
   }

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -724,8 +724,13 @@ export const updateEserviceDescriptorArchivingStatusErrorMapper = (
       "eServiceDescriptorNotFound",
       () => HTTP_STATUS_NOT_FOUND
     )
-    .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
+    .with(
+      "operationForbidden",
+      "descriptorArchivingNotCancelableByScope",
+      () => HTTP_STATUS_FORBIDDEN
+    )
     .with("notValidDescriptor", () => HTTP_STATUS_BAD_REQUEST)
+    .with("eserviceWithoutValidDescriptors", () => HTTP_STATUS_CONFLICT)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
 export const maintenanceResetEServicePersonalDataFlagErrorMapper = (

--- a/packages/catalog-process/src/utilities/versionGenerator.ts
+++ b/packages/catalog-process/src/utilities/versionGenerator.ts
@@ -1,4 +1,9 @@
-import { Descriptor, DescriptorState, EService } from "pagopa-interop-models";
+import {
+  Descriptor,
+  DescriptorState,
+  EService,
+  descriptorState,
+} from "pagopa-interop-models";
 import { z } from "zod";
 import {
   eserviceWithoutValidDescriptors,
@@ -28,6 +33,17 @@ export const getLatestDescriptor = (eservice: EService): Descriptor => {
   return latestDescriptor;
 };
 
+export const getLatestDescriptorByStates = (
+  eservice: EService,
+  states: DescriptorState[]
+): Descriptor | undefined =>
+  [...eservice.descriptors]
+    .filter((d) => states.includes(d.state))
+    .sort(
+      (a, b) => parseVersionNumber(a.version) - parseVersionNumber(b.version)
+    )
+    .at(-1);
+
 export const nextDescriptorVersion = (eservice: EService): string => {
   const currentVersion =
     eservice.descriptors.length === 0
@@ -47,3 +63,26 @@ export const getPreviousDescriptorByStates = (
       d.version === (parseVersionNumber(newVersion) - 1).toString() &&
       states.includes(d.state)
   );
+export function isLatestDescriptorVersion(
+  target: Descriptor,
+  allDescriptors: Descriptor[]
+): boolean {
+  const relevantStates: DescriptorState[] = [
+    descriptorState.suspended,
+    descriptorState.published,
+    descriptorState.deprecated,
+    descriptorState.archiving,
+    descriptorState.archivingSuspended,
+  ];
+
+  const versions = allDescriptors
+    .filter((d) => relevantStates.includes(d.state))
+    .map((d) => parseInt(d.version, 10));
+
+  if (versions.length === 0) {
+    return true;
+  }
+
+  const maxVersion = Math.max(...versions);
+  return parseInt(target.version, 10) === maxVersion;
+}

--- a/packages/catalog-process/src/utilities/versionGenerator.ts
+++ b/packages/catalog-process/src/utilities/versionGenerator.ts
@@ -1,9 +1,4 @@
-import {
-  Descriptor,
-  descriptorState,
-  DescriptorState,
-  EService,
-} from "pagopa-interop-models";
+import { Descriptor, DescriptorState, EService } from "pagopa-interop-models";
 import { z } from "zod";
 import {
   eserviceWithoutValidDescriptors,
@@ -52,26 +47,3 @@ export const getPreviousDescriptorByStates = (
       d.version === (parseVersionNumber(newVersion) - 1).toString() &&
       states.includes(d.state)
   );
-export function isLatestDescriptorVersion(
-  target: Descriptor,
-  allDescriptors: Descriptor[]
-): boolean {
-  const relevantStates: DescriptorState[] = [
-    descriptorState.suspended,
-    descriptorState.published,
-    descriptorState.deprecated,
-    descriptorState.archiving,
-    descriptorState.archivingSuspended,
-  ];
-
-  const versions = allDescriptors
-    .filter((d) => relevantStates.includes(d.state))
-    .map((d) => parseInt(d.version, 10));
-
-  if (versions.length === 0) {
-    return true;
-  }
-
-  const maxVersion = Math.max(...versions);
-  return parseInt(target.version, 10) === maxVersion;
-}

--- a/packages/catalog-process/src/utilities/versionGenerator.ts
+++ b/packages/catalog-process/src/utilities/versionGenerator.ts
@@ -1,8 +1,8 @@
 import {
   Descriptor,
+  descriptorState,
   DescriptorState,
   EService,
-  descriptorState,
 } from "pagopa-interop-models";
 import { z } from "zod";
 import {
@@ -32,17 +32,6 @@ export const getLatestDescriptor = (eservice: EService): Descriptor => {
 
   return latestDescriptor;
 };
-
-export const getLatestDescriptorByStates = (
-  eservice: EService,
-  states: DescriptorState[]
-): Descriptor | undefined =>
-  [...eservice.descriptors]
-    .filter((d) => states.includes(d.state))
-    .sort(
-      (a, b) => parseVersionNumber(a.version) - parseVersionNumber(b.version)
-    )
-    .at(-1);
 
 export const nextDescriptorVersion = (eservice: EService): string => {
   const currentVersion =

--- a/packages/catalog-process/test/api/cancelEServiceDescriptorArchiving.test.ts
+++ b/packages/catalog-process/test/api/cancelEServiceDescriptorArchiving.test.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import {
+  Descriptor,
+  DescriptorId,
+  descriptorState,
+  EService,
+  EServiceId,
+  generateId,
+  operationForbidden,
+} from "pagopa-interop-models";
+import {
+  generateToken,
+  getMockDescriptor,
+  getMockEService,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { api, catalogService } from "../vitest.api.setup.js";
+import {
+  eServiceDescriptorNotFound,
+  eServiceNotFound,
+  notValidDescriptorState,
+} from "../../src/model/domain/errors.js";
+import { eServiceToApiEService } from "../../src/model/domain/apiConverter.js";
+
+describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/scheduleArchive DELETE authorization test", () => {
+  const descriptor: Descriptor = {
+    ...getMockDescriptor(),
+    state: descriptorState.archiving,
+  };
+
+  const mockEService: EService = {
+    ...getMockEService(),
+    descriptors: [descriptor],
+  };
+
+  const mockApiEservice = eServiceToApiEService(mockEService);
+
+  const mockEserviceWithMetadata = getMockWithMetadata(mockEService);
+
+  catalogService.cancelEServiceDescriptorArchiving = vi
+    .fn()
+    .mockResolvedValue(mockEserviceWithMetadata);
+
+  const makeRequest = async (
+    token: string,
+    eServiceId: EServiceId,
+    descriptorId: DescriptorId
+  ) =>
+    request(api)
+      .delete(
+        `/eservices/${eServiceId}/descriptors/${descriptorId}/scheduleArchive`
+      )
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId());
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.API_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token, mockEService.id, descriptor.id);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockApiEservice);
+      expect(res.headers["x-metadata-version"]).toBe(
+        mockEserviceWithMetadata.metadata.version.toString()
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, mockEService.id, descriptor.id);
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {
+      error: eServiceNotFound(mockEService.id),
+      expectedStatus: 404,
+    },
+    {
+      error: eServiceDescriptorNotFound(mockEService.id, descriptor.id),
+      expectedStatus: 404,
+    },
+    {
+      error: operationForbidden,
+      expectedStatus: 403,
+    },
+    {
+      error: notValidDescriptorState(descriptor.id, descriptor.state),
+      expectedStatus: 400,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      catalogService.cancelEServiceDescriptorArchiving = vi
+        .fn()
+        .mockRejectedValue(error);
+
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, mockEService.id, descriptor.id);
+
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+
+  it.each([
+    {},
+    { eServiceId: "invalidId", descriptorId: descriptor.id },
+    { eServiceId: mockEService.id, descriptorId: "invalidId" },
+  ])(
+    "Should return 400 if passed invalid params: %s",
+    async ({ eServiceId, descriptorId }) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        eServiceId as EServiceId,
+        descriptorId as DescriptorId
+      );
+
+      expect(res.status).toBe(400);
+    }
+  );
+});

--- a/packages/catalog-process/test/api/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/api/updateDescriptorAttributes.test.ts
@@ -5,6 +5,7 @@ import {
   attributeKind,
   Descriptor,
   DescriptorId,
+  DescriptorState,
   descriptorState,
   EService,
   EServiceId,
@@ -205,7 +206,7 @@ describe("API /eservices/{eServiceId}/descriptors/{descriptorId}/attributes/upda
       expectedStatus: 400,
     },
     {
-      error: notValidDescriptorState(generateId(), ""),
+      error: notValidDescriptorState(generateId(), "" as DescriptorState),
       expectedStatus: 400,
     },
     {

--- a/packages/catalog-process/test/integration/cancelEServiceDescriptorArchiving.test.ts
+++ b/packages/catalog-process/test/integration/cancelEServiceDescriptorArchiving.test.ts
@@ -1,0 +1,275 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import {
+  decodeProtobufPayload,
+  getMockContext,
+  getMockAuthData,
+  getMockEService,
+  getMockDescriptor,
+  getMockDocument,
+} from "pagopa-interop-commons-test";
+import {
+  Descriptor,
+  descriptorState,
+  EService,
+  toEServiceV2,
+  operationForbidden,
+  EServiceDescriptorArchivingCanceledV2,
+  generateId,
+  archivingScope,
+} from "pagopa-interop-models";
+import { expect, describe, it } from "vitest";
+import {
+  eServiceNotFound,
+  eServiceDescriptorNotFound,
+  notValidDescriptorState,
+} from "../../src/model/domain/errors.js";
+import {
+  addOneEService,
+  catalogService,
+  readLastEserviceEvent,
+} from "../integrationUtils.js";
+
+describe("cancel archiving of a descriptor", () => {
+  const mockEService = getMockEService();
+  const mockDescriptor = getMockDescriptor();
+  const mockDocument = getMockDocument();
+
+  const archivingSchedule = {
+    archivableOn: new Date(),
+    startedAt: new Date(),
+    scope: archivingScope.descriptor,
+  };
+
+  it("should write on event-store to restore deprecated state for a descriptor in archiving state", async () => {
+    const descriptor1: Descriptor = {
+      ...mockDescriptor,
+      interface: mockDocument,
+      state: descriptorState.archiving,
+      version: "1",
+      archivingSchedule,
+    };
+    const descriptor2: Descriptor = {
+      ...mockDescriptor,
+      id: generateId(),
+      version: "2",
+      state: descriptorState.published,
+      interface: getMockDocument(),
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor1, descriptor2],
+    };
+    await addOneEService(eservice);
+    const cancelDescriptorArchivingResponse =
+      await catalogService.cancelEServiceDescriptorArchiving(
+        eservice.id,
+        descriptor1.id,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent.stream_id).toBe(eservice.id);
+    expect(writtenEvent.version).toBe("1");
+    expect(writtenEvent.type).toBe("EServiceDescriptorArchivingCanceled");
+    expect(writtenEvent.event_version).toBe(2);
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorArchivingCanceledV2,
+      payload: writtenEvent.data,
+    });
+
+    const expectedDescriptor1: Descriptor = {
+      ...descriptor1,
+      state: descriptorState.deprecated,
+      archivingSchedule: undefined,
+    };
+
+    const expectedEService: EService = {
+      ...eservice,
+      descriptors: [expectedDescriptor1, descriptor2],
+    };
+
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(expectedEService));
+    expect(writtenPayload.descriptorId).toEqual(descriptor1.id);
+    expect(cancelDescriptorArchivingResponse).toEqual({
+      data: expectedEService,
+      metadata: { version: parseInt(writtenEvent.version, 10) },
+    });
+  });
+
+  it("should write on event-store to restore suspended state for a descriptor in archivingSuspended state", async () => {
+    const descriptor1: Descriptor = {
+      ...mockDescriptor,
+      interface: mockDocument,
+      state: descriptorState.archivingSuspended,
+      suspendedAt: new Date(),
+      version: "1",
+      archivingSchedule,
+    };
+    const descriptor2: Descriptor = {
+      ...mockDescriptor,
+      id: generateId(),
+      version: "2",
+      state: descriptorState.published,
+      interface: getMockDocument(),
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor1, descriptor2],
+    };
+    await addOneEService(eservice);
+    const cancelDescriptorArchivingResponse =
+      await catalogService.cancelEServiceDescriptorArchiving(
+        eservice.id,
+        descriptor1.id,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent.stream_id).toBe(eservice.id);
+    expect(writtenEvent.version).toBe("1");
+    expect(writtenEvent.type).toBe("EServiceDescriptorArchivingCanceled");
+    expect(writtenEvent.event_version).toBe(2);
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorArchivingCanceledV2,
+      payload: writtenEvent.data,
+    });
+
+    const expectedDescriptor1: Descriptor = {
+      ...descriptor1,
+      state: descriptorState.suspended,
+      archivingSchedule: undefined,
+    };
+
+    const expectedEService: EService = {
+      ...eservice,
+      descriptors: [expectedDescriptor1, descriptor2],
+    };
+
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(expectedEService));
+    expect(writtenPayload.descriptorId).toEqual(descriptor1.id);
+    expect(cancelDescriptorArchivingResponse).toEqual({
+      data: expectedEService,
+      metadata: { version: parseInt(writtenEvent.version, 10) },
+    });
+  });
+
+  it("should throw eServiceNotFound if the eservice doesn't exist", () => {
+    expect(
+      catalogService.cancelEServiceDescriptorArchiving(
+        mockEService.id,
+        mockDescriptor.id,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      )
+    ).rejects.toThrowError(eServiceNotFound(mockEService.id));
+  });
+
+  it("should throw operationForbidden if the requester is not the producer", async () => {
+    const descriptor1: Descriptor = {
+      ...mockDescriptor,
+      interface: mockDocument,
+      state: descriptorState.archiving,
+      version: "1",
+      archivingSchedule,
+    };
+    const descriptor2: Descriptor = {
+      ...mockDescriptor,
+      id: generateId(),
+      version: "2",
+      state: descriptorState.published,
+      interface: getMockDocument(),
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor1, descriptor2],
+    };
+    await addOneEService(eservice);
+    expect(
+      catalogService.cancelEServiceDescriptorArchiving(
+        eservice.id,
+        descriptor1.id,
+        getMockContext({})
+      )
+    ).rejects.toThrowError(operationForbidden);
+  });
+
+  it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [],
+    };
+    await addOneEService(eservice);
+
+    expect(
+      catalogService.cancelEServiceDescriptorArchiving(
+        eservice.id,
+        mockDescriptor.id,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      )
+    ).rejects.toThrowError(
+      eServiceDescriptorNotFound(eservice.id, mockDescriptor.id)
+    );
+  });
+
+  it.each([
+    descriptorState.draft,
+    descriptorState.waitingForApproval,
+    descriptorState.deprecated,
+    descriptorState.published,
+    descriptorState.suspended,
+    descriptorState.archived,
+  ])(
+    "should throw notValidDescriptorState if the descriptor is in %s state",
+    async (state) => {
+      const descriptor1: Descriptor = {
+        ...mockDescriptor,
+        interface: mockDocument,
+        state,
+        version: "1",
+      };
+      const descriptor2: Descriptor = {
+        ...mockDescriptor,
+        id: generateId(),
+        version: "2",
+        state: descriptorState.published,
+        interface: getMockDocument(),
+      };
+      const eservice: EService = {
+        ...mockEService,
+        descriptors: [descriptor1, descriptor2],
+      };
+      await addOneEService(eservice);
+      expect(
+        catalogService.cancelEServiceDescriptorArchiving(
+          eservice.id,
+          descriptor1.id,
+          getMockContext({ authData: getMockAuthData(eservice.producerId) })
+        )
+      ).rejects.toThrowError(notValidDescriptorState(descriptor1.id, state));
+    }
+  );
+
+  it("should throw notValidDescriptorState if the descriptor is the latest version", async () => {
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      interface: mockDocument,
+      state: descriptorState.archiving,
+      version: "1",
+      archivingSchedule,
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+    expect(
+      catalogService.cancelEServiceDescriptorArchiving(
+        eservice.id,
+        descriptor.id,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      notValidDescriptorState(descriptor.id, descriptor.state)
+    );
+  });
+});

--- a/packages/catalog-process/test/integration/cancelEServiceDescriptorArchiving.test.ts
+++ b/packages/catalog-process/test/integration/cancelEServiceDescriptorArchiving.test.ts
@@ -22,6 +22,7 @@ import {
   eServiceNotFound,
   eServiceDescriptorNotFound,
   notValidDescriptorState,
+  descriptorArchivingNotCancelableByScope,
 } from "../../src/model/domain/errors.js";
 import {
   addOneEService,
@@ -247,6 +248,41 @@ describe("cancel archiving of a descriptor", () => {
       ).rejects.toThrowError(notValidDescriptorState(descriptor1.id, state));
     }
   );
+
+  it("should throw descriptorArchivingNotCancelableByScope if the descriptor archiving was scheduled at eservice scope", async () => {
+    const descriptor1: Descriptor = {
+      ...mockDescriptor,
+      interface: mockDocument,
+      state: descriptorState.archiving,
+      version: "1",
+      archivingSchedule: {
+        archivableOn: new Date(),
+        startedAt: new Date(),
+        scope: archivingScope.eservice,
+      },
+    };
+    const descriptor2: Descriptor = {
+      ...mockDescriptor,
+      id: generateId(),
+      version: "2",
+      state: descriptorState.published,
+      interface: getMockDocument(),
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor1, descriptor2],
+    };
+    await addOneEService(eservice);
+    await expect(
+      catalogService.cancelEServiceDescriptorArchiving(
+        eservice.id,
+        descriptor1.id,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      descriptorArchivingNotCancelableByScope(descriptor1.id)
+    );
+  });
 
   it("should throw notValidDescriptorState if the descriptor is the latest version", async () => {
     const descriptor: Descriptor = {

--- a/packages/catalog-process/test/integration/cancelEServiceDescriptorArchiving.test.ts
+++ b/packages/catalog-process/test/integration/cancelEServiceDescriptorArchiving.test.ts
@@ -154,6 +154,67 @@ describe("cancel archiving of a descriptor", () => {
     });
   });
 
+  it("should merge descriptor into global archiving if E-Service archiving is ongoing", async () => {
+    const eserviceArchivingSchedule = {
+      archivableOn: new Date(),
+      startedAt: new Date(),
+      scope: archivingScope.eservice,
+    };
+    const descriptor1: Descriptor = {
+      ...mockDescriptor,
+      interface: mockDocument,
+      state: descriptorState.archiving,
+      version: "1",
+      archivingSchedule,
+    };
+    const descriptor2: Descriptor = {
+      ...mockDescriptor,
+      id: generateId(),
+      version: "2",
+      state: descriptorState.archiving,
+      interface: getMockDocument(),
+      archivingSchedule: eserviceArchivingSchedule,
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor1, descriptor2],
+    };
+    await addOneEService(eservice);
+    const cancelDescriptorArchivingResponse =
+      await catalogService.cancelEServiceDescriptorArchiving(
+        eservice.id,
+        descriptor1.id,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent.stream_id).toBe(eservice.id);
+    expect(writtenEvent.version).toBe("1");
+    expect(writtenEvent.type).toBe("EServiceDescriptorArchivingCanceled");
+    expect(writtenEvent.event_version).toBe(2);
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorArchivingCanceledV2,
+      payload: writtenEvent.data,
+    });
+
+    const expectedDescriptor1: Descriptor = {
+      ...descriptor1,
+      archivingSchedule: eserviceArchivingSchedule,
+    };
+
+    const expectedEService: EService = {
+      ...eservice,
+      descriptors: [expectedDescriptor1, descriptor2],
+    };
+
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(expectedEService));
+    expect(writtenPayload.descriptorId).toEqual(descriptor1.id);
+    expect(cancelDescriptorArchivingResponse).toEqual({
+      data: expectedEService,
+      metadata: { version: parseInt(writtenEvent.version, 10) },
+    });
+  });
+
   it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
     await expect(
       catalogService.cancelEServiceDescriptorArchiving(

--- a/packages/catalog-process/test/integration/cancelEServiceDescriptorArchiving.test.ts
+++ b/packages/catalog-process/test/integration/cancelEServiceDescriptorArchiving.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import {
   decodeProtobufPayload,
   getMockContext,
@@ -154,8 +153,8 @@ describe("cancel archiving of a descriptor", () => {
     });
   });
 
-  it("should throw eServiceNotFound if the eservice doesn't exist", () => {
-    expect(
+  it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
+    await expect(
       catalogService.cancelEServiceDescriptorArchiving(
         mockEService.id,
         mockDescriptor.id,
@@ -184,7 +183,7 @@ describe("cancel archiving of a descriptor", () => {
       descriptors: [descriptor1, descriptor2],
     };
     await addOneEService(eservice);
-    expect(
+    await expect(
       catalogService.cancelEServiceDescriptorArchiving(
         eservice.id,
         descriptor1.id,
@@ -200,7 +199,7 @@ describe("cancel archiving of a descriptor", () => {
     };
     await addOneEService(eservice);
 
-    expect(
+    await expect(
       catalogService.cancelEServiceDescriptorArchiving(
         eservice.id,
         mockDescriptor.id,
@@ -239,7 +238,7 @@ describe("cancel archiving of a descriptor", () => {
         descriptors: [descriptor1, descriptor2],
       };
       await addOneEService(eservice);
-      expect(
+      await expect(
         catalogService.cancelEServiceDescriptorArchiving(
           eservice.id,
           descriptor1.id,
@@ -262,7 +261,7 @@ describe("cancel archiving of a descriptor", () => {
       descriptors: [descriptor],
     };
     await addOneEService(eservice);
-    expect(
+    await expect(
       catalogService.cancelEServiceDescriptorArchiving(
         eservice.id,
         descriptor.id,

--- a/packages/m2m-gateway-v3/src/routers/eserviceRouter.ts
+++ b/packages/m2m-gateway-v3/src/routers/eserviceRouter.ts
@@ -783,6 +783,34 @@ const eserviceRouter = (
         }
       }
     )
+    .delete(
+      "/eservices/:eserviceId/descriptors/:descriptorId/scheduleArchive",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          const eserviceDescriptor =
+            await eserviceService.cancelEServiceDescriptorArchiving(
+              unsafeBrandId(req.params.eserviceId),
+              unsafeBrandId(req.params.descriptorId),
+              ctx
+            );
+          return res
+            .status(200)
+            .send(m2mGatewayApiV3.EServiceDescriptor.parse(eserviceDescriptor));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error canceling archiving for descriptor ${req.params.descriptorId} for eservice ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
     .post("/eservices/:eserviceId/riskAnalyses", async (req, res) => {
       const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
 

--- a/packages/m2m-gateway-v3/src/services/eserviceService.ts
+++ b/packages/m2m-gateway-v3/src/services/eserviceService.ts
@@ -994,6 +994,32 @@ export function eserviceServiceBuilder(
 
       return toM2MGatewayApiEServiceDescriptor(descriptor);
     },
+    async cancelEServiceDescriptorArchiving(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.EServiceDescriptor> {
+      logger.info(
+        `Canceling archive for descriptor with id ${descriptorId} for eservice with id ${eserviceId}`
+      );
+
+      const response =
+        await clients.catalogProcessClient.cancelEServiceDescriptorArchiving(
+          undefined,
+          {
+            params: { eServiceId: eserviceId, descriptorId },
+            headers,
+          }
+        );
+      await pollEService(response, headers);
+
+      const descriptor = retrieveEServiceDescriptorById(
+        response,
+        unsafeBrandId(descriptorId)
+      );
+
+      return toM2MGatewayApiEServiceDescriptor(descriptor);
+    },
     async uploadEServiceDescriptorInterface(
       eserviceId: EServiceId,
       descriptorId: DescriptorId,

--- a/packages/m2m-gateway-v3/test/api/eservices/cancelEServiceDescriptorArchiving.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/cancelEServiceDescriptorArchiving.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  generateToken,
+  getMockedApiEservice,
+  getMockedApiEserviceDescriptor,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import { pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { catalogApi, m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { toM2MGatewayApiEServiceDescriptor } from "../../../src/api/eserviceApiConverter.js";
+import { config } from "../../../src/config/config.js";
+
+describe("DELETE /eservices/:eserviceId/descriptors/:descriptorId/scheduleArchive router test", () => {
+  const mockApiDescriptor: catalogApi.EServiceDescriptor = {
+    ...getMockedApiEserviceDescriptor(),
+    state: "ARCHIVING",
+  };
+
+  const mockApiEservice = getMockedApiEservice({
+    descriptors: [mockApiDescriptor],
+  });
+
+  const mockM2MEserviceDescriptorResponse: m2mGatewayApiV3.EServiceDescriptor =
+    toM2MGatewayApiEServiceDescriptor(mockApiDescriptor);
+
+  const makeRequest = async (
+    token: string,
+    eserviceId: string = mockApiEservice.id,
+    descriptorId: string = mockApiDescriptor.id
+  ) =>
+    request(api)
+      .delete(
+        `${appBasePath}/eservices/${eserviceId}/descriptors/${descriptorId}/scheduleArchive`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 and perform service calls for user with role %s",
+    async (role) => {
+      mockEserviceService.cancelEServiceDescriptorArchiving = vi
+        .fn()
+        .mockResolvedValue(mockM2MEserviceDescriptorResponse);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockM2MEserviceDescriptorResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 400 for invalid eservice id", async () => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, "INVALID_ID", mockApiDescriptor.id);
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 for invalid descriptor id", async () => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, mockApiEservice.id, "INVALID_ID");
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockEserviceService.cancelEServiceDescriptorArchiving = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(500);
+  });
+
+  it.each([
+    { ...mockM2MEserviceDescriptorResponse, createdAt: undefined },
+    { ...mockM2MEserviceDescriptorResponse, id: "invalidId" },
+    { ...mockM2MEserviceDescriptorResponse, extraParam: "extraValue" },
+    {},
+  ])(
+    "Should return 500 when API model parsing fails for response (resp #%#)",
+    async (resp) => {
+      mockEserviceService.cancelEServiceDescriptorArchiving = vi
+        .fn()
+        .mockResolvedValue(resp);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(500);
+    }
+  );
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/cancelEServiceDescriptorArchiving.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/cancelEServiceDescriptorArchiving.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockedApiEserviceDescriptor,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import { catalogApi } from "pagopa-interop-api-clients";
+import {
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+  eserviceService,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import {
+  eserviceDescriptorNotFound,
+  missingMetadata,
+} from "../../../src/model/errors.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+import { toM2MGatewayApiEServiceDescriptor } from "../../../src/api/eserviceApiConverter.js";
+
+describe("cancelEServiceDescriptorArchiving", () => {
+  const mockApiDescriptor: catalogApi.EServiceDescriptor = {
+    ...getMockedApiEserviceDescriptor(),
+    state: "ARCHIVING",
+  };
+
+  const mockApiEservice = getMockWithMetadata(
+    getMockedApiEservice({
+      descriptors: [mockApiDescriptor],
+    })
+  );
+
+  const mockM2MEserviceDescriptorResponse =
+    toM2MGatewayApiEServiceDescriptor(mockApiDescriptor);
+
+  const mockCancelArchiving = vi.fn().mockResolvedValue(mockApiEservice);
+  const mockGetEservice = vi.fn(mockPollingResponse(mockApiEservice, 2));
+
+  mockInteropBeClients.catalogProcessClient = {
+    getEServiceById: mockGetEservice,
+    cancelEServiceDescriptorArchiving: mockCancelArchiving,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockCancelArchiving.mockClear();
+    mockGetEservice.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const result = await eserviceService.cancelEServiceDescriptorArchiving(
+      unsafeBrandId(mockApiEservice.data.id),
+      unsafeBrandId(mockApiDescriptor.id),
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(mockM2MEserviceDescriptorResponse);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost: mockCancelArchiving,
+      params: {
+        eServiceId: mockApiEservice.data.id,
+        descriptorId: mockApiDescriptor.id,
+      },
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockApiEservice.data.id },
+    });
+    expect(
+      mockInteropBeClients.catalogProcessClient.getEServiceById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw eserviceDescriptorNotFound in case of descriptor missing in E-service returned by the process", async () => {
+    const eserviceWithoutDescriptor: catalogApi.EService = {
+      ...mockApiEservice.data,
+      descriptors: [],
+    };
+
+    mockCancelArchiving.mockResolvedValue({
+      data: eserviceWithoutDescriptor,
+      metadata: { version: 0 },
+    });
+    await expect(
+      eserviceService.cancelEServiceDescriptorArchiving(
+        unsafeBrandId(mockApiEservice.data.id),
+        unsafeBrandId(mockApiDescriptor.id),
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      eserviceDescriptorNotFound(mockApiEservice.data.id, mockApiDescriptor.id)
+    );
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the cancel call has no metadata", async () => {
+    mockCancelArchiving.mockResolvedValueOnce({
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.cancelEServiceDescriptorArchiving(
+        unsafeBrandId(mockApiEservice.data.id),
+        unsafeBrandId(mockApiDescriptor.id),
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the polling GET call has no metadata", async () => {
+    mockGetEservice.mockResolvedValueOnce({
+      data: mockApiEservice.data,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.cancelEServiceDescriptorArchiving(
+        unsafeBrandId(mockApiEservice.data.id),
+        unsafeBrandId(mockApiDescriptor.id),
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEservice.mockImplementation(
+      mockPollingResponse(mockApiEservice, config.defaultPollingMaxRetries + 1)
+    );
+
+    await expect(
+      eserviceService.cancelEServiceDescriptorArchiving(
+        unsafeBrandId(mockApiEservice.data.id),
+        unsafeBrandId(mockApiDescriptor.id),
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEservice).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});


### PR DESCRIPTION
## Issue
- [PIN-9862](https://pagopa.atlassian.net/browse/PIN-9862)
- [SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2803302507/DRAFT+SRS+Archiviazione+manuale+e-service)
## Context
This PR defines the API for canceling an archiving schedule associated with a single descriptor. The exposed endpoint is replicated on BFF and M2M gateways following standard authorization logics.

For more information, please consult the [SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2803302507/DRAFT+SRS+Archiviazione+manuale+e-service#%5BWork-Item-3%5D-Archiviazione-manuale-di-uno-specifico-descrittore%3A-catalog-process%2C-BFF%2C-M2M-CONSOLIDATO).
## Scope
- catalogProcess


[PIN-9862]: https://pagopa.atlassian.net/browse/PIN-9862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ