### PR TITLE
build: include dpop validation in BFF image (PIN-9011, PIN-9736, PIN-9737)

### DIFF
--- a/packages/backend-for-frontend/Dockerfile
+++ b/packages/backend-for-frontend/Dockerfile
@@ -17,6 +17,7 @@ COPY ./packages/models/package.json /app/packages/models/package.json
 COPY ./packages/api-clients/package.json /app/packages/api-clients/package.json
 COPY ./packages/agreement-lifecycle/package.json /app/packages/agreement-lifecycle/package.json
 COPY ./packages/client-assertion-validation/package.json /app/packages/client-assertion-validation/package.json
+COPY ./packages/dpop-validation/package.json /app/packages/dpop-validation/package.json
 COPY ./packages/application-audit/package.json /app/packages/application-audit/package.json
 COPY ./packages/kafka-iam-auth/package.json /app/packages/kafka-iam-auth/package.json
 
@@ -30,6 +31,7 @@ COPY ./packages/models /app/packages/models
 COPY ./packages/api-clients /app/packages/api-clients
 COPY ./packages/agreement-lifecycle /app/packages/agreement-lifecycle
 COPY ./packages/client-assertion-validation /app/packages/client-assertion-validation
+COPY ./packages/dpop-validation /app/packages/dpop-validation
 COPY ./packages/application-audit /app/packages/application-audit
 COPY ./packages/kafka-iam-auth /app/packages/kafka-iam-auth
 
@@ -46,6 +48,7 @@ RUN NODE_OPTIONS="--max-old-space-size=${NODE_HEAP_SIZE}" pnpm build && \
   packages/api-clients  \
   packages/agreement-lifecycle \
   packages/client-assertion-validation \
+  packages/dpop-validation \
   packages/application-audit \
   packages/kafka-iam-auth \
   packages/backend-for-frontend/dist && \


### PR DESCRIPTION
## Issue
- [PIN-9011](https://pagopa.atlassian.net/browse/PIN-9011)
- [PIN-9736](https://pagopa.atlassian.net/browse/PIN-9736)
- [PIN-9737](https://pagopa.atlassian.net/browse/PIN-9737)

## Context / Why
- The develop build failed after [PR #3016](https://github.com/pagopa/interop-be-monorepo/pull/3016) because the BFF Docker build did not include the new `pagopa-interop-dpop-validation` workspace package.
- Failed run: https://github.com/pagopa/interop-be-monorepo/actions/runs/25307058136/job/74185285230

## Scope
- Update the bff Dockerfile to copy `packages/dpop-validation` during install, build, and final image packaging.

## Testing / Validation
- [x] E2E/manual verification: built the BFF Docker image locally

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [ ] Service labels applied
- [ ] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated


[PIN-9011]: https://pagopa.atlassian.net/browse/PIN-9011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-9736]: https://pagopa.atlassian.net/browse/PIN-9736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-9737]: https://pagopa.atlassian.net/browse/PIN-9737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ