### PR TITLE
PIN-8976 - fix: Make e-service template version description required

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -29848,6 +29848,7 @@ components:
         - title
     UpdateEServiceTemplateVersionSeed:
       required:
+        - description
         - voucherLifespan
         - attributes
       type: object

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -1591,6 +1591,7 @@ components:
           nullable: true
     VersionSeedForEServiceTemplateCreation:
       required:
+        - description
         - voucherLifespan
       type: object
       additionalProperties: false
@@ -1620,6 +1621,7 @@ components:
           $ref: "#/components/schemas/AgreementApprovalPolicy"
     EServiceTemplateVersionSeed:
       required:
+        - description
         - voucherLifespan
         - attributes
         - docs
@@ -1657,6 +1659,7 @@ components:
             $ref: "#/components/schemas/CreateEServiceTemplateVersionDocumentSeed"
     UpdateEServiceTemplateVersionSeed:
       required:
+        - description
         - voucherLifespan
         - attributes
       type: object
@@ -2119,6 +2122,7 @@ components:
       required:
         - id
         - version
+        - description
         - docs
         - state
         - creationDate

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -21023,6 +21023,7 @@ components:
       required:
         - id
         - version
+        - description
         - state
         - creationDate
         - voucherLifespan
@@ -21080,6 +21081,7 @@ components:
           type: boolean
     VersionSeedForEServiceTemplateCreation:
       required:
+        - description
         - voucherLifespan
       type: object
       additionalProperties: false
@@ -21181,6 +21183,7 @@ components:
         agreementApprovalPolicy:
           $ref: "#/components/schemas/AgreementApprovalPolicy"
       required:
+        - description
         - voucherLifespan
     EServiceTemplateVersionDraftUpdateSeed:
       type: object

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -11939,6 +11939,7 @@ components:
       required:
         - id
         - version
+        - description
         - state
         - creationDate
         - voucherLifespan
@@ -11996,6 +11997,7 @@ components:
           type: boolean
     VersionSeedForEServiceTemplateCreation:
       required:
+        - description
         - voucherLifespan
       type: object
       additionalProperties: false
@@ -12097,6 +12099,7 @@ components:
         agreementApprovalPolicy:
           $ref: "#/components/schemas/AgreementApprovalPolicy"
       required:
+        - description
         - voucherLifespan
     EServiceTemplateVersionDraftUpdateSeed:
       type: object

--- a/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
@@ -128,6 +128,7 @@ export function toCatalogCreateEServiceTemplateSeed(
   return {
     ...eServiceTemplateSeed,
     version: {
+      description: eServiceTemplateSeed.description,
       voucherLifespan: 60,
     },
   };

--- a/packages/backend-for-frontend/test/mockUtils.ts
+++ b/packages/backend-for-frontend/test/mockUtils.ts
@@ -725,7 +725,7 @@ export const getMockBffApiEServiceTemplateUpdateSeed =
 
 export const getMockBffApiUpdateEServiceTemplateVersionSeed =
   (): bffApi.UpdateEServiceTemplateVersionSeed => ({
-    description: generateMock(z.string().min(10).max(250).optional()),
+    description: generateMock(z.string().min(10).max(250)),
     voucherLifespan: generateMock(z.number().int().gte(60).lte(86400)),
     dailyCallsPerConsumer: generateMock(
       z.number().int().gte(1).lte(1000000000).optional()

--- a/packages/commons-test/src/apiMocks.ts
+++ b/packages/commons-test/src/apiMocks.ts
@@ -490,6 +490,7 @@ export function getMockedApiEserviceTemplateVersion({
 } = {}): eserviceTemplateApi.EServiceTemplateVersion {
   return {
     id: generateId(),
+    description: "Mock template version description",
     state:
       state ?? generateMock(eserviceTemplateApi.EServiceTemplateVersionState),
     voucherLifespan: generateMock(z.number().positive()),

--- a/packages/m2m-gateway-v3/test/api/eServiceTemplates/updatePublishedEServiceTemplateVersionQuotas.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eServiceTemplates/updatePublishedEServiceTemplateVersionQuotas.test.ts
@@ -20,6 +20,7 @@ import { config } from "../../../src/config/config.js";
 describe("PATCH /eserviceTemplates/:templateId/versions/:versionId/quotas router test", () => {
   const mockVersion: eserviceTemplateApi.EServiceTemplateVersion = {
     id: generateId(),
+    description: "",
     state: "PUBLISHED",
     attributes: {
       declared: [],

--- a/packages/m2m-gateway/test/api/eServiceTemplates/updatePublishedEServiceTemplateVersionQuotas.test.ts
+++ b/packages/m2m-gateway/test/api/eServiceTemplates/updatePublishedEServiceTemplateVersionQuotas.test.ts
@@ -16,6 +16,7 @@ import { config } from "../../../src/config/config.js";
 describe("PATCH /eserviceTemplates/:templateId/versions/:versionId/quotas router test", () => {
   const mockVersion: eserviceTemplateApi.EServiceTemplateVersion = {
     id: generateId(),
+    description: "",
     state: "PUBLISHED",
     attributes: {
       declared: [],

--- a/packages/models/src/eservice-template/eserviceTemplate.ts
+++ b/packages/models/src/eservice-template/eserviceTemplate.ts
@@ -55,7 +55,7 @@ export const EServiceTemplateVersion = z.object({
   deprecatedAt: z.coerce.date().optional(),
 
   // Values to be set in all e-service descriptor instances created from this template, not editable by the user
-  description: z.string().optional(),
+  description: z.string(),
   interface: Document.optional(),
   docs: z.array(Document),
   voucherLifespan: z.number().int(),

--- a/packages/models/src/eservice-template/protobufConverterFromV2.ts
+++ b/packages/models/src/eservice-template/protobufConverterFromV2.ts
@@ -42,6 +42,7 @@ export const fromEServiceTemplateVersionV2 = (
   input: EServiceTemplateVersionV2
 ): EServiceTemplateVersion => ({
   ...input,
+  description: input.description ?? "",
   id: unsafeBrandId(input.id),
   version: Number(input.version),
   attributes:

--- a/packages/readmodel/src/eservice-template/aggregators.ts
+++ b/packages/readmodel/src/eservice-template/aggregators.ts
@@ -113,7 +113,7 @@ export const aggregateEServiceTemplateVersion = ({
       verified: verifiedAttributes,
     },
     ...(parsedInterface ? { interface: parsedInterface } : {}),
-    ...(versionSQL.description ? { description: versionSQL.description } : {}),
+    description: versionSQL.description ?? "",
     ...(versionSQL.agreementApprovalPolicy
       ? {
           agreementApprovalPolicy: AgreementApprovalPolicy.parse(

--- a/packages/readmodel/test/eservice-template/eserviceTemplateSplitter.test.ts
+++ b/packages/readmodel/test/eservice-template/eserviceTemplateSplitter.test.ts
@@ -201,7 +201,6 @@ describe("E-service template splitter", () => {
       },
       docs: [doc],
       interface: undefined,
-      description: undefined,
       publishedAt: undefined,
       suspendedAt: undefined,
       deprecatedAt: undefined,

--- a/packages/readmodel/test/eservice-template/eserviceTemplateSplitter.test.ts
+++ b/packages/readmodel/test/eservice-template/eserviceTemplateSplitter.test.ts
@@ -273,7 +273,7 @@ describe("E-service template splitter", () => {
       metadataVersion: 1,
       createdAt: version.createdAt.toISOString(),
       eserviceTemplateId: eserviceTemplate.id,
-      description: null,
+      description: version.description,
       publishedAt: null,
       suspendedAt: null,
       deprecatedAt: null,


### PR DESCRIPTION
[PIN-8976](https://pagopa.atlassian.net/browse/PIN-8976)

This pull request makes the `description` field required for e-service template versions across the API, models, and mocks. This change ensures consistency and enforces the presence of a description when creating or updating e-service template versions. The update affects OpenAPI specifications, backend converters, data models, and test mocks.

**API Schema Updates:**

* Made `description` a required field in multiple schemas, including `EServiceTemplateVersion`, `UpdateEServiceTemplateVersionSeed`, and `VersionSeedForEServiceTemplateCreation` in `bffApi.yml`, `eserviceTemplateApi.yml`, `m2mGatewayApi.yml`, and `m2mGatewayApiV3.yml`.

**Backend and Data Model Changes:**

* Updated the `EServiceTemplateVersion` model in `eserviceTemplate.ts` to make `description` required (was previously optional).
* Updated backend-for-frontend converter to always set `description` when creating a template seed.
* Updated protobuf converter and aggregator to ensure `description` is always set, defaulting to an empty string if missing. 

**Testing and Mock Data:**

* Updated `getMockedApiEserviceTemplateVersion` in test mocks to always include a mock `description`.

[PIN-8976]: https://pagopa.atlassian.net/browse/PIN-8976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ