### PR TITLE
fix: exclude Draft agreements from producer eservice filter (PIN-6779)

### DIFF
--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -742,6 +742,9 @@ const agreementRouter = (
             eserviceName: req.query.eServiceName,
             consumerIds: req.query.consumersIds.map(unsafeBrandId<TenantId>),
             producerIds: req.query.producersIds.map(unsafeBrandId<TenantId>),
+            agreementStates: req.query.agreementStates.map(
+              apiAgreementStateToAgreementState
+            ),
           },
           req.query.limit,
           req.query.offset,

--- a/packages/agreement-process/src/services/readModelService.ts
+++ b/packages/agreement-process/src/services/readModelService.ts
@@ -27,4 +27,5 @@ export type AgreementEServicesQueryFilters = {
   eserviceName: string | undefined;
   consumerIds: TenantId[];
   producerIds: TenantId[];
+  agreementStates: AgreementState[];
 };

--- a/packages/agreement-process/src/services/readModelServiceSQL.ts
+++ b/packages/agreement-process/src/services/readModelServiceSQL.ts
@@ -65,6 +65,7 @@ type AgreementEServicesQueryFilters = {
   eserviceName: string | undefined;
   consumerIds: TenantId[];
   producerIds: TenantId[];
+  agreementStates: AgreementState[];
 };
 
 async function filterAgreementsUpgradeable(
@@ -739,7 +740,8 @@ export function readModelServiceBuilderSQL(
       limit: number,
       offset: number
     ): Promise<ListResult<CompactEService>> {
-      const { consumerIds, producerIds, eserviceName } = filters;
+      const { consumerIds, producerIds, eserviceName, agreementStates } =
+        filters;
       const withDelegationFilter = true;
 
       const resultSet = await addDelegationJoins(
@@ -763,7 +765,8 @@ export function readModelServiceBuilderSQL(
               getNameFilter(eserviceInReadmodelCatalog.name, eserviceName),
               getProducerIdsFilter(producerIds, withDelegationFilter),
               getConsumerIdsFilter(consumerIds, false),
-              getVisibilityFilter(requesterId)
+              getVisibilityFilter(requesterId),
+              getAgreementStatesFilter(agreementStates)
             )
           )
           .groupBy(eserviceInReadmodelCatalog.id)

--- a/packages/agreement-process/test/integration/getAgreementsEservices.test.ts
+++ b/packages/agreement-process/test/integration/getAgreementsEservices.test.ts
@@ -14,6 +14,7 @@ import {
   EServiceId,
   delegationKind,
   delegationState,
+  agreementState,
 } from "pagopa-interop-models";
 import { describe, beforeEach, it, expect } from "vitest";
 import { CompactEService } from "../../src/model/domain/models.js";
@@ -180,6 +181,7 @@ describe("get agreements eservices", () => {
         eserviceName: undefined,
         consumerIds: [],
         producerIds: [],
+        agreementStates: [],
       },
       10,
       0,
@@ -196,6 +198,7 @@ describe("get agreements eservices", () => {
         eserviceName: undefined,
         consumerIds: [],
         producerIds: [],
+        agreementStates: [],
       },
       10,
       0,
@@ -212,6 +215,7 @@ describe("get agreements eservices", () => {
         eserviceName: undefined,
         consumerIds: [],
         producerIds: [],
+        agreementStates: [],
       },
       10,
       0,
@@ -231,6 +235,7 @@ describe("get agreements eservices", () => {
           eserviceName: undefined,
           consumerIds: [],
           producerIds: [],
+          agreementStates: [],
         },
         10,
         0,
@@ -249,6 +254,7 @@ describe("get agreements eservices", () => {
           eserviceName: undefined,
           consumerIds: [],
           producerIds: [],
+          agreementStates: [],
         },
         10,
         0,
@@ -265,6 +271,7 @@ describe("get agreements eservices", () => {
           eserviceName: undefined,
           consumerIds: [],
           producerIds: [],
+          agreementStates: [],
         },
         10,
         0,
@@ -282,6 +289,7 @@ describe("get agreements eservices", () => {
         eserviceName: "Foo",
         consumerIds: [],
         producerIds: [],
+        agreementStates: [],
       },
       10,
       0,
@@ -300,6 +308,7 @@ describe("get agreements eservices", () => {
         eserviceName: undefined,
         consumerIds: [delegateConsumer1.id, tenant2.id],
         producerIds: [],
+        agreementStates: [],
       },
       10,
       0,
@@ -318,6 +327,7 @@ describe("get agreements eservices", () => {
         eserviceName: undefined,
         producerIds: [tenant1.id],
         consumerIds: [],
+        agreementStates: [],
       },
       10,
       0,
@@ -336,6 +346,7 @@ describe("get agreements eservices", () => {
         eserviceName: "Foo",
         consumerIds: [tenant2.id],
         producerIds: [tenant1.id],
+        agreementStates: [],
       },
       10,
       0,
@@ -354,6 +365,7 @@ describe("get agreements eservices", () => {
         eserviceName: undefined,
         consumerIds: [],
         producerIds: [],
+        agreementStates: [],
       },
       2,
       0,
@@ -372,6 +384,7 @@ describe("get agreements eservices", () => {
         eserviceName: undefined,
         consumerIds: [],
         producerIds: [],
+        agreementStates: [],
       },
       2,
       1,
@@ -390,6 +403,7 @@ describe("get agreements eservices", () => {
         eserviceName: "Not existing name",
         consumerIds: [],
         producerIds: [],
+        agreementStates: [],
       },
       10,
       0,
@@ -405,6 +419,7 @@ describe("get agreements eservices", () => {
         eserviceName: undefined,
         producerIds: [delegateProducer1.id],
         consumerIds: [],
+        agreementStates: [],
       },
       10,
       0,
@@ -423,6 +438,7 @@ describe("get agreements eservices", () => {
         eserviceName: undefined,
         producerIds: [],
         consumerIds: [delegateConsumer1.id],
+        agreementStates: [],
       },
       10,
       0,
@@ -432,6 +448,128 @@ describe("get agreements eservices", () => {
     expectGenericSinglePageListResult(
       eservices,
       [eservice3, eservice4].map(toCompactEService)
+    );
+  });
+});
+
+describe("get agreements eservices with agreementStates filter", () => {
+  const toCompactEService = (eservice: EService): CompactEService => ({
+    id: eservice.id,
+    name: eservice.name,
+  });
+
+  it("should not return eservices whose agreements are all in a state excluded by the filter", async () => {
+    const producer = getMockTenant();
+    const consumer = getMockTenant();
+
+    const eserviceWithOnlyDraft = {
+      ...getMockEService(generateId<EServiceId>(), producer.id),
+      name: "EService Draft Only",
+    };
+    const eserviceWithActive = {
+      ...getMockEService(generateId<EServiceId>(), producer.id),
+      name: "EService Active",
+    };
+
+    await addOneTenant(producer);
+    await addOneTenant(consumer);
+    await addOneEService(eserviceWithOnlyDraft);
+    await addOneEService(eserviceWithActive);
+
+    await addOneAgreement({
+      ...getMockAgreement(eserviceWithOnlyDraft.id),
+      producerId: producer.id,
+      consumerId: consumer.id,
+      state: agreementState.draft,
+    });
+    await addOneAgreement({
+      ...getMockAgreement(eserviceWithActive.id),
+      producerId: producer.id,
+      consumerId: consumer.id,
+      state: agreementState.active,
+    });
+
+    const nonDraftStates = [
+      agreementState.active,
+      agreementState.archived,
+      agreementState.pending,
+      agreementState.suspended,
+      agreementState.rejected,
+    ];
+
+    const filtered = await agreementService.getAgreementsEServices(
+      {
+        eserviceName: undefined,
+        consumerIds: [],
+        producerIds: [producer.id],
+        agreementStates: nonDraftStates,
+      },
+      10,
+      0,
+      getMockContext({ authData: getMockAuthData(producer.id) })
+    );
+    expectGenericSinglePageListResult(
+      filtered,
+      [eserviceWithActive].map(toCompactEService)
+    );
+
+    const unfiltered = await agreementService.getAgreementsEServices(
+      {
+        eserviceName: undefined,
+        consumerIds: [],
+        producerIds: [producer.id],
+        agreementStates: [],
+      },
+      10,
+      0,
+      getMockContext({ authData: getMockAuthData(producer.id) })
+    );
+    expectGenericSinglePageListResult(
+      unfiltered,
+      [eserviceWithActive, eserviceWithOnlyDraft].map(toCompactEService)
+    );
+  });
+
+  it("should return an eservice when at least one of its agreements matches the filter", async () => {
+    const producer = getMockTenant();
+    const consumer = getMockTenant();
+
+    const eservice = {
+      ...getMockEService(generateId<EServiceId>(), producer.id),
+      name: "EService Mixed States",
+    };
+
+    await addOneTenant(producer);
+    await addOneTenant(consumer);
+    await addOneEService(eservice);
+
+    await addOneAgreement({
+      ...getMockAgreement(eservice.id),
+      producerId: producer.id,
+      consumerId: consumer.id,
+      state: agreementState.draft,
+    });
+    await addOneAgreement({
+      ...getMockAgreement(eservice.id),
+      producerId: producer.id,
+      consumerId: consumer.id,
+      state: agreementState.active,
+    });
+
+    const result = await agreementService.getAgreementsEServices(
+      {
+        eserviceName: undefined,
+        consumerIds: [],
+        producerIds: [producer.id],
+        agreementStates: [agreementState.active],
+      },
+      10,
+      0,
+      getMockContext({ authData: getMockAuthData(producer.id) })
+    );
+    expectGenericSinglePageListResult(
+      result,
+      [eservice].map(toCompactEService)
     );
   });
 });

--- a/packages/api-clients/open-api/agreementApi.yml
+++ b/packages/api-clients/open-api/agreementApi.yml
@@ -1049,6 +1049,15 @@ paths:
             default: []
           explode: false
         - in: query
+          name: agreementStates
+          description: comma separated sequence of agreement states to filter on
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/AgreementState"
+            default: []
+          explode: false
+        - in: query
           name: offset
           required: true
           schema:

--- a/packages/backend-for-frontend/src/api/agreementApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/agreementApiConverter.ts
@@ -4,7 +4,26 @@ import {
   bffApi,
   catalogApi,
 } from "pagopa-interop-api-clients";
+import { AgreementState } from "pagopa-interop-models";
+import { match } from "ts-pattern";
 import { isAgreementUpgradable } from "../services/validators.js";
+
+export function toApiAgreementState(
+  state: AgreementState
+): agreementApi.AgreementState {
+  return match<AgreementState, agreementApi.AgreementState>(state)
+    .with("Draft", () => agreementApi.AgreementState.Values.DRAFT)
+    .with("Active", () => agreementApi.AgreementState.Values.ACTIVE)
+    .with("Archived", () => agreementApi.AgreementState.Values.ARCHIVED)
+    .with("Pending", () => agreementApi.AgreementState.Values.PENDING)
+    .with("Suspended", () => agreementApi.AgreementState.Values.SUSPENDED)
+    .with(
+      "MissingCertifiedAttributes",
+      () => agreementApi.AgreementState.Values.MISSING_CERTIFIED_ATTRIBUTES
+    )
+    .with("Rejected", () => agreementApi.AgreementState.Values.REJECTED)
+    .exhaustive();
+}
 
 export function toBffCompactOrganization(
   organization: agreementApi.CompactOrganization,

--- a/packages/backend-for-frontend/src/services/agreementService.ts
+++ b/packages/backend-for-frontend/src/services/agreementService.ts
@@ -18,6 +18,7 @@ import {
   delegationApi,
 } from "pagopa-interop-api-clients";
 import { match, P } from "ts-pattern";
+import { agreementState } from "pagopa-interop-models";
 import { PagoPAInteropBeClients } from "../clients/clientsProvider.js";
 import { BffAppContext, Headers } from "../utilities/context.js";
 import {
@@ -35,6 +36,7 @@ import {
   toCompactDescriptor,
 } from "../api/catalogApiConverter.js";
 import {
+  toApiAgreementState,
   toBffAgreementConsumerDocument,
   toBffAttribute,
   toBffCompactOrganization,
@@ -496,6 +498,13 @@ export function agreementServiceBuilder(
           limit,
           eServiceName,
           producersIds: [authData.organizationId],
+          agreementStates: [
+            agreementState.active,
+            agreementState.archived,
+            agreementState.pending,
+            agreementState.suspended,
+            agreementState.rejected,
+          ].map(toApiAgreementState),
         },
         headers,
       });

--- a/packages/backend-for-frontend/test/api/agreementRouter/getAgreementsConsumerEServices.test.ts
+++ b/packages/backend-for-frontend/test/api/agreementRouter/getAgreementsConsumerEServices.test.ts
@@ -57,6 +57,15 @@ describe("API GET /consumers/agreements/eservices", () => {
     expect(res.body).toEqual(mockCompactEServicesLight);
   });
 
+  it("Should not constrain agreementStates upstream (consumer must still see own Drafts)", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    await makeRequest(token);
+    const mock = vi.mocked(
+      clients.agreementProcessClient.getAgreementsEServices
+    );
+    expect(mock.mock.calls[0][0].queries.agreementStates).toBeUndefined();
+  });
+
   it.each([
     { query: {} },
     { query: { offset: 0 } },

--- a/packages/backend-for-frontend/test/api/agreementRouter/getAgreementsProducerEServices.test.ts
+++ b/packages/backend-for-frontend/test/api/agreementRouter/getAgreementsProducerEServices.test.ts
@@ -58,6 +58,30 @@ describe("API GET /producers/agreements/eservices", () => {
     expect(res.body).toEqual(mockCompactEServicesLight);
   });
 
+  it("Should forward a non-Draft agreementStates filter to the upstream client", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    await makeRequest(token);
+    const mock = vi.mocked(
+      clients.agreementProcessClient.getAgreementsEServices
+    );
+    expect(mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queries: expect.objectContaining({
+          agreementStates: expect.arrayContaining([
+            "ACTIVE",
+            "ARCHIVED",
+            "PENDING",
+            "SUSPENDED",
+            "REJECTED",
+          ]),
+        }),
+      })
+    );
+    const passedStates = mock.mock.calls[0][0].queries.agreementStates;
+    expect(passedStates).not.toContain("DRAFT");
+    expect(passedStates).not.toContain("MISSING_CERTIFIED_ATTRIBUTES");
+  });
+
   it.each([
     { query: {} },
     { query: { offset: 0 } },


### PR DESCRIPTION
[PIN-6779](https://pagopa.atlassian.net/browse/PIN-6779)

## Context                                             

On `/erogazione/richieste`, the table only shows agreements forwarded by consumers (state ≠ Draft), but the "Cerca per e-service" filter (populated by `GET /producers/agreements/eservices`) was returning eservices that only had Draft agreements, producing empty result sets when the user picked one of those eservices.                                                                                                                                                                                                                   
## Changes
- `agreement-process`: `GET /agreements/filter/eservices` accepts a new optional `agreementStates` query param (default `[]` =
  no-filter, fully back-compat).
- `readModelServiceSQL`: applies `getAgreementStatesFilter` in `getAgreementsEServices`.
- BFF `getAgreementsProducerEServices`: passes the hardcoded default `[Active, Archived, Pending, Suspended, Rejected]` so Draft (and MissingCertifiedAttributes) eservices no longer surface.
- BFF `getAgreementsConsumerEServices`: intentionally **not** changed so consumers keep seeing their own Drafts in their filter.
                                                                                                                                            
## Notes for reviewers

Should `agreementStates also be exposed on the BFF route so the FE passes the same it uses for the listing? 
This question was already made in this [PR](https://github.com/pagopa/interop-be-monorepo/pull/2553) that was open for the same issue.

[PIN-6779]: https://pagopa.atlassian.net/browse/PIN-6779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ