### PR TITLE
fix(bff): return purposeIdNotProvided for missing purposeId (PIN-9999)

### DIFF
--- a/packages/backend-for-frontend/src/model/errors.ts
+++ b/packages/backend-for-frontend/src/model/errors.ts
@@ -35,7 +35,7 @@ const errorCodes = {
   privacyNoticeVersionIsNotTheLatest: "0027",
   missingActivePurposeVersion: "0028",
   activeAgreementByEserviceAndConsumerNotFound: "0029",
-  purposeIdNotFoundInClientAssertion: "0030",
+  purposeIdNotProvided: "0030",
   delegationNotFound: "0031",
   tenantNotAllowed: "0032",
   cannotGetKeyWithClient: "0033",
@@ -342,11 +342,11 @@ export function activeAgreementByEserviceAndConsumerNotFound(
   });
 }
 
-export function purposeIdNotFoundInClientAssertion(): ApiError<ErrorCodes> {
+export function purposeIdNotProvided(): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `PurposeId not found in client assertion`,
-    code: "purposeIdNotFoundInClientAssertion",
-    title: "PurposeId not found in client assertion",
+    detail: "Claim purposeId does not exist in this assertion",
+    code: "purposeIdNotProvided",
+    title: "Purpose Id not provided",
   });
 }
 

--- a/packages/backend-for-frontend/src/services/toolService.ts
+++ b/packages/backend-for-frontend/src/services/toolService.ts
@@ -45,7 +45,7 @@ import {
   eserviceDescriptorNotFound,
   missingActivePurposeVersion,
   tenantNotAllowed,
-  purposeIdNotFoundInClientAssertion,
+  purposeIdNotProvided,
   purposeNotFound,
 } from "../model/errors.js";
 import { PagoPAInteropBeClients } from "../clients/clientsProvider.js";
@@ -318,7 +318,7 @@ async function retrieveKeyAndEservice(
   if (!jwt.payload.purposeId) {
     return {
       data: undefined,
-      errors: [purposeIdNotFoundInClientAssertion()],
+      errors: [purposeIdNotProvided()],
     };
   }
   const purposeId = unsafeBrandId<PurposeId>(jwt.payload.purposeId);

--- a/packages/backend-for-frontend/test/validateTokenGeneration.test.ts
+++ b/packages/backend-for-frontend/test/validateTokenGeneration.test.ts
@@ -426,6 +426,80 @@ describe("validateTokenGeneration", () => {
       });
     });
 
+    it("should return purposeIdNotProvided when a consumer client assertion has no purposeId", async () => {
+      const clientsWithConsumerClient = {
+        authorizationClient: {
+          token: {
+            getKeyWithClientByKeyId: vi.fn().mockResolvedValue({
+              client: {
+                id: MOCK_CLIENT_ID,
+                consumerId: mockAuthData.organizationId,
+                kind: authorizationApi.ClientKind.enum.CONSUMER,
+              },
+            }),
+          },
+          client: {
+            getClientKeyById: vi
+              .fn()
+              .mockResolvedValue({ encodedPem: "encoded-pem" }),
+          },
+        },
+      } as unknown as PagoPAInteropBeClients;
+
+      vi.spyOn(
+        clientAssertionValidation,
+        "verifyClientAssertion"
+      ).mockReturnValue({
+        errors: undefined,
+        data: {
+          header: { kid: MOCK_KID, alg: "RS256", typ: "JWT" },
+          payload: {
+            ...MOCK_JWT_PAYLOAD,
+            purposeId: undefined,
+          },
+        },
+      });
+
+      const validationResult = await toolsServiceBuilder(
+        clientsWithConsumerClient
+      ).validateTokenGeneration(
+        MOCK_CLIENT_ID,
+        MOCK_CLIENT_ASSERTION,
+        MOCK_CLIENT_ASSERTION_TYPE,
+        MOCK_GRANT_TYPE,
+        undefined,
+        bffMockContext
+      );
+
+      expect(validationResult).toEqual({
+        clientKind: undefined,
+        eservice: undefined,
+        steps: {
+          clientAssertionValidation: {
+            result: bffApi.TokenGenerationValidationStepResult.Enum.PASSED,
+            failures: [],
+          },
+          publicKeyRetrieve: {
+            result: bffApi.TokenGenerationValidationStepResult.Enum.FAILED,
+            failures: [
+              {
+                code: "purposeIdNotProvided",
+                reason: "Claim purposeId does not exist in this assertion",
+              },
+            ],
+          },
+          clientAssertionSignatureVerification: {
+            result: bffApi.TokenGenerationValidationStepResult.Enum.SKIPPED,
+            failures: [],
+          },
+          platformStatesVerification: {
+            result: bffApi.TokenGenerationValidationStepResult.Enum.SKIPPED,
+            failures: [],
+          },
+        },
+      });
+    });
+
     it("should handle client assertion signature verification errors", async () => {
       const signatureVerificationError: ApiError<"invalidSignature"> = {
         code: "invalidSignature",


### PR DESCRIPTION
## Issue
- [PIN-9999](https://pagopa.atlassian.net/browse/PIN-9999)

## Context / Why
- The token generation debugger returned `purposeIdNotFoundInClientAssertion` when a CONSUMER client assertion omitted the `purposeId` claim.
- The expected public validation label for this scenario is `purposeIdNotProvided`.

## Scope
- Align BFF validation error code and message with the existing client assertion validation error.
- Return `purposeIdNotProvided` during public key retrieval when a CONSUMER assertion has no `purposeId`.
- Add a regression unit test for the missing `purposeId` CONSUMER case.

## Testing / Validation
- [x] Lint
- [x] Typecheck
- [x] Unit tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated


[PIN-9999]: https://pagopa.atlassian.net/browse/PIN-9999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ