### PR TITLE
fix: return 403 instead of 500 for unauthorized roles on token generation validation (PIN-10083)

### DIFF
--- a/packages/backend-for-frontend/src/routers/toolRouter.ts
+++ b/packages/backend-for-frontend/src/routers/toolRouter.ts
@@ -1,7 +1,9 @@
 import { ZodiosEndpointDefinitions } from "@zodios/core";
 import { ZodiosRouter } from "@zodios/express";
 import {
+  authRole,
   ExpressContext,
+  validateAuthorization,
   ZodiosContext,
   zodiosValidationErrorToApiProblem,
 } from "pagopa-interop-commons";
@@ -22,6 +24,12 @@ const toolRouter = (
     const ctx = fromBffAppContext(req.ctx, req.headers);
 
     try {
+      validateAuthorization(ctx, [
+        authRole.ADMIN_ROLE,
+        authRole.SECURITY_ROLE,
+        authRole.SUPPORT_ROLE,
+      ]);
+
       const result = await toolsService.validateTokenGeneration(
         req.body.client_id,
         req.body.client_assertion,

--- a/packages/backend-for-frontend/test/api/toolRouter/validateTokenGeneration.test.ts
+++ b/packages/backend-for-frontend/test/api/toolRouter/validateTokenGeneration.test.ts
@@ -75,11 +75,20 @@ describe("API POST /tools/validateTokenGeneration", () => {
       .set("X-Correlation-Id", generateId())
       .send(body);
 
-  it("Should return 200 with validation result for valid request", async () => {
-    const token = generateToken(authRole.ADMIN_ROLE);
+  it.each([authRole.ADMIN_ROLE, authRole.SECURITY_ROLE, authRole.SUPPORT_ROLE])(
+    "Should return 200 with validation result for valid request (role %s)",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockResult);
+    }
+  );
+
+  it("Should return 403 for a user role that is not allowed (api)", async () => {
+    const token = generateToken(authRole.API_ROLE);
     const res = await makeRequest(token);
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual(mockResult);
+    expect(res.status).toBe(403);
   });
 
   it("Should return 200 with DPoP validation steps when dpop_proof is provided", async () => {


### PR DESCRIPTION
## Summary
- Add an explicit `validateAuthorization` check at the BFF `POST /tools/validateTokenGeneration` handler.
- Allowed UI roles for this endpoint: `admin`, `security`, `support`. Any other role (e.g. `api`) now receives
 a clean `403` instead of a masked `500` (`008-9991 Unexpected error`).

## Context
The BFF route had no role check, so every UI user reached the service. When `authorization-process` rejected a
 non-admitted role (e.g. `api`) on `GET /clients/:clientId/keys/:keyId/bundle`, the BFF `.catch` rethrew
`cannotGetKeyWithClient`, which is not mapped by `toolsErrorMapper` and falls into 500.
`forceGenericProblemOn500` then masked it as `008-9991 Unexpected error`.

## Issue
[PIN-10083](https://pagopa.atlassian.net/browse/PIN-10083)

[PIN-10083]: https://pagopa.atlassian.net/browse/PIN-10083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ