### PR TITLE
chore: rename unexpectedClientAssertion error (PIN-10064)

### DIFF
--- a/packages/client-assertion-validation/src/errors.ts
+++ b/packages/client-assertion-validation/src/errors.ts
@@ -7,7 +7,7 @@ export const errorCodes = {
   invalidAudience: "0004",
   audienceNotFound: "0005",
   invalidClientAssertionFormat: "0006",
-  unexpectedClientAssertionPayload: "0007",
+  unexpectedClientAssertion: "0007",
   jtiNotFound: "0008",
   issuedAtNotFound: "0009",
   expNotFound: "0010",
@@ -104,12 +104,12 @@ export function invalidClientAssertionFormat(
   });
 }
 
-export function unexpectedClientAssertionPayload(
+export function unexpectedClientAssertion(
   message: string
 ): ApiError<ErrorCodes> {
   return new ApiError({
     detail: `Unexpected client assertion payload: ${message}`,
-    code: "unexpectedClientAssertionPayload",
+    code: "unexpectedClientAssertion",
     title: "Invalid client assertion payload",
   });
 }

--- a/packages/client-assertion-validation/src/validation.ts
+++ b/packages/client-assertion-validation/src/validation.ts
@@ -50,7 +50,7 @@ import {
   notBeforeError,
   purposeIdNotProvided,
   tokenExpiredError,
-  unexpectedClientAssertionPayload,
+  unexpectedClientAssertion,
   invalidSignature,
   clientAssertionInvalidClaims,
   algorithmNotAllowed,
@@ -232,7 +232,7 @@ export const verifyClientAssertion = (
       return failedValidation([invalidClientAssertionFormat(error.message)]);
     }
     const message = error instanceof Error ? error.message : "generic error";
-    return failedValidation([unexpectedClientAssertionPayload(message)]);
+    return failedValidation([unexpectedClientAssertion(message)]);
   }
 };
 

--- a/packages/client-assertion-validation/test/validation.test.ts
+++ b/packages/client-assertion-validation/test/validation.test.ts
@@ -324,7 +324,7 @@ describe("validation test", async () => {
       expect(errors![0]).toEqual(invalidAudience(aud));
     });
 
-    it("unexpectedClientAssertionPayload", async () => {
+    it("unexpectedClientAssertion", async () => {
       const { keySet } = generateKeySet();
       const options: jsonwebtoken.SignOptions = {
         header: {


### PR DESCRIPTION
## Issue
[PIN-10064](https://pagopa.atlassian.net/browse/PIN-10064)

## Summary
- Rename the error `unexpectedClientAssertionPayload` to `unexpectedClientAssertion` in the client-assertion-validation package.


[PIN-10064]: https://pagopa.atlassian.net/browse/PIN-10064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ