### PR TITLE
chore: nest asyncExchange override fields under asyncExchangeProperties

### DIFF
--- a/collections/catalog/Edit Eservice Descriptor Template Instance.bru
+++ b/collections/catalog/Edit Eservice Descriptor Template Instance.bru
@@ -31,8 +31,6 @@ body:json {
       "asyncExchangeProperties": {
         "responseTime": 60,
         "resourceAvailableTime": 120,
-        "confirmation": false,
-        "bulk": false,
         "maxResultSet": 100
       }
   }

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -26117,15 +26117,8 @@ components:
           $ref: "#/components/schemas/AgreementApprovalPolicy"
         attributes:
           $ref: "#/components/schemas/DescriptorAttributesSeed"
-        asyncExchangeResponseTime:
-          type: integer
-          format: int32
-        asyncExchangeResourceAvailableTime:
-          type: integer
-          format: int32
-        asyncExchangeMaxResultSet:
-          type: integer
-          format: int32
+        asyncExchangeProperties:
+          $ref: "#/components/schemas/AsyncExchangePropertiesInstanceSeed"
     Mail:
       type: object
       additionalProperties: false
@@ -28574,6 +28567,19 @@ components:
           type: boolean
         bulk:
           type: boolean
+        maxResultSet:
+          type: integer
+          format: int32
+    AsyncExchangePropertiesInstanceSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        responseTime:
+          type: integer
+          format: int32
+        resourceAvailableTime:
+          type: integer
+          format: int32
         maxResultSet:
           type: integer
           format: int32

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -3155,15 +3155,8 @@ components:
           $ref: "#/components/schemas/AgreementApprovalPolicy"
         attributes:
           $ref: "#/components/schemas/AttributesSeed"
-        asyncExchangeResponseTime:
-          type: integer
-          format: int32
-        asyncExchangeResourceAvailableTime:
-          type: integer
-          format: int32
-        asyncExchangeMaxResultSet:
-          type: integer
-          format: int32
+        asyncExchangeProperties:
+          $ref: "#/components/schemas/AsyncExchangePropertiesInstanceSeed"
     UpdateEServiceDescriptorQuotasSeed:
       type: object
       additionalProperties: false
@@ -3844,6 +3837,19 @@ components:
         maxResultSet:
           type: integer
           format: int32
+    AsyncExchangePropertiesInstanceSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        responseTime:
+          type: integer
+          format: int32
+        resourceAvailableTime:
+          type: integer
+          format: int32
+        maxResultSet:
+          type: integer
+          format: int32
     EServiceTechnology:
       type: string
       description: API Technology
@@ -3945,15 +3951,8 @@ components:
           type: string
           minLength: 1
           maxLength: 12
-        asyncExchangeResponseTime:
-          type: integer
-          format: int32
-        asyncExchangeResourceAvailableTime:
-          type: integer
-          format: int32
-        asyncExchangeMaxResultSet:
-          type: integer
-          format: int32
+        asyncExchangeProperties:
+          $ref: "#/components/schemas/AsyncExchangePropertiesInstanceSeed"
     EServiceInstanceLabelUpdateSeed:
       type: object
       additionalProperties: false

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1745,13 +1745,13 @@ export function catalogServiceBuilder(
             ? {
                 ...descriptor.asyncExchangeProperties,
                 responseTime:
-                  seed.asyncExchangeResponseTime ??
+                  seed.asyncExchangeProperties?.responseTime ??
                   descriptor.asyncExchangeProperties.responseTime,
                 resourceAvailableTime:
-                  seed.asyncExchangeResourceAvailableTime ??
+                  seed.asyncExchangeProperties?.resourceAvailableTime ??
                   descriptor.asyncExchangeProperties.resourceAvailableTime,
                 maxResultSet:
-                  seed.asyncExchangeMaxResultSet ??
+                  seed.asyncExchangeProperties?.maxResultSet ??
                   descriptor.asyncExchangeProperties.maxResultSet,
               }
             : descriptor.asyncExchangeProperties,
@@ -3626,14 +3626,14 @@ export function catalogServiceBuilder(
                 ? {
                     ...publishedVersion.asyncExchangeProperties,
                     responseTime:
-                      seed.asyncExchangeResponseTime ??
+                      seed.asyncExchangeProperties?.responseTime ??
                       publishedVersion.asyncExchangeProperties.responseTime,
                     resourceAvailableTime:
-                      seed.asyncExchangeResourceAvailableTime ??
+                      seed.asyncExchangeProperties?.resourceAvailableTime ??
                       publishedVersion.asyncExchangeProperties
                         .resourceAvailableTime,
                     maxResultSet:
-                      seed.asyncExchangeMaxResultSet ??
+                      seed.asyncExchangeProperties?.maxResultSet ??
                       publishedVersion.asyncExchangeProperties.maxResultSet,
                   }
                 : undefined,

--- a/packages/catalog-process/test/integration/createEServiceInstanceFromTemplate.test.ts
+++ b/packages/catalog-process/test/integration/createEServiceInstanceFromTemplate.test.ts
@@ -1090,9 +1090,11 @@ describe("create eService from template", () => {
     const eService = await catalogService.createEServiceInstanceFromTemplate(
       eServiceTemplate.id,
       {
-        asyncExchangeResponseTime: 1800,
-        asyncExchangeResourceAvailableTime: 3600,
-        asyncExchangeMaxResultSet: 500,
+        asyncExchangeProperties: {
+          responseTime: 1800,
+          resourceAvailableTime: 3600,
+          maxResultSet: 500,
+        },
       },
       getMockContext({ authData: getMockAuthData(mockEService.producerId) })
     );
@@ -1152,7 +1154,7 @@ describe("create eService from template", () => {
 
     const eService = await catalogService.createEServiceInstanceFromTemplate(
       eServiceTemplate.id,
-      { asyncExchangeResponseTime: 900 },
+      { asyncExchangeProperties: { responseTime: 900 } },
       getMockContext({ authData: getMockAuthData(mockEService.producerId) })
     );
 
@@ -1214,9 +1216,11 @@ describe("create eService from template", () => {
     const eService = await catalogService.createEServiceInstanceFromTemplate(
       eServiceTemplate.id,
       {
-        asyncExchangeResponseTime: 900,
-        asyncExchangeResourceAvailableTime: 1800,
-        asyncExchangeMaxResultSet: 500,
+        asyncExchangeProperties: {
+          responseTime: 900,
+          resourceAvailableTime: 1800,
+          maxResultSet: 500,
+        },
       },
       getMockContext({ authData: getMockAuthData(mockEService.producerId) })
     );

--- a/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
@@ -429,9 +429,11 @@ describe("update draft descriptor instance", () => {
     const expectedDescriptorSeed: catalogApi.UpdateEServiceDescriptorTemplateInstanceSeed =
       {
         ...buildUpdateDescriptorSeed(descriptor),
-        asyncExchangeResponseTime: 1800,
-        asyncExchangeResourceAvailableTime: 3600,
-        asyncExchangeMaxResultSet: 500,
+        asyncExchangeProperties: {
+          responseTime: 1800,
+          resourceAvailableTime: 3600,
+          maxResultSet: 500,
+        },
       };
 
     await catalogService.updateDraftDescriptorTemplateInstance(
@@ -508,9 +510,11 @@ describe("update draft descriptor instance", () => {
     const expectedDescriptorSeed: catalogApi.UpdateEServiceDescriptorTemplateInstanceSeed =
       {
         ...buildUpdateDescriptorSeed(descriptor),
-        asyncExchangeResponseTime: 1800,
-        asyncExchangeResourceAvailableTime: 3600,
-        asyncExchangeMaxResultSet: 500,
+        asyncExchangeProperties: {
+          responseTime: 1800,
+          resourceAvailableTime: 3600,
+          maxResultSet: 500,
+        },
       };
 
     await catalogService.updateDraftDescriptorTemplateInstance(


### PR DESCRIPTION
## Context
  Follow-up to #3172  and [PIN-9415](https://pagopa.atlassian.net/browse/PIN-9415), addressing [this](https://github.com/pagopa/interop-be-monorepo/pull/3172#discussion_r3241326316) review feedback on
   the API shape introduced there.
   
  ## Summary
  - Replaced the three flat fields `asyncExchangeResponseTime`, `asyncExchangeResourceAvailableTime`,
  `asyncExchangeMaxResultSet` with a nested `asyncExchangeProperties` sub-object in
  `UpdateEServiceDescriptorTemplateInstanceSeed` (catalog + BFF) and `InstanceEServiceSeed` (catalog).
  - Introduced a new `AsyncExchangePropertiesInstanceSeed` schema in both `catalogApi.yml` and `bffApi.yml`,
  exposing only the three fields an instance can override (`confirmation` and `bulk` remain template-driven).
  - Aligns these seeds with the conventions used elsewhere in the spec (e.g. `attributes` → `AttributesSeed`,
  `agreementApprovalPolicy` → `AgreementApprovalPolicy`) and removes the inconsistency of having both nested and
   flat fields inside the same schema.

[PIN-9415]: https://pagopa.atlassian.net/browse/PIN-9415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ