### PR TITLE
[PIN-7097] - add real read model DB in *-certified-attributes-importer tests

### DIFF
--- a/packages/anac-certified-attributes-importer/test/helpers.ts
+++ b/packages/anac-certified-attributes-importer/test/helpers.ts
@@ -1,19 +1,50 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { inject } from "vitest";
+import { setupTestContainersVitest } from "pagopa-interop-commons-test";
+import {
+  attributeReadModelServiceBuilder,
+  tenantReadModelServiceBuilder,
+} from "pagopa-interop-readmodel";
+import {
+  upsertAttribute,
+  upsertTenant,
+} from "pagopa-interop-readmodel/testUtils";
 import {
   Attribute,
   Tenant,
   TenantAttribute,
-  TenantId,
-  WithMetadata,
   unsafeBrandId,
 } from "pagopa-interop-models";
+import { readModelQueriesBuilderSQL } from "../src/service/readmodelQueriesServiceSQL.js";
 import { SftpConfig } from "../src/config/sftpConfig.js";
 import { InteropContext } from "../src/model/interopContextModel.js";
-import {
-  ANAC_ASSIGNED_CODE,
-  ANAC_ENABLED_CODE,
-  ANAC_IN_VALIDATION_CODE,
-} from "../src/service/processor.js";
+
+export const { cleanup, readModelDB } = await setupTestContainersVitest(
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  inject("readModelSQLConfig")
+);
+
+const tenantReadModelServiceSQL = tenantReadModelServiceBuilder(readModelDB);
+const attributeReadModelServiceSQL =
+  attributeReadModelServiceBuilder(readModelDB);
+
+export const readModelQueries = readModelQueriesBuilderSQL(
+  readModelDB,
+  tenantReadModelServiceSQL,
+  attributeReadModelServiceSQL
+);
+
+export const addOneAttribute = async (attribute: Attribute): Promise<void> => {
+  await upsertAttribute(readModelDB, attribute, 0);
+};
+
+export const addOneTenant = async (tenant: Tenant): Promise<void> => {
+  await upsertTenant(readModelDB, tenant, 0);
+};
 
 export const sftpConfigTest: SftpConfig = {
   host: "host",
@@ -25,10 +56,11 @@ export const sftpConfigTest: SftpConfig = {
   forceFileName: "test-file.csv",
 };
 
-const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
-0123456789,Org name in IPA,gsp1@pec.it,ipa_code_123,TRUE,FALSE,TRUE
-0011223344,E-Procurement 1,eprocurement1@pec.it,,TRUE,TRUE,FALSE
-0011223344,"E-Procurement 2 con , virgola nel nome",eprocurement1@pec.it,,TRUE,TRUE,FALSE`;
+export const CSV_HEADER =
+  "codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida";
+
+const csvFileContent = `${CSV_HEADER}
+0123456789,Org name in IPA,gsp1@pec.it,ipa_code_123,FALSE,FALSE,FALSE`;
 
 export const ATTRIBUTE_ANAC_ASSIGNED_ID =
   "b1d64ee0-fda9-48e2-84f8-1b62f1292b47";
@@ -36,25 +68,12 @@ export const ATTRIBUTE_ANAC_ENABLED_ID = "dc77c852-7635-4522-bc1c-e431c5d68b55";
 export const ATTRIBUTE_ANAC_IN_VALIDATION_ID =
   "97dec753-8a6e-4a25-aa02-95ac8602b364";
 
+export const ANAC_CERTIFIER_ID = "ANAC";
+export const ANAC_TENANT_ID = "69e2865e-65ab-4e48-a638-2037a9ee2ee7";
+
 export const downloadCSVMockGenerator =
   (csvContent: string) => (): Promise<string> =>
     Promise.resolve(csvContent);
-export const getTenantsMockGenerator =
-  (f: (codes: string[]) => Tenant[]) =>
-  (codes: string[]): Promise<Tenant[]> =>
-    Promise.resolve(f(codes));
-export const getTenantByIdMockGenerator =
-  (f: (tenantId: TenantId) => Tenant) =>
-  (tenantId: TenantId): Promise<Tenant> =>
-    Promise.resolve(f(tenantId));
-const getTenantByIdWithMetadataMockGenerator =
-  (f: (tenantId: TenantId) => Tenant) =>
-  (tenantId: TenantId): Promise<WithMetadata<Tenant>> =>
-    Promise.resolve({
-      data: f(tenantId),
-      metadata: { version: 1 },
-    } as WithMetadata<Tenant>);
-
 export const downloadCSVMock = downloadCSVMockGenerator(csvFileContent);
 
 export const internalAssignCertifiedAttributeMock = (
@@ -72,60 +91,6 @@ export const internalRevokeCertifiedAttributeMock = (
   _context: InteropContext
 ): Promise<{ version: number } | undefined> => Promise.resolve({ version: 1 });
 
-export const getPATenantsMock = getTenantsMockGenerator((ipaCodes) =>
-  ipaCodes.map((c) => ({
-    ...persistentTenant,
-    externalId: { origin: "tenantOrigin", value: c },
-  }))
-);
-export const getNonPATenantsMock = getTenantsMockGenerator((taxCodes) =>
-  taxCodes.map((c) => ({
-    ...persistentTenant,
-    externalId: { origin: "tenantOrigin", value: c },
-  }))
-);
-const buildAnacTenantById = (tenantId: TenantId): Tenant => ({
-  ...persistentTenant,
-  id: tenantId,
-  features: [{ type: "PersistentCertifier", certifierId: "ANAC" }],
-});
-export const getTenantByIdMock =
-  getTenantByIdMockGenerator(buildAnacTenantById);
-export const getTenantByIdWithMetadataMock =
-  getTenantByIdWithMetadataMockGenerator(buildAnacTenantById);
-export const getAttributeByExternalIdMock = (
-  origin: string,
-  code: string
-): Promise<Attribute> => {
-  switch (code) {
-    case ANAC_ENABLED_CODE:
-      return Promise.resolve({
-        ...persistentAttribute,
-        id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-        origin,
-        code,
-      });
-    case ANAC_IN_VALIDATION_CODE:
-      return Promise.resolve({
-        ...persistentAttribute,
-        id: unsafeBrandId(ATTRIBUTE_ANAC_IN_VALIDATION_ID),
-        origin,
-        code,
-      });
-    case ANAC_ASSIGNED_CODE:
-      return Promise.resolve({
-        ...persistentAttribute,
-        id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
-        origin,
-        code,
-      });
-    default:
-      return Promise.reject(new Error("Unexpected attribute code"));
-  }
-};
-export const getTenantsWithAttributesMock = (_: string[]) =>
-  Promise.resolve([]);
-
 export const persistentTenant: Tenant = {
   id: unsafeBrandId("091fbea1-0c8e-411b-988f-5098b6a33ba7"),
   externalId: { origin: "tenantOrigin", value: "tenantValue" },
@@ -136,7 +101,7 @@ export const persistentTenant: Tenant = {
   mails: [],
 };
 
-const persistentAttribute: Attribute = {
+export const persistentAttribute: Attribute = {
   id: unsafeBrandId("7a04c906-1525-4c68-8a5b-d740d77d9c80"),
   origin: "attributeOrigin",
   code: "attributeCode",
@@ -151,3 +116,18 @@ export const persistentTenantAttribute: TenantAttribute = {
   type: "PersistentCertifiedAttribute",
   assignmentTimestamp: new Date(),
 };
+
+export const buildAnacCertifierTenant = (): Tenant => ({
+  ...persistentTenant,
+  id: unsafeBrandId(ANAC_TENANT_ID),
+  name: "ANAC certifier tenant",
+  features: [{ type: "PersistentCertifier", certifierId: ANAC_CERTIFIER_ID }],
+});
+
+export const buildAnacAttribute = (id: string, code: string): Attribute => ({
+  ...persistentAttribute,
+  id: unsafeBrandId(id),
+  origin: ANAC_CERTIFIER_ID,
+  code,
+  name: code,
+});

--- a/packages/anac-certified-attributes-importer/test/helpers.ts
+++ b/packages/anac-certified-attributes-importer/test/helpers.ts
@@ -68,7 +68,7 @@ export const ATTRIBUTE_ANAC_ENABLED_ID = "dc77c852-7635-4522-bc1c-e431c5d68b55";
 export const ATTRIBUTE_ANAC_IN_VALIDATION_ID =
   "97dec753-8a6e-4a25-aa02-95ac8602b364";
 
-export const ANAC_CERTIFIER_ID = "ANAC";
+const ANAC_CERTIFIER_ID = "ANAC";
 export const ANAC_TENANT_ID = "69e2865e-65ab-4e48-a638-2037a9ee2ee7";
 
 export const downloadCSVMockGenerator =
@@ -101,7 +101,7 @@ export const persistentTenant: Tenant = {
   mails: [],
 };
 
-export const persistentAttribute: Attribute = {
+const persistentAttribute: Attribute = {
   id: unsafeBrandId("7a04c906-1525-4c68-8a5b-d740d77d9c80"),
   origin: "attributeOrigin",
   code: "attributeCode",

--- a/packages/anac-certified-attributes-importer/test/processor.test.ts
+++ b/packages/anac-certified-attributes-importer/test/processor.test.ts
@@ -1,42 +1,58 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { afterEach, beforeAll, describe, expect, it, vi, vitest } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   InteropInternalToken,
   InteropTokenGenerator,
   RefreshableInteropToken,
   genericLogger,
 } from "pagopa-interop-commons";
-import { generateId, Tenant, unsafeBrandId } from "pagopa-interop-models";
 import {
-  attributeReadModelServiceBuilder,
-  makeDrizzleConnection,
-  tenantReadModelServiceBuilder,
-} from "pagopa-interop-readmodel";
+  PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+  Tenant,
+  generateId,
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { TenantProcessService } from "../src/service/tenantProcessService.js";
 import { SftpClient } from "../src/service/sftpService.js";
-import { readModelQueriesBuilderSQL } from "../src/service/readmodelQueriesServiceSQL.js";
-import { importAttributes } from "../src/service/processor.js";
-import { config } from "../src/config/config.js";
 import {
+  ANAC_ASSIGNED_CODE,
+  ANAC_ENABLED_CODE,
+  ANAC_IN_VALIDATION_CODE,
+  importAttributes,
+} from "../src/service/processor.js";
+import {
+  ANAC_TENANT_ID,
   ATTRIBUTE_ANAC_ASSIGNED_ID,
   ATTRIBUTE_ANAC_ENABLED_ID,
   ATTRIBUTE_ANAC_IN_VALIDATION_ID,
+  CSV_HEADER,
+  addOneAttribute,
+  addOneTenant,
+  cleanup,
+  buildAnacAttribute,
+  buildAnacCertifierTenant,
   downloadCSVMock,
   downloadCSVMockGenerator,
-  getAttributeByExternalIdMock,
-  getNonPATenantsMock,
-  getPATenantsMock,
-  getTenantByIdMock,
-  getTenantByIdWithMetadataMock,
-  getTenantByIdMockGenerator,
-  getTenantsMockGenerator,
-  getTenantsWithAttributesMock,
   internalAssignCertifiedAttributeMock,
   internalRevokeCertifiedAttributeMock,
   persistentTenant,
   persistentTenantAttribute,
+  readModelQueries,
   sftpConfigTest,
 } from "./helpers.js";
+
+const waitForReadModelMetadataVersionMock = vi.fn(
+  (): Promise<void> => Promise.resolve()
+);
+
+vi.mock("pagopa-interop-commons", async () => {
+  const actual = await vi.importActual("pagopa-interop-commons");
+  return {
+    ...actual,
+    waitForReadModelMetadataVersion: waitForReadModelMetadataVersionMock,
+  };
+});
 
 describe("ANAC Certified Attributes Importer", () => {
   const tokenGeneratorMock = {} as InteropTokenGenerator;
@@ -44,22 +60,8 @@ describe("ANAC Certified Attributes Importer", () => {
   const tenantProcessMock = new TenantProcessService("url");
   const sftpClientMock = new SftpClient(sftpConfigTest);
 
-  const db = makeDrizzleConnection(config);
-  const tenantReadModelService = tenantReadModelServiceBuilder(db);
-  const attributeReadModelService = attributeReadModelServiceBuilder(db);
-  const readModelQueriesMock = readModelQueriesBuilderSQL(
-    db,
-    tenantReadModelService,
-    attributeReadModelService
-  );
-
   const interopInternalToken: InteropInternalToken = {
-    header: {
-      alg: "algorithm",
-      use: "use",
-      typ: "type",
-      kid: "key-id",
-    },
+    header: { alg: "algorithm", use: "use", typ: "type", kid: "key-id" },
     payload: {
       jti: "token-id",
       iss: "issuer",
@@ -72,28 +74,10 @@ describe("ANAC Certified Attributes Importer", () => {
     },
     serialized: "the-token",
   };
-  const generateInternalTokenMock = (): Promise<InteropInternalToken> =>
-    Promise.resolve(interopInternalToken);
-
-  const run = () =>
-    importAttributes(
-      sftpClientMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      10,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "anac-tenant-id",
-      genericLogger,
-      generateId()
-    );
 
   const refreshableInternalTokenSpy = vi
     .spyOn(refreshableTokenMock, "get")
-    .mockImplementation(generateInternalTokenMock);
+    .mockImplementation(() => Promise.resolve(interopInternalToken));
 
   const internalAssignCertifiedAttributeSpy = vi
     .spyOn(tenantProcessMock, "internalAssignCertifiedAttribute")
@@ -102,582 +86,398 @@ describe("ANAC Certified Attributes Importer", () => {
     .spyOn(tenantProcessMock, "internalRevokeCertifiedAttribute")
     .mockImplementation(internalRevokeCertifiedAttributeMock);
 
-  const getPATenantsSpy = vi
-    .spyOn(readModelQueriesMock, "getPATenants")
-    .mockImplementation(getPATenantsMock);
-  const getNonPATenantsSpy = vi
-    .spyOn(readModelQueriesMock, "getNonPATenants")
-    .mockImplementation(getNonPATenantsMock);
-  const getTenantByIdSpy = vi
-    .spyOn(readModelQueriesMock, "getTenantById")
-    .mockImplementation((id) => getTenantByIdMock(unsafeBrandId(id)));
-  const getTenantByIdWithMetadataSpy = vi
-    .spyOn(readModelQueriesMock, "getTenantByIdWithMetadata")
-    .mockImplementation((id) =>
-      getTenantByIdWithMetadataMock(unsafeBrandId(id))
+  const pollingConfig = {
+    defaultPollingMaxRetries: 1,
+    defaultPollingRetryDelay: 1,
+  };
+
+  const run = (batchSize: number = 10) =>
+    importAttributes(
+      sftpClientMock,
+      readModelQueries,
+      tenantProcessMock,
+      refreshableTokenMock,
+      batchSize,
+      pollingConfig,
+      ANAC_TENANT_ID,
+      genericLogger,
+      generateId()
     );
-  const getAttributeByExternalIdSpy = vi
-    .spyOn(readModelQueriesMock, "getAttributeByExternalId")
-    .mockImplementation(getAttributeByExternalIdMock);
-  const getTenantsWithAttributesSpy = vi
-    .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-    .mockImplementation(getTenantsWithAttributesMock);
+
+  const seedCertifierAndAttributes = async (): Promise<void> => {
+    await addOneTenant(buildAnacCertifierTenant());
+    await addOneAttribute(
+      buildAnacAttribute(ATTRIBUTE_ANAC_ENABLED_ID, ANAC_ENABLED_CODE)
+    );
+    await addOneAttribute(
+      buildAnacAttribute(ATTRIBUTE_ANAC_ASSIGNED_ID, ANAC_ASSIGNED_CODE)
+    );
+    await addOneAttribute(
+      buildAnacAttribute(
+        ATTRIBUTE_ANAC_IN_VALIDATION_ID,
+        ANAC_IN_VALIDATION_CODE
+      )
+    );
+  };
 
   beforeAll(() => {
-    vitest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vitest.clearAllMocks();
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await cleanup();
   });
 
   it("should succeed", async () => {
+    const csv = `${CSV_HEADER}
+0123456789,Org name in IPA,gsp1@pec.it,ipa_code_123,TRUE,TRUE,TRUE`;
     const downloadCSVSpy = vi
       .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(downloadCSVMock);
+      .mockImplementation(downloadCSVMockGenerator(csv));
+
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
+      },
+      attributes: [],
+    });
 
     await run();
 
     expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(3);
-
-    expect(getPATenantsSpy).toBeCalledTimes(1);
-    expect(getNonPATenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
     expect(refreshableInternalTokenSpy).toBeCalled();
-    expect(internalAssignCertifiedAttributeSpy).toBeCalled();
+    expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(3);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should fail if polling max retries are reached after assign", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+    const csv = `${CSV_HEADER}
 0123456789,Org name in IPA,gsp1@pec.it,ipa_code_123,FALSE,TRUE,FALSE`;
-
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_123" },
-        attributes: [],
-      },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
     vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
-      localDownloadCSVMock
+      downloadCSVMockGenerator(csv)
     );
 
-    getPATenantsSpy.mockImplementationOnce(
-      getTenantsMockGenerator((_) => readModelTenants)
-    );
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
+      },
+      attributes: [],
+    });
 
     internalAssignCertifiedAttributeSpy.mockResolvedValueOnce({ version: 5 });
+    waitForReadModelMetadataVersionMock.mockRejectedValueOnce(
+      pollingMaxRetriesExceeded(1, 1)
+    );
 
-    await expect(
-      importAttributes(
-        sftpClientMock,
-        readModelQueriesMock,
-        tenantProcessMock,
-        refreshableTokenMock,
-        10,
-        {
-          defaultPollingMaxRetries: 1,
-          defaultPollingRetryDelay: 1,
-        },
-        "anac-tenant-id",
-        genericLogger,
-        generateId()
-      )
-    ).rejects.toThrowError();
-
+    await expect(run()).rejects.toThrowError();
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(1);
-    expect(getTenantByIdWithMetadataSpy).toBeCalled();
+    expect(waitForReadModelMetadataVersionMock).toBeCalled();
   });
 
   it("should fail if polling max retries are reached after revoke", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+    const csv = `${CSV_HEADER}
 0123456789,Org name in IPA,gsp1@pec.it,ipa_code_123,FALSE,FALSE,FALSE`;
-
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_123" },
-        attributes: [],
-      },
-    ];
-
-    const tenantsWithAttribute: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "missing_from_csv" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-        ],
-      },
-    ];
-
     vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
-      downloadCSVMockGenerator(csvFileContent)
+      downloadCSVMockGenerator(csv)
     );
 
-    getPATenantsSpy.mockImplementationOnce(
-      getTenantsMockGenerator((_) => readModelTenants)
-    );
-
-    getTenantsWithAttributesSpy.mockImplementationOnce(
-      getTenantsMockGenerator((_) => tenantsWithAttribute)
-    );
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
+      },
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
+        },
+      ],
+    });
 
     internalRevokeCertifiedAttributeSpy.mockResolvedValueOnce({ version: 5 });
+    waitForReadModelMetadataVersionMock.mockRejectedValueOnce(
+      pollingMaxRetriesExceeded(1, 1)
+    );
 
-    await expect(
-      importAttributes(
-        sftpClientMock,
-        readModelQueriesMock,
-        tenantProcessMock,
-        refreshableTokenMock,
-        10,
-        {
-          defaultPollingMaxRetries: 1,
-          defaultPollingRetryDelay: 1,
-        },
-        "anac-tenant-id",
-        genericLogger,
-        generateId()
-      )
-    ).rejects.toThrowError();
-
+    await expect(run()).rejects.toThrowError();
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(1);
-    expect(getTenantByIdWithMetadataSpy).toBeCalled();
+    expect(waitForReadModelMetadataVersionMock).toBeCalled();
   });
 
   it("should succeed, assigning only missing attributes", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+    const csv = `${CSV_HEADER}
 0123456789,Org name in IPA,gsp1@pec.it,ipa_code_123,TRUE,TRUE,TRUE`;
+    vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
+      downloadCSVMockGenerator(csv)
+    );
 
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_123" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-        ],
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
       },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-    const downloadCSVSpy = vi
-      .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(localDownloadCSVMock);
-
-    const getPATenantsMock = getTenantsMockGenerator((_) => readModelTenants);
-    const getPATenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getPATenants")
-      .mockImplementation(getPATenantsMock);
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
+        },
+      ],
+    });
 
     await run();
 
-    expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(3);
-
-    expect(getPATenantsSpy).toBeCalledTimes(1);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(2);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should succeed, unassigning only existing attributes", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+    const csv = `${CSV_HEADER}
 0123456789,Org name in IPA,gsp1@pec.it,ipa_code_123,FALSE,FALSE,FALSE`;
+    vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
+      downloadCSVMockGenerator(csv)
+    );
 
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_123" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
-          },
-        ],
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
       },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-    const downloadCSVSpy = vi
-      .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(localDownloadCSVMock);
-
-    const getPATenantsMock = getTenantsMockGenerator((_) => readModelTenants);
-    const getPATenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getPATenants")
-      .mockImplementation(getPATenantsMock);
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
+        },
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
+        },
+      ],
+    });
 
     await run();
 
-    expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(3);
-
-    expect(getPATenantsSpy).toBeCalledTimes(1);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(2);
   });
 
-  it("should succeed, only for tenants that exist on read model ", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+  it("should succeed, only for tenants that exist on read model", async () => {
+    const csv = `${CSV_HEADER}
 0123456789,Org name in IPA,gsp1@pec.it,ipa_code_123,TRUE,TRUE,TRUE
 9876543210,Org name not in Tenants,gsp2@pec.it,ipa_code_456,TRUE,TRUE,TRUE`;
+    vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
+      downloadCSVMockGenerator(csv)
+    );
 
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_123" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-        ],
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
       },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-    const downloadCSVSpy = vi
-      .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(localDownloadCSVMock);
-
-    const getPATenantsMock = getTenantsMockGenerator((_) => readModelTenants);
-    const getPATenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getPATenants")
-      .mockImplementation(getPATenantsMock);
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
+        },
+      ],
+    });
 
     await run();
 
-    expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(3);
-
-    expect(getPATenantsSpy).toBeCalledTimes(1);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(2);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should succeed with more than one batch", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+    const csv = `${CSV_HEADER}
 0123456789,Org name in IPA,gsp1@pec.it,ipa_code_123,TRUE,TRUE,TRUE
 9876543210,Org name not in Tenants,gsp2@pec.it,ipa_code_456,TRUE,TRUE,TRUE
 9876543299,Org name not in Tenants,gsp3@pec.it,ipa_code_789,TRUE,TRUE,TRUE`;
-
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_123" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-        ],
-      },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-    const downloadCSVSpy = vi
-      .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(localDownloadCSVMock);
-
-    const getPATenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getPATenants")
-      .mockImplementationOnce(getTenantsMockGenerator((_) => readModelTenants))
-      .mockImplementation(getTenantsMockGenerator((_) => []));
-
-    await importAttributes(
-      sftpClientMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      1,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "anac-tenant-id",
-      genericLogger,
-      generateId()
+    vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
+      downloadCSVMockGenerator(csv)
     );
 
-    expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getTenantByIdWithMetadataSpy).toBeCalled();
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(3);
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
+      },
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
+        },
+      ],
+    });
 
-    expect(getPATenantsSpy).toBeCalledTimes(3);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
+    await run(1);
 
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(2);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should succeed, unassign attributes for tenants not in the file", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+    const csv = `${CSV_HEADER}
 0123456781,Org name in IPA,gsp1@pec.it,ipa_code_1,TRUE,TRUE,TRUE`;
-
-    const readModelTenants: Tenant[] = [
-      {
-        // Tenant with attributes that should be kept
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_1" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
-          },
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_IN_VALIDATION_ID),
-          },
-        ],
-      },
-      {
-        // IPA Tenant with ANAC_ABILITATO attribute that should be removed
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_2" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-        ],
-      },
-      {
-        // IPA Tenant with ANAC_INCARICATO attribute that should be removed
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_3" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
-          },
-        ],
-      },
-      {
-        // IPA Tenant with ANAC_IN_CONVALIDA attribute that should be removed
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_4" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_IN_VALIDATION_ID),
-          },
-        ],
-      },
-      {
-        // IPA Tenant with multiple attributes that should be removed
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_5" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
-          },
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_IN_VALIDATION_ID),
-          },
-        ],
-      },
-      {
-        // Private Tenant with multiple attributes that should be removed
-        ...persistentTenant,
-        externalId: { origin: "ANAC", value: "0123456786" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
-          },
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_IN_VALIDATION_ID),
-          },
-        ],
-      },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-    const downloadCSVSpy = vi
-      .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(localDownloadCSVMock);
-
-    const getPATenantsMock = getTenantsMockGenerator((_) => readModelTenants);
-    const getPATenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getPATenants")
-      .mockImplementation(getPATenantsMock);
-
-    const getTenantsWithAttributesMock = getTenantsMockGenerator(
-      (_) => readModelTenants
+    vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
+      downloadCSVMockGenerator(csv)
     );
-    const getTenantsWithAttributesSpy = vi
-      .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-      .mockImplementationOnce(getTenantsWithAttributesMock);
+
+    await seedCertifierAndAttributes();
+
+    // Tenant in CSV — has all 3 attributes, nothing to assign or revoke
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_1",
+      },
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
+        },
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
+        },
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_IN_VALIDATION_ID),
+        },
+      ],
+    });
+
+    // Tenants NOT in CSV but with ANAC attributes — should be revoked
+    const orphanTenantsAttributes = [
+      [ATTRIBUTE_ANAC_ENABLED_ID],
+      [ATTRIBUTE_ANAC_ASSIGNED_ID],
+      [ATTRIBUTE_ANAC_IN_VALIDATION_ID],
+      [
+        ATTRIBUTE_ANAC_ENABLED_ID,
+        ATTRIBUTE_ANAC_ASSIGNED_ID,
+        ATTRIBUTE_ANAC_IN_VALIDATION_ID,
+      ],
+    ];
+    for (const [idx, attrs] of orphanTenantsAttributes.entries()) {
+      await addOneTenant({
+        ...persistentTenant,
+        id: generateId(),
+        externalId: {
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          value: `ipa_code_orphan_${idx}`,
+        },
+        attributes: attrs.map((id) => ({
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(id),
+        })),
+      });
+    }
 
     await run();
 
-    expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(3);
-
-    expect(getPATenantsSpy).toBeCalledTimes(1);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(9);
+    const totalRevokes = orphanTenantsAttributes.flat().length;
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
-    expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(9);
+    expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(totalRevokes);
   });
 
   it("should succeed, case insensivity for IPA code", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+    const csv = `${CSV_HEADER}
 0123456789,Org name in IPA,gsp1@pec.it,ipa_CODE_123,TRUE,TRUE,TRUE`;
+    vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
+      downloadCSVMockGenerator(csv)
+    );
 
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_123" },
-        attributes: [],
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
       },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-    const downloadCSVSpy = vi
-      .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(localDownloadCSVMock);
-
-    const getPATenantsMock = getTenantsMockGenerator((_) => readModelTenants);
-    const getPATenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getPATenants")
-      .mockImplementation(getPATenantsMock);
+      attributes: [],
+    });
 
     await run();
 
-    expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(3);
-
-    expect(getPATenantsSpy).toBeCalledTimes(1);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(3);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(3);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should succeed, unassigning existing attributes with case insensivity for IPA code", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+    const csv = `${CSV_HEADER}
 0123456789,Org name in IPA,gsp1@pec.it,ipa_CODE_123,TRUE,TRUE,FALSE`;
+    vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
+      downloadCSVMockGenerator(csv)
+    );
 
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_123" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_IN_VALIDATION_ID),
-          },
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
-          },
-        ],
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
       },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-    const downloadCSVSpy = vi
-      .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(localDownloadCSVMock);
-
-    const getPATenantsMock = getTenantsMockGenerator((_) => readModelTenants);
-    const getPATenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getPATenants")
-      .mockImplementation(getPATenantsMock);
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_IN_VALIDATION_ID),
+        },
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
+        },
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ASSIGNED_ID),
+        },
+      ],
+    });
 
     await run();
 
-    expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(3);
-
-    expect(getPATenantsSpy).toBeCalledTimes(1);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(1);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(1);
   });
 
   it("should fail on CSV retrieve error", async () => {
-    const localDownloadCSVMock = (): Promise<string> =>
-      Promise.reject(new Error("CSV Retrieve error"));
+    await seedCertifierAndAttributes();
+
     const downloadCSVSpy = vi
       .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(localDownloadCSVMock);
+      .mockImplementation(() =>
+        Promise.reject(new Error("CSV Retrieve error"))
+      );
 
     await expect(() => run()).rejects.toThrowError("CSV Retrieve error");
 
     expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(0);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(0);
-
-    expect(getPATenantsSpy).toBeCalledTimes(0);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(0);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(0);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
@@ -687,72 +487,49 @@ describe("ANAC Certified Attributes Importer", () => {
       .spyOn(sftpClientMock, "downloadCSV")
       .mockImplementation(downloadCSVMock);
 
-    const getTenantByIdMock = getTenantByIdMockGenerator((tenantId) => ({
+    const nonCertifierTenant: Tenant = {
       ...persistentTenant,
-      id: tenantId,
+      id: unsafeBrandId(ANAC_TENANT_ID),
       features: [],
-    }));
-    getTenantByIdSpy.mockImplementationOnce((id) =>
-      getTenantByIdMock(unsafeBrandId(id))
-    );
+    };
+    await addOneTenant(nonCertifierTenant);
 
     await expect(() => run()).rejects.toThrowError(
-      "Tenant with id anac-tenant-id is not a certifier"
+      `Tenant with id ${ANAC_TENANT_ID} is not a certifier`
     );
 
     expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(0);
-
-    expect(getPATenantsSpy).toBeCalledTimes(0);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(0);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(0);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should skip CSV file rows with unexpected schema", async () => {
-    const csvFileContent = `codiceFiscaleGestore,denominazioneGestore,PEC,codiceIPA,ANAC_incaricato,ANAC_abilitato,ANAC_in_convalida
+    const csv = `${CSV_HEADER}
     ,Wrong format row,gsp1@pec.it,ipa_code_123,TRUE,TRUE,
     ,Wrong "quotes" row,gsp1@pec.it,ipa_code_123,TRUE,TRUE,TRUE
     0123456789,"Org name, in IPA",gsp1@pec.it,ipa_code_123,TRUE,TRUE,TRUE`;
+    vi.spyOn(sftpClientMock, "downloadCSV").mockImplementation(
+      downloadCSVMockGenerator(csv)
+    );
 
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IPA", value: "ipa_code_123" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
-          },
-        ],
+    await seedCertifierAndAttributes();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: {
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        value: "ipa_code_123",
       },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-    const downloadCSVSpy = vi
-      .spyOn(sftpClientMock, "downloadCSV")
-      .mockImplementation(localDownloadCSVMock);
-
-    const getPATenantsMock = getTenantsMockGenerator((_) => readModelTenants);
-    const getPATenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getPATenants")
-      .mockImplementation(getPATenantsMock);
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_ANAC_ENABLED_ID),
+        },
+      ],
+    });
 
     await run();
 
-    expect(downloadCSVSpy).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(3);
-
-    expect(getPATenantsSpy).toBeCalledTimes(1);
-    expect(getNonPATenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(2);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });

--- a/packages/anac-certified-attributes-importer/test/processor.test.ts
+++ b/packages/anac-certified-attributes-importer/test/processor.test.ts
@@ -42,9 +42,11 @@ import {
   sftpConfigTest,
 } from "./helpers.js";
 
-const waitForReadModelMetadataVersionMock = vi.fn(
-  (): Promise<void> => Promise.resolve()
-);
+const { waitForReadModelMetadataVersionMock } = vi.hoisted(() => ({
+  waitForReadModelMetadataVersionMock: vi.fn(
+    (): Promise<void> => Promise.resolve()
+  ),
+}));
 
 vi.mock("pagopa-interop-commons", async () => {
   const actual = await vi.importActual("pagopa-interop-commons");

--- a/packages/ipa-certified-attributes-importer/test/readModelServiceSQL.test.ts
+++ b/packages/ipa-certified-attributes-importer/test/readModelServiceSQL.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeAll, describe, expect, it, inject } from "vitest";
+import { setupTestContainersVitest } from "pagopa-interop-commons-test";
+import {
+  attributeReadModelServiceBuilder,
+  tenantReadModelServiceBuilder,
+} from "pagopa-interop-readmodel";
+import {
+  upsertAttribute,
+  upsertTenant,
+} from "pagopa-interop-readmodel/testUtils";
+import {
+  Attribute,
+  PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+  Tenant,
+  attributeKind,
+  generateId,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import { readModelServiceBuilderSQL } from "../src/services/readModelServiceSQL.js";
+
+const { cleanup, readModelDB } = await setupTestContainersVitest(
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  inject("readModelSQLConfig")
+);
+
+const tenantReadModelServiceSQL = tenantReadModelServiceBuilder(readModelDB);
+const attributeReadModelServiceSQL =
+  attributeReadModelServiceBuilder(readModelDB);
+
+const readModelServiceSQL = readModelServiceBuilderSQL({
+  readModelDB,
+  attributeReadModelServiceSQL,
+  tenantReadModelServiceSQL,
+});
+
+const baseTenant = (): Tenant => ({
+  id: generateId(),
+  externalId: { origin: "unset", value: "unset" },
+  attributes: [],
+  features: [],
+  name: "tenantName",
+  createdAt: new Date(),
+  mails: [],
+});
+
+const baseAttribute = (): Attribute => ({
+  id: generateId(),
+  origin: "unset",
+  code: "unset",
+  name: "attributeName",
+  kind: attributeKind.certified,
+  creationTime: new Date(),
+  description: "attributeDescription",
+});
+
+describe("IPA readModelServiceSQL", () => {
+  beforeAll(async () => {
+    await cleanup();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("getIPATenants", () => {
+    it("should return only tenants with IPA external id origin", async () => {
+      const ipaTenant1: Tenant = {
+        ...baseTenant(),
+        externalId: {
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          value: "ipa-1",
+        },
+      };
+      const ipaTenant2: Tenant = {
+        ...baseTenant(),
+        externalId: {
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          value: "ipa-2",
+        },
+      };
+      const nonIpaTenant: Tenant = {
+        ...baseTenant(),
+        externalId: { origin: "ANAC", value: "non-ipa" },
+      };
+
+      await upsertTenant(readModelDB, ipaTenant1, 0);
+      await upsertTenant(readModelDB, ipaTenant2, 0);
+      await upsertTenant(readModelDB, nonIpaTenant, 0);
+
+      const tenants = await readModelServiceSQL.getIPATenants();
+
+      expect(tenants).toHaveLength(2);
+      const ids = tenants.map((t) => t.id).sort();
+      expect(ids).toEqual([ipaTenant1.id, ipaTenant2.id].sort());
+    });
+
+    it("should return an empty array when no IPA tenants exist", async () => {
+      await upsertTenant(
+        readModelDB,
+        {
+          ...baseTenant(),
+          externalId: { origin: "ANAC", value: "non-ipa" },
+        },
+        0
+      );
+
+      const tenants = await readModelServiceSQL.getIPATenants();
+
+      expect(tenants).toHaveLength(0);
+    });
+  });
+
+  describe("getAttributes", () => {
+    it("should return only certified attributes with IPA origin", async () => {
+      const ipaCertifiedAttr1: Attribute = {
+        ...baseAttribute(),
+        kind: attributeKind.certified,
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        code: "code-1",
+      };
+      const ipaCertifiedAttr2: Attribute = {
+        ...baseAttribute(),
+        kind: attributeKind.certified,
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        code: "code-2",
+      };
+      const ipaDeclaredAttr: Attribute = {
+        ...baseAttribute(),
+        kind: attributeKind.declared,
+        origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+        code: "code-3",
+      };
+      const nonIpaCertifiedAttr: Attribute = {
+        ...baseAttribute(),
+        kind: attributeKind.certified,
+        origin: "ANAC",
+        code: "code-4",
+      };
+
+      await upsertAttribute(readModelDB, ipaCertifiedAttr1, 0);
+      await upsertAttribute(readModelDB, ipaCertifiedAttr2, 0);
+      await upsertAttribute(readModelDB, ipaDeclaredAttr, 0);
+      await upsertAttribute(readModelDB, nonIpaCertifiedAttr, 0);
+
+      const attributes = await readModelServiceSQL.getAttributes();
+
+      expect(attributes).toHaveLength(2);
+      const ids = attributes.map((a) => a.id).sort();
+      expect(ids).toEqual([ipaCertifiedAttr1.id, ipaCertifiedAttr2.id].sort());
+    });
+
+    it("should return an empty array when no matching attributes exist", async () => {
+      await upsertAttribute(
+        readModelDB,
+        {
+          ...baseAttribute(),
+          kind: attributeKind.declared,
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          code: "code-declared",
+        },
+        0
+      );
+
+      const attributes = await readModelServiceSQL.getAttributes();
+
+      expect(attributes).toHaveLength(0);
+    });
+  });
+
+  describe("getTenantByExternalIdWithMetadata", () => {
+    it("should return metadata when the tenant exists", async () => {
+      const tenant: Tenant = {
+        ...baseTenant(),
+        externalId: {
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          value: "ipa-ext-1",
+        },
+      };
+      await upsertTenant(readModelDB, tenant, 7);
+
+      const result =
+        await readModelServiceSQL.getTenantByExternalIdWithMetadata({
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          value: "ipa-ext-1",
+        });
+
+      expect(result).toEqual({ metadata: { version: 7 } });
+    });
+
+    it("should return undefined when the tenant does not exist", async () => {
+      const result =
+        await readModelServiceSQL.getTenantByExternalIdWithMetadata({
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          value: "missing",
+        });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should match only tenants with the exact origin and value", async () => {
+      await upsertTenant(
+        readModelDB,
+        {
+          ...baseTenant(),
+          id: unsafeBrandId(generateId()),
+          externalId: {
+            origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+            value: "shared-value",
+          },
+        },
+        0
+      );
+      await upsertTenant(
+        readModelDB,
+        {
+          ...baseTenant(),
+          id: unsafeBrandId(generateId()),
+          externalId: { origin: "ANAC", value: "shared-value" },
+        },
+        0
+      );
+
+      const result =
+        await readModelServiceSQL.getTenantByExternalIdWithMetadata({
+          origin: "ANAC",
+          value: "shared-value",
+        });
+
+      expect(result).toEqual({ metadata: { version: 0 } });
+    });
+  });
+});

--- a/packages/ivass-certified-attributes-importer/package.json
+++ b/packages/ivass-certified-attributes-importer/package.json
@@ -36,7 +36,6 @@
     "pagopa-interop-models": "workspace:*",
     "pagopa-interop-readmodel": "workspace:*",
     "pagopa-interop-readmodel-models": "workspace:*",
-    "ts-pattern": "catalog:",
     "zod": "catalog:"
   }
 }

--- a/packages/ivass-certified-attributes-importer/test/helpers.ts
+++ b/packages/ivass-certified-attributes-importer/test/helpers.ts
@@ -91,7 +91,7 @@ export const persistentTenant: Tenant = {
   name: "tenantName",
 };
 
-export const persistentAttribute: Attribute = {
+const persistentAttribute: Attribute = {
   id: unsafeBrandId("7a04c906-1525-4c68-8a5b-d740d77d9c80"),
   origin: "attributeOrigin",
   code: "attributeCode",

--- a/packages/ivass-certified-attributes-importer/test/helpers.ts
+++ b/packages/ivass-certified-attributes-importer/test/helpers.ts
@@ -1,46 +1,69 @@
+/* eslint-disable prettier/prettier */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { inject } from "vitest";
+import { setupTestContainersVitest } from "pagopa-interop-commons-test";
+import {
+  attributeReadModelServiceBuilder,
+  tenantReadModelServiceBuilder,
+} from "pagopa-interop-readmodel";
+import {
+  upsertAttribute,
+  upsertTenant,
+} from "pagopa-interop-readmodel/testUtils";
 import {
   Attribute,
-  AttributeId,
   Tenant,
-  TenantId,
   TenantAttribute,
-  WithMetadata,
   unsafeBrandId,
 } from "pagopa-interop-models";
-import { vi } from "vitest";
-import { match } from "ts-pattern";
-import { IVASS_INSURANCES_ATTRIBUTE_CODE } from "../src/config/constants.js";
+import { readModelQueriesBuilderSQL } from "../src/service/readModelQueriesServiceSQL.js";
+import {
+  IVASS_INSURANCES_ATTRIBUTE_CODE,
+  IVASS_ORIGIN_NAME,
+} from "../src/config/constants.js";
 import { InteropContext } from "../src/model/interopContextModel.js";
 
-const csvFileContent = `OTHER_FIELD;CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-F1;D0001;2020-12-02;9999-12-31;Org1;0000012345678901
-F2;D0002;2020-06-10;9999-12-31;Org2;0000012345678902
-F3;D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
+export const { cleanup, readModelDB } = await setupTestContainersVitest(
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  inject("readModelSQLConfig")
+);
+
+const tenantReadModelServiceSQL = tenantReadModelServiceBuilder(readModelDB);
+const attributeReadModelServiceSQL =
+  attributeReadModelServiceBuilder(readModelDB);
+
+export const readModelQueries = readModelQueriesBuilderSQL(
+  readModelDB,
+  tenantReadModelServiceSQL,
+  attributeReadModelServiceSQL
+);
+
+export const addOneAttribute = async (attribute: Attribute): Promise<void> => {
+  await upsertAttribute(readModelDB, attribute, 0);
+};
+
+export const addOneTenant = async (tenant: Tenant): Promise<void> => {
+  await upsertTenant(readModelDB, tenant, 0);
+};
+
+export const CSV_HEADER =
+  "CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE";
+
+const csvFileContent = `${CSV_HEADER}
+D0001;2020-12-02;9999-12-31;Org1;0000012345678901`;
 
 export const ATTRIBUTE_IVASS_INSURANCES_ID =
   "b1d64ee0-fda9-48e2-84f8-1b62f1292b47";
 
-export const downloadCSVMockGenerator = (csvContent: string) =>
-  vi
-    .fn()
-    .mockImplementation((): Promise<string> => Promise.resolve(csvContent));
-export const getTenantsMockGenerator =
-  (f: (codes: string[]) => Tenant[]) =>
-  (codes: string[]): Promise<Tenant[]> =>
-    Promise.resolve(f(codes));
-export const getTenantByIdMockGenerator =
-  (f: (tenantId: TenantId) => Tenant) =>
-  (tenantId: TenantId): Promise<Tenant> =>
-    Promise.resolve(f(tenantId));
-const getTenantByIdWithMetadataMockGenerator =
-  (f: (tenantId: TenantId) => Tenant) =>
-  (tenantId: TenantId): Promise<WithMetadata<Tenant>> =>
-    Promise.resolve({
-      data: f(tenantId),
-      metadata: { version: 1 },
-    } as WithMetadata<Tenant>);
+export const IVASS_TENANT_ID = "69e2865e-65ab-4e48-a638-2037a9ee2ee8";
 
+export const downloadCSVMockGenerator =
+  (csvContent: string) => (): Promise<string> =>
+    Promise.resolve(csvContent);
 export const downloadCSVMock = downloadCSVMockGenerator(csvFileContent);
 
 export const internalAssignCertifiedAttributeMock = (
@@ -58,38 +81,6 @@ export const internalRevokeCertifiedAttributeMock = (
   _context: InteropContext
 ): Promise<{ version: number } | undefined> => Promise.resolve({ version: 1 });
 
-export const getIVASSTenantsMock = getTenantsMockGenerator((taxCodes) =>
-  taxCodes.map((c) => ({
-    ...persistentTenant,
-    externalId: { origin: "tenantOrigin", value: c },
-  }))
-);
-export const getTenantsWithAttributesMock = (_: string[]) =>
-  Promise.resolve([]);
-const buildIvassTenantById = (tenantId: TenantId): Tenant => ({
-  ...persistentTenant,
-  id: tenantId,
-  features: [{ type: "PersistentCertifier", certifierId: "IVASS" }],
-});
-export const getTenantByIdMock =
-  getTenantByIdMockGenerator(buildIvassTenantById);
-export const getTenantByIdWithMetadataMock =
-  getTenantByIdWithMetadataMockGenerator(buildIvassTenantById);
-export const getAttributeByExternalIdMock = (
-  origin: string,
-  code: string
-): Promise<Attribute> =>
-  match(code)
-    .with(IVASS_INSURANCES_ATTRIBUTE_CODE, () =>
-      Promise.resolve({
-        ...persistentAttribute,
-        id: unsafeBrandId<AttributeId>(ATTRIBUTE_IVASS_INSURANCES_ID),
-        origin,
-        code,
-      })
-    )
-    .otherwise(() => Promise.reject(new Error("Unexpected attribute code")));
-
 export const persistentTenant: Tenant = {
   id: unsafeBrandId("091fbea1-0c8e-411b-988f-5098b6a33ba7"),
   externalId: { origin: "tenantOrigin", value: "tenantValue" },
@@ -100,7 +91,7 @@ export const persistentTenant: Tenant = {
   name: "tenantName",
 };
 
-const persistentAttribute: Attribute = {
+export const persistentAttribute: Attribute = {
   id: unsafeBrandId("7a04c906-1525-4c68-8a5b-d740d77d9c80"),
   origin: "attributeOrigin",
   code: "attributeCode",
@@ -115,3 +106,20 @@ export const persistentTenantAttribute: TenantAttribute = {
   type: "PersistentCertifiedAttribute",
   assignmentTimestamp: new Date(),
 };
+
+export const buildIvassCertifierTenant = (): Tenant => ({
+  ...persistentTenant,
+  id: unsafeBrandId(IVASS_TENANT_ID),
+  name: "IVASS certifier tenant",
+  features: [
+    { type: "PersistentCertifier", certifierId: IVASS_ORIGIN_NAME },
+  ],
+});
+
+export const buildIvassInsurancesAttribute = (): Attribute => ({
+  ...persistentAttribute,
+  id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
+  origin: IVASS_ORIGIN_NAME,
+  code: IVASS_INSURANCES_ATTRIBUTE_CODE,
+  name: IVASS_INSURANCES_ATTRIBUTE_CODE,
+});

--- a/packages/ivass-certified-attributes-importer/test/processor.test.ts
+++ b/packages/ivass-certified-attributes-importer/test/processor.test.ts
@@ -1,77 +1,66 @@
+/* eslint-disable prettier/prettier */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { randomUUID } from "crypto";
-import { it, afterEach, beforeAll, describe, expect, vi, vitest } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   InteropInternalToken,
   InteropTokenGenerator,
   RefreshableInteropToken,
   genericLogger,
 } from "pagopa-interop-commons";
-import { generateId, Tenant, unsafeBrandId } from "pagopa-interop-models";
 import {
-  tenantReadModelServiceBuilder,
-  attributeReadModelServiceBuilder,
-  makeDrizzleConnection,
-} from "pagopa-interop-readmodel";
+  Tenant,
+  generateId,
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { TenantProcessService } from "../src/service/tenantProcessService.js";
 import { importAttributes } from "../src/service/processor.js";
-import { readModelQueriesBuilderSQL } from "../src/service/readModelQueriesServiceSQL.js";
-import { config } from "../src/config/config.js";
+import { IVASS_ORIGIN_NAME } from "../src/config/constants.js";
 import {
   ATTRIBUTE_IVASS_INSURANCES_ID,
+  CSV_HEADER,
+  IVASS_TENANT_ID,
+  addOneAttribute,
+  addOneTenant,
+  buildIvassCertifierTenant,
+  buildIvassInsurancesAttribute,
+  cleanup,
   downloadCSVMock,
   downloadCSVMockGenerator,
-  getAttributeByExternalIdMock,
-  getIVASSTenantsMock,
-  getTenantByIdMock,
-  getTenantByIdWithMetadataMock,
-  getTenantByIdMockGenerator,
-  getTenantsMockGenerator,
-  getTenantsWithAttributesMock,
   internalAssignCertifiedAttributeMock,
   internalRevokeCertifiedAttributeMock,
   persistentTenant,
   persistentTenantAttribute,
+  readModelQueries,
 } from "./helpers.js";
+
+const waitForReadModelMetadataVersionMock = vi.fn(
+  (): Promise<void> => Promise.resolve()
+);
+
+vi.mock("pagopa-interop-commons", async () => {
+  const actual = await vi.importActual("pagopa-interop-commons");
+  return {
+    ...actual,
+    waitForReadModelMetadataVersion: waitForReadModelMetadataVersionMock,
+  };
+});
 
 describe("IVASS Certified Attributes Importer", () => {
   const tokenGeneratorMock = {} as InteropTokenGenerator;
   const refreshableTokenMock = new RefreshableInteropToken(tokenGeneratorMock);
   const tenantProcessMock = new TenantProcessService("url");
-  const csvDownloaderMock = downloadCSVMock;
-
-  const db = makeDrizzleConnection(config);
-  const tenantReadModelService = tenantReadModelServiceBuilder(db);
-  const attributeReadModelService = attributeReadModelServiceBuilder(db);
-  const readModelQueriesMock = readModelQueriesBuilderSQL(
-    db,
-    tenantReadModelService,
-    attributeReadModelService
-  );
-
-  const run = () =>
-    importAttributes(
-      csvDownloaderMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      10,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
-      genericLogger,
-      generateId()
-    );
 
   const interopInternalToken: InteropInternalToken = {
-    header: {
-      alg: "algorithm",
-      use: "use",
-      typ: "type",
-      kid: "key-id",
-    },
+    header: { alg: "algorithm", use: "use", typ: "type", kid: "key-id" },
     payload: {
       jti: "token-id",
       iss: "issuer",
@@ -84,12 +73,10 @@ describe("IVASS Certified Attributes Importer", () => {
     },
     serialized: "the-token",
   };
-  const generateInternalTokenMock = (): Promise<InteropInternalToken> =>
-    Promise.resolve(interopInternalToken);
 
   const refreshableInternalTokenSpy = vi
     .spyOn(refreshableTokenMock, "get")
-    .mockImplementation(generateInternalTokenMock);
+    .mockImplementation(() => Promise.resolve(interopInternalToken));
 
   const internalAssignCertifiedAttributeSpy = vi
     .spyOn(tenantProcessMock, "internalAssignCertifiedAttribute")
@@ -98,738 +85,409 @@ describe("IVASS Certified Attributes Importer", () => {
     .spyOn(tenantProcessMock, "internalRevokeCertifiedAttribute")
     .mockImplementation(internalRevokeCertifiedAttributeMock);
 
-  const getIVASSTenantsSpy = vi
-    .spyOn(readModelQueriesMock, "getIVASSTenants")
-    .mockImplementation(getIVASSTenantsMock);
-  const getTenantsWithAttributesSpy = vi
-    .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-    .mockImplementation(getTenantsWithAttributesMock);
-  const getTenantByIdSpy = vi
-    .spyOn(readModelQueriesMock, "getTenantById")
-    .mockImplementation((id) => getTenantByIdMock(unsafeBrandId(id)));
-  const getTenantByIdWithMetadataSpy = vi
-    .spyOn(readModelQueriesMock, "getTenantByIdWithMetadata")
-    .mockImplementation((id) =>
-      getTenantByIdWithMetadataMock(unsafeBrandId(id))
-    );
-  const getAttributeByExternalIdSpy = vi
-    .spyOn(readModelQueriesMock, "getAttributeByExternalId")
-    .mockImplementation(getAttributeByExternalIdMock);
+  const pollingConfig = {
+    defaultPollingMaxRetries: 1,
+    defaultPollingRetryDelay: 1,
+  };
 
-  beforeAll(() => {
-    vitest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vitest.clearAllMocks();
-  });
-
-  it("should succeed", async () => {
-    await run();
-
-    expect(downloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getTenantByIdWithMetadataSpy).toBeCalled();
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalled();
-    expect(internalAssignCertifiedAttributeSpy).toBeCalled();
-    expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
-  });
-
-  it("should fail if polling max retries are reached after assign", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-    D0001;2020-12-02;9999-12-31;Org1;0000012345678901`;
-
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IVASS", value: "12345678901" },
-        attributes: [],
-      },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-
-    getIVASSTenantsSpy.mockImplementationOnce(
-      getTenantsMockGenerator((_) => readModelTenants)
-    );
-
-    internalAssignCertifiedAttributeSpy.mockResolvedValueOnce({ version: 5 });
-
-    await expect(
-      importAttributes(
-        localDownloadCSVMock,
-        readModelQueriesMock,
-        tenantProcessMock,
-        refreshableTokenMock,
-        10,
-        {
-          defaultPollingMaxRetries: 1,
-          defaultPollingRetryDelay: 1,
-        },
-        "ivass-tenant-id",
-        genericLogger,
-        generateId()
-      )
-    ).rejects.toThrowError();
-
-    expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(1);
-    expect(getTenantByIdWithMetadataSpy).toBeCalled();
-  });
-
-  it("should fail if polling max retries are reached after revoke", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-    D0001;2020-12-02;9999-12-31;Org1;0000012345678901`;
-
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IVASS", value: "12345678901" },
-        attributes: [],
-      },
-    ];
-
-    const tenantsWithAttribute: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IVASS", value: "not_in_csv" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
-          },
-        ],
-      },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-
-    getIVASSTenantsSpy.mockImplementationOnce(
-      getTenantsMockGenerator((_) => readModelTenants)
-    );
-
-    getTenantsWithAttributesSpy.mockImplementationOnce(
-      getTenantsMockGenerator((_) => tenantsWithAttribute)
-    );
-
-    internalRevokeCertifiedAttributeSpy.mockResolvedValueOnce({ version: 5 });
-
-    await expect(
-      importAttributes(
-        localDownloadCSVMock,
-        readModelQueriesMock,
-        tenantProcessMock,
-        refreshableTokenMock,
-        10,
-        {
-          defaultPollingMaxRetries: 1,
-          defaultPollingRetryDelay: 1,
-        },
-        "ivass-tenant-id",
-        genericLogger,
-        generateId()
-      )
-    ).rejects.toThrowError();
-
-    expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(1);
-    expect(getTenantByIdWithMetadataSpy).toBeCalled();
-  });
-
-  it("should succeed with fields starting with quotes", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-    D0001;2020-12-02;9999-12-31;"DE ROTTERDAM" BUILDING, 29TH FLOOR, EAST TOWER, WILHELMINAKADE 149A (3072 AP)  ROTTERDAM PAESI BASSI;0000012345678901
-    `;
-
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IVASS", value: "12345678901" },
-        attributes: [],
-      },
-    ];
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-
-    const getIVASSTenantsMock = getTenantsMockGenerator(
-      (_) => readModelTenants
-    );
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementation(getIVASSTenantsMock);
-
-    await importAttributes(
-      localDownloadCSVMock,
-      readModelQueriesMock,
+  const run = (csvDownloader: () => Promise<string>, batchSize: number = 10) =>
+    importAttributes(
+      csvDownloader,
+      readModelQueries,
       tenantProcessMock,
       refreshableTokenMock,
-      10,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
+      batchSize,
+      pollingConfig,
+      IVASS_TENANT_ID,
       genericLogger,
       generateId()
     );
 
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
+  const seedCertifierAndAttribute = async (): Promise<void> => {
+    await addOneTenant(buildIvassCertifierTenant());
+    await addOneAttribute(buildIvassInsurancesAttribute());
+  };
 
-    expect(getIVASSTenantsSpy).toHaveBeenCalledWith(
-      readModelTenants.map((t) => t.externalId.value)
+  beforeAll(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await cleanup();
+  });
+
+  it("should succeed", async () => {
+    await seedCertifierAndAttribute();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678901" },
+      attributes: [],
+    });
+
+    await run(downloadCSVMock);
+
+    expect(refreshableInternalTokenSpy).toBeCalled();
+    expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(1);
+    expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
+  });
+
+  it("should fail if polling max retries are reached after assign", async () => {
+    const csv = `${CSV_HEADER}
+D0001;2020-12-02;9999-12-31;Org1;0000012345678901`;
+
+    await seedCertifierAndAttribute();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678901" },
+      attributes: [],
+    });
+
+    internalAssignCertifiedAttributeSpy.mockResolvedValueOnce({ version: 5 });
+    waitForReadModelMetadataVersionMock.mockRejectedValueOnce(
+      pollingMaxRetriesExceeded(1, 1)
     );
-    expect(getIVASSTenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
 
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(1);
+    await expect(run(downloadCSVMockGenerator(csv))).rejects.toThrowError();
+    expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(1);
+    expect(waitForReadModelMetadataVersionMock).toBeCalled();
+  });
+
+  it("should fail if polling max retries are reached after revoke", async () => {
+    const csv = `${CSV_HEADER}
+D0001;2020-12-02;9999-12-31;Org1;0000012345678901`;
+
+    await seedCertifierAndAttribute();
+    // Tenant in CSV — already has attribute → assign skipped
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678901" },
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
+        },
+      ],
+    });
+    // Tenant NOT in CSV with attribute → revoke will be attempted
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "not_in_csv" },
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
+        },
+      ],
+    });
+
+    internalRevokeCertifiedAttributeSpy.mockResolvedValueOnce({ version: 5 });
+    waitForReadModelMetadataVersionMock.mockRejectedValueOnce(
+      pollingMaxRetriesExceeded(1, 1)
+    );
+
+    await expect(run(downloadCSVMockGenerator(csv))).rejects.toThrowError();
+    expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(1);
+    expect(waitForReadModelMetadataVersionMock).toBeCalled();
+  });
+
+  it("should succeed with fields starting with quotes", async () => {
+    const csv = `${CSV_HEADER}
+D0001;2020-12-02;9999-12-31;"DE ROTTERDAM" BUILDING, 29TH FLOOR, EAST TOWER, WILHELMINAKADE 149A (3072 AP)  ROTTERDAM PAESI BASSI;0000012345678901
+`;
+
+    await seedCertifierAndAttribute();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678901" },
+      attributes: [],
+    });
+
+    await run(downloadCSVMockGenerator(csv));
+
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(1);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should succeed, assigning only missing attributes", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-    D0001;2020-12-02;9999-12-31;Org1;0000012345678901
-    D0002;2020-06-10;9999-12-31;Org2;0000012345678902
-    D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
+    const csv = `${CSV_HEADER}
+D0001;2020-12-02;9999-12-31;Org1;0000012345678901
+D0002;2020-06-10;9999-12-31;Org2;0000012345678902
+D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
 
-    const readModelTenants: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IVASS", value: "12345678901" },
-        attributes: [
-          {
-            ...persistentTenantAttribute,
-            id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
-          },
-        ],
-      },
-      {
-        ...persistentTenant,
-        externalId: { origin: "IVASS", value: "12345678902" },
-        attributes: [{ ...persistentTenantAttribute }],
-      },
-      {
-        ...persistentTenant,
-        externalId: { origin: "IVASS", value: "12345678903" },
-        attributes: [],
-      },
-    ];
+    await seedCertifierAndAttribute();
+    // Tenant 1 — has IVASS attribute (skip assign)
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678901" },
+      attributes: [
+        {
+          ...persistentTenantAttribute,
+          id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
+        },
+      ],
+    });
+    // Tenant 2 — has a different attribute (will be assigned IVASS)
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678902" },
+      attributes: [{ ...persistentTenantAttribute }],
+    });
+    // Tenant 3 — no attributes (will be assigned)
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678903" },
+      attributes: [],
+    });
 
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
+    await run(downloadCSVMockGenerator(csv));
 
-    const getIVASSTenantsMock = getTenantsMockGenerator(
-      (_) => readModelTenants
-    );
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementation(getIVASSTenantsMock);
-
-    await importAttributes(
-      localDownloadCSVMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      10,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
-      genericLogger,
-      generateId()
-    );
-
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toHaveBeenCalledWith(
-      readModelTenants.map((t) => t.externalId.value)
-    );
-    expect(getIVASSTenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(2);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
-  it("should succeed, unassigning expired organizations ", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-    D0001;2020-12-02;2021-12-31;Org1;0000012345678901
-    D0002;2100-06-10;9999-12-31;Org2;0000012345678902
-    D0003;2000-06-10;9999-12-31;Org3;0000012345678903`;
+  it("should succeed, unassigning expired organizations", async () => {
+    const csv = `${CSV_HEADER}
+D0001;2020-12-02;2021-12-31;Org1;0000012345678901
+D0002;2100-06-10;9999-12-31;Org2;0000012345678902
+D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
 
-    const tenant1: Tenant = {
+    await seedCertifierAndAttribute();
+    await addOneTenant({
       ...persistentTenant,
-      externalId: { origin: "IVASS", value: "12345678901" },
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678901" },
       attributes: [
         {
           ...persistentTenantAttribute,
           id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
         },
       ],
-    };
-    const tenant2: Tenant = {
+    });
+    await addOneTenant({
       ...persistentTenant,
-      externalId: { origin: "IVASS", value: "12345678902" },
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678902" },
       attributes: [
         {
           ...persistentTenantAttribute,
           id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
         },
       ],
-    };
-    const tenant3: Tenant = {
+    });
+    await addOneTenant({
       ...persistentTenant,
-      externalId: { origin: "IVASS", value: "12345678903" },
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678903" },
       attributes: [
         {
           ...persistentTenantAttribute,
           id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
         },
       ],
-    };
+    });
 
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
+    await run(downloadCSVMockGenerator(csv));
 
-    const getIVASSTenantsMock = getTenantsMockGenerator((_) => [tenant3]);
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementation(getIVASSTenantsMock);
-
-    const getTenantsWithAttributesMock = getTenantsMockGenerator((_) => [
-      tenant1,
-      tenant2,
-      tenant3,
-    ]);
-    const getTenantsWithAttributesSpy = vi
-      .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-      .mockImplementation(getTenantsWithAttributesMock);
-
-    await importAttributes(
-      localDownloadCSVMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      10,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
-      genericLogger,
-      generateId()
-    );
-
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toHaveBeenCalledWith([tenant3.externalId.value]);
-    expect(getIVASSTenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(2);
   });
 
   it("should succeed, unassigning only existing attributes", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-    D0001;2020-12-02;2021-12-31;Org1;0000012345678901
-    D0002;2020-06-10;2021-12-31;Org2;0000012345678902
-    D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
+    const csv = `${CSV_HEADER}
+D0001;2020-12-02;2021-12-31;Org1;0000012345678901
+D0002;2020-06-10;2021-12-31;Org2;0000012345678902
+D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
 
-    const tenant3: Tenant = {
+    await seedCertifierAndAttribute();
+    // Only one tenant, with the attribute, NOT matching row3's id → will be revoked
+    await addOneTenant({
       ...persistentTenant,
-      externalId: { origin: "IVASS", value: "12345678901" },
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678901" },
       attributes: [
         {
           ...persistentTenantAttribute,
           id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
         },
       ],
-    };
+    });
 
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
+    await run(downloadCSVMockGenerator(csv));
 
-    const getIVASSTenantsMock = getTenantsMockGenerator((_) => []);
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementation(getIVASSTenantsMock);
-
-    const getTenantsWithAttributesMock = getTenantsMockGenerator((_) => [
-      tenant3,
-    ]);
-    const getTenantsWithAttributesSpy = vi
-      .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-      .mockImplementation(getTenantsWithAttributesMock);
-
-    await importAttributes(
-      localDownloadCSVMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      10,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
-      genericLogger,
-      generateId()
-    );
-
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toHaveBeenCalledWith(["12345678903"]);
-    expect(getIVASSTenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(1);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(1);
   });
 
-  it("should succeed, only for tenants that exist on read model ", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-    D0001;2020-12-02;9999-12-31;Org1;0000012345678901
-    D0002;2020-06-10;2021-12-31;Org2;0000012345678902
-    D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
+  it("should succeed, only for tenants that exist on read model", async () => {
+    const csv = `${CSV_HEADER}
+D0001;2020-12-02;9999-12-31;Org1;0000012345678901
+D0002;2020-06-10;2021-12-31;Org2;0000012345678902
+D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
 
-    const tenant3: Tenant = {
+    await seedCertifierAndAttribute();
+    // Only tenant for 12345678903 seeded — row1 (12345678901) has no tenant in DB
+    await addOneTenant({
       ...persistentTenant,
-      externalId: { origin: "IVASS", value: "12345678903" },
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678903" },
       attributes: [{ ...persistentTenantAttribute }],
-    };
+    });
 
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
+    await run(downloadCSVMockGenerator(csv));
 
-    const getIVASSTenantsMock = getTenantsMockGenerator((_) => [tenant3]);
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementation(getIVASSTenantsMock);
-
-    const getTenantsWithAttributesSpy = vi
-      .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-      .mockImplementation(getTenantsWithAttributesMock);
-
-    await importAttributes(
-      localDownloadCSVMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      10,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
-      genericLogger,
-      generateId()
-    );
-
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toHaveBeenCalledWith([
-      "12345678901",
-      tenant3.externalId.value,
-    ]);
-    expect(getIVASSTenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(1);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(1);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should succeed with more than one batch", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-      D0001;2020-12-02;9999-12-31;Org1;0000012345678901
-      D0002;2020-06-10;2021-12-31;Org2;0000012345678902
-      D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
+    const csv = `${CSV_HEADER}
+D0001;2020-12-02;9999-12-31;Org1;0000012345678901
+D0002;2020-06-10;2021-12-31;Org2;0000012345678902
+D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
 
-    const readModelTenantsBatch1: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IVASS", value: "12345678901" },
-        attributes: [{ ...persistentTenantAttribute }],
-      },
-    ];
+    await seedCertifierAndAttribute();
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678901" },
+      attributes: [{ ...persistentTenantAttribute }],
+    });
+    await addOneTenant({
+      ...persistentTenant,
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678903" },
+      attributes: [{ ...persistentTenantAttribute }],
+    });
 
-    const readModelTenantsBatch2: Tenant[] = [
-      {
-        ...persistentTenant,
-        externalId: { origin: "IVASS", value: "12345678903" },
-        attributes: [{ ...persistentTenantAttribute }],
-      },
-    ];
+    await run(downloadCSVMockGenerator(csv), 1);
 
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementationOnce(
-        getTenantsMockGenerator((_) => readModelTenantsBatch1)
-      )
-      .mockImplementation(
-        getTenantsMockGenerator((_) => readModelTenantsBatch2)
-      );
-
-    const getTenantsWithAttributesSpy = vi
-      .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-      .mockImplementation(getTenantsWithAttributesMock);
-
-    await importAttributes(
-      localDownloadCSVMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      1,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
-      genericLogger,
-      generateId()
-    );
-
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toBeCalledTimes(2);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(2);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should fail on CSV retrieve error", async () => {
-    const localDownloadCSVMock = vi
-      .fn()
-      .mockImplementation(
-        (): Promise<string> => Promise.reject(new Error("CSV Retrieve error"))
-      );
+    await seedCertifierAndAttribute();
 
-    await expect(() =>
-      importAttributes(
-        localDownloadCSVMock,
-        readModelQueriesMock,
-        tenantProcessMock,
-        refreshableTokenMock,
-        1,
-        {
-          defaultPollingMaxRetries: 1,
-          defaultPollingRetryDelay: 1,
-        },
-        "ivass-tenant-id",
-        genericLogger,
-        generateId()
-      )
-    ).rejects.toThrowError("CSV Retrieve error");
+    const rejectingDownload = (): Promise<string> =>
+      Promise.reject(new Error("CSV Retrieve error"));
 
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(0);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(0);
+    await expect(() => run(rejectingDownload)).rejects.toThrowError(
+      "CSV Retrieve error"
+    );
 
-    expect(getIVASSTenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(0);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(0);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should fail if the tenant is not configured as certifier", async () => {
-    const getTenantByIdMock = getTenantByIdMockGenerator((tenantId) => ({
+    const nonCertifierTenant: Tenant = {
       ...persistentTenant,
-      id: tenantId,
+      id: unsafeBrandId(IVASS_TENANT_ID),
       features: [],
-    }));
-    getTenantByIdSpy.mockImplementationOnce((id) =>
-      getTenantByIdMock(unsafeBrandId(id))
+    };
+    await addOneTenant(nonCertifierTenant);
+
+    await expect(() => run(downloadCSVMock)).rejects.toThrowError(
+      `Tenant with id ${IVASS_TENANT_ID} is not a certifier`
     );
 
-    await expect(() => run()).rejects.toThrowError(
-      "Tenant with id ivass-tenant-id is not a certifier"
-    );
-
-    expect(downloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(0);
-
-    expect(getIVASSTenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(0);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(0);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });
 
   it("should skip CSV file rows with unexpected schema", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-      ;Unexpected value;;Org1;0000012345678901
-      D0002;2020-06-10;2021-12-31;Org2;0000012345678902
-      D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
+    const csv = `${CSV_HEADER}
+;Unexpected value;;Org1;0000012345678901
+D0002;2020-06-10;2021-12-31;Org2;0000012345678902
+D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
 
-    const tenant2: Tenant = {
+    await seedCertifierAndAttribute();
+    // tenant2 has attribute (not in allOrgsInFile → will be revoked)
+    await addOneTenant({
       ...persistentTenant,
-      externalId: { origin: "IVASS", value: "12345678902" },
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678902" },
       attributes: [
         {
           ...persistentTenantAttribute,
           id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
         },
       ],
-    };
-    const tenant3: Tenant = {
+    });
+    // tenant3 active, no IVASS attribute (assign)
+    await addOneTenant({
       ...persistentTenant,
-      externalId: { origin: "IVASS", value: "12345678903" },
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678903" },
       attributes: [{ ...persistentTenantAttribute }],
-    };
+    });
 
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
+    await run(downloadCSVMockGenerator(csv));
 
-    const getIVASSTenantsMock = getTenantsMockGenerator((_) => [tenant3]);
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementation(getIVASSTenantsMock);
-
-    const getTenantsWithAttributesMock = getTenantsMockGenerator((_) => [
-      tenant2,
-    ]);
-    const getTenantsWithAttributesSpy = vi
-      .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-      .mockImplementation(getTenantsWithAttributesMock);
-
-    await importAttributes(
-      localDownloadCSVMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      10,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
-      genericLogger,
-      generateId()
-    );
-
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(1);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(1);
   });
 
   it("should succeed with missing Tax Code", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-      D0001;2020-12-02;9999-12-31;Org1;
-      D0002;2020-06-10;9999-12-31;Org2;0000012345678902
-      D0003;2019-07-19;9999-12-31;Org3;`;
+    const csv = `${CSV_HEADER}
+D0001;2020-12-02;9999-12-31;Org1;
+D0002;2020-06-10;9999-12-31;Org2;0000012345678902
+D0003;2019-07-19;9999-12-31;Org3;`;
 
-    const tenant1: Tenant = {
+    await seedCertifierAndAttribute();
+    // Tenant 1 — matched by CODICE_IVASS "D0001", has the attribute
+    await addOneTenant({
       ...persistentTenant,
       id: unsafeBrandId(randomUUID()),
-      externalId: { origin: "IVASS", value: "D0001" },
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "D0001" },
       attributes: [
         {
           ...persistentTenantAttribute,
           id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
         },
       ],
-    };
-    const tenant2: Tenant = {
+    });
+    // Tenant 2 — matched by CODICE_IVASS "D0003" (no tax code), no attribute
+    await addOneTenant({
       ...persistentTenant,
       id: unsafeBrandId(randomUUID()),
-      externalId: { origin: "IVASS", value: "D0003" },
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "D0003" },
       attributes: [],
-    };
-
-    const tenant3: Tenant = {
+    });
+    // Tenant 3 — NOT in CSV, has the attribute (will be revoked)
+    await addOneTenant({
       ...persistentTenant,
       id: unsafeBrandId(randomUUID()),
-      externalId: { origin: "IVASS", value: "D0005" },
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "D0005" },
       attributes: [
         {
           ...persistentTenantAttribute,
           id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
         },
       ],
-    };
+    });
 
-    const readModelTenants: Tenant[] = [tenant1, tenant2, tenant3];
+    await run(downloadCSVMockGenerator(csv));
 
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-
-    const getIVASSTenantsMock = getTenantsMockGenerator(
-      (_) => readModelTenants
-    );
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementation(getIVASSTenantsMock);
-
-    const getTenantsWithAttributesMock = getTenantsMockGenerator((_) => [
-      tenant1,
-      tenant3,
-    ]);
-    const getTenantsWithAttributesSpy = vi
-      .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-      .mockImplementation(getTenantsWithAttributesMock);
-
-    await importAttributes(
-      localDownloadCSVMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      10,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
-      genericLogger,
-      generateId()
-    );
-
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(2);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(1);
     expect(internalAssignCertifiedAttributeSpy.mock.calls[0][0]).toEqual(
-      "IVASS"
+      IVASS_ORIGIN_NAME
     );
     expect(internalAssignCertifiedAttributeSpy.mock.calls[0][1]).toEqual(
       "D0003"
     );
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(1);
     expect(internalRevokeCertifiedAttributeSpy.mock.calls[0][0]).toEqual(
-      "IVASS"
+      IVASS_ORIGIN_NAME
     );
     expect(internalRevokeCertifiedAttributeSpy.mock.calls[0][1]).toEqual(
       "D0005"
@@ -837,110 +495,50 @@ describe("IVASS Certified Attributes Importer", () => {
   });
 
   it("should unassign attribute for tenants not in the file", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-      D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
+    const csv = `${CSV_HEADER}
+D0003;2019-07-19;9999-12-31;Org3;0000012345678903`;
 
-    const tenant1: Tenant = {
+    await seedCertifierAndAttribute();
+    // Tenant in CSV — already has IVASS attribute (skip assign)
+    await addOneTenant({
       ...persistentTenant,
-      externalId: { origin: "IVASS", value: "12345678901" },
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678903" },
       attributes: [
         {
           ...persistentTenantAttribute,
           id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
         },
       ],
-    };
-
-    const tenant3: Tenant = {
+    });
+    // Tenant NOT in CSV — has the attribute, will be revoked
+    await addOneTenant({
       ...persistentTenant,
-      externalId: { origin: "IVASS", value: "12345678903" },
+      id: generateId(),
+      externalId: { origin: IVASS_ORIGIN_NAME, value: "12345678901" },
       attributes: [
         {
           ...persistentTenantAttribute,
           id: unsafeBrandId(ATTRIBUTE_IVASS_INSURANCES_ID),
         },
       ],
-    };
+    });
 
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
+    await run(downloadCSVMockGenerator(csv), 1);
 
-    const getIVASSTenantsMock = getTenantsMockGenerator((_) => [tenant3]);
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementation(getIVASSTenantsMock);
-
-    const getTenantsWithAttributesMock = getTenantsMockGenerator((_) => [
-      tenant1,
-    ]);
-    const getTenantsWithAttributesSpy = vi
-      .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-      .mockImplementation(getTenantsWithAttributesMock);
-
-    await importAttributes(
-      localDownloadCSVMock,
-      readModelQueriesMock,
-      tenantProcessMock,
-      refreshableTokenMock,
-      1,
-      {
-        defaultPollingMaxRetries: 1,
-        defaultPollingRetryDelay: 1,
-      },
-      "ivass-tenant-id",
-      genericLogger,
-      generateId()
-    );
-
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toBeCalledTimes(1);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(1);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(1);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(1);
   });
 
   it("should fail if the file does not contain records", async () => {
-    const csvFileContent = `CODICE_IVASS;DATA_ISCRIZIONE_ALBO_ELENCO;DATA_CANCELLAZIONE_ALBO_ELENCO;DENOMINAZIONE_IMPRESA;CODICE_FISCALE
-      `;
-
-    const localDownloadCSVMock = downloadCSVMockGenerator(csvFileContent);
-
-    const getIVASSTenantsSpy = vi
-      .spyOn(readModelQueriesMock, "getIVASSTenants")
-      .mockImplementation(getIVASSTenantsMock);
-    const getTenantsWithAttributesSpy = vi
-      .spyOn(readModelQueriesMock, "getTenantsWithAttributes")
-      .mockImplementation(getTenantsWithAttributesMock);
+    const csv = `${CSV_HEADER}
+`;
+    await seedCertifierAndAttribute();
 
     await expect(() =>
-      importAttributes(
-        localDownloadCSVMock,
-        readModelQueriesMock,
-        tenantProcessMock,
-        refreshableTokenMock,
-        10,
-        {
-          defaultPollingMaxRetries: 1,
-          defaultPollingRetryDelay: 1,
-        },
-        "ivass-tenant-id",
-        genericLogger,
-        generateId()
-      )
+      run(downloadCSVMockGenerator(csv))
     ).rejects.toThrowError("File does not contain valid assignments");
 
-    expect(localDownloadCSVMock).toBeCalledTimes(1);
-    expect(getTenantByIdSpy).toBeCalledTimes(1);
-    expect(getAttributeByExternalIdSpy).toBeCalledTimes(1);
-
-    expect(getIVASSTenantsSpy).toBeCalledTimes(0);
-    expect(getTenantsWithAttributesSpy).toBeCalledTimes(0);
-
-    expect(refreshableInternalTokenSpy).toBeCalledTimes(0);
     expect(internalAssignCertifiedAttributeSpy).toBeCalledTimes(0);
     expect(internalRevokeCertifiedAttributeSpy).toBeCalledTimes(0);
   });

--- a/packages/ivass-certified-attributes-importer/test/processor.test.ts
+++ b/packages/ivass-certified-attributes-importer/test/processor.test.ts
@@ -42,9 +42,11 @@ import {
   readModelQueries,
 } from "./helpers.js";
 
-const waitForReadModelMetadataVersionMock = vi.fn(
-  (): Promise<void> => Promise.resolve()
-);
+const { waitForReadModelMetadataVersionMock } = vi.hoisted(() => ({
+  waitForReadModelMetadataVersionMock: vi.fn(
+    (): Promise<void> => Promise.resolve()
+  ),
+}));
 
 vi.mock("pagopa-interop-commons", async () => {
   const actual = await vi.importActual("pagopa-interop-commons");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3592,9 +3592,6 @@ importers:
       pagopa-interop-readmodel-models:
         specifier: workspace:*
         version: link:../readmodel-models
-      ts-pattern:
-        specifier: 'catalog:'
-        version: 5.2.0
       zod:
         specifier: 'catalog:'
         version: 3.23.8


### PR DESCRIPTION
## Context                                                                                                  
                                                                                                            
The `anac-` and `ivass-certified-attributes-importer` tests instantiated the real                           
`readModelQueriesBuilderSQL` but then mocked every single method on it via
`vi.spyOn(...).mockImplementation(...)`, so the SQL queries were never exercised at test time. Similarly,   
the IPA `readModelServiceSQL` (`getIPATenants`, `getAttributes`, `getTenantByExternalIdWithMetadata`) had no
 test coverage at all — existing IPA tests only cover pure business functions that receive pre-resolved
data.                                                                                                       


## Summary

- **anac-certified-attributes-importer** — `test/helpers.ts` now wires `setupTestContainersVitest(...,      
inject("readModelSQLConfig"))` and exposes `addOneTenant` / `addOneAttribute`; `test/processor.test.ts`
seeds tenants/attributes in the real DB per test instead of spying on `readModelQueries`. Assertions on     
internal query call counts replaced by assertions on observable boundary effects (calls to
`internalAssignCertifiedAttribute` / `internalRevokeCertifiedAttribute` and their arguments).
`test/download-csv.test.ts` untouched (pure SFTP unit test).
- **ivass-certified-attributes-importer** — identical treatment on `test/helpers.ts` and
`test/processor.test.ts`.                                                                                   
- **ipa-certified-attributes-importer** — new `test/readModelServiceSQL.test.ts` covering the three
read-model methods against a real DB (`getIPATenants`, `getAttributes`,                                     
`getTenantByExternalIdWithMetadata`). The 8 existing unit tests are left unchanged.
- **private-certified-attributes-importer** — no changes (reference implementation). 

## Issue
[PIN-7097](https://pagopa.atlassian.net/browse/PIN-7097)

[PIN-7097]: https://pagopa.atlassian.net/browse/PIN-7097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ