### PR TITLE
feature: e-service archiving work item 4: POST /internal/eservices/{eServiceId}/archive (PIN-10050)

### DIFF
--- a/collections/catalog/Archive EService.bru
+++ b/collections/catalog/Archive EService.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Archive EService
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{host-catalog}}/internal/eservices/:eserviceId/archive
+  body: none
+  auth: none
+}
+
+params:path {
+  eserviceId: {{eserviceId}}
+}
+
+headers {
+  Authorization: {{JWT}}
+  X-Correlation-Id: {{correlation-id}}
+}

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -1278,6 +1278,51 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /internal/eservices/{eServiceId}/archive:
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - process
+      summary: Archive the selected E-Service.
+      operationId: archiveEService
+      description: Archives the specified E-Service
+      parameters:
+        - $ref: "#/components/parameters/CorrelationIdHeader"
+        - name: eServiceId
+          in: path
+          description: the eservice id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: E-Service archived
+        "400":
+          description: Invalid input
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: E-Service not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /eservices/{eServiceId}/descriptors/{descriptorId}/update:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -79,6 +79,7 @@ const errorCodes = {
   descriptorAlreadyArchived: "0061",
   notValidEServiceState: "0062",
   eserviceNotInArchiving: "0063",
+  eServiceAlreadyArchived: "0064",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -728,5 +729,15 @@ export function eserviceNotInArchiving(
     detail: `EService ${eserviceId} does not have an ongoing global archiving orchestration`,
     code: "eserviceNotInArchiving",
     title: "EService not in archiving",
+  });
+}
+
+export function eServiceAlreadyArchived(
+  eserviceId: EServiceId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `EService ${eserviceId} is already archived`,
+    code: "eServiceAlreadyArchived",
+    title: "EService already archived",
   });
 }

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -1126,3 +1126,20 @@ export const toCreateEventEServiceArchivingCanceled = (
   },
   correlationId,
 });
+
+export const toCreateEventEServiceArchivingCompleted = (
+  version: number,
+  eservice: EService,
+  correlationId: CorrelationId
+): CreateEvent<EServiceEvent> => ({
+  streamId: eservice.id,
+  version,
+  event: {
+    type: "EServiceArchivingCompleted",
+    event_version: 2,
+    data: {
+      eservice: toEServiceV2(eservice),
+    },
+  },
+  correlationId,
+});

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -860,6 +860,26 @@ const eservicesRouter = (
         }
       }
     )
+    .post("/internal/eservices/:eServiceId/archive", async (req, res) => {
+      const ctx = fromAppContext(req.ctx);
+
+      try {
+        validateAuthorization(ctx, [INTERNAL_ROLE]);
+
+        await catalogService.archiveEService(
+          unsafeBrandId(req.params.eServiceId),
+          ctx
+        );
+        return res.status(204).send();
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          archiveDescriptorErrorMapper,
+          ctx
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
     .post(
       "/eservices/:eServiceId/descriptors/:descriptorId/update",
       async (req, res) => {

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -82,6 +82,7 @@ import {
   maintenanceResetEServicePersonalDataFlagErrorMapper,
   updateEServiceArchivingStatusErrorMapper,
   cancelEServiceArchivingErrorMapper,
+  archiveEServiceErrorMapper,
 } from "../utilities/errorMappers.js";
 import { CatalogService } from "../services/catalogService.js";
 
@@ -872,11 +873,7 @@ const eservicesRouter = (
         );
         return res.status(204).send();
       } catch (error) {
-        const errorRes = makeApiProblem(
-          error,
-          archiveDescriptorErrorMapper,
-          ctx
-        );
+        const errorRes = makeApiProblem(error, archiveEServiceErrorMapper, ctx);
         return res.status(errorRes.status).send(errorRes);
       }
     })

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -171,6 +171,7 @@ import {
   toCreateEventEServiceArchivingScheduled,
   toCreateEventEServiceDescriptorArchivingCompleted,
   toCreateEventEServiceArchivingCanceled,
+  toCreateEventEServiceArchivingCompleted,
 } from "../model/domain/toEvent.js";
 import {
   getLatestDescriptor,
@@ -219,6 +220,7 @@ import {
   assertTemplateInstanceAttributeStructureUnchanged,
   assertIsNotDraftEservice,
   assertEServiceIsInArchiving,
+  assertEServiceIsNotAlreadyArchived,
 } from "./validators.js";
 import type { ReadModelServiceSQL } from "./readModelServiceTypes.js";
 import { calculateArchivableOn } from "../utilities/dateCalculator.js";
@@ -2240,6 +2242,39 @@ export function catalogServiceBuilder(
               correlationId
             );
 
+      await repository.createEvent(event);
+    },
+    async archiveEService(
+      eserviceId: EServiceId,
+      { correlationId, logger }: WithLogger<AppContext<InternalAuthData>>
+    ): Promise<void> {
+      logger.info(`Archiving EService ${eserviceId}`);
+
+      const { data: eservice, metadata } = await retrieveEService(
+        eserviceId,
+        readModelService
+      );
+
+      assertEServiceIsNotAlreadyArchived(eservice);
+
+      const descriptors = eservice.descriptors.map((d) =>
+        d.state === descriptorState.archived
+          ? d
+          : updateDescriptorState(
+              { ...d, archivingSchedule: undefined },
+              descriptorState.archived
+            )
+      );
+      const updatedEservice: EService = {
+        ...eservice,
+        descriptors,
+      };
+
+      const event = toCreateEventEServiceArchivingCompleted(
+        metadata.version,
+        updatedEservice,
+        correlationId
+      );
       await repository.createEvent(event);
     },
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -4374,7 +4374,6 @@ async function processEserviceArchiving(
           )
         )
         .with(descriptorState.draft, descriptorState.waitingForApproval, () => {
-          //Should never happen since we already deleted draft/waiting descriptors, but we put it here for type safety reasons
           throw notValidDescriptorState(descriptor.id, descriptor.state);
         })
         .exhaustive()

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -2260,10 +2260,7 @@ export function catalogServiceBuilder(
       const descriptors = eservice.descriptors.map((d) =>
         d.state === descriptorState.archived
           ? d
-          : updateDescriptorState(
-              { ...d, archivingSchedule: undefined },
-              descriptorState.archived
-            )
+          : updateDescriptorState(d, descriptorState.archived)
       );
       const updatedEservice: EService = {
         ...eservice,

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -784,11 +784,8 @@ export function assertEServiceIsInArchiving(eservice: EService): void {
 }
 
 export function assertEServiceIsNotAlreadyArchived(eservice: EService): void {
-  // TODO: Use different logic
-  if (
-    eservice.descriptors.filter((d) => d.state !== descriptorState.archived)
-      .length === 0
-  ) {
+  const latestDescriptor = getLatestDescriptor(eservice);
+  if (latestDescriptor.state === descriptorState.archived) {
     throw eServiceAlreadyArchived(eservice.id);
   }
 }

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -69,6 +69,7 @@ import {
   descriptorAlreadyArchived,
   eserviceInDraftState,
   eserviceNotInArchiving,
+  eServiceAlreadyArchived,
 } from "../model/domain/errors.js";
 import type { ReadModelServiceSQL } from "./readModelServiceTypes.js";
 import {
@@ -779,5 +780,15 @@ export function assertEServiceIsInArchiving(eservice: EService): void {
 
   if (!hasEServiceScopeArchiving || hasDescriptorInWrongState) {
     throw eserviceNotInArchiving(eservice.id);
+  }
+}
+
+export function assertEServiceIsNotAlreadyArchived(eservice: EService): void {
+  // TODO: Use different logic
+  if (
+    eservice.descriptors.filter((d) => d.state !== descriptorState.archived)
+      .length === 0
+  ) {
+    throw eServiceAlreadyArchived(eservice.id);
   }
 }

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -797,3 +797,11 @@ export const maintenanceResetEServicePersonalDataFlagErrorMapper = (
     .with("eServiceNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with("eserviceInDraftState", () => HTTP_STATUS_BAD_REQUEST)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const archiveEServiceErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with("eServiceNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("eServiceAlreadyArchived", () => HTTP_STATUS_CONFLICT)
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -803,5 +803,6 @@ export const archiveEServiceErrorMapper = (
 ): number =>
   match(error.code)
     .with("eServiceNotFound", () => HTTP_STATUS_NOT_FOUND)
+    .with("eserviceWithoutValidDescriptors", () => HTTP_STATUS_BAD_REQUEST)
     .with("eServiceAlreadyArchived", () => HTTP_STATUS_CONFLICT)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/catalog-process/test/api/archiveEService.test.ts
+++ b/packages/catalog-process/test/api/archiveEService.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import {
+  EService,
+  EServiceId,
+  generateId,
+  operationForbidden,
+} from "pagopa-interop-models";
+import { authRole } from "pagopa-interop-commons";
+import { generateToken, getMockEService } from "pagopa-interop-commons-test";
+import { api, catalogService } from "../vitest.api.setup.js";
+import {
+  eServiceNotFound,
+  eServiceAlreadyArchived,
+} from "../../src/model/domain/errors.js";
+
+describe("API /internal/eservices/{eServiceId}/archive authorization test", () => {
+  const mockEService: EService = {
+    ...getMockEService(),
+    descriptors: [],
+  };
+
+  catalogService.archiveEService = vi.fn().mockResolvedValue({});
+
+  const makeRequest = async (token: string, eServiceId: EServiceId) =>
+    request(api)
+      .post(`/internal/eservices/${eServiceId}/archive`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send();
+
+  it("Should return 204 for user with role internal", async () => {
+    const token = generateToken(authRole.INTERNAL_ROLE);
+    const res = await makeRequest(token, mockEService.id);
+
+    expect(res.status).toBe(204);
+  });
+
+  it.each(
+    Object.values(authRole).filter((role) => role !== authRole.INTERNAL_ROLE)
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, mockEService.id);
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {
+      error: operationForbidden,
+      expectedStatus: 403,
+    },
+    {
+      error: eServiceNotFound(mockEService.id),
+      expectedStatus: 404,
+    },
+    {
+      error: eServiceAlreadyArchived(mockEService.id),
+      expectedStatus: 409,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      catalogService.archiveEService = vi.fn().mockRejectedValue(error);
+
+      const token = generateToken(authRole.INTERNAL_ROLE);
+      const res = await makeRequest(token, mockEService.id);
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+
+  it("Should return 400 if passed invalid eserviceId", async () => {
+    const token = generateToken(authRole.INTERNAL_ROLE);
+    const res = await makeRequest(token, "eServiceId" as EServiceId);
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/catalog-process/test/api/archiveEService.test.ts
+++ b/packages/catalog-process/test/api/archiveEService.test.ts
@@ -72,7 +72,7 @@ describe("API /internal/eservices/{eServiceId}/archive authorization test", () =
 
   it("Should return 400 if passed invalid eserviceId", async () => {
     const token = generateToken(authRole.INTERNAL_ROLE);
-    const res = await makeRequest(token, "eServiceId" as EServiceId);
+    const res = await makeRequest(token, "invalidId" as EServiceId);
 
     expect(res.status).toBe(400);
   });

--- a/packages/catalog-process/test/integration/archiveEService.test.ts
+++ b/packages/catalog-process/test/integration/archiveEService.test.ts
@@ -109,28 +109,28 @@ describe("archiveEService", () => {
   )(
     "should write on event-store for the archiving of an EService with %i descriptor(s) in state %s and %i already archived descriptor(s)",
     async (countToArchive, state, alreadyArchivedCount) => {
-      const descriptorsToArchive: Descriptor[] = Array.from(
-        { length: countToArchive },
-        (_, idx) => ({
-          ...getMockDescriptor(),
-          interface: getMockDocument(),
-          version: (idx + 1).toString(),
-          state,
-        })
-      );
-
       const archivedDescriptors: Descriptor[] = Array.from(
         { length: alreadyArchivedCount },
         (_, idx) => ({
           ...getMockDescriptor(),
           interface: getMockDocument(),
-          version: (countToArchive + idx + 1).toString(),
+          version: (idx + 1).toString(),
           state: descriptorState.archived,
           archivedAt: new Date(new Date().getTime() - 30 * 24 * 60 * 60 * 1000),
         })
       );
 
-      const allDescriptors = [...descriptorsToArchive, ...archivedDescriptors];
+      const descriptorsToArchive: Descriptor[] = Array.from(
+        { length: countToArchive },
+        (_, idx) => ({
+          ...getMockDescriptor(),
+          interface: getMockDocument(),
+          version: (alreadyArchivedCount + idx + 1).toString(),
+          state,
+        })
+      );
+
+      const allDescriptors = [...archivedDescriptors, ...descriptorsToArchive];
 
       const eservice: EService = {
         ...mockEService,
@@ -159,14 +159,17 @@ describe("archiveEService", () => {
       });
 
       const expectedDescriptors = [
+        ...archivedDescriptors,
         ...descriptorsToArchive.map((descriptor, idx) => ({
           ...descriptor,
           state: descriptorState.archived,
           archivedAt: new Date(
-            Number(writtenPayload.eservice!.descriptors[idx]!.archivedAt)
+            Number(
+              writtenPayload.eservice!.descriptors[idx + alreadyArchivedCount]!
+                .archivedAt
+            )
           ),
         })),
-        ...archivedDescriptors,
       ];
 
       const expectedEService = toEServiceV2({
@@ -178,7 +181,7 @@ describe("archiveEService", () => {
     }
   );
 
-  it.each([0, 1, 2, 5])(
+  it.each([1, 2, 5])(
     "should throw eServiceAlreadyArchived if the eservice has %i descriptors, all in state archived",
     async (count) => {
       const descriptors: Descriptor[] = Array.from(

--- a/packages/catalog-process/test/integration/archiveEService.test.ts
+++ b/packages/catalog-process/test/integration/archiveEService.test.ts
@@ -26,7 +26,7 @@ import {
   readLastEserviceEvent,
 } from "../integrationUtils.js";
 
-describe("archive eservice", () => {
+describe("archiveEService", () => {
   const mockEService = getMockEService();
 
   const invalidStates = [
@@ -40,7 +40,7 @@ describe("archive eservice", () => {
 
   it.each(
     validStates.flatMap((state) =>
-      [1, 2, 3, 4, 5].map((count) => [count, state] as const)
+      [1, 2, 5].map((count) => [count, state] as const)
     )
   )(
     "should write on event-store for the archiving of an EService with %i descriptor(s) in state %s",

--- a/packages/catalog-process/test/integration/archiveEService.test.ts
+++ b/packages/catalog-process/test/integration/archiveEService.test.ts
@@ -97,6 +97,87 @@ describe("archiveEService", () => {
     }
   );
 
+  it.each(
+    validStates.flatMap((state) =>
+      [1, 2, 5].flatMap((countToArchive) =>
+        [1, 3].map(
+          (alreadyArchivedCount) =>
+            [countToArchive, state, alreadyArchivedCount] as const
+        )
+      )
+    )
+  )(
+    "should write on event-store for the archiving of an EService with %i descriptor(s) in state %s and %i already archived descriptor(s)",
+    async (countToArchive, state, alreadyArchivedCount) => {
+      const descriptorsToArchive: Descriptor[] = Array.from(
+        { length: countToArchive },
+        (_, idx) => ({
+          ...getMockDescriptor(),
+          interface: getMockDocument(),
+          version: (idx + 1).toString(),
+          state,
+        })
+      );
+
+      const archivedDescriptors: Descriptor[] = Array.from(
+        { length: alreadyArchivedCount },
+        (_, idx) => ({
+          ...getMockDescriptor(),
+          interface: getMockDocument(),
+          version: (countToArchive + idx + 1).toString(),
+          state: descriptorState.archived,
+          archivedAt: new Date(new Date().getTime() - 30 * 24 * 60 * 60 * 1000),
+        })
+      );
+
+      const allDescriptors = [...descriptorsToArchive, ...archivedDescriptors];
+
+      const eservice: EService = {
+        ...mockEService,
+        descriptors: allDescriptors,
+      };
+
+      await addOneEService(eservice);
+
+      await catalogService.archiveEService(
+        eservice.id,
+        getMockContextInternal({})
+      );
+
+      const writtenEvent = await readLastEserviceEvent(eservice.id);
+
+      expect(writtenEvent).toMatchObject({
+        stream_id: eservice.id,
+        version: "1",
+        type: "EServiceArchivingCompleted",
+        event_version: 2,
+      });
+
+      const writtenPayload = decodeProtobufPayload({
+        messageType: EServiceArchivingCompletedV2,
+        payload: writtenEvent.data,
+      });
+
+      const expectedDescriptors = [
+        ...descriptorsToArchive.map((descriptor, idx) => ({
+          ...descriptor,
+          state: descriptorState.archived,
+          archivedAt: new Date(
+            Number(writtenPayload.eservice!.descriptors[idx]!.archivedAt)
+          ),
+        })),
+        ...archivedDescriptors,
+      ];
+
+      const expectedEService = toEServiceV2({
+        ...eservice,
+        descriptors: expectedDescriptors,
+      });
+
+      expect(writtenPayload.eservice).toEqual(expectedEService);
+    }
+  );
+
   it.each([0, 1, 2, 5])(
     "should throw eServiceAlreadyArchived if the eservice has %i descriptors, all in state archived",
     async (count) => {

--- a/packages/catalog-process/test/integration/archiveEservice.test.ts
+++ b/packages/catalog-process/test/integration/archiveEservice.test.ts
@@ -1,0 +1,133 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import {
+  decodeProtobufPayload,
+  getMockContextInternal,
+  getMockEService,
+  getMockDescriptor,
+  getMockDocument,
+} from "pagopa-interop-commons-test";
+import {
+  Descriptor,
+  DescriptorState,
+  descriptorState,
+  EService,
+  EServiceArchivingCompletedV2,
+  toEServiceV2,
+} from "pagopa-interop-models";
+import { expect, describe, it } from "vitest";
+import {
+  eServiceAlreadyArchived,
+  eServiceNotFound,
+} from "../../src/model/domain/errors.js";
+import {
+  addOneEService,
+  catalogService,
+  readLastEserviceEvent,
+} from "../integrationUtils.js";
+
+describe("archive eservice", () => {
+  const mockEService = getMockEService();
+
+  const invalidStates = [
+    descriptorState.archived,
+    descriptorState.draft,
+    descriptorState.waitingForApproval,
+  ] as DescriptorState[];
+  const validStates = Object.values(descriptorState).filter(
+    (s) => !invalidStates.includes(s)
+  );
+
+  it.each(
+    validStates.flatMap((state) =>
+      [1, 2, 3, 4, 5].map((count) => [count, state] as const)
+    )
+  )(
+    "should write on event-store for the archiving of an EService with %i descriptor(s) in state %s",
+    async (count, state) => {
+      const descriptors: Descriptor[] = Array.from(
+        { length: count },
+        (_, idx) => ({
+          ...getMockDescriptor(),
+          interface: getMockDocument(),
+          version: (idx + 1).toString(),
+          state,
+        })
+      );
+      const eservice: EService = {
+        ...mockEService,
+        descriptors,
+      };
+      await addOneEService(eservice);
+      await catalogService.archiveEService(
+        eservice.id,
+        getMockContextInternal({})
+      );
+
+      const writtenEvent = await readLastEserviceEvent(eservice.id);
+      expect(writtenEvent).toMatchObject({
+        stream_id: eservice.id,
+        version: "1",
+        type: "EServiceArchivingCompleted",
+        event_version: 2,
+      });
+
+      const writtenPayload = decodeProtobufPayload({
+        messageType: EServiceArchivingCompletedV2,
+        payload: writtenEvent.data,
+      });
+
+      const expectedDescriptors = descriptors.map((descriptor, idx) => {
+        const expectedDescriptor = {
+          ...descriptor,
+          state: descriptorState.archived,
+          archivedAt: new Date(
+            Number(writtenPayload.eservice!.descriptors[idx]!.archivedAt)
+          ),
+        };
+
+        return expectedDescriptor;
+      });
+
+      const expectedEService = toEServiceV2({
+        ...eservice,
+        descriptors: expectedDescriptors,
+      });
+      expect(writtenPayload.eservice).toEqual(expectedEService);
+    }
+  );
+
+  it.each([0, 1, 2, 5])(
+    "should throw eServiceAlreadyArchived if the eservice has %i descriptors, all in state archived",
+    async (count) => {
+      const descriptors: Descriptor[] = Array.from(
+        { length: count },
+        (_, idx) => ({
+          ...getMockDescriptor(),
+          interface: getMockDocument(),
+          version: (idx + 1).toString(),
+          state: descriptorState.archived,
+        })
+      );
+      const eservice: EService = {
+        ...mockEService,
+        descriptors,
+      };
+      await addOneEService(eservice);
+      expect(
+        catalogService.archiveEService(eservice.id, getMockContextInternal({}))
+      ).rejects.toThrowError(eServiceAlreadyArchived(eservice.id));
+    }
+  );
+
+  it("should throw eServiceNotFound if the eservice doesn't exist", async () => {
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [],
+    };
+
+    expect(
+      catalogService.archiveEService(eservice.id, getMockContextInternal({}))
+    ).rejects.toThrowError(eServiceNotFound(eservice.id));
+  });
+});


### PR DESCRIPTION
## Issue
- [PIN-10050](https://pagopa.atlassian.net/browse/PIN-10050)
- [SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2803302507/DRAFT+SRS+Archiviazione+manuale+e-service)

## Context

This PR introduces a new internal endpoint for archiving an E-Service as a whole.

The only check for the endpoint logic is to check if the E-Service is already archived. The reason behind this check alone is because the actual checks should be implemented by the caller (seeing as this is an internal endpoint), but while still allowing idempotency so that the same E-Service can be passed more than once, but the event will be produced only once.

## Scope
- `catalog-process`

## Traceability Checklist
- [X] Branch contains Jira key
- [X] PR title compliant (type(scope): description (KEY))
- [X] Service labels applied


[PIN-10050]: https://pagopa.atlassian.net/browse/PIN-10050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ