### PR TITLE
feature: add M2M threshold endpoints (PIN-10013)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -22814,7 +22814,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DescriptorAttributesSeed"
+              $ref: "#/components/schemas/EServiceTemplateAttributesSeed"
       responses:
         "204":
           description: EService template version attributes updated
@@ -28574,7 +28574,7 @@ components:
           items:
             type: array
             items:
-              $ref: "#/components/schemas/DescriptorAttributeSeed"
+              $ref: "#/components/schemas/CertifiedDescriptorAttributeSeed"
         declared:
           type: array
           items:
@@ -28591,7 +28591,7 @@ components:
         - certified
         - declared
         - verified
-    DescriptorAttributeSeed:
+    CertifiedDescriptorAttributeSeed:
       type: object
       additionalProperties: false
       properties:
@@ -28605,6 +28605,18 @@ components:
           format: int32
           minimum: 1
           maximum: 1000000000
+      required:
+        - id
+        - explicitAttributeVerification
+    DescriptorAttributeSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        explicitAttributeVerification:
+          type: boolean
       required:
         - id
         - explicitAttributeVerification

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -3275,8 +3275,8 @@ paths:
     post:
       tags:
         - eservices
-      summary: Bulk update E-Service Descriptor Attributes
-      description: Bulk update the Descriptor Attributes, including differentiated thresholds on Certified Attributes. The response contains an empty object so Integrity REST 02 response headers can be generated.
+      summary: Update E-Service Descriptor Attributes
+      description: Update the Descriptor Attributes, including differentiated thresholds on Certified Attributes.
       operationId: updateEServiceDescriptorAttributes
       requestBody:
         required: true

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -3258,6 +3258,62 @@ paths:
           $ref: "#/components/responses/Conflict"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+  /eservices/{eserviceId}/descriptors/{descriptorId}/attributes/update:
+    parameters:
+      - name: eserviceId
+        in: path
+        description: The E-Service ID of the Descriptor
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceId"
+      - name: descriptorId
+        in: path
+        description: The ID of the Descriptor
+        required: true
+        schema:
+          $ref: "#/components/schemas/DescriptorId"
+    post:
+      tags:
+        - eservices
+      summary: Bulk update E-Service Descriptor Attributes
+      description: Bulk update the Descriptor Attributes, including differentiated thresholds on Certified Attributes. The response contains an empty object so Integrity REST 02 response headers can be generated.
+      operationId: updateEServiceDescriptorAttributes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DescriptorAttributesSeed"
+      responses:
+        "200":
+          description: E-Service Descriptor Attributes updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VoidObject"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
   /eservices/{eserviceId}/descriptors/{descriptorId}/documents:
     parameters:
       - name: eserviceId
@@ -9900,6 +9956,118 @@ paths:
           $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+  /templates/eservices/{eserviceId}/descriptors/{descriptorId}:
+    parameters:
+      - name: eserviceId
+        in: path
+        description: The E-Service template instance ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceId"
+      - name: descriptorId
+        in: path
+        description: The ID of the template instance Descriptor
+        required: true
+        schema:
+          $ref: "#/components/schemas/DescriptorId"
+    post:
+      tags:
+        - eservices
+      summary: Update draft E-Service template instance Descriptor
+      description: Update a draft E-Service template instance Descriptor, including differentiated thresholds on Certified Attributes
+      operationId: updateDraftEServiceDescriptorTemplateInstance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEServiceDescriptorTemplateInstanceSeed"
+      responses:
+        "200":
+          description: E-Service template instance Descriptor updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedResource"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /templates/eservices/{eserviceId}/descriptors/{descriptorId}/update:
+    parameters:
+      - name: eserviceId
+        in: path
+        description: The E-Service template instance ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceId"
+      - name: descriptorId
+        in: path
+        description: The ID of the template instance Descriptor
+        required: true
+        schema:
+          $ref: "#/components/schemas/DescriptorId"
+    post:
+      tags:
+        - eservices
+      summary: Update E-Service template instance Descriptor
+      description: Update a published or suspended E-Service template instance Descriptor, including differentiated thresholds on Certified Attributes
+      operationId: updateEServiceTemplateInstanceDescriptor
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEServiceTemplateInstanceDescriptorQuotasSeed"
+      responses:
+        "200":
+          description: E-Service template instance Descriptor updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedResource"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
   /producerKeychains/{keychainId}/users/{userId}:
     parameters:
       - name: keychainId
@@ -11675,6 +11843,120 @@ components:
           format: int32
           minimum: 1
           maximum: 1000000000
+    UpdateEServiceDescriptorTemplateInstanceSeed:
+      type: object
+      additionalProperties: false
+      required:
+        - audience
+        - dailyCallsPerConsumer
+        - dailyCallsTotal
+        - agreementApprovalPolicy
+      properties:
+        audience:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 250
+        dailyCallsPerConsumer:
+          description: Maximum number of daily calls that this descriptor can afford per consumer
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        dailyCallsTotal:
+          description: Total daily calls available for this E-Service
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        agreementApprovalPolicy:
+          $ref: "#/components/schemas/AgreementApprovalPolicy"
+        attributes:
+          $ref: "#/components/schemas/DescriptorAttributesSeed"
+    UpdateEServiceTemplateInstanceDescriptorQuotasSeed:
+      type: object
+      additionalProperties: false
+      required:
+        - dailyCallsPerConsumer
+        - dailyCallsTotal
+      properties:
+        dailyCallsPerConsumer:
+          description: Maximum number of daily calls that this descriptor can afford per consumer
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        dailyCallsTotal:
+          description: Total daily calls available for this E-Service
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        attributes:
+          $ref: "#/components/schemas/DescriptorAttributesSeed"
+    CreatedResource:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/EServiceId"
+    DescriptorAttributesSeed:
+      type: object
+      additionalProperties: false
+      required:
+        - certified
+        - declared
+        - verified
+      properties:
+        certified:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/CertifiedDescriptorAttributeSeed"
+        declared:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/DescriptorAttributeSeed"
+        verified:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/DescriptorAttributeSeed"
+    CertifiedDescriptorAttributeSeed:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - explicitAttributeVerification
+      properties:
+        id:
+          $ref: "#/components/schemas/AttributeId"
+        explicitAttributeVerification:
+          type: boolean
+        dailyCallsPerConsumer:
+          description: Maximum number of daily calls that this Certified Attribute can afford per consumer
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+    DescriptorAttributeSeed:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - explicitAttributeVerification
+      properties:
+        id:
+          $ref: "#/components/schemas/AttributeId"
+        explicitAttributeVerification:
+          type: boolean
     EServiceMode:
       type: string
       description: Indicates if the E-Service is intended for receiving or delivering data

--- a/packages/backend-for-frontend/src/services/eserviceTemplateService.ts
+++ b/packages/backend-for-frontend/src/services/eserviceTemplateService.ts
@@ -219,7 +219,7 @@ export function eserviceTemplateServiceBuilder(
     updateEServiceTemplateVersionAttributes: async (
       templateId: EServiceTemplateId,
       templateVersionId: EServiceTemplateVersionId,
-      seed: bffApi.DescriptorAttributesSeed,
+      seed: bffApi.EServiceTemplateAttributesSeed,
       { logger, headers }: WithLogger<BffAppContext>
     ): Promise<void> => {
       logger.info(

--- a/packages/backend-for-frontend/test/api/catalogRouter/updateDescriptorAttributes.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/updateDescriptorAttributes.test.ts
@@ -47,8 +47,36 @@ describe("API POST /eservices/:eServiceId/descriptors/:descriptorId/attributes/u
     { body: { ...mockDescriptorAttributesSeed, certified: ["invalid"] } },
     { body: { ...mockDescriptorAttributesSeed, declared: "invalid" } },
     { body: { ...mockDescriptorAttributesSeed, declared: ["invalid"] } },
+    {
+      body: {
+        ...mockDescriptorAttributesSeed,
+        declared: [
+          [
+            {
+              id: generateId(),
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+      },
+    },
     { body: { ...mockDescriptorAttributesSeed, verified: "invalid" } },
     { body: { ...mockDescriptorAttributesSeed, verified: ["invalid"] } },
+    {
+      body: {
+        ...mockDescriptorAttributesSeed,
+        verified: [
+          [
+            {
+              id: generateId(),
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+      },
+    },
   ])(
     "Should return 400 if passed an invalid parameter",
     async ({ eServiceId, descriptorId, body }) => {

--- a/packages/backend-for-frontend/test/api/eserviceTemplateRouter/updateEServiceTemplateVersionAttributes.test.ts
+++ b/packages/backend-for-frontend/test/api/eserviceTemplateRouter/updateEServiceTemplateVersionAttributes.test.ts
@@ -11,10 +11,11 @@ import request from "supertest";
 import { bffApi } from "pagopa-interop-api-clients";
 import { api, clients } from "../../vitest.api.setup.js";
 import { appBasePath } from "../../../src/config/appBasePath.js";
-import { getMockBffApiDescriptorAttributesSeed } from "../../mockUtils.js";
+import { getMockBffApiEServiceTemplateAttributesSeed } from "../../mockUtils.js";
 
 describe("API POST /eservices/templates/:eServiceTemplateId/versions/:eServiceTemplateVersionId/attributes/update", () => {
-  const mockDescriptorAttributesSeed = getMockBffApiDescriptorAttributesSeed();
+  const mockEServiceTemplateAttributesSeed =
+    getMockBffApiEServiceTemplateAttributesSeed();
 
   beforeEach(() => {
     clients.eserviceTemplateProcessClient.updateTemplateVersionAttributes = vi
@@ -26,7 +27,7 @@ describe("API POST /eservices/templates/:eServiceTemplateId/versions/:eServiceTe
     token: string,
     eServiceTemplateId: EServiceTemplateId = generateId(),
     eServiceTemplateVersionId: EServiceTemplateVersionId = generateId(),
-    body: bffApi.DescriptorAttributesSeed = mockDescriptorAttributesSeed
+    body: bffApi.EServiceTemplateAttributesSeed = mockEServiceTemplateAttributesSeed
   ) =>
     request(api)
       .post(
@@ -48,25 +49,39 @@ describe("API POST /eservices/templates/:eServiceTemplateId/versions/:eServiceTe
     { body: {} },
     {
       body: {
-        ...mockDescriptorAttributesSeed,
+        ...mockEServiceTemplateAttributesSeed,
         extraField: 1,
       },
     },
     {
       body: {
-        ...mockDescriptorAttributesSeed,
+        ...mockEServiceTemplateAttributesSeed,
         certified: "invalid",
       },
     },
     {
       body: {
-        ...mockDescriptorAttributesSeed,
+        ...mockEServiceTemplateAttributesSeed,
+        certified: [
+          [
+            {
+              id: generateId(),
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+      },
+    },
+    {
+      body: {
+        ...mockEServiceTemplateAttributesSeed,
         declared: "invalid",
       },
     },
     {
       body: {
-        ...mockDescriptorAttributesSeed,
+        ...mockEServiceTemplateAttributesSeed,
         verified: "invalid",
       },
     },
@@ -78,7 +93,7 @@ describe("API POST /eservices/templates/:eServiceTemplateId/versions/:eServiceTe
         token,
         eServiceTemplateId,
         eServiceTemplateVersionId,
-        body as bffApi.DescriptorAttributesSeed
+        body as bffApi.EServiceTemplateAttributesSeed
       );
       expect(res.status).toBe(400);
     }

--- a/packages/backend-for-frontend/test/mockUtils.ts
+++ b/packages/backend-for-frontend/test/mockUtils.ts
@@ -390,9 +390,24 @@ export const getMockCatalogApiUpdateEServiceDescriptorQuotasSeed =
 
 export const getMockBffApiDescriptorAttributesSeed =
   (): bffApi.DescriptorAttributesSeed => ({
-    certified: generateMock(z.array(z.array(bffApi.DescriptorAttributeSeed))),
+    certified: generateMock(
+      z.array(z.array(bffApi.CertifiedDescriptorAttributeSeed))
+    ),
     declared: generateMock(z.array(z.array(bffApi.DescriptorAttributeSeed))),
     verified: generateMock(z.array(z.array(bffApi.DescriptorAttributeSeed))),
+  });
+
+export const getMockBffApiEServiceTemplateAttributesSeed =
+  (): bffApi.EServiceTemplateAttributesSeed => ({
+    certified: generateMock(
+      z.array(z.array(bffApi.EServiceTemplateVersionAttributeSeed))
+    ),
+    declared: generateMock(
+      z.array(z.array(bffApi.EServiceTemplateVersionAttributeSeed))
+    ),
+    verified: generateMock(
+      z.array(z.array(bffApi.EServiceTemplateVersionAttributeSeed))
+    ),
   });
 
 export const getMockBffApiUpdateEServiceDescriptorSeed =

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -668,7 +668,7 @@ const eservicesRouter = (
         const ctx = fromAppContext(req.ctx);
 
         try {
-          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE]);
+          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
 
           const updatedEService =
             await catalogService.updateDraftDescriptorTemplateInstance(
@@ -1485,7 +1485,7 @@ const eservicesRouter = (
         const ctx = fromAppContext(req.ctx);
 
         try {
-          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE]);
+          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
 
           const updatedEService =
             await catalogService.updateTemplateInstanceDescriptor(

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1572,7 +1572,11 @@ export function catalogServiceBuilder(
       eserviceId: EServiceId,
       descriptorId: DescriptorId,
       seed: catalogApi.UpdateEServiceDescriptorTemplateInstanceSeed,
-      { authData, correlationId, logger }: WithLogger<AppContext<UIAuthData>>
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<EService> {
       logger.info(
         `Updating draft Descriptor ${descriptorId} for EService ${eserviceId} template instance`
@@ -2148,7 +2152,11 @@ export function catalogServiceBuilder(
       eserviceId: EServiceId,
       descriptorId: DescriptorId,
       seed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed,
-      { authData, correlationId, logger }: WithLogger<AppContext<UIAuthData>>
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<EService> {
       logger.info(
         `Updating Descriptor ${descriptorId} for EService ${eserviceId} template instance`

--- a/packages/catalog-process/test/api/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/catalog-process/test/api/updateDraftDescriptorTemplateInstance.test.ts
@@ -69,7 +69,11 @@ describe("API /templates/eservices/{eServiceId}/descriptors/{descriptorId} autho
       .set("X-Correlation-Id", generateId())
       .send(body);
 
-  const authorizedRoles: AuthRole[] = [authRole.ADMIN_ROLE, authRole.API_ROLE];
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.API_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
   it.each(authorizedRoles)(
     "Should return 200 for user with role %s",
     async (role) => {

--- a/packages/catalog-process/test/api/updateTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/api/updateTemplateInstanceDescriptor.test.ts
@@ -62,7 +62,11 @@ describe("API /templates/eservices/{eServiceId}/descriptors/{descriptorId}/updat
       .set("X-Correlation-Id", generateId())
       .send(body);
 
-  const authorizedRoles: AuthRole[] = [authRole.ADMIN_ROLE, authRole.API_ROLE];
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.API_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
   it.each(authorizedRoles)(
     "Should return 200 for user with role %s",
     async (role) => {

--- a/packages/m2m-gateway-v3/src/model/errors.ts
+++ b/packages/m2m-gateway-v3/src/model/errors.ts
@@ -67,6 +67,17 @@ const errorCodes = {
   dpopTokenBindingFailed: "0045",
   purposeVersionDocumentNotReady: "0046",
   clientNotFound: "0047",
+  eServiceNotFound: "0048",
+  eServiceDescriptorNotFound: "0049",
+  inconsistentAttributesSeedGroupsCount: "0050",
+  descriptorAttributeGroupSupersetMissingInAttributesSeed: "0051",
+  attributeDuplicatedInGroup: "0052",
+  notValidDescriptor: "0053",
+  attributeDailyCallsNotAllowed: "0054",
+  templateInstanceNotAllowed: "0055",
+  inconsistentDailyCalls: "0056",
+  unchangedAttributes: "0057",
+  eServiceNotAnInstance: "0058",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;

--- a/packages/m2m-gateway-v3/src/routers/eserviceRouter.ts
+++ b/packages/m2m-gateway-v3/src/routers/eserviceRouter.ts
@@ -24,6 +24,9 @@ import {
   createEServiceDescriptorAttributeGroupsErrorMapper,
   deleteEServiceDescriptorAttributeFromGroupErrorMapper,
   assignEServiceDescriptorAttributesErrorMapper,
+  updateDraftEServiceDescriptorTemplateInstanceErrorMapper,
+  updateEServiceDescriptorAttributesErrorMapper,
+  updateEServiceTemplateInstanceDescriptorErrorMapper,
 } from "../utils/errorMappers.js";
 import { sendDownloadedDocumentAsFormData } from "../utils/fileDownload.js";
 
@@ -416,6 +419,93 @@ const eserviceRouter = (
             emptyErrorMapper,
             ctx,
             `Error updating quotas for eservice descriptor with id ${req.params.descriptorId} for eservice ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/eservices/:eserviceId/descriptors/:descriptorId/attributes/update",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          await eserviceService.updateEServiceDescriptorAttributes(
+            unsafeBrandId(req.params.eserviceId),
+            unsafeBrandId(req.params.descriptorId),
+            req.body,
+            ctx
+          );
+
+          return res.status(200).send({});
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            updateEServiceDescriptorAttributesErrorMapper,
+            ctx,
+            `Error bulk updating attributes for eservice descriptor with id ${req.params.descriptorId} for eservice ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/templates/eservices/:eserviceId/descriptors/:descriptorId",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          const createdResource =
+            await eserviceService.updateDraftEServiceDescriptorTemplateInstance(
+              unsafeBrandId(req.params.eserviceId),
+              unsafeBrandId(req.params.descriptorId),
+              req.body,
+              ctx
+            );
+
+          return res
+            .status(200)
+            .send(m2mGatewayApiV3.CreatedResource.parse(createdResource));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            updateDraftEServiceDescriptorTemplateInstanceErrorMapper,
+            ctx,
+            `Error updating draft template instance descriptor with id ${req.params.descriptorId} for eservice ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/templates/eservices/:eserviceId/descriptors/:descriptorId/update",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          const createdResource =
+            await eserviceService.updateEServiceTemplateInstanceDescriptor(
+              unsafeBrandId(req.params.eserviceId),
+              unsafeBrandId(req.params.descriptorId),
+              req.body,
+              ctx
+            );
+
+          return res
+            .status(200)
+            .send(m2mGatewayApiV3.CreatedResource.parse(createdResource));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            updateEServiceTemplateInstanceDescriptorErrorMapper,
+            ctx,
+            `Error updating template instance descriptor with id ${req.params.descriptorId} for eservice ${req.params.eserviceId}`
           );
           return res.status(errorRes.status).send(errorRes);
         }

--- a/packages/m2m-gateway-v3/src/services/eserviceService.ts
+++ b/packages/m2m-gateway-v3/src/services/eserviceService.ts
@@ -1102,6 +1102,81 @@ export function eserviceServiceBuilder(
       );
     },
 
+    async updateEServiceDescriptorAttributes(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      seed: m2mGatewayApiV3.DescriptorAttributesSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<void> {
+      logger.info(
+        `Bulk updating attributes for E-Service Descriptor with id ${descriptorId} for E-Service ${eserviceId}`
+      );
+
+      const eservice = await retrieveEServiceById(headers, eserviceId);
+      const descriptor = retrieveEServiceDescriptorById(eservice, descriptorId);
+      const configOptions = {
+        params: { eServiceId: eserviceId, descriptorId },
+        headers,
+      };
+
+      const response = await (descriptor.state ===
+      catalogApi.EServiceDescriptorState.Values.DRAFT
+        ? clients.catalogProcessClient.patchUpdateDraftDescriptor(
+            { attributes: seed },
+            configOptions
+          )
+        : clients.catalogProcessClient.updateDescriptorAttributes(
+            seed,
+            configOptions
+          ));
+
+      await pollEService(response, headers);
+    },
+
+    async updateDraftEServiceDescriptorTemplateInstance(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      seed: m2mGatewayApiV3.UpdateEServiceDescriptorTemplateInstanceSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.CreatedResource> {
+      logger.info(
+        `Updating draft template instance Descriptor with id ${descriptorId} for E-Service ${eserviceId}`
+      );
+
+      const { data: updatedEService } =
+        await clients.catalogProcessClient.updateDraftDescriptorTemplateInstance(
+          seed,
+          {
+            params: { eServiceId: eserviceId, descriptorId },
+            headers,
+          }
+        );
+
+      return { id: updatedEService.id };
+    },
+
+    async updateEServiceTemplateInstanceDescriptor(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      seed: m2mGatewayApiV3.UpdateEServiceTemplateInstanceDescriptorQuotasSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.CreatedResource> {
+      logger.info(
+        `Updating template instance Descriptor with id ${descriptorId} for E-Service ${eserviceId}`
+      );
+
+      const { data: updatedEService } =
+        await clients.catalogProcessClient.updateTemplateInstanceDescriptor(
+          seed,
+          {
+            params: { eServiceId: eserviceId, descriptorId },
+            headers,
+          }
+        );
+
+      return { id: updatedEService.id };
+    },
+
     async getEServiceRiskAnalyses(
       eserviceId: EServiceId,
       { limit, offset }: m2mGatewayApiV3.GetEServiceRiskAnalysesQueryParams,

--- a/packages/m2m-gateway-v3/src/services/eserviceService.ts
+++ b/packages/m2m-gateway-v3/src/services/eserviceService.ts
@@ -1109,7 +1109,7 @@ export function eserviceServiceBuilder(
       { headers, logger }: WithLogger<M2MGatewayAppContext>
     ): Promise<void> {
       logger.info(
-        `Bulk updating attributes for E-Service Descriptor with id ${descriptorId} for E-Service ${eserviceId}`
+        `Updating attributes for E-Service Descriptor with id ${descriptorId} for E-Service ${eserviceId}`
       );
 
       const eservice = await retrieveEServiceById(headers, eserviceId);

--- a/packages/m2m-gateway-v3/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway-v3/src/utils/errorMappers.ts
@@ -4,7 +4,24 @@ import { ApiError, CommonErrorCodes } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { ErrorCodes as M2MGatewayErrorCodes } from "../model/errors.js";
 
-type ErrorCodes = M2MGatewayErrorCodes | CommonErrorCodes;
+type CatalogProcessErrorCodes =
+  | "eServiceNotFound"
+  | "eServiceDescriptorNotFound"
+  | "attributeNotFound"
+  | "inconsistentAttributesSeedGroupsCount"
+  | "descriptorAttributeGroupSupersetMissingInAttributesSeed"
+  | "attributeDuplicatedInGroup"
+  | "notValidDescriptor"
+  | "attributeDailyCallsNotAllowed"
+  | "templateInstanceNotAllowed"
+  | "inconsistentDailyCalls"
+  | "unchangedAttributes"
+  | "eServiceNotAnInstance";
+
+type ErrorCodes =
+  | M2MGatewayErrorCodes
+  | CommonErrorCodes
+  | CatalogProcessErrorCodes;
 
 const {
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -289,6 +306,78 @@ export const assignEServiceTemplateVersionAttributesErrorMapper = (
       "eserviceTemplateVersionAttributeGroupNotFound",
       "eserviceTemplateVersionAttributeNotFound",
       () => HTTP_STATUS_NOT_FOUND
+    )
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const updateEServiceDescriptorAttributesErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "eServiceNotFound",
+      "eServiceDescriptorNotFound",
+      "attributeNotFound",
+      "eserviceDescriptorNotFound",
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with(
+      "inconsistentAttributesSeedGroupsCount",
+      "descriptorAttributeGroupSupersetMissingInAttributesSeed",
+      "attributeDuplicatedInGroup",
+      "notValidDescriptor",
+      "attributeDailyCallsNotAllowed",
+      "templateInstanceNotAllowed",
+      "inconsistentDailyCalls",
+      () => HTTP_STATUS_BAD_REQUEST
+    )
+    .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
+    .with("unchangedAttributes", () => HTTP_STATUS_CONFLICT)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const updateDraftEServiceDescriptorTemplateInstanceErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "eServiceNotFound",
+      "eServiceDescriptorNotFound",
+      "eserviceDescriptorNotFound",
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with(
+      "notValidDescriptor",
+      "inconsistentDailyCalls",
+      "attributeNotFound",
+      "eServiceNotAnInstance",
+      "attributeDailyCallsNotAllowed",
+      "templateInstanceNotAllowed",
+      () => HTTP_STATUS_BAD_REQUEST
+    )
+    .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const updateEServiceTemplateInstanceDescriptorErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "eServiceNotFound",
+      "eServiceDescriptorNotFound",
+      "eserviceDescriptorNotFound",
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with(
+      "notValidDescriptor",
+      "inconsistentDailyCalls",
+      "attributeNotFound",
+      "attributeDailyCallsNotAllowed",
+      "templateInstanceNotAllowed",
+      () => HTTP_STATUS_BAD_REQUEST
+    )
+    .with(
+      "eServiceNotAnInstance",
+      "operationForbidden",
+      () => HTTP_STATUS_FORBIDDEN
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 

--- a/packages/m2m-gateway-v3/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway-v3/src/utils/errorMappers.ts
@@ -4,24 +4,7 @@ import { ApiError, CommonErrorCodes } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { ErrorCodes as M2MGatewayErrorCodes } from "../model/errors.js";
 
-type CatalogProcessErrorCodes =
-  | "eServiceNotFound"
-  | "eServiceDescriptorNotFound"
-  | "attributeNotFound"
-  | "inconsistentAttributesSeedGroupsCount"
-  | "descriptorAttributeGroupSupersetMissingInAttributesSeed"
-  | "attributeDuplicatedInGroup"
-  | "notValidDescriptor"
-  | "attributeDailyCallsNotAllowed"
-  | "templateInstanceNotAllowed"
-  | "inconsistentDailyCalls"
-  | "unchangedAttributes"
-  | "eServiceNotAnInstance";
-
-type ErrorCodes =
-  | M2MGatewayErrorCodes
-  | CommonErrorCodes
-  | CatalogProcessErrorCodes;
+type ErrorCodes = M2MGatewayErrorCodes | CommonErrorCodes;
 
 const {
   HTTP_STATUS_INTERNAL_SERVER_ERROR,

--- a/packages/m2m-gateway-v3/test/api/eservices/updateDraftEServiceDescriptorTemplateInstance.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/updateDraftEServiceDescriptorTemplateInstance.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  generateToken,
+  getMockedApiEservice,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import { ApiError, generateId, unsafeBrandId } from "pagopa-interop-models";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("POST /templates/eservices/{eserviceId}/descriptors/{descriptorId} router test", () => {
+  const mockEService = getMockedApiEservice();
+  const mockDescriptor = mockEService.descriptors[0]!;
+  const mockAttributeId = generateId();
+
+  const mockSeed: m2mGatewayApiV3.UpdateEServiceDescriptorTemplateInstanceSeed =
+    {
+      audience: ["https://api.example.test"],
+      dailyCallsPerConsumer: 100,
+      dailyCallsTotal: 1000,
+      agreementApprovalPolicy: "AUTOMATIC",
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockAttributeId,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+  const mockResponse: m2mGatewayApiV3.CreatedResource = {
+    id: mockEService.id,
+  };
+
+  const makeRequest = async (
+    token: string,
+    body: m2mGatewayApiV3.UpdateEServiceDescriptorTemplateInstanceSeed = mockSeed
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/templates/eservices/${mockEService.id}/descriptors/${mockDescriptor.id}`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+
+  it.each(authorizedRoles)(
+    "Should return 200 and update draft template instance descriptor for user with role %s",
+    async (role) => {
+      mockEserviceService.updateDraftEServiceDescriptorTemplateInstance = vi
+        .fn()
+        .mockResolvedValue(mockResponse);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockResponse);
+      expect(
+        mockEserviceService.updateDraftEServiceDescriptorTemplateInstance
+      ).toHaveBeenCalledWith(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        expect.anything()
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {},
+    { ...mockSeed, dailyCallsPerConsumer: 0 },
+    { ...mockSeed, attributes: { certified: [], declared: [] } },
+    { ...mockSeed, attributes: { ...mockSeed.attributes, extraParam: true } },
+  ])(
+    "Should return 400 if passed invalid template instance seed %#",
+    async (body) => {
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        body as m2mGatewayApiV3.UpdateEServiceDescriptorTemplateInstanceSeed
+      );
+
+      expect(res.status).toBe(400);
+    }
+  );
+
+  it("Should return 400 in case of eServiceNotAnInstance error", async () => {
+    mockEserviceService.updateDraftEServiceDescriptorTemplateInstance = vi
+      .fn()
+      .mockRejectedValue(
+        new ApiError({
+          code: "eServiceNotAnInstance",
+          title: "E-Service is not an instance",
+          detail: "E-Service is not an instance",
+        })
+      );
+
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/eservices/updateEServiceDescriptorAttributes.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/updateEServiceDescriptorAttributes.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from "vitest";
+import { generateToken, getMockDPoPProof } from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import { ApiError, generateId, unsafeBrandId } from "pagopa-interop-models";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("POST /eservices/{eserviceId}/descriptors/{descriptorId}/attributes/update router test", () => {
+  const eserviceId = generateId();
+  const descriptorId = generateId();
+  const attributeId = generateId();
+
+  const mockAttributesSeed: m2mGatewayApiV3.DescriptorAttributesSeed = {
+    certified: [
+      [
+        {
+          id: attributeId,
+          explicitAttributeVerification: false,
+          dailyCallsPerConsumer: 500,
+        },
+      ],
+    ],
+    declared: [],
+    verified: [],
+  };
+
+  const makeRequest = async (
+    token: string,
+    body: m2mGatewayApiV3.DescriptorAttributesSeed = mockAttributesSeed
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/eservices/${eserviceId}/descriptors/${descriptorId}/attributes/update`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+
+  it.each(authorizedRoles)(
+    "Should return 200 and update descriptor attributes for user with role %s",
+    async (role) => {
+      mockEserviceService.updateEServiceDescriptorAttributes = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({});
+      expect(res.headers).toHaveProperty("digest");
+      expect(res.headers).toHaveProperty("agid-jwt-signature");
+      expect(
+        mockEserviceService.updateEServiceDescriptorAttributes
+      ).toHaveBeenCalledWith(
+        unsafeBrandId(eserviceId),
+        unsafeBrandId(descriptorId),
+        mockAttributesSeed,
+        expect.anything()
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {},
+    { ...mockAttributesSeed, certified: [[{ id: attributeId }]] },
+    {
+      ...mockAttributesSeed,
+      declared: [[{ id: attributeId, explicitAttributeVerification: false }]],
+      extraParam: "notAllowed",
+    },
+    {
+      ...mockAttributesSeed,
+      declared: [
+        [
+          {
+            id: attributeId,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 500,
+          },
+        ],
+      ],
+    },
+  ])("Should return 400 if passed invalid attributes seed %#", async (body) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      body as m2mGatewayApiV3.DescriptorAttributesSeed
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 404 in case of eServiceDescriptorNotFound error", async () => {
+    mockEserviceService.updateEServiceDescriptorAttributes = vi
+      .fn()
+      .mockRejectedValue(
+        new ApiError({
+          code: "eServiceDescriptorNotFound",
+          title: "E-Service descriptor not found",
+          detail: "E-Service descriptor not found",
+        })
+      );
+
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("Should return 409 in case of unchangedAttributes error", async () => {
+    mockEserviceService.updateEServiceDescriptorAttributes = vi
+      .fn()
+      .mockRejectedValue(
+        new ApiError({
+          code: "unchangedAttributes",
+          title: "Unchanged attributes",
+          detail: "Unchanged attributes",
+        })
+      );
+
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(409);
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/eservices/updateEServiceTemplateInstanceDescriptor.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/updateEServiceTemplateInstanceDescriptor.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  generateToken,
+  getMockedApiEservice,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import request from "supertest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import { ApiError, generateId, unsafeBrandId } from "pagopa-interop-models";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("POST /templates/eservices/{eserviceId}/descriptors/{descriptorId}/update router test", () => {
+  const mockEService = getMockedApiEservice();
+  const mockDescriptor = mockEService.descriptors[0]!;
+  const mockAttributeId = generateId();
+
+  const mockSeed: m2mGatewayApiV3.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+    {
+      dailyCallsPerConsumer: 100,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockAttributeId,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+  const mockResponse: m2mGatewayApiV3.CreatedResource = {
+    id: mockEService.id,
+  };
+
+  const makeRequest = async (
+    token: string,
+    body: m2mGatewayApiV3.UpdateEServiceTemplateInstanceDescriptorQuotasSeed = mockSeed
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/templates/eservices/${mockEService.id}/descriptors/${mockDescriptor.id}/update`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+
+  it.each(authorizedRoles)(
+    "Should return 200 and update template instance descriptor for user with role %s",
+    async (role) => {
+      mockEserviceService.updateEServiceTemplateInstanceDescriptor = vi
+        .fn()
+        .mockResolvedValue(mockResponse);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockResponse);
+      expect(
+        mockEserviceService.updateEServiceTemplateInstanceDescriptor
+      ).toHaveBeenCalledWith(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        expect.anything()
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {},
+    { ...mockSeed, dailyCallsTotal: 0 },
+    { ...mockSeed, attributes: { certified: [], declared: [] } },
+    { ...mockSeed, attributes: { ...mockSeed.attributes, extraParam: true } },
+  ])(
+    "Should return 400 if passed invalid template instance seed %#",
+    async (body) => {
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        body as m2mGatewayApiV3.UpdateEServiceTemplateInstanceDescriptorQuotasSeed
+      );
+
+      expect(res.status).toBe(400);
+    }
+  );
+
+  it("Should return 403 in case of eServiceNotAnInstance error", async () => {
+    mockEserviceService.updateEServiceTemplateInstanceDescriptor = vi
+      .fn()
+      .mockRejectedValue(
+        new ApiError({
+          code: "eServiceNotAnInstance",
+          title: "E-Service is not an instance",
+          detail: "E-Service is not an instance",
+        })
+      );
+
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/updateDraftEServiceDescriptorTemplateInstance.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/updateDraftEServiceDescriptorTemplateInstance.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { catalogApi, m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import { generateId, unsafeBrandId } from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockedApiEserviceDescriptor,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceService,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("updateDraftEServiceDescriptorTemplateInstance", () => {
+  const mockAttributeId = generateId();
+  const mockDescriptor = getMockedApiEserviceDescriptor({
+    state: catalogApi.EServiceDescriptorState.Values.DRAFT,
+  });
+  const mockEService = getMockedApiEservice({
+    descriptors: [mockDescriptor],
+  });
+  const mockSeed: catalogApi.UpdateEServiceDescriptorTemplateInstanceSeed = {
+    audience: ["https://api.example.test"],
+    dailyCallsPerConsumer: 100,
+    dailyCallsTotal: 1000,
+    agreementApprovalPolicy: "AUTOMATIC",
+    attributes: {
+      certified: [
+        [
+          {
+            id: mockAttributeId,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 500,
+          },
+        ],
+      ],
+      declared: [],
+      verified: [],
+    },
+  };
+  const mockUpdateDraftDescriptorTemplateInstance = vi
+    .fn()
+    .mockResolvedValue({ data: mockEService });
+
+  mockInteropBeClients.catalogProcessClient = {
+    updateDraftDescriptorTemplateInstance:
+      mockUpdateDraftDescriptorTemplateInstance,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockUpdateDraftDescriptorTemplateInstance.mockClear();
+  });
+
+  it("Should update draft template instance descriptor and return the e-service id", async () => {
+    const result =
+      await eserviceService.updateDraftEServiceDescriptorTemplateInstance(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      );
+
+    const expectedResource: m2mGatewayApiV3.CreatedResource = {
+      id: mockEService.id,
+    };
+
+    expect(result).toStrictEqual(expectedResource);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient
+          .updateDraftDescriptorTemplateInstance,
+      params: {
+        eServiceId: mockEService.id,
+        descriptorId: mockDescriptor.id,
+      },
+      body: mockSeed,
+    });
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/updateEServiceDescriptorAttributes.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/updateEServiceDescriptorAttributes.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  generateId,
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockedApiEserviceDescriptor,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import { catalogApi } from "pagopa-interop-api-clients";
+import {
+  eserviceService,
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { config } from "../../../src/config/config.js";
+
+describe("updateEServiceDescriptorAttributes", () => {
+  const mockAttributeId = generateId();
+  const mockSeed: catalogApi.AttributesSeed = {
+    certified: [
+      [
+        {
+          id: mockAttributeId,
+          explicitAttributeVerification: false,
+          dailyCallsPerConsumer: 500,
+        },
+      ],
+    ],
+    declared: [],
+    verified: [],
+  };
+
+  const draftDescriptor = getMockedApiEserviceDescriptor({
+    state: catalogApi.EServiceDescriptorState.Values.DRAFT,
+  });
+  const publishedDescriptor = getMockedApiEserviceDescriptor({
+    state: catalogApi.EServiceDescriptorState.Values.PUBLISHED,
+  });
+  const mockEService = getMockedApiEservice({
+    descriptors: [draftDescriptor, publishedDescriptor],
+  });
+  const mockEServiceResponse = getMockWithMetadata(mockEService);
+
+  const mockGetEService = vi.fn();
+  const mockPatchUpdateDraftDescriptor = vi.fn();
+  const mockUpdateDescriptorAttributes = vi.fn();
+
+  mockInteropBeClients.catalogProcessClient = {
+    getEServiceById: mockGetEService,
+    patchUpdateDraftDescriptor: mockPatchUpdateDraftDescriptor,
+    updateDescriptorAttributes: mockUpdateDescriptorAttributes,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockGetEService.mockReset();
+    mockPatchUpdateDraftDescriptor.mockReset();
+    mockUpdateDescriptorAttributes.mockReset();
+    mockPatchUpdateDraftDescriptor.mockResolvedValue(mockEServiceResponse);
+    mockUpdateDescriptorAttributes.mockResolvedValue(mockEServiceResponse);
+  });
+
+  it("Should update draft descriptor attributes through patchUpdateDraftDescriptor", async () => {
+    mockGetEService
+      .mockResolvedValueOnce(mockEServiceResponse)
+      .mockImplementation(mockPollingResponse(mockEServiceResponse, 2));
+
+    await eserviceService.updateEServiceDescriptorAttributes(
+      unsafeBrandId(mockEService.id),
+      unsafeBrandId(draftDescriptor.id),
+      mockSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient.patchUpdateDraftDescriptor,
+      params: {
+        eServiceId: mockEService.id,
+        descriptorId: draftDescriptor.id,
+      },
+      body: { attributes: mockSeed },
+    });
+    expect(mockUpdateDescriptorAttributes).not.toHaveBeenCalled();
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockEService.id },
+    });
+    expect(mockGetEService).toHaveBeenCalledTimes(3);
+  });
+
+  it("Should update non-draft descriptor attributes through updateDescriptorAttributes", async () => {
+    mockGetEService
+      .mockResolvedValueOnce(mockEServiceResponse)
+      .mockImplementation(mockPollingResponse(mockEServiceResponse, 2));
+
+    await eserviceService.updateEServiceDescriptorAttributes(
+      unsafeBrandId(mockEService.id),
+      unsafeBrandId(publishedDescriptor.id),
+      mockSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient.updateDescriptorAttributes,
+      params: {
+        eServiceId: mockEService.id,
+        descriptorId: publishedDescriptor.id,
+      },
+      body: mockSeed,
+    });
+    expect(mockPatchUpdateDraftDescriptor).not.toHaveBeenCalled();
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockEService.id },
+    });
+    expect(mockGetEService).toHaveBeenCalledTimes(3);
+  });
+
+  it("Should throw missingMetadata in case the update response has no metadata", async () => {
+    mockGetEService.mockResolvedValueOnce(mockEServiceResponse);
+    mockUpdateDescriptorAttributes.mockResolvedValueOnce({
+      ...mockEServiceResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.updateEServiceDescriptorAttributes(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(publishedDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEService
+      .mockResolvedValueOnce(mockEServiceResponse)
+      .mockImplementation(
+        mockPollingResponse(
+          mockEServiceResponse,
+          config.defaultPollingMaxRetries + 1
+        )
+      );
+
+    await expect(
+      eserviceService.updateEServiceDescriptorAttributes(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(publishedDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/updateEServiceTemplateInstanceDescriptor.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/updateEServiceTemplateInstanceDescriptor.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { catalogApi, m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import { generateId, unsafeBrandId } from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockedApiEserviceDescriptor,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceService,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("updateEServiceTemplateInstanceDescriptor", () => {
+  const mockAttributeId = generateId();
+  const mockDescriptor = getMockedApiEserviceDescriptor({
+    state: catalogApi.EServiceDescriptorState.Values.PUBLISHED,
+  });
+  const mockEService = getMockedApiEservice({
+    descriptors: [mockDescriptor],
+  });
+  const mockSeed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+    {
+      dailyCallsPerConsumer: 100,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockAttributeId,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+  const mockUpdateTemplateInstanceDescriptor = vi
+    .fn()
+    .mockResolvedValue({ data: mockEService });
+
+  mockInteropBeClients.catalogProcessClient = {
+    updateTemplateInstanceDescriptor: mockUpdateTemplateInstanceDescriptor,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockUpdateTemplateInstanceDescriptor.mockClear();
+  });
+
+  it("Should update template instance descriptor and return the e-service id", async () => {
+    const result =
+      await eserviceService.updateEServiceTemplateInstanceDescriptor(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      );
+
+    const expectedResource: m2mGatewayApiV3.CreatedResource = {
+      id: mockEService.id,
+    };
+
+    expect(result).toStrictEqual(expectedResource);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient
+          .updateTemplateInstanceDescriptor,
+      params: {
+        eServiceId: mockEService.id,
+        descriptorId: mockDescriptor.id,
+      },
+      body: mockSeed,
+    });
+  });
+});


### PR DESCRIPTION
## Jira Issue
[PIN-10013](https://pagopa.atlassian.net/browse/PIN-10013)

## Context
- Add M2M endpoints mirroring BFF/frontend flows for differentiated attribute thresholds on e-services and template instances.

## Services Affected
- api-clients
- m2m-gateway-v3
- catalog-process
- backend-for-frontend

## Key Changes
- Added M2M attribute update endpoint for e-service descriptors.
- Added M2M template instance descriptor update endpoints returning `CreatedResource`.
- Added M2M error mapping and API/integration coverage.
- Restricted BFF attribute seed contracts so `dailyCallsPerConsumer` is accepted only for certified attributes on e-services/template instances.
- Switched BFF template version attribute updates to the template attributes seed, preventing thresholds on templates.

## More Changes to do
- Remove the legacy endpoints used to add and remove attributes. Alternatively, add `dailyCallsPerConsumer` support to the POST endpoints and add the UPDATE endpoints to update the `dailyCallsPerConsumer` values.
- Remove the previous `assertDailyCallsForCertifiedAttributesOnly` validation.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [x] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)


[PIN-10013]: https://pagopa.atlassian.net/browse/PIN-10013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ