### PR TITLE
PIN-10119 :  bugfix flaky test: patchUpdateReversePurpose should update the purpose and return the updated purpose

### DIFF
--- a/packages/purpose-process/test/integration/patchUpdateReversePurpose.test.ts
+++ b/packages/purpose-process/test/integration/patchUpdateReversePurpose.test.ts
@@ -715,7 +715,9 @@ describe("patchUpdateReversePurpose", () => {
         updatedAt: new Date(),
       };
 
-      expect(patchPurposeResult.data.purpose).toEqual(expectedPurpose);
+      expect(sortPurpose(patchPurposeResult.data.purpose)).toEqual(
+        sortPurpose(expectedPurpose)
+      );
     }
   );
 


### PR DESCRIPTION
[PIN-10119](https://pagopa.atlassian.net/browse/PIN-10119)
This pull request makes a minor adjustment to the integration test for `patchUpdateReversePurpose`. The change ensures that the comparison between the actual and expected purpose objects is order-insensitive by using the `sortPurpose` function on both before asserting equality.

[PIN-10119]: https://pagopa.atlassian.net/browse/PIN-10119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ