### PR TITLE
fix(catalog-process): restore daily calls <= validation (PIN-9958)

### DIFF
--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -194,7 +194,7 @@ export function attributeNotFound(attributeId: string): ApiError<ErrorCodes> {
 
 export function inconsistentDailyCalls(): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `dailyCallsPerConsumer can't be greater than or equal to dailyCallsTotal`,
+    detail: `dailyCallsPerConsumer can't be greater than dailyCallsTotal`,
     code: "inconsistentDailyCalls",
     title: "Inconsistent daily calls",
   });

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -358,7 +358,7 @@ export function assertConsistentDailyCalls({
   dailyCallsPerConsumer: number;
   dailyCallsTotal: number;
 }): void {
-  if (dailyCallsPerConsumer >= dailyCallsTotal) {
+  if (dailyCallsPerConsumer > dailyCallsTotal) {
     throw inconsistentDailyCalls();
   }
 }
@@ -507,7 +507,7 @@ export function assertAttributeDailyCallsConsistentWithTotal(
     for (const attribute of attributeGroup) {
       if (
         attribute.dailyCallsPerConsumer !== undefined &&
-        attribute.dailyCallsPerConsumer >= dailyCallsTotal
+        attribute.dailyCallsPerConsumer > dailyCallsTotal
       ) {
         throw inconsistentDailyCalls();
       }

--- a/packages/catalog-process/test/integration/createDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/createDescriptor.test.ts
@@ -528,6 +528,42 @@ describe("create descriptor", async () => {
       )
     ).rejects.toThrowError(inconsistentDailyCalls());
   });
+
+  it("should create a new descriptor when dailyCallsPerConsumer equals dailyCallsTotal", async () => {
+    const existingDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      interface: getMockDocument(),
+      state: descriptorState.published,
+    };
+    const descriptorSeed: catalogApi.EServiceDescriptorSeed = {
+      ...buildCreateDescriptorSeed(getMockDescriptor()),
+      dailyCallsPerConsumer: 100,
+      dailyCallsTotal: 100,
+    };
+    const eservice: EService = {
+      ...getMockEService(),
+      descriptors: [existingDescriptor],
+    };
+
+    await addOneEService(eservice);
+
+    const createDescriptorResponse = await catalogService.createDescriptor(
+      eservice.id,
+      descriptorSeed,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    expect(createDescriptorResponse.data.eservice.descriptors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: createDescriptorResponse.data.createdDescriptorId,
+          dailyCallsPerConsumer: 100,
+          dailyCallsTotal: 100,
+        }),
+      ])
+    );
+  });
+
   it("should throw templateInstanceNotAllowed if the templateId is defined", async () => {
     const templateId = unsafeBrandId<EServiceTemplateId>(generateId());
     const descriptorSeed: catalogApi.EServiceDescriptorSeed = {

--- a/packages/catalog-process/test/integration/createEService.test.ts
+++ b/packages/catalog-process/test/integration/createEService.test.ts
@@ -368,28 +368,22 @@ describe("create eservice", () => {
     ).rejects.toThrowError(originNotCompliant("not-allowed-origin"));
   });
 
-  it.each([
-    { dailyCallsPerConsumer: 100, dailyCallsTotal: 99 },
-    { dailyCallsPerConsumer: 100, dailyCallsTotal: 100 },
-  ])(
-    "should throw inconsistentDailyCalls if the descriptor seed has dailyCallsPerConsumer >= dailyCallsTotal",
-    async ({ dailyCallsPerConsumer, dailyCallsTotal }) => {
-      expect(
-        catalogService.createEService(
-          {
-            name: mockEService.name,
-            description: mockEService.description,
-            technology: "REST",
-            mode: "DELIVER",
-            descriptor: {
-              ...buildDescriptorSeedForEserviceCreation(mockDescriptor),
-              dailyCallsPerConsumer,
-              dailyCallsTotal,
-            },
+  it("should throw inconsistentDailyCalls if the descriptor seed has dailyCallsPerConsumer > dailyCallsTotal", async () => {
+    expect(
+      catalogService.createEService(
+        {
+          name: mockEService.name,
+          description: mockEService.description,
+          technology: "REST",
+          mode: "DELIVER",
+          descriptor: {
+            ...buildDescriptorSeedForEserviceCreation(mockDescriptor),
+            dailyCallsPerConsumer: 100,
+            dailyCallsTotal: 99,
           },
-          getMockContext({ authData: getMockAuthData(mockEService.producerId) })
-        )
-      ).rejects.toThrowError(inconsistentDailyCalls());
-    }
-  );
+        },
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      )
+    ).rejects.toThrowError(inconsistentDailyCalls());
+  });
 });

--- a/packages/catalog-process/test/integration/createTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/createTemplateInstanceDescriptor.test.ts
@@ -409,47 +409,43 @@ describe("create descriptor", async () => {
       )
     ).rejects.toThrowError(operationForbidden);
   });
-  it.each([
-    { dailyCallsPerConsumer: 60, dailyCallsTotal: 50 },
-    { dailyCallsPerConsumer: 50, dailyCallsTotal: 50 },
-  ])(
-    "should throw inconsistentDailyCalls if dailyCallsPerConsumer is greater than or equal to dailyCallsTotal",
-    async ({ dailyCallsPerConsumer, dailyCallsTotal }) => {
-      const templateVersion: EServiceTemplateVersion = {
-        ...getMockEServiceTemplateVersion(),
-        state: eserviceTemplateVersionState.published,
-        interface: getMockDocument(),
-      };
-      const template: EServiceTemplate = {
-        ...getMockEServiceTemplate(),
-        versions: [templateVersion],
-      };
+  it("should throw inconsistentDailyCalls if dailyCallsPerConsumer is greater than dailyCallsTotal", async () => {
+    const dailyCallsPerConsumer = 60;
+    const dailyCallsTotal = 50;
+    const templateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      state: eserviceTemplateVersionState.published,
+      interface: getMockDocument(),
+    };
+    const template: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      versions: [templateVersion],
+    };
 
-      const prevDescriptor: Descriptor = {
-        ...getMockDescriptor(),
-        version: "1",
-        state: descriptorState.published,
-        interface: getMockDocument(),
-        templateVersionRef: {
-          id: templateVersion.id,
-        },
-      };
-      const eservice: EService = {
-        ...getMockEService(),
-        descriptors: [prevDescriptor],
-        templateId: template.id,
-      };
+    const prevDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      version: "1",
+      state: descriptorState.published,
+      interface: getMockDocument(),
+      templateVersionRef: {
+        id: templateVersion.id,
+      },
+    };
+    const eservice: EService = {
+      ...getMockEService(),
+      descriptors: [prevDescriptor],
+      templateId: template.id,
+    };
 
-      await addOneEService(eservice);
-      await addOneEServiceTemplate(template);
+    await addOneEService(eservice);
+    await addOneEServiceTemplate(template);
 
-      expect(
-        catalogService.createTemplateInstanceDescriptor(
-          eservice.id,
-          { audience: [], dailyCallsPerConsumer, dailyCallsTotal },
-          getMockContext({ authData: getMockAuthData(eservice.producerId) })
-        )
-      ).rejects.toThrowError(inconsistentDailyCalls());
-    }
-  );
+    expect(
+      catalogService.createTemplateInstanceDescriptor(
+        eservice.id,
+        { audience: [], dailyCallsPerConsumer, dailyCallsTotal },
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(inconsistentDailyCalls());
+  });
 });

--- a/packages/catalog-process/test/integration/patchUpdateDraftDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/patchUpdateDraftDescriptor.test.ts
@@ -447,11 +447,10 @@ describe("patchUpdateDraftDescriptor", () => {
 
   it.each([
     { dailyCallsPerConsumer: 300, dailyCallsTotal: 200 },
-    { dailyCallsPerConsumer: 200, dailyCallsTotal: 200 },
     { dailyCallsPerConsumer: 300 },
     { dailyCallsTotal: 50 },
   ])(
-    "should throw inconsistentDailyCalls if dailyCallsPerConsumer is greater than or equal to dailyCallsTotal",
+    "should throw inconsistentDailyCalls if dailyCallsPerConsumer is greater than dailyCallsTotal",
     async (seed) => {
       const descriptor: Descriptor = {
         ...mockDescriptor,

--- a/packages/catalog-process/test/integration/updateDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptor.test.ts
@@ -321,7 +321,7 @@ describe("update descriptor", () => {
     ).rejects.toThrowError(operationForbidden);
   });
 
-  it("should throw inconsistentDailyCalls if dailyCallsPerConsumer is greater than or equal to dailyCallsTotal", async () => {
+  it("should throw inconsistentDailyCalls if dailyCallsPerConsumer is greater than dailyCallsTotal", async () => {
     const descriptor: Descriptor = {
       ...mockDescriptor,
       state: descriptorState.published,
@@ -471,102 +471,6 @@ describe("update descriptor", () => {
     });
   });
 
-  it("should throw inconsistentDailyCalls when a new certified attribute has dailyCallsPerConsumer greater than or equal to the descriptor dailyCallsTotal", async () => {
-    const certifiedAttribute = getMockAttribute(attributeKind.certified);
-    await addOneAttribute(certifiedAttribute);
-
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
-      state: descriptorState.published,
-      interface: mockDocument,
-      publishedAt: new Date(),
-      dailyCallsPerConsumer: 1,
-      dailyCallsTotal: 1000,
-      attributes: {
-        certified: [
-          [
-            {
-              id: certifiedAttribute.id,
-              explicitAttributeVerification: false,
-              dailyCallsPerConsumer: 500,
-            },
-          ],
-        ],
-        declared: [],
-        verified: [],
-      },
-    };
-    const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
-    };
-    await addOneEService(eservice);
-
-    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
-      voucherLifespan: 1000,
-      dailyCallsPerConsumer: 1,
-      dailyCallsTotal: 1000,
-      attributes: {
-        certified: [
-          [
-            {
-              id: certifiedAttribute.id,
-              explicitAttributeVerification: false,
-            },
-          ],
-        ],
-        declared: [],
-        verified: [],
-      },
-    };
-
-    const expectedEService: EService = {
-      ...eservice,
-      descriptors: [
-        {
-          ...descriptor,
-          voucherLifespan: 1000,
-          dailyCallsPerConsumer: 1,
-          dailyCallsTotal: 1000,
-          attributes: {
-            certified: [
-              [
-                {
-                  id: certifiedAttribute.id,
-                  explicitAttributeVerification: false,
-                },
-              ],
-            ],
-            declared: [],
-            verified: [],
-          },
-        },
-      ],
-    };
-
-    const returnedEService = await catalogService.updateDescriptor(
-      eservice.id,
-      descriptor.id,
-      seed,
-      getMockContext({ authData: getMockAuthData(eservice.producerId) })
-    );
-
-    const lastEvent = await readLastEserviceEvent(eservice.id);
-    const writtenPayload = decodeProtobufPayload({
-      messageType: EServiceDescriptorQuotasUpdatedV2,
-      payload: lastEvent.data,
-    });
-
-    expect(writtenPayload).toEqual({
-      eservice: toEServiceV2(expectedEService),
-      descriptorId: descriptor.id,
-    });
-    expect(returnedEService).toEqual({
-      data: expectedEService,
-      metadata: { version: 1 },
-    });
-  });
-
   it("should clear existing certified attribute dailyCallsPerConsumer when seed.attributes omits them", async () => {
     const certifiedAttribute = getMockAttribute(attributeKind.certified);
     await addOneAttribute(certifiedAttribute);
@@ -663,7 +567,7 @@ describe("update descriptor", () => {
     });
   });
 
-  it("should throw inconsistentDailyCalls when a new certified attribute has dailyCallsPerConsumer greater than or equal to the descriptor dailyCallsTotal", async () => {
+  it("should throw inconsistentDailyCalls when a new certified attribute dailyCallsPerConsumer exceeds the descriptor dailyCallsTotal", async () => {
     const certifiedAttribute = getMockAttribute(attributeKind.certified);
     await addOneAttribute(certifiedAttribute);
 

--- a/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
@@ -1325,58 +1325,55 @@ describe("update descriptor", () => {
     );
   });
 
-  it.each([{ dailyCallsPerConsumer: 200 }, { dailyCallsPerConsumer: 100 }])(
-    "should throw inconsistentDailyCalls if a certified attribute dailyCallsPerConsumer meets or exceeds descriptor dailyCallsTotal",
-    async ({ dailyCallsPerConsumer }) => {
-      const mockDescriptor: Descriptor = {
-        ...getMockDescriptor(),
-        state: descriptorState.published,
-        dailyCallsTotal: 100,
-        attributes: {
-          certified: [
-            [
-              {
-                id: mockCertifiedAttribute1.id,
-                explicitAttributeVerification: false,
-              },
-            ],
-          ],
-          verified: [],
-          declared: [],
-        },
-      };
-
-      const mockEService: EService = {
-        ...getMockEService(),
-        descriptors: [mockDescriptor],
-      };
-
-      await addOneEService(mockEService);
-
-      const seed: catalogApi.AttributesSeed = {
+  it("should throw inconsistentDailyCalls if a certified attribute dailyCallsPerConsumer exceeds descriptor dailyCallsTotal", async () => {
+    const mockDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      state: descriptorState.published,
+      dailyCallsTotal: 100,
+      attributes: {
         certified: [
           [
             {
               id: mockCertifiedAttribute1.id,
               explicitAttributeVerification: false,
-              dailyCallsPerConsumer,
             },
           ],
         ],
         verified: [],
         declared: [],
-      };
+      },
+    };
 
-      await expect(
-        catalogService.updateDescriptorAttributes(
-          mockEService.id,
-          mockDescriptor.id,
-          seed,
-          getMockContext({ authData: getMockAuthData(mockEService.producerId) })
-        )
-      ).rejects.toThrowError(inconsistentDailyCalls());
-    }
-  );
+    const mockEService: EService = {
+      ...getMockEService(),
+      descriptors: [mockDescriptor],
+    };
+
+    await addOneEService(mockEService);
+
+    const seed: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedAttribute1.id,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 101,
+          },
+        ],
+      ],
+      verified: [],
+      declared: [],
+    };
+
+    await expect(
+      catalogService.updateDescriptorAttributes(
+        mockEService.id,
+        mockDescriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      )
+    ).rejects.toThrowError(inconsistentDailyCalls());
+  });
 
   it("should correctly match certified groups by content when seed groups are in different order than the descriptor groups", async () => {
     const mockDescriptor: Descriptor = {
@@ -1483,7 +1480,7 @@ describe("update descriptor", () => {
     ).toBe(true);
   });
 
-  it("should throw inconsistentDailyCalls when updating dailyCallsPerConsumer on a newly added certified attribute to meet or exceed dailyCallsTotal", async () => {
+  it("should throw inconsistentDailyCalls when updating dailyCallsPerConsumer on a newly added certified attribute to exceed dailyCallsTotal", async () => {
     const mockDescriptor: Descriptor = {
       ...getMockDescriptor(),
       state: descriptorState.published,

--- a/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
@@ -321,7 +321,7 @@ describe("update draft descriptor instance", () => {
     ).rejects.toThrowError(operationForbidden);
   });
 
-  it("should throw inconsistentDailyCalls if dailyCallsPerConsumer is greater than or equal to dailyCallsTotal", async () => {
+  it("should throw inconsistentDailyCalls if dailyCallsPerConsumer is greater than dailyCallsTotal", async () => {
     const template = getMockEServiceTemplate();
 
     const descriptor: Descriptor = {


### PR DESCRIPTION
## Jira Issue
[PIN-9958](https://pagopa.atlassian.net/browse/PIN-9958)

## Context
- Since 2.17.0, the backend validation required `dailyCallsPerConsumer` to be strictly lower than `dailyCallsTotal`.
- This caused a regression when creating a new draft descriptor/version because the BFF reuses the quotas from the latest existing version.
- When both values are equal, for example `10` and `10`, the backend returns an error.
- This hotfix restores the expected validation rule: `dailyCallsPerConsumer <= dailyCallsTotal`.

## Services Affected
- `catalog-process`

## Key Changes
- Restored the daily calls validation in `catalog-process` validators to allow equality between `dailyCallsPerConsumer` and `dailyCallsTotal`.
- Updated the affected integration tests to cover the restored rule.
- Fixed outdated test descriptions that still referred to the previous `>=` behavior.
- Removed one redundant integration test and added a positive regression test for the equality case.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [x] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection updated (if required)

[PIN-9958]: https://pagopa.atlassian.net/browse/PIN-9958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ