### PR TITLE
fix: return 404 when removing users from hidden producer keychains (PIN-9361)

### DIFF
--- a/packages/authorization-process/src/utilities/errorMappers.ts
+++ b/packages/authorization-process/src/utilities/errorMappers.ts
@@ -261,9 +261,9 @@ export const removeProducerKeychainUserErrorMapper = (
     .with(
       "producerKeychainNotFound",
       "producerKeychainUserIdNotFound",
+      "tenantNotAllowedOnProducerKeychain",
       () => HTTP_STATUS_NOT_FOUND
     )
-    .with("tenantNotAllowedOnProducerKeychain", () => HTTP_STATUS_FORBIDDEN)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
 export const deleteProducerKeychainKeyByIdErrorMapper = (

--- a/packages/authorization-process/test/api/removeProducerKeychainUser.test.ts
+++ b/packages/authorization-process/test/api/removeProducerKeychainUser.test.ts
@@ -108,7 +108,7 @@ describe("API /producerKeychains/{producerKeychainId}/users/{userId} authorizati
         generateId(),
         mockProducerKeychain.id
       ),
-      expectedStatus: 403,
+      expectedStatus: 404,
     },
   ])(
     "Should return $expectedStatus for $error.code",


### PR DESCRIPTION
## Issue
- [PIN-9361](https://pagopa.atlassian.net/browse/PIN-9361)

## Context / Why
- Align the remove producer keychain user endpoint with the expected behavior for hidden producer keychains.
- When a tenant is not allowed on a producer keychain, the endpoint should not reveal the resource existence and should return `404 Not Found`.

## Scope
- Updated the `removeProducerKeychainUserErrorMapper` to map `tenantNotAllowedOnProducerKeychain` to `404`.
- Updated the API test for `DELETE /producerKeychains/{producerKeychainId}/users/{userId}` to expect `404` for hidden producer keychains.

## Testing / Validation
- [x] Lint
- [x] Type Check
- [x] Api tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated


[PIN-9361]: https://pagopa.atlassian.net/browse/PIN-9361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ