### PR TITLE
feature: add catalog descriptor keychain flags (PIN-10099)

### DIFF
--- a/packages/api-clients/open-api/authorizationApi.yml
+++ b/packages/api-clients/open-api/authorizationApi.yml
@@ -1252,6 +1252,49 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /producerKeychains/eservices/{eserviceId}/flags:
+    parameters:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+    get:
+      tags:
+        - producerKeychain
+      summary: Get producer keychain flags for an eservice
+      description: Get producer keychain flags for an eservice
+      operationId: getProducerKeychainEServiceFlags
+      parameters:
+        - name: eserviceId
+          in: path
+          description: E-Service identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: producerId
+          in: query
+          description: E-Service producer identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Producer keychain flags found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProducerKeychainEServiceFlags"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /producerKeychains/{producerKeychainId}:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"
@@ -2394,6 +2437,17 @@ components:
       required:
         - results
         - totalCount
+    ProducerKeychainEServiceFlags:
+      type: object
+      additionalProperties: false
+      properties:
+        hasProducerKeychain:
+          type: boolean
+        hasProducerKeychainKeys:
+          type: boolean
+      required:
+        - hasProducerKeychain
+        - hasProducerKeychainKeys
     ProducerKeychainSeed:
       description: Producer keychain creation request body
       type: object

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -26342,6 +26342,8 @@ components:
         - hasCertifiedAttributes
         - isSubscribed
         - agreements
+        - hasProducerKeychain
+        - hasProducerKeychainKeys
       properties:
         id:
           type: string
@@ -26378,6 +26380,10 @@ components:
               - the requester is the delegated consumer for the eservice and
                 the delegator has the certified attributes required to consume the eservice
         isSubscribed:
+          type: boolean
+        hasProducerKeychain:
+          type: boolean
+        hasProducerKeychainKeys:
           type: boolean
         activeDescriptor:
           $ref: "#/components/schemas/CompactDescriptor"

--- a/packages/authorization-process/src/routers/AuthorizationRouter.ts
+++ b/packages/authorization-process/src/routers/AuthorizationRouter.ts
@@ -730,6 +730,44 @@ const authorizationRouter = (
         return res.status(errorRes.status).send(errorRes);
       }
     })
+    .get("/producerKeychains/eservices/:eserviceId/flags", async (req, res) => {
+      const ctx = fromAppContext(req.ctx);
+
+      try {
+        validateAuthorization(ctx, [
+          ADMIN_ROLE,
+          SECURITY_ROLE,
+          API_ROLE,
+          M2M_ROLE,
+          SUPPORT_ROLE,
+          M2M_ADMIN_ROLE,
+        ]);
+
+        const producerKeychainEServiceFlags =
+          await authorizationService.getProducerKeychainEServiceFlags(
+            {
+              eserviceId: unsafeBrandId<EServiceId>(req.params.eserviceId),
+              producerId: unsafeBrandId<TenantId>(req.query.producerId),
+            },
+            ctx
+          );
+
+        return res
+          .status(200)
+          .send(
+            authorizationApi.ProducerKeychainEServiceFlags.parse(
+              producerKeychainEServiceFlags
+            )
+          );
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          getProducerKeychainsErrorMapper,
+          ctx
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
     .get("/producerKeychains/:producerKeychainId", async (req, res) => {
       const ctx = fromAppContext(req.ctx);
 

--- a/packages/authorization-process/src/services/authorizationService.ts
+++ b/packages/authorization-process/src/services/authorizationService.ts
@@ -101,6 +101,7 @@ import {
 } from "../model/domain/apiConverter.js";
 import {
   GetClientsFilters,
+  ProducerKeychainEServiceFlags,
   GetProducerKeychainsFilters,
 } from "./readModelService.js";
 import {
@@ -1095,6 +1096,27 @@ export function authorizationServiceBuilder(
           offset,
           limit,
         }
+      );
+    },
+    async getProducerKeychainEServiceFlags(
+      {
+        producerId,
+        eserviceId,
+      }: {
+        producerId: TenantId;
+        eserviceId: EServiceId;
+      },
+      {
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAuthData | M2MAdminAuthData>>
+    ): Promise<ProducerKeychainEServiceFlags> {
+      logger.info(
+        `Retrieving producer keychain flags for producerId ${producerId} and eserviceId ${eserviceId}`
+      );
+
+      return await readModelService.getProducerKeychainEServiceFlags(
+        producerId,
+        eserviceId
       );
     },
     async getProducerKeychainById(

--- a/packages/authorization-process/src/services/readModelService.ts
+++ b/packages/authorization-process/src/services/readModelService.ts
@@ -20,3 +20,8 @@ export type GetProducerKeychainsFilters = {
   producerId: TenantId | undefined;
   eserviceId: EServiceId | undefined;
 };
+
+export type ProducerKeychainEServiceFlags = {
+  hasProducerKeychain: boolean;
+  hasProducerKeychainKeys: boolean;
+};

--- a/packages/authorization-process/src/services/readModelServiceSQL.ts
+++ b/packages/authorization-process/src/services/readModelServiceSQL.ts
@@ -80,7 +80,7 @@ export type GetProducerKeychainsFilters = {
   eserviceId: EServiceId | undefined;
 };
 
-export type ProducerKeychainEServiceFlags = {
+type ProducerKeychainEServiceFlags = {
   hasProducerKeychain: boolean;
   hasProducerKeychainKeys: boolean;
 };

--- a/packages/authorization-process/src/services/readModelServiceSQL.ts
+++ b/packages/authorization-process/src/services/readModelServiceSQL.ts
@@ -80,6 +80,11 @@ export type GetProducerKeychainsFilters = {
   eserviceId: EServiceId | undefined;
 };
 
+export type ProducerKeychainEServiceFlags = {
+  hasProducerKeychain: boolean;
+  hasProducerKeychainKeys: boolean;
+};
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function readModelServiceBuilderSQL({
   readModelDB,
@@ -410,6 +415,74 @@ export function readModelServiceBuilderSQL({
           toProducerKeychainAggregatorArray(queryResult)
         ).map((p) => p.data),
         totalCount: queryResult[0]?.totalCount ?? 0,
+      };
+    },
+    async getProducerKeychainEServiceFlags(
+      producerId: TenantId,
+      eserviceId: EServiceId
+    ): Promise<ProducerKeychainEServiceFlags> {
+      const producerKeychain = await readModelDB
+        .select({
+          id: producerKeychainInReadmodelProducerKeychain.id,
+        })
+        .from(producerKeychainEserviceInReadmodelProducerKeychain)
+        .innerJoin(
+          producerKeychainInReadmodelProducerKeychain,
+          eq(
+            producerKeychainEserviceInReadmodelProducerKeychain.producerKeychainId,
+            producerKeychainInReadmodelProducerKeychain.id
+          )
+        )
+        .where(
+          and(
+            eq(
+              producerKeychainInReadmodelProducerKeychain.producerId,
+              producerId
+            ),
+            eq(
+              producerKeychainEserviceInReadmodelProducerKeychain.eserviceId,
+              eserviceId
+            )
+          )
+        )
+        .limit(1);
+
+      const producerKeychainWithKeys = await readModelDB
+        .select({
+          id: producerKeychainInReadmodelProducerKeychain.id,
+        })
+        .from(producerKeychainEserviceInReadmodelProducerKeychain)
+        .innerJoin(
+          producerKeychainInReadmodelProducerKeychain,
+          eq(
+            producerKeychainEserviceInReadmodelProducerKeychain.producerKeychainId,
+            producerKeychainInReadmodelProducerKeychain.id
+          )
+        )
+        .innerJoin(
+          producerKeychainKeyInReadmodelProducerKeychain,
+          eq(
+            producerKeychainInReadmodelProducerKeychain.id,
+            producerKeychainKeyInReadmodelProducerKeychain.producerKeychainId
+          )
+        )
+        .where(
+          and(
+            eq(
+              producerKeychainInReadmodelProducerKeychain.producerId,
+              producerId
+            ),
+            eq(
+              producerKeychainEserviceInReadmodelProducerKeychain.eserviceId,
+              eserviceId
+            )
+          )
+        )
+        .limit(1);
+
+      return {
+        hasProducerKeychain: producerKeychain.length > 0,
+        hasProducerKeychainKeys: producerKeychainWithKeys.length > 0,
       };
     },
     async getProducerKeychainById(

--- a/packages/authorization-process/test/api/getProducerKeychainEServiceFlags.test.ts
+++ b/packages/authorization-process/test/api/getProducerKeychainEServiceFlags.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import { EServiceId, TenantId, generateId } from "pagopa-interop-models";
+import { generateToken } from "pagopa-interop-commons-test";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { api, authorizationService } from "../vitest.api.setup.js";
+
+describe("API /producerKeychains/eservices/{eserviceId}/flags authorization test", () => {
+  const eserviceId = generateId<EServiceId>();
+  const producerId = generateId<TenantId>();
+  const response = {
+    hasProducerKeychain: true,
+    hasProducerKeychainKeys: true,
+  };
+
+  authorizationService.getProducerKeychainEServiceFlags = vi
+    .fn()
+    .mockResolvedValue(response);
+
+  const makeRequest = async (
+    token: string,
+    query: { producerId?: TenantId | string } = { producerId }
+  ) =>
+    request(api)
+      .get(`/producerKeychains/eservices/${eserviceId}/flags`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .query(query);
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.SECURITY_ROLE,
+    authRole.API_ROLE,
+    authRole.SUPPORT_ROLE,
+    authRole.M2M_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+
+  it.each(authorizedRoles)(
+    "Should return 200 with role %s and return producer keychain eservice flags",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(response);
+      expect(
+        authorizationService.getProducerKeychainEServiceFlags
+      ).toHaveBeenCalledWith(
+        {
+          eserviceId,
+          producerId,
+        },
+        expect.anything()
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([{}, { producerId: "invalid-producer-id" }])(
+    "Should return 400 if passed invalid params: %s",
+    async (query) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, query);
+
+      expect(res.status).toBe(400);
+    }
+  );
+});

--- a/packages/authorization-process/test/integration/getProducerKeychainEServiceFlags.test.ts
+++ b/packages/authorization-process/test/integration/getProducerKeychainEServiceFlags.test.ts
@@ -1,0 +1,85 @@
+import {
+  EServiceId,
+  ProducerKeychain,
+  TenantId,
+  generateId,
+} from "pagopa-interop-models";
+import { describe, expect, it } from "vitest";
+import {
+  getMockAuthData,
+  getMockContext,
+  getMockKey,
+  getMockProducerKeychain,
+} from "pagopa-interop-commons-test";
+import {
+  addOneProducerKeychain,
+  authorizationService,
+} from "../integrationUtils.js";
+
+describe("getProducerKeychainEServiceFlags", async () => {
+  const producerId = generateId<TenantId>();
+  const eserviceId = generateId<EServiceId>();
+  const requesterId = generateId<TenantId>();
+
+  const mockProducerKeychain = (
+    eservices: EServiceId[],
+    keys: ProducerKeychain["keys"] = []
+  ): ProducerKeychain => ({
+    ...getMockProducerKeychain({ producerId }),
+    eservices,
+    keys,
+  });
+
+  it("should return false flags when no producer keychain is linked to the eservice", async () => {
+    await addOneProducerKeychain(mockProducerKeychain([]));
+
+    const result = await authorizationService.getProducerKeychainEServiceFlags(
+      {
+        producerId,
+        eserviceId,
+      },
+      getMockContext({ authData: getMockAuthData(requesterId) })
+    );
+
+    expect(result).toEqual({
+      hasProducerKeychain: false,
+      hasProducerKeychainKeys: false,
+    });
+  });
+
+  it("should distinguish a linked producer keychain without keys", async () => {
+    await addOneProducerKeychain(mockProducerKeychain([eserviceId]));
+
+    const result = await authorizationService.getProducerKeychainEServiceFlags(
+      {
+        producerId,
+        eserviceId,
+      },
+      getMockContext({ authData: getMockAuthData(requesterId) })
+    );
+
+    expect(result).toEqual({
+      hasProducerKeychain: true,
+      hasProducerKeychainKeys: false,
+    });
+  });
+
+  it("should return true flags when a linked producer keychain has keys", async () => {
+    await addOneProducerKeychain(
+      mockProducerKeychain([eserviceId], [getMockKey()])
+    );
+
+    const result = await authorizationService.getProducerKeychainEServiceFlags(
+      {
+        producerId,
+        eserviceId,
+      },
+      getMockContext({ authData: getMockAuthData(requesterId) })
+    );
+
+    expect(result).toEqual({
+      hasProducerKeychain: true,
+      hasProducerKeychainKeys: true,
+    });
+  });
+});

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -101,7 +101,9 @@ export async function toBffCatalogDescriptorEService(
   producerTenant: tenantApi.Tenant,
   agreements: agreementApi.Agreement[],
   requesterTenant: tenantApi.Tenant,
-  consumerDelegators: tenantApi.Tenant[]
+  consumerDelegators: tenantApi.Tenant[],
+  hasProducerKeychain: boolean,
+  hasProducerKeychainKeys: boolean
 ): Promise<bffApi.CatalogDescriptorEService> {
   const activeDescriptor = getLatestActiveDescriptor(eservice);
   return {
@@ -142,6 +144,8 @@ export async function toBffCatalogDescriptorEService(
     isClientAccessDelegable: eservice.isClientAccessDelegable,
     personalData: eservice.personalData,
     asyncExchange: eservice.asyncExchange,
+    hasProducerKeychain,
+    hasProducerKeychainKeys,
   };
 }
 

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -9,8 +9,6 @@ import {
 } from "pagopa-interop-api-clients";
 import {
   Descriptor,
-  descriptorState,
-  DescriptorState,
   EServiceAttribute,
   Technology,
   technology,
@@ -149,7 +147,7 @@ export async function toBffCatalogDescriptorEService(
   };
 }
 
-export function toBffCatalogApiDescriptorAttribute(
+function toBffCatalogApiDescriptorAttribute(
   attributes: attributeRegistryApi.Attribute[],
   attribute: catalogApi.Attribute
 ): bffApi.DescriptorAttribute {
@@ -326,7 +324,7 @@ export async function enhanceEServiceRiskAnalysisArray(
   );
 }
 
-export function toEserviceAttribute(
+function toEserviceAttribute(
   attributes: catalogApi.Attribute[]
 ): EServiceAttribute[] {
   return attributes.map((attribute) => ({
@@ -469,18 +467,5 @@ export function apiTechnologyToTechnology(
   return match<catalogApi.EServiceTechnology, Technology>(input)
     .with("REST", () => technology.rest)
     .with("SOAP", () => technology.soap)
-    .exhaustive();
-}
-
-export function apiDescriptorStateToDescriptorState(
-  input: catalogApi.EServiceDescriptorState
-): DescriptorState {
-  return match<catalogApi.EServiceDescriptorState, DescriptorState>(input)
-    .with("DRAFT", () => descriptorState.draft)
-    .with("PUBLISHED", () => descriptorState.published)
-    .with("SUSPENDED", () => descriptorState.suspended)
-    .with("DEPRECATED", () => descriptorState.deprecated)
-    .with("ARCHIVED", () => descriptorState.archived)
-    .with("WAITING_FOR_APPROVAL", () => descriptorState.waitingForApproval)
     .exhaustive();
 }

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -320,6 +320,17 @@ const getAllProducerKeychainsByEService = async (
     })
   );
 
+const getProducerKeychainFlags = (
+  producerKeychains: authorizationApi.ProducerKeychain[]
+): { hasProducerKeychain: boolean; hasProducerKeychainKeys: boolean } => ({
+  hasProducerKeychain: producerKeychains.length > 0,
+  hasProducerKeychainKeys: producerKeychains.some(
+    (keychain) =>
+      keychain.visibility === authorizationApi.Visibility.Values.FULL &&
+      keychain.keys.length > 0
+  ),
+});
+
 export function catalogServiceBuilder(
   catalogProcessClient: catalogApi.CatalogProcessClient,
   tenantProcessClient: TenantProcessClient,
@@ -419,12 +430,8 @@ export function catalogServiceBuilder(
         ),
       ]);
 
-      const hasProducerKeychain = producerKeychains.length > 0;
-      const hasProducerKeychainKeys = producerKeychains.some(
-        (keychain) =>
-          keychain.visibility === authorizationApi.Visibility.Values.FULL &&
-          keychain.keys.length > 0
-      );
+      const { hasProducerKeychain, hasProducerKeychainKeys } =
+        getProducerKeychainFlags(producerKeychains);
 
       const descriptorAttributes = toBffCatalogApiDescriptorAttributes(
         attributes,
@@ -924,11 +931,18 @@ export function catalogServiceBuilder(
 
       const descriptor = retrieveEserviceDescriptor(eservice, descriptorId);
       const attributeIds = getAttributeIds(descriptor);
-      const attributes = await getAllBulkAttributes(
-        attributeProcessClient,
-        headers,
-        attributeIds
-      );
+      const [attributes, producerKeychains] = await Promise.all([
+        getAllBulkAttributes(attributeProcessClient, headers, attributeIds),
+        getAllProducerKeychainsByEService(
+          authorizationClient,
+          headers,
+          eserviceId,
+          unsafeBrandId<TenantId>(eservice.producerId)
+        ),
+      ]);
+
+      const { hasProducerKeychain, hasProducerKeychainKeys } =
+        getProducerKeychainFlags(producerKeychains);
 
       const descriptorAttributes = toBffCatalogApiDescriptorAttributes(
         attributes,
@@ -1001,7 +1015,9 @@ export function catalogServiceBuilder(
           producerTenant,
           agreements,
           requesterTenant,
-          consumerDelegators
+          consumerDelegators,
+          hasProducerKeychain,
+          hasProducerKeychainKeys
         ),
       };
     },

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -302,34 +302,39 @@ const getAllEserviceConsumers = async (
     })
   );
 
-const getAllProducerKeychainsByEService = async (
+const producerKeychainHasKeys = (
+  keychain: authorizationApi.ProducerKeychain
+): boolean =>
+  keychain.visibility === authorizationApi.Visibility.Values.FULL &&
+  keychain.keys.length > 0;
+
+const getProducerKeychainFlagsByEService = async (
   authorizationClient: AuthorizationProcessClient,
   headers: Headers,
   eServiceId: EServiceId,
   producerId: TenantId
-): Promise<authorizationApi.ProducerKeychain[]> =>
-  await getAllFromPaginated(async (offset, limit) =>
-    authorizationClient.producerKeychain.getProducerKeychains({
+): Promise<{
+  hasProducerKeychain: boolean;
+  hasProducerKeychainKeys: boolean;
+}> => {
+  const producerKeychains =
+    await authorizationClient.producerKeychain.getProducerKeychains({
       headers,
       queries: {
         eserviceId: eServiceId,
         producerId,
-        offset,
-        limit,
+        offset: 0,
+        limit: 1,
       },
-    })
-  );
+    });
 
-const getProducerKeychainFlags = (
-  producerKeychains: authorizationApi.ProducerKeychain[]
-): { hasProducerKeychain: boolean; hasProducerKeychainKeys: boolean } => ({
-  hasProducerKeychain: producerKeychains.length > 0,
-  hasProducerKeychainKeys: producerKeychains.some(
-    (keychain) =>
-      keychain.visibility === authorizationApi.Visibility.Values.FULL &&
-      keychain.keys.length > 0
-  ),
-});
+  return {
+    hasProducerKeychain: producerKeychains.totalCount > 0,
+    hasProducerKeychainKeys: producerKeychains.results.some(
+      producerKeychainHasKeys
+    ),
+  };
+};
 
 export function catalogServiceBuilder(
   catalogProcessClient: catalogApi.CatalogProcessClient,
@@ -416,13 +421,13 @@ export function catalogServiceBuilder(
 
       const descriptorAttributeIds = getAttributeIds(descriptor);
 
-      const [attributes, producerKeychains] = await Promise.all([
+      const [attributes, producerKeychainFlags] = await Promise.all([
         getAllBulkAttributes(
           attributeProcessClient,
           headers,
           descriptorAttributeIds
         ),
-        getAllProducerKeychainsByEService(
+        getProducerKeychainFlagsByEService(
           authorizationClient,
           headers,
           eserviceId,
@@ -431,7 +436,7 @@ export function catalogServiceBuilder(
       ]);
 
       const { hasProducerKeychain, hasProducerKeychainKeys } =
-        getProducerKeychainFlags(producerKeychains);
+        producerKeychainFlags;
 
       const descriptorAttributes = toBffCatalogApiDescriptorAttributes(
         attributes,
@@ -931,9 +936,9 @@ export function catalogServiceBuilder(
 
       const descriptor = retrieveEserviceDescriptor(eservice, descriptorId);
       const attributeIds = getAttributeIds(descriptor);
-      const [attributes, producerKeychains] = await Promise.all([
+      const [attributes, producerKeychainFlags] = await Promise.all([
         getAllBulkAttributes(attributeProcessClient, headers, attributeIds),
-        getAllProducerKeychainsByEService(
+        getProducerKeychainFlagsByEService(
           authorizationClient,
           headers,
           eserviceId,
@@ -942,7 +947,7 @@ export function catalogServiceBuilder(
       ]);
 
       const { hasProducerKeychain, hasProducerKeychainKeys } =
-        getProducerKeychainFlags(producerKeychains);
+        producerKeychainFlags;
 
       const descriptorAttributes = toBffCatalogApiDescriptorAttributes(
         attributes,

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -302,39 +302,21 @@ const getAllEserviceConsumers = async (
     })
   );
 
-const producerKeychainHasKeys = (
-  keychain: authorizationApi.ProducerKeychain
-): boolean =>
-  keychain.visibility === authorizationApi.Visibility.Values.FULL &&
-  keychain.keys.length > 0;
-
 const getProducerKeychainFlagsByEService = async (
   authorizationClient: AuthorizationProcessClient,
   headers: Headers,
   eServiceId: EServiceId,
   producerId: TenantId
-): Promise<{
-  hasProducerKeychain: boolean;
-  hasProducerKeychainKeys: boolean;
-}> => {
-  const producerKeychains =
-    await authorizationClient.producerKeychain.getProducerKeychains({
-      headers,
-      queries: {
-        eserviceId: eServiceId,
-        producerId,
-        offset: 0,
-        limit: 1,
-      },
-    });
-
-  return {
-    hasProducerKeychain: producerKeychains.totalCount > 0,
-    hasProducerKeychainKeys: producerKeychains.results.some(
-      producerKeychainHasKeys
-    ),
-  };
-};
+): Promise<authorizationApi.ProducerKeychainEServiceFlags> =>
+  await authorizationClient.producerKeychain.getProducerKeychainEServiceFlags({
+    headers,
+    params: {
+      eserviceId: eServiceId,
+    },
+    queries: {
+      producerId,
+    },
+  });
 
 export function catalogServiceBuilder(
   catalogProcessClient: catalogApi.CatalogProcessClient,

--- a/packages/backend-for-frontend/test/getCatalogEServiceDescriptor.test.ts
+++ b/packages/backend-for-frontend/test/getCatalogEServiceDescriptor.test.ts
@@ -370,7 +370,7 @@ describe("getCatalogEServiceDescriptor", () => {
         eserviceId: eServiceId,
         producerId: eService.producerId,
         offset: 0,
-        limit: 50,
+        limit: 1,
       },
     });
     expect(

--- a/packages/backend-for-frontend/test/getCatalogEServiceDescriptor.test.ts
+++ b/packages/backend-for-frontend/test/getCatalogEServiceDescriptor.test.ts
@@ -5,10 +5,12 @@ import {
   EServiceId,
   generateId,
   TenantId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import {
   agreementApi,
   attributeRegistryApi,
+  authorizationApi,
   bffApi,
   catalogApi,
   eserviceTemplateApi,
@@ -127,6 +129,8 @@ describe("getCatalogEServiceDescriptor", () => {
     isSignalHubEnabled: eService.isSignalHubEnabled,
     isConsumerDelegable: eService.isConsumerDelegable,
     isClientAccessDelegable: eService.isClientAccessDelegable,
+    hasProducerKeychain: false,
+    hasProducerKeychainKeys: false,
   };
 
   const expectedResult: bffApi.CatalogEServiceDescriptor = {
@@ -206,7 +210,16 @@ describe("getCatalogEServiceDescriptor", () => {
     }),
   } as unknown as attributeRegistryApi.AttributeProcessClient;
 
-  const mockAuthorizationClient = {} as unknown as AuthorizationProcessClient;
+  const mockProducerKeychains = vi.fn().mockResolvedValue({
+    results: [],
+    totalCount: 0,
+  });
+
+  const mockAuthorizationClient = {
+    producerKeychain: {
+      getProducerKeychains: mockProducerKeychains,
+    },
+  } as unknown as AuthorizationProcessClient;
 
   const mockDelegationProcessClient = {
     producer: {},
@@ -303,6 +316,74 @@ describe("getCatalogEServiceDescriptor", () => {
       mockAttributeProcessClient,
       bffMockContext.headers,
       [certifiedAttributeId, declaredAttributeId, verifiedAttributeId]
+    );
+  });
+
+  const mockKey = (): authorizationApi.Key => ({
+    userId: generateId(),
+    kid: "mockKid",
+    name: "mockKey",
+    encodedPem: "mockPem",
+    algorithm: "RS256",
+    use: authorizationApi.KeyUse.Values.SIG,
+    createdAt: new Date().toISOString(),
+  });
+
+  const mockFullProducerKeychain = (
+    keys: authorizationApi.Key[]
+  ): authorizationApi.ProducerKeychain => ({
+    visibility: authorizationApi.Visibility.Values.FULL,
+    id: generateId(),
+    name: "mockProducerKeychain",
+    producerId: unsafeBrandId<TenantId>(eService.producerId),
+    createdAt: new Date().toISOString(),
+    eservices: [eServiceId],
+    description: "mockDescription",
+    users: [],
+    keys,
+  });
+
+  it("should expose producer keychain flags on the catalog descriptor eservice", async () => {
+    mockProducerKeychains.mockResolvedValueOnce({
+      results: [mockFullProducerKeychain([mockKey()])],
+      totalCount: 1,
+    });
+    vi.mocked(
+      catalogApiConverter.toBffCatalogDescriptorEService
+    ).mockResolvedValueOnce({
+      ...catalogDescriptorEService,
+      hasProducerKeychain: true,
+      hasProducerKeychainKeys: true,
+    });
+
+    const result = await catalogService.getCatalogEServiceDescriptor(
+      eServiceId,
+      mockDescriptorId,
+      bffMockContext
+    );
+
+    expect(result.eservice.hasProducerKeychain).toBe(true);
+    expect(result.eservice.hasProducerKeychainKeys).toBe(true);
+    expect(mockProducerKeychains).toHaveBeenCalledWith({
+      headers: bffMockContext.headers,
+      queries: {
+        eserviceId: eServiceId,
+        producerId: eService.producerId,
+        offset: 0,
+        limit: 50,
+      },
+    });
+    expect(
+      catalogApiConverter.toBffCatalogDescriptorEService
+    ).toHaveBeenCalledWith(
+      eService,
+      eServiceDescriptor,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      true,
+      true
     );
   });
 

--- a/packages/backend-for-frontend/test/getCatalogEServiceDescriptor.test.ts
+++ b/packages/backend-for-frontend/test/getCatalogEServiceDescriptor.test.ts
@@ -5,12 +5,10 @@ import {
   EServiceId,
   generateId,
   TenantId,
-  unsafeBrandId,
 } from "pagopa-interop-models";
 import {
   agreementApi,
   attributeRegistryApi,
-  authorizationApi,
   bffApi,
   catalogApi,
   eserviceTemplateApi,
@@ -210,14 +208,14 @@ describe("getCatalogEServiceDescriptor", () => {
     }),
   } as unknown as attributeRegistryApi.AttributeProcessClient;
 
-  const mockProducerKeychains = vi.fn().mockResolvedValue({
-    results: [],
-    totalCount: 0,
+  const mockProducerKeychainEServiceFlags = vi.fn().mockResolvedValue({
+    hasProducerKeychain: false,
+    hasProducerKeychainKeys: false,
   });
 
   const mockAuthorizationClient = {
     producerKeychain: {
-      getProducerKeychains: mockProducerKeychains,
+      getProducerKeychainEServiceFlags: mockProducerKeychainEServiceFlags,
     },
   } as unknown as AuthorizationProcessClient;
 
@@ -319,34 +317,10 @@ describe("getCatalogEServiceDescriptor", () => {
     );
   });
 
-  const mockKey = (): authorizationApi.Key => ({
-    userId: generateId(),
-    kid: "mockKid",
-    name: "mockKey",
-    encodedPem: "mockPem",
-    algorithm: "RS256",
-    use: authorizationApi.KeyUse.Values.SIG,
-    createdAt: new Date().toISOString(),
-  });
-
-  const mockFullProducerKeychain = (
-    keys: authorizationApi.Key[]
-  ): authorizationApi.ProducerKeychain => ({
-    visibility: authorizationApi.Visibility.Values.FULL,
-    id: generateId(),
-    name: "mockProducerKeychain",
-    producerId: unsafeBrandId<TenantId>(eService.producerId),
-    createdAt: new Date().toISOString(),
-    eservices: [eServiceId],
-    description: "mockDescription",
-    users: [],
-    keys,
-  });
-
   it("should expose producer keychain flags on the catalog descriptor eservice", async () => {
-    mockProducerKeychains.mockResolvedValueOnce({
-      results: [mockFullProducerKeychain([mockKey()])],
-      totalCount: 1,
+    mockProducerKeychainEServiceFlags.mockResolvedValueOnce({
+      hasProducerKeychain: true,
+      hasProducerKeychainKeys: true,
     });
     vi.mocked(
       catalogApiConverter.toBffCatalogDescriptorEService
@@ -364,13 +338,11 @@ describe("getCatalogEServiceDescriptor", () => {
 
     expect(result.eservice.hasProducerKeychain).toBe(true);
     expect(result.eservice.hasProducerKeychainKeys).toBe(true);
-    expect(mockProducerKeychains).toHaveBeenCalledWith({
+    expect(mockProducerKeychainEServiceFlags).toHaveBeenCalledWith({
       headers: bffMockContext.headers,
+      params: { eserviceId: eServiceId },
       queries: {
-        eserviceId: eServiceId,
         producerId: eService.producerId,
-        offset: 0,
-        limit: 1,
       },
     });
     expect(

--- a/packages/backend-for-frontend/test/getProducerEServiceDescriptor.test.ts
+++ b/packages/backend-for-frontend/test/getProducerEServiceDescriptor.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   attributeRegistryApi,
-  authorizationApi,
   catalogApi,
   agreementApi,
   eserviceTemplateApi,
@@ -100,12 +99,12 @@ describe("getProducerEServiceDescriptor", () => {
     }),
   } as unknown as attributeRegistryApi.AttributeProcessClient;
 
-  const mockProducerKeychains = vi.fn();
+  const mockProducerKeychainEServiceFlags = vi.fn();
   const mockGetDelegations = vi.fn();
 
   const mockAuthorizationClient = {
     producerKeychain: {
-      getProducerKeychains: mockProducerKeychains,
+      getProducerKeychainEServiceFlags: mockProducerKeychainEServiceFlags,
     },
   } as unknown as AuthorizationProcessClient;
 
@@ -133,37 +132,13 @@ describe("getProducerEServiceDescriptor", () => {
     config
   );
 
-  const mockKey = (): authorizationApi.Key => ({
-    userId: generateId(),
-    kid: "mockKid",
-    name: "mockKey",
-    encodedPem: "mockPem",
-    algorithm: "RS256",
-    use: authorizationApi.KeyUse.Values.SIG,
-    createdAt: new Date().toISOString(),
-  });
-
-  const mockFullProducerKeychain = (
-    keys: authorizationApi.Key[],
-    producerId: TenantId = tenantId
-  ): authorizationApi.ProducerKeychain => ({
-    visibility: authorizationApi.Visibility.Values.FULL,
-    id: generateId(),
-    name: "mockProducerKeychain",
-    producerId,
-    createdAt: new Date().toISOString(),
-    eservices: [eServiceId],
-    description: "mockDescription",
-    users: [],
-    keys,
-  });
-
-  const mockProducerKeychainsResponse = (
-    results: authorizationApi.ProducerKeychain[]
+  const mockProducerKeychainEServiceFlagsResponse = (
+    hasProducerKeychain: boolean,
+    hasProducerKeychainKeys: boolean
   ): void => {
-    mockProducerKeychains.mockResolvedValueOnce({
-      results,
-      totalCount: results.length,
+    mockProducerKeychainEServiceFlags.mockResolvedValueOnce({
+      hasProducerKeychain,
+      hasProducerKeychainKeys,
     });
   };
 
@@ -177,7 +152,7 @@ describe("getProducerEServiceDescriptor", () => {
   };
 
   beforeEach(() => {
-    mockProducerKeychains.mockReset();
+    mockProducerKeychainEServiceFlags.mockReset();
     mockGetDelegations.mockReset();
     mockGetDelegations.mockResolvedValue({
       results: [],
@@ -186,7 +161,7 @@ describe("getProducerEServiceDescriptor", () => {
   });
 
   it("should return false fields when the descriptor eservice has no producer keychain", async () => {
-    mockProducerKeychainsResponse([]);
+    mockProducerKeychainEServiceFlagsResponse(false, false);
 
     const result = await catalogService.getProducerEServiceDescriptor(
       eServiceId,
@@ -199,7 +174,7 @@ describe("getProducerEServiceDescriptor", () => {
   });
 
   it("should distinguish a producer keychain without keys", async () => {
-    mockProducerKeychainsResponse([mockFullProducerKeychain([])]);
+    mockProducerKeychainEServiceFlagsResponse(true, false);
 
     const result = await catalogService.getProducerEServiceDescriptor(
       eServiceId,
@@ -212,7 +187,7 @@ describe("getProducerEServiceDescriptor", () => {
   });
 
   it("should return true fields when the producer keychain has keys", async () => {
-    mockProducerKeychainsResponse([mockFullProducerKeychain([mockKey()])]);
+    mockProducerKeychainEServiceFlagsResponse(true, true);
 
     const result = await catalogService.getProducerEServiceDescriptor(
       eServiceId,
@@ -222,13 +197,13 @@ describe("getProducerEServiceDescriptor", () => {
 
     expect(result.eservice.hasProducerKeychain).toBe(true);
     expect(result.eservice.hasProducerKeychainKeys).toBe(true);
-    expect(mockProducerKeychains).toHaveBeenCalledWith({
+    expect(mockProducerKeychainEServiceFlags).toHaveBeenCalledWith({
       headers: bffMockContext.headers,
-      queries: {
+      params: {
         eserviceId: eServiceId,
+      },
+      queries: {
         producerId: tenantId,
-        offset: 0,
-        limit: 1,
       },
     });
   });
@@ -238,9 +213,7 @@ describe("getProducerEServiceDescriptor", () => {
       results: [mockActiveProducerDelegation],
       totalCount: 1,
     });
-    mockProducerKeychainsResponse([
-      mockFullProducerKeychain([mockKey()], delegateId),
-    ]);
+    mockProducerKeychainEServiceFlagsResponse(true, true);
 
     const result = await catalogService.getProducerEServiceDescriptor(
       eServiceId,
@@ -250,13 +223,13 @@ describe("getProducerEServiceDescriptor", () => {
 
     expect(result.eservice.hasProducerKeychain).toBe(true);
     expect(result.eservice.hasProducerKeychainKeys).toBe(true);
-    expect(mockProducerKeychains).toHaveBeenCalledWith({
+    expect(mockProducerKeychainEServiceFlags).toHaveBeenCalledWith({
       headers: delegateBffMockContext.headers,
-      queries: {
+      params: {
         eserviceId: eServiceId,
+      },
+      queries: {
         producerId: delegateId,
-        offset: 0,
-        limit: 1,
       },
     });
   });

--- a/packages/backend-for-frontend/test/getProducerEServiceDescriptor.test.ts
+++ b/packages/backend-for-frontend/test/getProducerEServiceDescriptor.test.ts
@@ -228,7 +228,7 @@ describe("getProducerEServiceDescriptor", () => {
         eserviceId: eServiceId,
         producerId: tenantId,
         offset: 0,
-        limit: 50,
+        limit: 1,
       },
     });
   });
@@ -256,7 +256,7 @@ describe("getProducerEServiceDescriptor", () => {
         eserviceId: eServiceId,
         producerId: delegateId,
         offset: 0,
-        limit: 50,
+        limit: 1,
       },
     });
   });


### PR DESCRIPTION
## Issue
- [PIN-10099](https://pagopa.atlassian.net/browse/PIN-10099)

## Context / Why
- The consumer catalog descriptor response needs producer keychain readiness data for async e-services.
- The producer descriptor already exposes these flags, the catalog descriptor now exposes them too.

## Scope
- Added `hasProducerKeychain` and `hasProducerKeychainKeys` to `CatalogDescriptorEService`.
- Populated the fields in `GET /catalog/eservices/{eserviceId}/descriptor/{descriptorId}`.
- Updated BFF OpenAPI schema.
- Added targeted unit coverage for the catalog descriptor flow.

## Testing / Validation
- [x] Lint
- [x] Typecheck
- [x] Unit tests
- [x] Api tests
- [x] OpenAPI spec validation

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [x] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10099]: https://pagopa.atlassian.net/browse/PIN-10099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ