### PR TITLE
PIN-9555: add openapiVersionNotRecognized error handling in error mapper

### DIFF
--- a/packages/backend-for-frontend/src/utilities/errorMappers.ts
+++ b/packages/backend-for-frontend/src/utilities/errorMappers.ts
@@ -172,6 +172,7 @@ export const createEServiceDocumentErrorMapper = (
       "invalidContentTypeDetected",
       "invalidEserviceInterfaceFileDetected",
       "invalidServerUrl",
+      "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -185,6 +186,7 @@ export const createEServiceTemplateDocumentErrorMapper = (
       "invalidContentTypeDetected",
       "invalidEserviceInterfaceFileDetected",
       "invalidServerUrl",
+      "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -257,6 +259,7 @@ export const addEServiceInterfaceByTemplateErrorMapper = (
       "invalidContentTypeDetected",
       "eserviceTemplateInterfaceDataNotValid",
       "invalidInterfaceFile",
+      "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .with("invalidEserviceRequester", () => HTTP_STATUS_FORBIDDEN)

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -621,6 +621,7 @@ export const addEServiceTemplateInstanceInterfaceErrorMapper = (
       "invalidContentTypeDetected",
       "documentPrettyNameDuplicate",
       "notValidDescriptor",
+      "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .with(

--- a/packages/m2m-gateway-v3/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway-v3/src/utils/errorMappers.ts
@@ -178,6 +178,7 @@ export const uploadEServiceDescriptorInterfaceErrorMapper = (
       "invalidContentTypeDetected",
       "invalidEserviceInterfaceFileDetected",
       "invalidServerUrl",
+      "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/m2m-gateway/src/utils/errorMappers.ts
+++ b/packages/m2m-gateway/src/utils/errorMappers.ts
@@ -156,6 +156,7 @@ export const uploadEServiceDescriptorInterfaceErrorMapper = (
       "invalidContentTypeDetected",
       "invalidEserviceInterfaceFileDetected",
       "invalidServerUrl",
+      "openapiVersionNotRecognized",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
[PIN-9555](https://pagopa.atlassian.net/browse/PIN-9555)
This pull request updates error handling across multiple services to recognize and handle a new error type, `openapiVersionNotRecognized`, by mapping it to a `400 Bad Request` HTTP status. This ensures that when an unrecognized OpenAPI version is encountered, clients receive a clear and consistent response.

Error mapping improvements:

* Added support for the `openapiVersionNotRecognized` error in the following error mappers, mapping it to `HTTP_STATUS_BAD_REQUEST`:
  * `createEServiceDocumentErrorMapper` in `backend-for-frontend/src/utilities/errorMappers.ts`
  * `createEServiceTemplateDocumentErrorMapper` in `backend-for-frontend/src/utilities/errorMappers.ts`
  * `addEServiceInterfaceByTemplateErrorMapper` in `backend-for-frontend/src/utilities/errorMappers.ts`
  * `addEServiceTemplateInstanceInterfaceErrorMapper` in `catalog-process/src/utilities/errorMappers.ts`
  * `uploadEServiceDescriptorInterfaceErrorMapper` in `m2m-gateway-v3/src/utils/errorMappers.ts`
  * `uploadEServiceDescriptorInterfaceErrorMapper` in `m2m-gateway/src/utils/errorMappers.ts`

[PIN-9555]: https://pagopa.atlassian.net/browse/PIN-9555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ