### PR TITLE
fix: validate client_id format in token generation validation request (PIN-10060)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -25737,6 +25737,7 @@ components:
       properties:
         client_id:
           type: string
+          format: uuid
           example: e58035ce-c753-4f72-b613-46f8a17b71cc
         client_assertion:
           type: string

--- a/packages/backend-for-frontend/test/api/toolRouter/validateTokenGeneration.test.ts
+++ b/packages/backend-for-frontend/test/api/toolRouter/validateTokenGeneration.test.ts
@@ -95,6 +95,7 @@ describe("API POST /tools/validateTokenGeneration", () => {
   it.each([
     { body: {} },
     { body: { client_id: "invalid" } },
+    { body: { ...mockRequest, client_id: "not-a-uuid" } },
     { body: { ...mockRequest, client_assertion: 123 } },
     { body: { ...mockRequest, client_assertion_type: 123 } },
     { body: { ...mockRequest, grant_type: 123 } },


### PR DESCRIPTION
## Issue
- [PIN-10060](https://pagopa.atlassian.net/browse/PIN-10060)

## Context / Why
- The fix has already been applied on the frontend side for parity, the BFF contract is aligned to the same constraint: the `client_id` field in the `/tools/validateTokenGeneration` request must be a valid UUID (RFC 9562, 36 characters).


[PIN-10060]: https://pagopa.atlassian.net/browse/PIN-10060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ