### PR TITLE
fix: validate client assertion kid format (PIN-9998)

### DIFF
--- a/packages/backend-for-frontend/test/validateTokenGeneration.test.ts
+++ b/packages/backend-for-frontend/test/validateTokenGeneration.test.ts
@@ -147,6 +147,61 @@ describe("validateTokenGeneration", () => {
   });
 
   describe("Failure cases", () => {
+    it("should return invalidKidFormat in client assertion validation and skip public key retrieve", async () => {
+      const invalidKidFormatError =
+        clientAssertionValidation.invalidKidFormat();
+
+      vi.spyOn(
+        clientAssertionValidation,
+        "verifyClientAssertion"
+      ).mockReturnValue({
+        errors: [invalidKidFormatError],
+        data: undefined,
+      });
+      const getKeyWithClientByKeyIdMock = vi.mocked(
+        mockClients.authorizationClient.token.getKeyWithClientByKeyId
+      );
+      getKeyWithClientByKeyIdMock.mockClear();
+
+      const validationResult = await toolService.validateTokenGeneration(
+        MOCK_CLIENT_ID,
+        MOCK_CLIENT_ASSERTION,
+        MOCK_CLIENT_ASSERTION_TYPE,
+        MOCK_GRANT_TYPE,
+        undefined,
+        bffMockContext
+      );
+
+      expect(validationResult).toEqual({
+        clientKind: undefined,
+        eservice: undefined,
+        steps: {
+          clientAssertionValidation: {
+            result: bffApi.TokenGenerationValidationStepResult.Enum.FAILED,
+            failures: [
+              {
+                code: "invalidKidFormat",
+                reason: invalidKidFormatError.message,
+              },
+            ],
+          },
+          publicKeyRetrieve: {
+            result: bffApi.TokenGenerationValidationStepResult.Enum.SKIPPED,
+            failures: [],
+          },
+          clientAssertionSignatureVerification: {
+            result: bffApi.TokenGenerationValidationStepResult.Enum.SKIPPED,
+            failures: [],
+          },
+          platformStatesVerification: {
+            result: bffApi.TokenGenerationValidationStepResult.Enum.SKIPPED,
+            failures: [],
+          },
+        },
+      });
+      expect(getKeyWithClientByKeyIdMock).not.toHaveBeenCalled();
+    });
+
     it("should handle parameters validation errors", async () => {
       const parameterValidationError: ApiError<"invalidAssertionType"> = {
         code: "invalidAssertionType",

--- a/packages/client-assertion-validation/src/utils.ts
+++ b/packages/client-assertion-validation/src/utils.ts
@@ -120,8 +120,8 @@ export const validateKid = (kid?: string): ValidationResult<string> => {
     return failedValidation([kidNotFound()]);
   }
 
-  const alphanumericRegex = new RegExp("^[a-zA-Z0-9-_]+$");
-  if (alphanumericRegex.test(kid)) {
+  const jwkThumbprintRegex = new RegExp("^[a-zA-Z0-9_-]{43}$");
+  if (jwkThumbprintRegex.test(kid)) {
     return successfulValidation(kid);
   }
   return failedValidation([invalidKidFormat()]);

--- a/packages/client-assertion-validation/test/validation.test.ts
+++ b/packages/client-assertion-validation/test/validation.test.ts
@@ -662,6 +662,21 @@ describe("validation test", async () => {
       expect(errors).toHaveLength(1);
       expect(errors![0]).toEqual(invalidKidFormat());
     });
+
+    it("InvalidKidFormat when kid is not a JWK thumbprint", async () => {
+      const { jws } = await getMockClientAssertion({
+        customHeader: { kid: "not-a-valid-kid-format" },
+      });
+      const { errors } = verifyClientAssertion(
+        jws,
+        undefined,
+        expectedAudiences,
+        genericLogger
+      );
+      expect(errors).toBeDefined();
+      expect(errors).toHaveLength(1);
+      expect(errors![0]).toEqual(invalidKidFormat());
+    });
   });
 
   describe("verifyClientAssertionSignature", async () => {

--- a/packages/commons-test/src/testUtils.ts
+++ b/packages/commons-test/src/testUtils.ts
@@ -832,7 +832,7 @@ export const getMockClientAssertion = async (props?: {
 
   const headers: jose.JWTHeaderParameters = {
     alg: algorithm.RS256,
-    kid: "kid",
+    kid: "23j6WZbSbFiX_By98MBDgjnL3ZPkJJU83euQxrZxVsA",
     ...props?.customHeader,
   };
 


### PR DESCRIPTION
## Issue
- [PIN-9998](https://pagopa.atlassian.net/browse/PIN-9998)

## Context / Why
- Token generation validation returned `clientAssertionPublicKeyNotFound` when a Client Assertion header contained a malformed `kid`.
- The malformed `kid` must fail during client assertion validation with `invalidKidFormat`, before public key retrieval.

## Scope
- Tightened Client Assertion `kid` validation to accept only valid JWK thumbprint-shaped values.
- Added regression coverage for `not-a-valid-kid-format`.
- Added BFF validation coverage to ensure public key retrieval is skipped when `invalidKidFormat` is returned.

## Testing / Validation
- [x] Lint
- [x] Type check
- [x] Unit tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated


[PIN-9998]: https://pagopa.atlassian.net/browse/PIN-9998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ