### PR TITLE
perf: short-circuit retrieval enrichment on empty link results (PIN-10004)

### DIFF
--- a/packages/m2m-gateway-v3/src/services/purposeTemplateService.ts
+++ b/packages/m2m-gateway-v3/src/services/purposeTemplateService.ts
@@ -42,6 +42,18 @@ export type PurposeTemplateService = ReturnType<
   typeof purposeTemplateServiceBuilder
 >;
 
+const emptyPage = (
+  limit: number,
+  offset: number,
+  totalCount: number
+): {
+  results: never[];
+  pagination: { limit: number; offset: number; totalCount: number };
+} => ({
+  results: [],
+  pagination: { limit, offset, totalCount },
+});
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function purposeTemplateServiceBuilder(
   clients: PagoPAInteropBeClients,
@@ -338,10 +350,7 @@ export function purposeTemplateServiceBuilder(
         });
 
       if (processResults.length === 0) {
-        return {
-          results: [],
-          pagination: { limit, offset, totalCount },
-        };
+        return emptyPage(limit, offset, totalCount);
       }
 
       const eserviceIds = processResults.map(({ eserviceId }) => eserviceId);
@@ -671,10 +680,7 @@ export function purposeTemplateServiceBuilder(
         );
 
       if (processResults.length === 0) {
-        return {
-          results: [],
-          pagination: { limit, offset, totalCount },
-        };
+        return emptyPage(limit, offset, totalCount);
       }
 
       const eserviceTemplateIds = processResults.map(

--- a/packages/m2m-gateway-v3/src/services/purposeTemplateService.ts
+++ b/packages/m2m-gateway-v3/src/services/purposeTemplateService.ts
@@ -337,6 +337,13 @@ export function purposeTemplateServiceBuilder(
           headers,
         });
 
+      if (processResults.length === 0) {
+        return {
+          results: [],
+          pagination: { limit, offset, totalCount },
+        };
+      }
+
       const eserviceIds = processResults.map(({ eserviceId }) => eserviceId);
       const eservices = await clients.catalogProcessClient
         .getEServices({
@@ -662,6 +669,13 @@ export function purposeTemplateServiceBuilder(
             headers,
           }
         );
+
+      if (processResults.length === 0) {
+        return {
+          results: [],
+          pagination: { limit, offset, totalCount },
+        };
+      }
 
       const eserviceTemplateIds = processResults.map(
         ({ eserviceTemplateId }) => eserviceTemplateId

--- a/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServiceTemplates.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServiceTemplates.test.ts
@@ -159,14 +159,11 @@ describe("getPurposeTemplateEServiceTemplates", () => {
     expect(result.pagination.totalCount).not.toBe(result.results.length);
   });
 
-  it("Should always invoke the enrichment client even when there are no links (locked: no empty short-circuit)", async () => {
+  it("Should short-circuit and not invoke the enrichment client when there are no links (PIN-10004)", async () => {
     const purposeTemplateId = generateId<PurposeTemplateId>();
     mockGetPurposeTemplateEServiceTemplates.mockResolvedValueOnce({
       data: { results: [], totalCount: 0 },
       metadata: undefined,
-    });
-    mockGetEServiceTemplates.mockResolvedValueOnce({
-      data: { results: [] },
     });
 
     const result =
@@ -184,13 +181,6 @@ describe("getPurposeTemplateEServiceTemplates", () => {
       },
       results: [],
     });
-    expect(mockGetEServiceTemplates).toHaveBeenCalledTimes(1);
-    expect(mockGetEServiceTemplates).toHaveBeenCalledWith(
-      expect.objectContaining({
-        queries: expect.objectContaining({
-          eserviceTemplatesIds: [],
-        }),
-      })
-    );
+    expect(mockGetEServiceTemplates).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServiceTemplates.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServiceTemplates.test.ts
@@ -159,7 +159,7 @@ describe("getPurposeTemplateEServiceTemplates", () => {
     expect(result.pagination.totalCount).not.toBe(result.results.length);
   });
 
-  it("Should short-circuit and not invoke the enrichment client when there are no links (PIN-10004)", async () => {
+  it("Should short-circuit and not invoke the enrichment client when there are no links", async () => {
     const purposeTemplateId = generateId<PurposeTemplateId>();
     mockGetPurposeTemplateEServiceTemplates.mockResolvedValueOnce({
       data: { results: [], totalCount: 0 },

--- a/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServices.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServices.test.ts
@@ -112,7 +112,7 @@ describe("getPurposeTemplateEServiceDescriptors", () => {
     });
   });
 
-  it("Should short-circuit and not invoke the enrichment client when there are no links (PIN-10004)", async () => {
+  it("Should short-circuit and not invoke the enrichment client when there are no links", async () => {
     const purposeTemplateId = generateId<PurposeTemplateId>();
     mockGetPurposeTemplateEServices.mockResolvedValueOnce({
       data: { results: [], totalCount: 0 },

--- a/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServices.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/purposeTemplates/getPurposeTemplateEServices.test.ts
@@ -74,6 +74,7 @@ describe("getPurposeTemplateEServiceDescriptors", () => {
 
   beforeEach(() => {
     mockGetPurposeTemplateEServices.mockClear();
+    mockGetEServices.mockClear();
   });
 
   it("Should succeed and perform API clients calls", async () => {
@@ -109,5 +110,29 @@ describe("getPurposeTemplateEServiceDescriptors", () => {
         producerIds: [],
       } satisfies m2mGatewayApiV3.GetPurposeTemplateEServicesQueryParams,
     });
+  });
+
+  it("Should short-circuit and not invoke the enrichment client when there are no links (PIN-10004)", async () => {
+    const purposeTemplateId = generateId<PurposeTemplateId>();
+    mockGetPurposeTemplateEServices.mockResolvedValueOnce({
+      data: { results: [], totalCount: 0 },
+      metadata: undefined,
+    });
+
+    const result = await purposeTemplateService.getPurposeTemplateEServices(
+      purposeTemplateId,
+      mockParams,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual({
+      pagination: {
+        offset: mockParams.offset,
+        limit: mockParams.limit,
+        totalCount: 0,
+      },
+      results: [],
+    });
+    expect(mockGetEServices).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/m2m-gateway/src/services/purposeTemplateService.ts
+++ b/packages/m2m-gateway/src/services/purposeTemplateService.ts
@@ -38,6 +38,18 @@ export type PurposeTemplateService = ReturnType<
   typeof purposeTemplateServiceBuilder
 >;
 
+const emptyPage = (
+  limit: number,
+  offset: number,
+  totalCount: number
+): {
+  results: never[];
+  pagination: { limit: number; offset: number; totalCount: number };
+} => ({
+  results: [],
+  pagination: { limit, offset, totalCount },
+});
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function purposeTemplateServiceBuilder(
   clients: PagoPAInteropBeClients,
@@ -302,10 +314,7 @@ export function purposeTemplateServiceBuilder(
         });
 
       if (processResults.length === 0) {
-        return {
-          results: [],
-          pagination: { limit, offset, totalCount },
-        };
+        return emptyPage(limit, offset, totalCount);
       }
 
       const eserviceIds = processResults.map(({ eserviceId }) => eserviceId);

--- a/packages/m2m-gateway/src/services/purposeTemplateService.ts
+++ b/packages/m2m-gateway/src/services/purposeTemplateService.ts
@@ -301,6 +301,13 @@ export function purposeTemplateServiceBuilder(
           headers,
         });
 
+      if (processResults.length === 0) {
+        return {
+          results: [],
+          pagination: { limit, offset, totalCount },
+        };
+      }
+
       const eserviceIds = processResults.map(({ eserviceId }) => eserviceId);
       const eservices = await clients.catalogProcessClient
         .getEServices({

--- a/packages/m2m-gateway/test/integration/purposeTemplates/getPurposeTemplateEServices.test.ts
+++ b/packages/m2m-gateway/test/integration/purposeTemplates/getPurposeTemplateEServices.test.ts
@@ -71,6 +71,7 @@ describe("getPurposeTemplateEServiceDescriptors", () => {
 
   beforeEach(() => {
     mockGetPurposeTemplateEServices.mockClear();
+    mockGetEServices.mockClear();
   });
 
   it("Should succeed and perform API clients calls", async () => {
@@ -106,5 +107,29 @@ describe("getPurposeTemplateEServiceDescriptors", () => {
         producerIds: [],
       } satisfies m2mGatewayApi.GetPurposeTemplateEServicesQueryParams,
     });
+  });
+
+  it("Should short-circuit and not invoke the enrichment client when there are no links (PIN-10004)", async () => {
+    const purposeTemplateId = generateId<PurposeTemplateId>();
+    mockGetPurposeTemplateEServices.mockResolvedValueOnce({
+      data: { results: [], totalCount: 0 },
+      metadata: undefined,
+    });
+
+    const result = await purposeTemplateService.getPurposeTemplateEServices(
+      purposeTemplateId,
+      mockParams,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual({
+      pagination: {
+        offset: mockParams.offset,
+        limit: mockParams.limit,
+        totalCount: 0,
+      },
+      results: [],
+    });
+    expect(mockGetEServices).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/m2m-gateway/test/integration/purposeTemplates/getPurposeTemplateEServices.test.ts
+++ b/packages/m2m-gateway/test/integration/purposeTemplates/getPurposeTemplateEServices.test.ts
@@ -109,7 +109,7 @@ describe("getPurposeTemplateEServiceDescriptors", () => {
     });
   });
 
-  it("Should short-circuit and not invoke the enrichment client when there are no links (PIN-10004)", async () => {
+  it("Should short-circuit and not invoke the enrichment client when there are no links", async () => {
     const purposeTemplateId = generateId<PurposeTemplateId>();
     mockGetPurposeTemplateEServices.mockResolvedValueOnce({
       data: { results: [], totalCount: 0 },


### PR DESCRIPTION
## Summary

Optimize the M2M Gateway retrieval handlers that chain a purpose-template-process call with an enrichment call to catalog-process / eservice-template-process: when the upstream returns no links, skip the enrichment call and return an empty page directly.

Applied symmetrically to all three handlers:

- `m2m-gateway` (v2) — `getPurposeTemplateEServices` (concrete e-services enrichment)
- `m2m-gateway-v3` — `getPurposeTemplateEServices` (concrete e-services enrichment)
- `m2m-gateway-v3` — `getPurposeTemplateEServiceTemplates` (e-service templates enrichment)

## Note

Inverts the AS-IS-symmetric integration test introduced in PIN-9929 that asserted "no short-circuit on empty results"; new tests assert `toHaveBeenCalledTimes(0)` on the enrichment client mock for all three handlers.

[PIN-10004](https://pagopa.atlassian.net/browse/PIN-10004)

[PIN-10004]: https://pagopa.atlassian.net/browse/PIN-10004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ