### PR TITLE
hotfix/PIN-9965 Allow new descriptors with obsolete risk analysis

### DIFF
--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -246,6 +246,12 @@ export function assertRiskAnalysisIsValidForPublication(
     throw eServiceRiskAnalysisIsRequired(eservice.id);
   }
 
+  const firstPublishedAt = eservice.descriptors.find(
+    (d) => d.publishedAt !== undefined
+  )?.publishedAt;
+
+  const dateForRiskAnalysisValidation = firstPublishedAt ?? new Date();
+
   eservice.riskAnalysis.forEach((riskAnalysis) => {
     const result = validateRiskAnalysis(
       riskAnalysisFormToRiskAnalysisFormToValidate(
@@ -253,7 +259,7 @@ export function assertRiskAnalysisIsValidForPublication(
       ),
       false,
       tenantKind,
-      new Date(),
+      dateForRiskAnalysisValidation,
       eservice.personalData
     );
 

--- a/packages/catalog-process/test/integration/publishDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/publishDescriptor.test.ts
@@ -756,7 +756,7 @@ describe("publish descriptor", () => {
   });
 
   it("should succeed publishing a new descriptor when risk analysis form version is expired but was valid at first publication", async () => {
-    const firstPublishedAt = new Date("2026-07-01");
+    const firstPublishedAt = new Date("2023-07-01");
 
     const descriptor1: Descriptor = {
       ...mockDescriptor,
@@ -779,7 +779,7 @@ describe("publish descriptor", () => {
       kind: tenantKind.PA,
     };
 
-    // PA 2.0 is expired, but was valid at firstPublishedAt (2026-07-01)
+    // PA 2.0 is expired, but was valid at firstPublishedAt (2023-07-01)
     const riskAnalysis = getMockExpiredRiskAnalysis(tenantKind.PA);
 
     const eservice: EService = {

--- a/packages/catalog-process/test/integration/publishDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/publishDescriptor.test.ts
@@ -4,6 +4,7 @@ import {
   randomArrayItem,
   getMockTenant,
   getMockValidRiskAnalysis,
+  getMockExpiredRiskAnalysis,
   getMockDelegation,
   getMockAuthData,
   getMockContext,
@@ -752,5 +753,86 @@ describe("publish descriptor", () => {
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
     ).rejects.toThrowError(missingPersonalDataFlag(eservice.id, descriptor.id));
+  });
+
+  it("should succeed publishing a new descriptor when risk analysis form version is expired but was valid at first publication", async () => {
+    const firstPublishedAt = new Date("2026-07-01");
+
+    const descriptor1: Descriptor = {
+      ...mockDescriptor,
+      id: generateId(),
+      version: "1",
+      state: descriptorState.published,
+      publishedAt: firstPublishedAt,
+      interface: getMockDocument(),
+    };
+    const descriptor2: Descriptor = {
+      ...mockDescriptor,
+      id: generateId(),
+      version: "2",
+      state: descriptorState.draft,
+      interface: getMockDocument(),
+    };
+
+    const producer: Tenant = {
+      ...getMockTenant(),
+      kind: tenantKind.PA,
+    };
+
+    // PA 2.0 is expired, but was valid at firstPublishedAt (2026-07-01)
+    const riskAnalysis = getMockExpiredRiskAnalysis(tenantKind.PA);
+
+    const eservice: EService = {
+      ...mockEService,
+      producerId: producer.id,
+      mode: eserviceMode.receive,
+      descriptors: [descriptor1, descriptor2],
+      riskAnalysis: [riskAnalysis],
+      personalData: true,
+    };
+
+    await addOneTenant(producer);
+    await addOneEService(eservice);
+
+    const publishDescriptorResponse = await catalogService.publishDescriptor(
+      eservice.id,
+      descriptor2.id,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: eservice.id,
+      version: "1",
+      type: "EServiceDescriptorPublished",
+      event_version: 2,
+    });
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorPublishedV2,
+      payload: writtenEvent.data,
+    });
+
+    const expectedDescriptor1: Descriptor = {
+      ...descriptor1,
+      archivedAt: new Date(),
+      state: descriptorState.archived,
+    };
+    const expectedDescriptor2: Descriptor = {
+      ...descriptor2,
+      publishedAt: new Date(),
+      state: descriptorState.published,
+    };
+
+    const expectedEservice: EService = {
+      ...eservice,
+      descriptors: [expectedDescriptor1, expectedDescriptor2],
+    };
+
+    expect(publishDescriptorResponse).toEqual({
+      data: expectedEservice,
+      metadata: { version: parseInt(writtenEvent.version, 10) },
+    });
+    expect(writtenPayload.descriptorId).toEqual(descriptor2.id);
+    expect(writtenPayload.eservice).toEqual(toEServiceV2(expectedEservice));
   });
 });


### PR DESCRIPTION
This PR is for allowing the creation of of a descriptor (not the first one) if the risk-analysis has become obsolete. We could take for granted that it wasn't obsolete at the time of the first publication.