### PR TITLE
PIN-10018 Fix api interpolation

### DIFF
--- a/packages/commons-test/test/interpolateTemplateRestApiSpec.test.ts
+++ b/packages/commons-test/test/interpolateTemplateRestApiSpec.test.ts
@@ -50,6 +50,13 @@ describe("interpolateTemplateRestApiSpec", async () => {
       eserviceInstanceInterfaceData.serverUrls.length
     );
 
+    const inputJson = JSON.parse(file);
+    expect(parsedJson.components.schemas).toBeDefined();
+    expect(Object.keys(parsedJson.components.schemas)).toEqual(
+      Object.keys(inputJson.components.schemas)
+    );
+    expect(jsonString).toContain('"$ref"');
+
     const yamlFileString: string = await readFileContent(
       "test.openapi.3.0.2.yaml"
     );
@@ -88,6 +95,9 @@ describe("interpolateTemplateRestApiSpec", async () => {
     expect(parsedYaml.servers).toHaveLength(
       eserviceInstanceInterfaceData.serverUrls.length
     );
+
+    expect(yamlString).not.toMatch(/&a\d+/);
+    expect(yamlString).not.toMatch(/\*a\d+/);
   });
 
   it("should throw invalidInterfaceFileDetected error for unsupported file type", async () => {

--- a/packages/commons-test/test/interpolateTemplateRestApiSpec.test.ts
+++ b/packages/commons-test/test/interpolateTemplateRestApiSpec.test.ts
@@ -98,6 +98,7 @@ describe("interpolateTemplateRestApiSpec", async () => {
 
     expect(yamlString).not.toMatch(/&a\d+/);
     expect(yamlString).not.toMatch(/\*a\d+/);
+    expect(yamlString).toContain("$ref");
   });
 
   it("should throw invalidInterfaceFileDetected error for unsupported file type", async () => {

--- a/packages/commons/src/eservice-documents/eserviceDocumentUtils.ts
+++ b/packages/commons/src/eservice-documents/eserviceDocumentUtils.ts
@@ -192,7 +192,7 @@ export const interpolateTemplateRestApiSpec = async (
   /* eslint-enable */
 
   try {
-    await SwaggerParser.validate(jsonApi);
+    await SwaggerParser.validate(structuredClone(jsonApi));
     const updatedInterfaceBuffer = restApiFileToBuffer(
       concreteFileType,
       jsonApi


### PR DESCRIPTION
This PR fixes an unwanted behavior related to the api spec of an eservice instantiated from template.
If the api contained $ref components, they were being resolved in this way:
- cloned in case of `json` file
- rebuilt as anchors (like `&a1`) in case of `yaml` file

The fix ensures that the components are kept like initially written. That behavior was due to how the validation works: it resolves the references in place (in the actual file). Now with this fix the validation (in place) happens on a cloned interface, so we are not altering the one we are checking (apart from adding the custom fields)