### PR TITLE
fix(bff): add ASYNC_EXCHANGE_CALLBACK_INTERFACE to document kind (PIN-9235)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -4516,6 +4516,7 @@ paths:
                   enum:
                     - INTERFACE
                     - DOCUMENT
+                    - ASYNC_EXCHANGE_CALLBACK_INTERFACE
                 prettyName:
                   type: string
                 doc:
@@ -23328,6 +23329,7 @@ paths:
                   enum:
                     - INTERFACE
                     - DOCUMENT
+                    - ASYNC_EXCHANGE_CALLBACK_INTERFACE
                 prettyName:
                   type: string
                 doc:


### PR DESCRIPTION
## Context 
Follow-up to #3101 and [PIN-9235](https://pagopa.atlassian.net/browse/PIN-9235)

## Summary
Aligned the BFF OpenAPI spec with the new `ASYNC_EXCHANGE_CALLBACK_INTERFACE`.



[PIN-9235]: https://pagopa.atlassian.net/browse/PIN-9235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ