### PR TITLE
feat: add e-service template retrieval, link and unlink to M2M v3 (PIN-9929)

### DIFF
--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -8855,6 +8855,152 @@ paths:
           $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+  /purposeTemplates/{purposeTemplateId}/eserviceTemplates:
+    parameters:
+      - name: purposeTemplateId
+        in: path
+        description: The Purpose Template ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/PurposeTemplateId"
+    get:
+      tags:
+        - purposeTemplates
+      summary: List E-Service Templates linked to a Purpose Template
+      description: Retrieve a list of E-Service Templates linked to a specific Purpose Template, enriched with full template metadata
+      operationId: getPurposeTemplateEServiceTemplates
+      parameters:
+        - in: query
+          name: creatorIds
+          description: Filter Purpose Template linked E-Service Templates by Creator IDs. If not specified, return linked E-Service Templates for any Creator.
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
+            default: []
+          explode: false
+        - in: query
+          name: eserviceTemplateName
+          description: Filter Purpose Template linked E-Service Templates by name. If not specified, return linked E-Service Templates for any name.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/OffsetParam"
+        - $ref: "#/components/parameters/LimitParam"
+      responses:
+        "200":
+          description: Purpose Template E-Service Templates retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceTemplates"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+    post:
+      tags:
+        - purposeTemplates
+      summary: Link an E-Service Template to a Purpose Template
+      description: Link an E-Service Template to a Purpose Template that is in Draft or Active state
+      operationId: addPurposeTemplateEServiceTemplate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PurposeTemplateLinkEServiceTemplate"
+        required: true
+      responses:
+        "200":
+          description: E-Service Template linked to Purpose Template
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VoidObject"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /purposeTemplates/{purposeTemplateId}/eserviceTemplates/{eserviceTemplateId}:
+    parameters:
+      - name: purposeTemplateId
+        in: path
+        description: The Purpose Template ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/PurposeTemplateId"
+      - name: eserviceTemplateId
+        in: path
+        description: The E-Service Template ID to unlink
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceTemplateId"
+    delete:
+      tags:
+        - purposeTemplates
+      summary: Unlink an E-Service Template From Purpose Template
+      description: Unlink an E-Service Template From a Purpose Template that is in Draft or Active state
+      operationId: removePurposeTemplateEServiceTemplate
+      responses:
+        "200":
+          description: E-Service Template unlinked from Purpose Template
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VoidObject"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
   /purposeTemplates/{purposeTemplateId}/publish:
     parameters:
       - name: purposeTemplateId
@@ -12725,6 +12871,14 @@ components:
           $ref: "#/components/schemas/EServiceId"
       required:
         - eserviceId
+    PurposeTemplateLinkEServiceTemplate:
+      type: object
+      additionalProperties: false
+      properties:
+        eserviceTemplateId:
+          $ref: "#/components/schemas/EServiceTemplateId"
+      required:
+        - eserviceTemplateId
     RemainingDailyCallsResponse:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/purposeTemplateApi.yml
+++ b/packages/api-clients/open-api/purposeTemplateApi.yml
@@ -752,6 +752,46 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /purposeTemplates/{id}/eserviceTemplates/{eserviceTemplateId}:
+    parameters:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: eserviceTemplateId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - purposeTemplate
+      summary: Get a Purpose Template E-Service Template link
+      operationId: getPurposeTemplateEServiceTemplate
+      description: Retrieve a single E-Service Template linked to the Purpose Template
+      responses:
+        "200":
+          description: Purpose Template E-Service Template link retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceTemplateVersionPurposeTemplate"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Purpose Template or link Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /purposeTemplates/{id}/eservices/{eserviceId}:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"

--- a/packages/api-clients/src/m2mGatewayApiV3.ts
+++ b/packages/api-clients/src/m2mGatewayApiV3.ts
@@ -202,6 +202,12 @@ export type GetPurposeTemplateEServicesQueryParams = QueryParametersByAlias<
   "getPurposeTemplateEServices"
 >;
 
+export type GetPurposeTemplateEServiceTemplatesQueryParams =
+  QueryParametersByAlias<
+    PurposeTemplateApi,
+    "getPurposeTemplateEServiceTemplates"
+  >;
+
 export type GetRiskAnalysisTemplateAnnotationDocumentsQueryParams =
   QueryParametersByAlias<
     PurposeTemplateApi,

--- a/packages/m2m-gateway-v3/src/routers/purposeTemplateRouter.ts
+++ b/packages/m2m-gateway-v3/src/routers/purposeTemplateRouter.ts
@@ -309,6 +309,89 @@ const purposeTemplateRouter = (
         }
       }
     )
+    .get(
+      "/purposeTemplates/:purposeTemplateId/eserviceTemplates",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ROLE, M2M_ADMIN_ROLE]);
+
+          const purposeTemplateEServiceTemplates =
+            await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+              unsafeBrandId(req.params.purposeTemplateId),
+              req.query,
+              ctx
+            );
+
+          return res
+            .status(200)
+            .send(
+              m2mGatewayApiV3.EServiceTemplates.parse(
+                purposeTemplateEServiceTemplates
+              )
+            );
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error retrieving purpose template e-service templates for purpose template ${req.params.purposeTemplateId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/purposeTemplates/:purposeTemplateId/eserviceTemplates",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          await purposeTemplateService.addPurposeTemplateEServiceTemplate(
+            unsafeBrandId(req.params.purposeTemplateId),
+            req.body,
+            ctx
+          );
+
+          return res.status(200).send({});
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error linking e-service template to purpose template ${req.params.purposeTemplateId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .delete(
+      "/purposeTemplates/:purposeTemplateId/eserviceTemplates/:eserviceTemplateId",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          await purposeTemplateService.removePurposeTemplateEServiceTemplate(
+            unsafeBrandId(req.params.purposeTemplateId),
+            unsafeBrandId(req.params.eserviceTemplateId),
+            ctx
+          );
+
+          return res.status(200).send({});
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error unlinking e-service template ${req.params.eserviceTemplateId} from purpose template ${req.params.purposeTemplateId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
     .post("/purposeTemplates/:purposeTemplateId/publish", async (req, res) => {
       const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
 

--- a/packages/m2m-gateway-v3/src/services/purposeTemplateService.ts
+++ b/packages/m2m-gateway-v3/src/services/purposeTemplateService.ts
@@ -9,6 +9,7 @@ import {
 } from "pagopa-interop-commons";
 import {
   EServiceId,
+  EServiceTemplateId,
   generateId,
   PurposeTemplateId,
   RiskAnalysisTemplateAnswerAnnotationDocumentId,
@@ -27,6 +28,7 @@ import {
   toPurposeTemplateApiRiskAnalysisFormTemplateSeed,
 } from "../api/purposeTemplateApiConverter.js";
 import { toM2MGatewayApiEService } from "../api/eserviceApiConverter.js";
+import { toM2MGatewayEServiceTemplate } from "../api/eserviceTemplateApiConverter.js";
 import { toM2MGatewayApiRiskAnalysisFormTemplate } from "../api/riskAnalysisFormTemplateApiConverter.js";
 import { purposeTemplateRiskAnalysisFormNotFound } from "../model/errors.js";
 import {
@@ -90,6 +92,36 @@ export function purposeTemplateServiceBuilder(
       retrieveEServiceDescriptorPurposeTemplate(
         purposeTemplateId,
         eserviceId,
+        headers
+      )
+    )({});
+
+  const retrieveEServiceTemplateVersionPurposeTemplate = async (
+    purposeTemplateId: PurposeTemplateId,
+    eserviceTemplateId: EServiceTemplateId,
+    headers: M2MGatewayAppContext["headers"]
+  ): Promise<
+    WithMaybeMetadata<purposeTemplateApi.EServiceTemplateVersionPurposeTemplate>
+  > =>
+    await clients.purposeTemplateProcessClient.getPurposeTemplateEServiceTemplate(
+      {
+        params: {
+          id: purposeTemplateId,
+          eserviceTemplateId,
+        },
+        headers,
+      }
+    );
+
+  const pollServiceTemplateVersionPurposeTemplateUntilDeletion = (
+    purposeTemplateId: PurposeTemplateId,
+    eserviceTemplateId: EServiceTemplateId,
+    headers: M2MGatewayAppContext["headers"]
+  ): Promise<void> =>
+    pollResourceUntilDeletion(() =>
+      retrieveEServiceTemplateVersionPurposeTemplate(
+        purposeTemplateId,
+        eserviceTemplateId,
         headers
       )
     )({});
@@ -601,6 +633,109 @@ export function purposeTemplateServiceBuilder(
       await pollServiceDescriptorPurposeTemplateUntilDeletion(
         purposeTemplateId,
         eserviceId,
+        headers
+      );
+    },
+    async getPurposeTemplateEServiceTemplates(
+      purposeTemplateId: PurposeTemplateId,
+      queryParams: m2mGatewayApiV3.GetPurposeTemplateEServiceTemplatesQueryParams,
+      { logger, headers }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.EServiceTemplates> {
+      const { creatorIds, eserviceTemplateName, limit, offset } = queryParams;
+
+      logger.info(
+        `Retrieving e-service templates linked to purpose template ${purposeTemplateId} with filters: creatorIds ${creatorIds.toString()}, eserviceTemplateName ${eserviceTemplateName}, limit ${limit}, offset ${offset}`
+      );
+
+      const {
+        data: { results: processResults, totalCount },
+      } =
+        await clients.purposeTemplateProcessClient.getPurposeTemplateEServiceTemplates(
+          {
+            params: { id: purposeTemplateId },
+            queries: {
+              creatorIds,
+              eserviceTemplateName,
+              limit,
+              offset,
+            },
+            headers,
+          }
+        );
+
+      const eserviceTemplateIds = processResults.map(
+        ({ eserviceTemplateId }) => eserviceTemplateId
+      );
+      const eserviceTemplates = await clients.eserviceTemplateProcessClient
+        .getEServiceTemplates({
+          queries: {
+            eserviceTemplatesIds: eserviceTemplateIds,
+            offset: 0,
+            limit,
+          },
+          headers,
+        })
+        .then(({ data }) => data.results);
+
+      return {
+        results: eserviceTemplates.map(toM2MGatewayEServiceTemplate),
+        pagination: {
+          limit,
+          offset,
+          totalCount,
+        },
+      };
+    },
+    async addPurposeTemplateEServiceTemplate(
+      purposeTemplateId: PurposeTemplateId,
+      {
+        eserviceTemplateId,
+      }: m2mGatewayApiV3.PurposeTemplateLinkEServiceTemplate,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<void> {
+      logger.info(
+        `Linking e-service template ${eserviceTemplateId} to purpose template ${purposeTemplateId}`
+      );
+
+      const { metadata } =
+        await clients.purposeTemplateProcessClient.linkEServiceTemplatesToPurposeTemplate(
+          {
+            eserviceTemplateIds: [eserviceTemplateId],
+          },
+          {
+            headers,
+            params: {
+              id: purposeTemplateId,
+            },
+          }
+        );
+
+      await pollPurposeTemplateById(purposeTemplateId, metadata, headers);
+    },
+    async removePurposeTemplateEServiceTemplate(
+      purposeTemplateId: PurposeTemplateId,
+      eserviceTemplateId: EServiceTemplateId,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<void> {
+      logger.info(
+        `Unlinking e-service template ${eserviceTemplateId} from purpose template ${purposeTemplateId}`
+      );
+
+      await clients.purposeTemplateProcessClient.unlinkEServiceTemplatesFromPurposeTemplate(
+        {
+          eserviceTemplateIds: [eserviceTemplateId],
+        },
+        {
+          headers,
+          params: {
+            id: purposeTemplateId,
+          },
+        }
+      );
+
+      await pollServiceTemplateVersionPurposeTemplateUntilDeletion(
+        purposeTemplateId,
+        eserviceTemplateId,
         headers
       );
     },

--- a/packages/m2m-gateway-v3/test/api/purposeTemplates/addPurposeTemplateEServiceTemplate.test.ts
+++ b/packages/m2m-gateway-v3/test/api/purposeTemplates/addPurposeTemplateEServiceTemplate.test.ts
@@ -1,0 +1,117 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { generateToken, getMockDPoPProof } from "pagopa-interop-commons-test";
+import {
+  EServiceTemplateId,
+  generateId,
+  pollingMaxRetriesExceeded,
+  PurposeTemplateId,
+} from "pagopa-interop-models";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { api, mockPurposeTemplateService } from "../../vitest.api.setup.js";
+
+describe("POST /purposeTemplates/:purposeTemplateId/eserviceTemplates route test", () => {
+  const mockDate = new Date();
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const mockRequestBody = {
+    eserviceTemplateId: generateId<EServiceTemplateId>(),
+  };
+
+  const makeRequest = async (
+    token: string,
+    purposeTemplateId: PurposeTemplateId,
+    body: m2mGatewayApiV3.PurposeTemplateLinkEServiceTemplate
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/purposeTemplates/${purposeTemplateId}/eserviceTemplates`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 and perform service calls for user with role %s",
+    async (role) => {
+      const purposeTemplateId = generateId<PurposeTemplateId>();
+      mockPurposeTemplateService.addPurposeTemplateEServiceTemplate = vi.fn();
+
+      const token = generateToken(role);
+      const res = await makeRequest(token, purposeTemplateId, mockRequestBody);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({});
+      expect(
+        mockPurposeTemplateService.addPurposeTemplateEServiceTemplate
+      ).toHaveBeenCalledWith(
+        purposeTemplateId,
+        mockRequestBody,
+        expect.any(Object) // Context object
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, generateId(), mockRequestBody);
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 400 for incorrect value for purpose template id", async () => {
+    mockPurposeTemplateService.addPurposeTemplateEServiceTemplate = vi.fn();
+
+    const token = generateToken(authRole.M2M_ROLE);
+    const res = await makeRequest(
+      token,
+      "INVALID ID" as PurposeTemplateId,
+      mockRequestBody
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    {},
+    { eserviceTemplateId: undefined },
+    { eserviceTemplateId: "invalid-eservice-template-id" },
+  ])("Should return 400 if passed an invalid request body", async (body) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      body as m2mGatewayApiV3.PurposeTemplateLinkEServiceTemplate
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockPurposeTemplateService.addPurposeTemplateEServiceTemplate = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, generateId(), mockRequestBody);
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/purposeTemplates/getPurposeTemplateEServiceTemplates.test.ts
+++ b/packages/m2m-gateway-v3/test/api/purposeTemplates/getPurposeTemplateEServiceTemplates.test.ts
@@ -1,0 +1,159 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import {
+  generateToken,
+  getMockedApiEServiceTemplate,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { generateId } from "pagopa-interop-models";
+import { describe, expect, it, vi } from "vitest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import request from "supertest";
+import { authRole, AuthRole } from "pagopa-interop-commons";
+import { generateMock } from "@anatine/zod-mock";
+import { z } from "zod";
+import { api, mockPurposeTemplateService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { toM2MGatewayEServiceTemplate } from "../../../src/api/eserviceTemplateApiConverter.js";
+
+describe("API GET /purposeTemplates/:purposeTemplateId/eserviceTemplates", () => {
+  const authorizedRoles: AuthRole[] = [
+    authRole.M2M_ADMIN_ROLE,
+    authRole.M2M_ROLE,
+  ];
+
+  const makeRequest = async (
+    token: string,
+    purposeTemplateId: string = generateId(),
+    query: m2mGatewayApiV3.GetPurposeTemplateEServiceTemplatesQueryParams = mockQueryParams
+  ) =>
+    request(api)
+      .get(
+        `${appBasePath}/purposeTemplates/${purposeTemplateId}/eserviceTemplates`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .query(query)
+      .send();
+
+  const mockApiEServiceTemplate1 = getMockedApiEServiceTemplate();
+  const mockApiEServiceTemplate2 = getMockedApiEServiceTemplate();
+  const mockApiEServiceTemplate3 = getMockedApiEServiceTemplate();
+
+  const mockM2MPurposeTemplateEServiceTemplatesResponse: m2mGatewayApiV3.EServiceTemplates =
+    {
+      pagination: { offset: 0, limit: 10, totalCount: 3 },
+      results: [
+        toM2MGatewayEServiceTemplate(mockApiEServiceTemplate1),
+        toM2MGatewayEServiceTemplate(mockApiEServiceTemplate2),
+        toM2MGatewayEServiceTemplate(mockApiEServiceTemplate3),
+      ],
+    };
+
+  const mockQueryParams: m2mGatewayApiV3.GetPurposeTemplateEServiceTemplatesQueryParams =
+    {
+      offset: 0,
+      limit: 10,
+      eserviceTemplateName: generateMock(z.string().optional()),
+      creatorIds: [generateId(), generateId()],
+    };
+
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      mockPurposeTemplateService.getPurposeTemplateEServiceTemplates = vi
+        .fn()
+        .mockResolvedValue(mockM2MPurposeTemplateEServiceTemplatesResponse);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockM2MPurposeTemplateEServiceTemplatesResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 200 with empty results when no templates are linked", async () => {
+    const emptyResponse: m2mGatewayApiV3.EServiceTemplates = {
+      pagination: { offset: 0, limit: 10, totalCount: 0 },
+      results: [],
+    };
+    mockPurposeTemplateService.getPurposeTemplateEServiceTemplates = vi
+      .fn()
+      .mockResolvedValue(emptyResponse);
+
+    const token = generateToken(authRole.M2M_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(emptyResponse);
+  });
+
+  it.each([
+    { query: {} },
+    { query: { offset: 0 } },
+    { query: { limit: 10 } },
+    { query: { offset: -1, limit: 10 } },
+    { query: { offset: 0, limit: -2 } },
+    { query: { offset: 0, limit: 55 } },
+    { query: { offset: "invalid", limit: 10 } },
+    { query: { offset: 0, limit: "invalid" } },
+    {
+      query: {
+        ...mockQueryParams,
+        eserviceTemplateName: [1, 2, 3],
+      },
+    },
+    {
+      query: {
+        ...mockQueryParams,
+        creatorIds: [`${generateId()}`, "invalid"],
+      },
+    },
+  ])("Should return 400 if passed invalid data: %s", async ({ query }) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      query as m2mGatewayApiV3.GetPurposeTemplateEServiceTemplatesQueryParams
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    {
+      ...mockM2MPurposeTemplateEServiceTemplatesResponse,
+      results: [
+        {
+          ...mockM2MPurposeTemplateEServiceTemplatesResponse.results[0],
+          id: undefined,
+        },
+      ],
+    },
+    {
+      ...mockM2MPurposeTemplateEServiceTemplatesResponse,
+      pagination: {
+        offset: "invalidOffset",
+        limit: "invalidLimit",
+        totalCount: 0,
+      },
+    },
+  ])(
+    "Should return 500 when API model parsing fails for response",
+    async (resp) => {
+      mockPurposeTemplateService.getPurposeTemplateEServiceTemplates = vi
+        .fn()
+        .mockResolvedValueOnce(resp);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token, generateId(), mockQueryParams);
+
+      expect(res.status).toBe(500);
+    }
+  );
+});

--- a/packages/m2m-gateway-v3/test/api/purposeTemplates/removePurposeTemplateEServiceTemplate.test.ts
+++ b/packages/m2m-gateway-v3/test/api/purposeTemplates/removePurposeTemplateEServiceTemplate.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { generateToken, getMockDPoPProof } from "pagopa-interop-commons-test";
+import {
+  EServiceTemplateId,
+  generateId,
+  pollingMaxRetriesExceeded,
+  PurposeTemplateId,
+} from "pagopa-interop-models";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { api, mockPurposeTemplateService } from "../../vitest.api.setup.js";
+
+describe("DELETE /purposeTemplates/:purposeTemplateId/eserviceTemplates/:eserviceTemplateId route test", () => {
+  const mockDate = new Date();
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const purposeTemplateId = generateId<PurposeTemplateId>();
+  const mockEserviceTemplateId = generateId<EServiceTemplateId>();
+
+  const makeRequest = async (
+    token: string,
+    purposeTemplateId: PurposeTemplateId,
+    eserviceTemplateId: EServiceTemplateId
+  ) =>
+    request(api)
+      .delete(
+        `${appBasePath}/purposeTemplates/${purposeTemplateId}/eserviceTemplates/${eserviceTemplateId}`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send();
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 and perform service calls for user with role %s",
+    async (role) => {
+      mockPurposeTemplateService.removePurposeTemplateEServiceTemplate =
+        vi.fn();
+
+      const token = generateToken(role);
+      const res = await makeRequest(
+        token,
+        purposeTemplateId,
+        mockEserviceTemplateId
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({});
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    mockPurposeTemplateService.removePurposeTemplateEServiceTemplate = vi.fn();
+
+    const token = generateToken(role);
+    const res = await makeRequest(token, generateId(), mockEserviceTemplateId);
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 400 for incorrect value for purpose template id", async () => {
+    const token = generateToken(authRole.M2M_ROLE);
+    const res = await makeRequest(
+      token,
+      "INVALID ID" as PurposeTemplateId,
+      mockEserviceTemplateId
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 400 for incorrect value for eservice template id", async () => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      "INVALID ID" as EServiceTemplateId
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockPurposeTemplateService.removePurposeTemplateEServiceTemplate = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, generateId(), mockEserviceTemplateId);
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServiceTemplates.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServiceTemplates.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  m2mGatewayApiV3,
+  purposeTemplateApi,
+} from "pagopa-interop-api-clients";
+import { getMockedApiEServiceTemplate } from "pagopa-interop-commons-test";
+import { generateId, PurposeTemplateId } from "pagopa-interop-models";
+import {
+  expectApiClientGetToHaveBeenCalledWith,
+  mockInteropBeClients,
+  purposeTemplateService,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+import { WithMaybeMetadata } from "../../../src/clients/zodiosWithMetadataPatch.js";
+import { toM2MGatewayEServiceTemplate } from "../../../src/api/eserviceTemplateApiConverter.js";
+
+describe("getPurposeTemplateEServiceTemplates", () => {
+  const mockParams: m2mGatewayApiV3.GetPurposeTemplateEServiceTemplatesQueryParams =
+    {
+      offset: 0,
+      limit: 10,
+      creatorIds: [],
+    };
+
+  const mockApiEServiceTemplate1 = getMockedApiEServiceTemplate();
+  const mockApiEServiceTemplate2 = getMockedApiEServiceTemplate();
+  const mockApiEServiceTemplates = [
+    mockApiEServiceTemplate1,
+    mockApiEServiceTemplate2,
+  ];
+
+  const mockGetEServiceTemplates = vi.fn(
+    ({ queries: { eserviceTemplatesIds } }) =>
+      Promise.resolve({
+        data: {
+          results: mockApiEServiceTemplates.filter((t) =>
+            eserviceTemplatesIds.includes(t.id)
+          ),
+        },
+      })
+  );
+  mockInteropBeClients.eserviceTemplateProcessClient = {
+    getEServiceTemplates: mockGetEServiceTemplates,
+  } as unknown as PagoPAInteropBeClients["eserviceTemplateProcessClient"];
+
+  const mockApiPurposeTemplateEServiceTemplateLink1: purposeTemplateApi.EServiceTemplateVersionPurposeTemplate =
+    {
+      purposeTemplateId: generateId(),
+      eserviceTemplateId: mockApiEServiceTemplate1.id,
+      eserviceTemplateVersionId: generateId(),
+      createdAt: new Date().toISOString(),
+    };
+  const mockApiPurposeTemplateEServiceTemplateLink2: purposeTemplateApi.EServiceTemplateVersionPurposeTemplate =
+    {
+      purposeTemplateId: generateId(),
+      eserviceTemplateId: mockApiEServiceTemplate2.id,
+      eserviceTemplateVersionId: generateId(),
+      createdAt: new Date().toISOString(),
+    };
+  const mockApiPurposeTemplateEServiceTemplateLinks = [
+    mockApiPurposeTemplateEServiceTemplateLink1,
+    mockApiPurposeTemplateEServiceTemplateLink2,
+  ];
+
+  const mockPurposeTemplateEServiceTemplatesProcessResponse: WithMaybeMetadata<purposeTemplateApi.EServiceTemplateVersionsPurposeTemplate> =
+    {
+      data: {
+        results: mockApiPurposeTemplateEServiceTemplateLinks,
+        totalCount: mockApiPurposeTemplateEServiceTemplateLinks.length,
+      },
+      metadata: undefined,
+    };
+
+  const mockGetPurposeTemplateEServiceTemplates = vi
+    .fn()
+    .mockResolvedValue(mockPurposeTemplateEServiceTemplatesProcessResponse);
+
+  mockInteropBeClients.purposeTemplateProcessClient = {
+    getPurposeTemplateEServiceTemplates:
+      mockGetPurposeTemplateEServiceTemplates,
+  } as unknown as PagoPAInteropBeClients["purposeTemplateProcessClient"];
+
+  beforeEach(() => {
+    mockGetPurposeTemplateEServiceTemplates.mockClear();
+    mockGetEServiceTemplates.mockClear();
+  });
+
+  it("Should succeed and chain process retrieval + enrichment client calls", async () => {
+    const purposeTemplateId = generateId<PurposeTemplateId>();
+    const expected: m2mGatewayApiV3.EServiceTemplates = {
+      pagination: {
+        limit: mockParams.limit,
+        offset: mockParams.offset,
+        totalCount:
+          mockPurposeTemplateEServiceTemplatesProcessResponse.data.totalCount,
+      },
+      results: [mockApiEServiceTemplate1, mockApiEServiceTemplate2].map(
+        toM2MGatewayEServiceTemplate
+      ),
+    };
+
+    const result =
+      await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        purposeTemplateId,
+        mockParams,
+        getMockM2MAdminAppContext()
+      );
+
+    expect(result).toStrictEqual(expected);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet:
+        mockInteropBeClients.purposeTemplateProcessClient
+          .getPurposeTemplateEServiceTemplates,
+      params: { id: purposeTemplateId },
+      queries: {
+        offset: mockParams.offset,
+        limit: mockParams.limit,
+        eserviceTemplateName: mockParams.eserviceTemplateName,
+        creatorIds: [],
+      } satisfies m2mGatewayApiV3.GetPurposeTemplateEServiceTemplatesQueryParams,
+    });
+    expect(mockGetEServiceTemplates).toHaveBeenCalledTimes(1);
+    expect(mockGetEServiceTemplates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queries: expect.objectContaining({
+          eserviceTemplatesIds: [
+            mockApiEServiceTemplate1.id,
+            mockApiEServiceTemplate2.id,
+          ],
+          offset: 0,
+          limit: mockParams.limit,
+        }),
+      })
+    );
+  });
+
+  it("Should silently drop links whose template is not returned by enrichment (locked semantics)", async () => {
+    const purposeTemplateId = generateId<PurposeTemplateId>();
+    // Process returns 2 links but enrichment finds only 1: the M2M response has
+    // 1 result while pagination.totalCount stays at 2 (no cross-validation).
+    mockGetEServiceTemplates.mockResolvedValueOnce({
+      data: {
+        results: [mockApiEServiceTemplate1],
+      },
+    });
+
+    const result =
+      await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        purposeTemplateId,
+        mockParams,
+        getMockM2MAdminAppContext()
+      );
+
+    expect(result.results).toStrictEqual([
+      toM2MGatewayEServiceTemplate(mockApiEServiceTemplate1),
+    ]);
+    expect(result.pagination.totalCount).toBe(2);
+    expect(result.pagination.totalCount).not.toBe(result.results.length);
+  });
+
+  it("Should always invoke the enrichment client even when there are no links (locked: no empty short-circuit)", async () => {
+    const purposeTemplateId = generateId<PurposeTemplateId>();
+    mockGetPurposeTemplateEServiceTemplates.mockResolvedValueOnce({
+      data: { results: [], totalCount: 0 },
+      metadata: undefined,
+    });
+    mockGetEServiceTemplates.mockResolvedValueOnce({
+      data: { results: [] },
+    });
+
+    const result =
+      await purposeTemplateService.getPurposeTemplateEServiceTemplates(
+        purposeTemplateId,
+        mockParams,
+        getMockM2MAdminAppContext()
+      );
+
+    expect(result).toStrictEqual({
+      pagination: {
+        offset: mockParams.offset,
+        limit: mockParams.limit,
+        totalCount: 0,
+      },
+      results: [],
+    });
+    expect(mockGetEServiceTemplates).toHaveBeenCalledTimes(1);
+    expect(mockGetEServiceTemplates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queries: expect.objectContaining({
+          eserviceTemplatesIds: [],
+        }),
+      })
+    );
+  });
+});

--- a/packages/purpose-template-process/src/model/domain/errors.ts
+++ b/packages/purpose-template-process/src/model/domain/errors.ts
@@ -48,6 +48,7 @@ const errorCodes = {
   tooManyEServiceTemplatesForPurposeTemplate: "0031",
   disassociationEServiceTemplatesFromPurposeTemplateFailed: "0032",
   associationBetweenEServiceTemplateAndPurposeTemplateDoesNotExist: "0033",
+  eServiceTemplateVersionPurposeTemplateNotFound: "0034",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -372,6 +373,17 @@ export function eServiceDescriptorPurposeTemplateNotFound(
     detail: `No e-service descriptor found for purpose template ${purposeTemplateId} and e-service id ${eServiceId}`,
     code: "eServiceDescriptorPurposeTemplateNotFound",
     title: "E-Service Descriptor Purpose Template not found",
+  });
+}
+
+export function eServiceTemplateVersionPurposeTemplateNotFound(
+  purposeTemplateId: PurposeTemplateId,
+  eserviceTemplateId: EServiceTemplateId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `No e-service template link found for purpose template ${purposeTemplateId} and e-service template id ${eserviceTemplateId}`,
+    code: "eServiceTemplateVersionPurposeTemplateNotFound",
+    title: "E-Service Template Version Purpose Template link not found",
   });
 }
 

--- a/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
+++ b/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
@@ -49,6 +49,7 @@ import {
   updateRiskAnalysisTemplateAnswerAnnotationDocumentErrorMapper,
   updatePurposeTemplateRiskAnalysisErrorMapper,
   getPurposeTemplateEServiceDescriptorErrorMapper,
+  getPurposeTemplateEServiceTemplateErrorMapper,
   addRiskAnalysisTemplateDocumentErrorMapper,
   getRiskAnalysisTemplateSignedDocumentErrorMapper,
   getRiskAnalysisTemplateDocumentErrorMapper,
@@ -430,6 +431,46 @@ const purposeTemplateRouter = (
         return res.status(errorRes.status).send(errorRes);
       }
     })
+    .get(
+      "/purposeTemplates/:id/eserviceTemplates/:eserviceTemplateId",
+      async (req, res) => {
+        const ctx = fromAppContext(req.ctx);
+        try {
+          validateAuthorization(ctx, [
+            ADMIN_ROLE,
+            API_ROLE,
+            M2M_ADMIN_ROLE,
+            M2M_ROLE,
+            SECURITY_ROLE,
+            SUPPORT_ROLE,
+          ]);
+
+          const link =
+            await purposeTemplateService.getPurposeTemplateEServiceTemplate(
+              unsafeBrandId(req.params.id),
+              unsafeBrandId(req.params.eserviceTemplateId),
+              ctx
+            );
+
+          return res
+            .status(200)
+            .send(
+              purposeTemplateApi.EServiceTemplateVersionPurposeTemplate.parse(
+                eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate(
+                  link
+                )
+              )
+            );
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            getPurposeTemplateEServiceTemplateErrorMapper,
+            ctx
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
     .post("/purposeTemplates/:id/linkEservices", async (req, res) => {
       const ctx = fromAppContext(req.ctx);
       try {

--- a/packages/purpose-template-process/src/services/purposeTemplateService.ts
+++ b/packages/purpose-template-process/src/services/purposeTemplateService.ts
@@ -55,6 +55,7 @@ import {
   disassociationEServicesFromPurposeTemplateFailed,
   disassociationEServiceTemplatesFromPurposeTemplateFailed,
   eServiceDescriptorPurposeTemplateNotFound,
+  eServiceTemplateVersionPurposeTemplateNotFound,
   invalidAssociatedEServiceForPublication,
   missingRiskAnalysisFormTemplate,
   purposeTemplateNotFound,
@@ -154,6 +155,25 @@ async function retrievePurposeTemplateEserviceDescriptor(
     );
   }
   return eServiceDescriptorPurposeTemplate;
+}
+
+async function retrieveEServiceTemplateVersionPurposeTemplate(
+  purposeTemplateId: PurposeTemplateId,
+  eserviceTemplateId: EServiceTemplateId,
+  readModelService: ReadModelServiceSQL
+): Promise<EServiceTemplateVersionPurposeTemplate> {
+  const link =
+    await readModelService.getEServiceTemplateVersionPurposeTemplateByPurposeTemplateIdAndEServiceTemplateId(
+      purposeTemplateId,
+      eserviceTemplateId
+    );
+  if (!link) {
+    throw eServiceTemplateVersionPurposeTemplateNotFound(
+      purposeTemplateId,
+      eserviceTemplateId
+    );
+  }
+  return link;
 }
 
 function retrieveRiskAnalysisFormTemplate(
@@ -1118,6 +1138,29 @@ export function purposeTemplateServiceBuilder(
       return await retrievePurposeTemplateEserviceDescriptor(
         purposeTemplateId,
         eserviceId,
+        readModelService
+      );
+    },
+    async getPurposeTemplateEServiceTemplate(
+      purposeTemplateId: PurposeTemplateId,
+      eserviceTemplateId: EServiceTemplateId,
+      {
+        authData,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAuthData | M2MAdminAuthData>>
+    ): Promise<EServiceTemplateVersionPurposeTemplate> {
+      logger.info(
+        `Retrieving e-service template link with id ${eserviceTemplateId} for purpose template ${purposeTemplateId}`
+      );
+
+      applyVisibilityToPurposeTemplate(
+        await retrievePurposeTemplate(purposeTemplateId, readModelService),
+        authData
+      );
+
+      return await retrieveEServiceTemplateVersionPurposeTemplate(
+        purposeTemplateId,
+        eserviceTemplateId,
         readModelService
       );
     },

--- a/packages/purpose-template-process/src/utilities/errorMappers.ts
+++ b/packages/purpose-template-process/src/utilities/errorMappers.ts
@@ -62,6 +62,18 @@ export const getPurposeTemplateEServiceDescriptorErrorMapper = (
     .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
+export const getPurposeTemplateEServiceTemplateErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "purposeTemplateNotFound",
+      "eServiceTemplateVersionPurposeTemplateNotFound",
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with("tenantNotAllowed", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
 export const getRiskAnalysisTemplateAnnotationDocumentsErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number => commonPurposeTemplatesErrorMapper(error);

--- a/packages/purpose-template-process/test/api/getPurposeTemplateEServiceTemplate.test.ts
+++ b/packages/purpose-template-process/test/api/getPurposeTemplateEServiceTemplate.test.ts
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { purposeTemplateApi } from "pagopa-interop-api-clients";
+import { authRole, AuthRole } from "pagopa-interop-commons";
+import { generateToken } from "pagopa-interop-commons-test";
+import {
+  EServiceTemplateId,
+  EServiceTemplateVersionPurposeTemplate,
+  generateId,
+  PurposeTemplateId,
+} from "pagopa-interop-models";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  eServiceTemplateVersionPurposeTemplateNotFound,
+  purposeTemplateNotFound,
+} from "../../src/model/domain/errors.js";
+import { api, purposeTemplateService } from "../vitest.api.setup.js";
+import { eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate } from "../../src/model/domain/apiConverter.js";
+
+describe("API GET /purposeTemplates/:id/eserviceTemplates/:eserviceTemplateId", () => {
+  const purposeTemplateId = generateId<PurposeTemplateId>();
+  const eserviceTemplateId = generateId<EServiceTemplateId>();
+  const eserviceTemplateVersionPurposeTemplate: EServiceTemplateVersionPurposeTemplate =
+    {
+      purposeTemplateId,
+      eserviceTemplateId,
+      eserviceTemplateVersionId: generateId(),
+      createdAt: new Date(),
+    };
+
+  const apiResponse =
+    purposeTemplateApi.EServiceTemplateVersionPurposeTemplate.parse(
+      eserviceTemplateVersionPurposeTemplateToApiEServiceTemplateVersionPurposeTemplate(
+        eserviceTemplateVersionPurposeTemplate
+      )
+    );
+
+  beforeEach(() => {
+    purposeTemplateService.getPurposeTemplateEServiceTemplate = vi
+      .fn()
+      .mockResolvedValue(eserviceTemplateVersionPurposeTemplate);
+  });
+
+  const makeRequest = async (
+    token: string,
+    purposeTemplateId: PurposeTemplateId = generateId(),
+    eserviceTemplateId: EServiceTemplateId = generateId()
+  ) =>
+    request(api)
+      .get(
+        `/purposeTemplates/${purposeTemplateId}/eserviceTemplates/${eserviceTemplateId}`
+      )
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send();
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.API_ROLE,
+    authRole.SECURITY_ROLE,
+    authRole.M2M_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+    authRole.SUPPORT_ROLE,
+  ];
+
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(apiResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {
+      error: purposeTemplateNotFound(generateId()),
+      expectedStatus: 404,
+    },
+    {
+      error: eServiceTemplateVersionPurposeTemplateNotFound(
+        generateId(),
+        generateId()
+      ),
+      expectedStatus: 404,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      purposeTemplateService.getPurposeTemplateEServiceTemplate = vi
+        .fn()
+        .mockRejectedValue(error);
+
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+
+  it.each([
+    {
+      purposeTemplateId: "invalid" as PurposeTemplateId,
+      eserviceTemplateId,
+    },
+    {
+      purposeTemplateId,
+      eserviceTemplateId: "invalid" as EServiceTemplateId,
+    },
+  ])(
+    "Should return 400 if passed invalid data: %s",
+    async ({ purposeTemplateId, eserviceTemplateId }) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        purposeTemplateId,
+        eserviceTemplateId
+      );
+      expect(res.status).toBe(400);
+    }
+  );
+});


### PR DESCRIPTION
**Jira**: [PIN-9929](https://pagopa.atlassian.net/browse/PIN-9929)

## Summary

- Expose the e-service template ↔ purpose template flows in `m2m-gateway-v3`, mirroring the AS-IS pattern for concrete e-services (PIN-8621): `GET /purposeTemplates/{id}/eserviceTemplates` (retrieval enriched with full template metadata via `eserviceTemplateProcessClient.getEServiceTemplates`), `POST /purposeTemplates/{id}/eserviceTemplates` (link single-entity), `DELETE /purposeTemplates/{id}/eserviceTemplates/{eserviceTemplateId}` (unlink single-entity). Auth: `M2M_ROLE | M2M_ADMIN_ROLE` for retrieval, `M2M_ADMIN_ROLE` for write.
- New service helpers `retrieveEServiceTemplateVersionPurposeTemplate` and `pollServiceTemplateVersionPurposeTemplateUntilDeletion` in the M2M service, parallel to the AS-IS descriptor pair. The unlink polling reuses the shared `pollResourceUntilDeletion` from `utils/polling.ts`.
- Add a small process-side pre-req endpoint `GET /purposeTemplates/{id}/eserviceTemplates/{eserviceTemplateId}` (`getPurposeTemplateEServiceTemplate`) parallel to the AS-IS `getPurposeTemplateEServiceDescriptor`, with a new error code `0034` `eServiceTemplateVersionPurposeTemplateNotFound`. Required to back the symmetric unlink polling on the M2M side.
- New OpenAPI schema `PurposeTemplateLinkEServiceTemplate` and new query-params alias `GetPurposeTemplateEServiceTemplatesQueryParams`. The list response reuses the existing `EServiceTemplates` schema.

## Note

Retrieval semantics are intentionally aligned with the AS-IS sibling `getPurposeTemplateEServices`: results are returned in enrichment-side order (no re-ordering to match process-side link order), missing templates after enrichment are silently dropped (no cross-validation between `processResults.length` and `eserviceTemplates.length`), and the empty-list case is not short-circuited (the second upstream call always fires). Any future tightening of these properties should be applied symmetrically to both flows (template + concrete) as a single follow-up.

The process-side single-link endpoint is added here rather than as a separate stacked PR because it is consumed exclusively by the M2M unlink polling introduced in this same change — keeping them together avoids leaving an orphan endpoint in the process layer.

[PIN-9929]: https://pagopa.atlassian.net/browse/PIN-9929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ