### PR TITLE
feature: e-service archiving: work item 14: M2M events and events preservation (PIN-9916)

### DIFF
--- a/packages/events-signer/src/handlers/handleCatalogMessageV2.ts
+++ b/packages/events-signer/src/handlers/handleCatalogMessageV2.ts
@@ -75,6 +75,31 @@ export const handleCatalogMessageV2 = async (
       .with(
         {
           type: P.union(
+            "EServiceArchivingScheduled",
+            "EServiceArchivingCanceled",
+            "EServiceArchivingCompleted"
+          ),
+        },
+        (event) => {
+          if (!event.data.eservice?.id) {
+            throw missingKafkaMessageDataError("eserviceId", event.type);
+          }
+          const eservice = fromEServiceV2(event.data.eservice);
+          const eserviceEntries = eservice.descriptors.map((descriptor) => ({
+            event_name: event.type,
+            id: eservice.id,
+            descriptor_id: descriptor.id,
+            state: descriptor.state,
+            eventTimestamp: timestamp,
+            correlationId,
+          }));
+
+          allCatalogDataToStore.push(...eserviceEntries);
+        }
+      )
+      .with(
+        {
+          type: P.union(
             "EServiceAdded",
             "DraftEServiceUpdated",
             "EServiceDeleted",
@@ -115,9 +140,6 @@ export const handleCatalogMessageV2 = async (
             "EServicePersonalDataFlagUpdatedAfterPublication",
             "EServicePersonalDataFlagUpdatedByTemplateUpdate",
             "EServiceInstanceLabelUpdated",
-            "EServiceArchivingScheduled",
-            "EServiceArchivingCanceled",
-            "EServiceArchivingCompleted",
             "MaintenanceEServicePersonalDataFlagReset"
           ),
         },

--- a/packages/events-signer/test/handlers/handleCatalogMessageV2.test.ts
+++ b/packages/events-signer/test/handlers/handleCatalogMessageV2.test.ts
@@ -10,6 +10,9 @@ import {
   EServiceDescriptorActivatedV2,
   EServiceAddedV2,
   toEServiceV2,
+  EServiceArchivingScheduledV2,
+  EServiceArchivingCompletedV2,
+  EServiceArchivingCanceledV2,
 } from "pagopa-interop-models";
 import {
   FileManager,
@@ -122,6 +125,80 @@ describe("handleCatalogMessageV2 - Integration Test", () => {
       path: "path/to",
     });
   });
+
+  it.each([
+    "EServiceArchivingScheduled",
+    "EServiceArchivingCanceled",
+    "EServiceArchivingCompleted",
+  ])(
+    "should process an %s event and save all descriptors with archiving state in DynamoDB",
+    async (eventType) => {
+      const descriptor = getMockDescriptorArchiving();
+      const mockEService = getMockEService(undefined, undefined, [descriptor]);
+
+      const message: EServiceEventEnvelopeV2 = {
+        sequence_num: 1,
+        stream_id: mockEService.id,
+        version: 1,
+        event_version: 2,
+        type: eventType as
+          | "EServiceArchivingScheduled"
+          | "EServiceArchivingCanceled"
+          | "EServiceArchivingCompleted",
+        data: {
+          eservice: toEServiceV2({
+            ...mockEService,
+            descriptors: mockEService.descriptors.map((desc) => ({
+              ...desc,
+              state: "Archiving",
+            })),
+          }),
+        } as
+          | EServiceArchivingScheduledV2
+          | EServiceArchivingCanceledV2
+          | EServiceArchivingCompletedV2,
+        log_date: new Date(),
+      };
+
+      const eventsWithTimestamp = [
+        {
+          eserviceV2: message,
+          timestamp: new Date(),
+        },
+      ];
+
+      vi.spyOn(safeStorageService, "createFile").mockResolvedValue({
+        uploadMethod: "POST",
+        uploadUrl: "mock-upload-url",
+        secret: "mock-secret",
+        key: mockSafeStorageId,
+      });
+      vi.spyOn(safeStorageService, "uploadFileContent").mockResolvedValue(
+        undefined
+      );
+
+      await handleCatalogMessageV2(
+        eventsWithTimestamp,
+        fileManager,
+        signatureService,
+        safeStorageService
+      );
+
+      const retrievedReference = await signatureService.readSignatureReference(
+        mockSafeStorageId,
+        genericLogger
+      );
+
+      expect(retrievedReference).toEqual({
+        safeStorageId: mockSafeStorageId,
+        fileKind: "EVENT_JOURNAL",
+        fileName: expect.stringMatching(/.ndjson.gz$/),
+        correlationId: expect.any(String),
+        creationTimestamp: expect.any(Number),
+        path: "path/to",
+      });
+    }
+  );
 
   it("should not process an EServiceAdded event", async () => {
     const descriptor = getMockDescriptorPublished();

--- a/packages/events-signer/test/handlers/handleCatalogMessageV2.test.ts
+++ b/packages/events-signer/test/handlers/handleCatalogMessageV2.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   buildDynamoDBTables,
   deleteDynamoDBTables,
+  getMockDescriptorArchiving,
   getMockDescriptorPublished,
   getMockEService,
 } from "pagopa-interop-commons-test";


### PR DESCRIPTION
## Issue
[PIN-9916](https://pagopa.atlassian.net/browse/PIN-9916)

## Context
This PR extends the `events-signer` package to intercept and properly decompose global E-Service archiving domain events (`EServiceArchivingScheduled`, `EServiceArchivingCanceled`, and `EServiceArchivingCompleted`). Since global archiving events operate at the service level but structurally affect every underlying active descriptor version, this change expands bulk actions into atomic descriptor entries to ensure absolute data consistency for historical audit logs and legally mandated document preservation.

## Scope
* `packages/events-signer`

### Changes Detail
1. **Message Handler Refactoring:** Isolated global bulk events into a dedicated matching branch in `handleCatalogMessageV2.ts`. Instead of a generic fallback, the handler now safely unpacks the E-Service V2 envelope and generates granular row records for each attached descriptor version.
2. **Fallback Cleanup:** Removed the three bulk events from the broad generic match block to prevent data duplication and schema processing conflicts.
3. **Integration Tests:** Introduced a fully parameterized integration test covering all three bulk archiving event scenarios. It mocks the secure storage integration and ensures that transaction records are flattened, correctly serialized to NDJSON format, compressed, and signed as part of the immutable event journal.

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title compliant (feat(events-signer): handle global eservice archiving events fan-out (PIN-9916))
- [x] Service labels applied

---



[PIN-9916]: https://pagopa.atlassian.net/browse/PIN-9916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ