### PR TITLE
feat(bff): expose latestDescriptorId in producer eservice details

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -26429,6 +26429,9 @@ components:
           type: boolean
         asyncExchange:
           type: boolean
+        latestDescriptorId:
+          type: string
+          format: uuid
     EServiceMode:
       type: string
       description: Risk Analysis Mode

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -26429,7 +26429,7 @@ components:
           type: boolean
         asyncExchange:
           type: boolean
-        latestDescriptorId:
+        latestActiveDescriptorId:
           type: string
           format: uuid
     EServiceMode:

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -589,7 +589,7 @@ export function catalogServiceBuilder(
         isClientAccessDelegable: eservice.isClientAccessDelegable,
         personalData: eservice.personalData,
         asyncExchange: eservice.asyncExchange,
-        latestDescriptorId: getLatestActiveDescriptor(eservice)?.id,
+        latestActiveDescriptorId: getLatestActiveDescriptor(eservice)?.id,
       };
     },
     updateEServiceDescription: async (

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -588,6 +588,8 @@ export function catalogServiceBuilder(
         isConsumerDelegable: eservice.isConsumerDelegable,
         isClientAccessDelegable: eservice.isClientAccessDelegable,
         personalData: eservice.personalData,
+        asyncExchange: eservice.asyncExchange,
+        latestDescriptorId: getLatestActiveDescriptor(eservice)?.id,
       };
     },
     updateEServiceDescription: async (

--- a/packages/backend-for-frontend/test/getProducerEServiceDetails.test.ts
+++ b/packages/backend-for-frontend/test/getProducerEServiceDetails.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  attributeRegistryApi,
+  agreementApi,
+  catalogApi,
+  eserviceTemplateApi,
+  inAppNotificationApi,
+} from "pagopa-interop-api-clients";
+import {
+  DescriptorId,
+  EServiceId,
+  TenantId,
+  generateId,
+} from "pagopa-interop-models";
+import { AuthData } from "pagopa-interop-commons";
+import { getMockAuthData, getMockContext } from "pagopa-interop-commons-test";
+import type {
+  AuthorizationProcessClient,
+  DelegationProcessClient,
+  TenantProcessClient,
+} from "../src/clients/clientsProvider.js";
+import { catalogServiceBuilder } from "../src/services/catalogService.js";
+import { config } from "../src/config/config.js";
+import { fileManager, getBffMockContext } from "./utils.js";
+
+describe("getProducerEServiceDetails", () => {
+  const tenantId: TenantId = generateId<TenantId>();
+  const eServiceId: EServiceId = generateId<EServiceId>();
+
+  const authData: AuthData = {
+    ...getMockAuthData(),
+    organizationId: tenantId,
+  };
+  const bffMockContext = getBffMockContext(getMockContext({ authData }));
+
+  const baseDescriptor = (
+    state: catalogApi.EServiceDescriptorState,
+    version: string
+  ): catalogApi.EServiceDescriptor => ({
+    id: generateId<DescriptorId>(),
+    state,
+    version,
+    attributes: { declared: [], certified: [], verified: [] },
+    serverUrls: [],
+    audience: [],
+    voucherLifespan: 60,
+    dailyCallsPerConsumer: 1,
+    dailyCallsTotal: 1,
+    docs: [],
+    agreementApprovalPolicy:
+      catalogApi.AgreementApprovalPolicy.Values.AUTOMATIC,
+  });
+
+  const deprecatedDescriptor = baseDescriptor(
+    catalogApi.EServiceDescriptorState.Values.DEPRECATED,
+    "1"
+  );
+  const publishedDescriptor = baseDescriptor(
+    catalogApi.EServiceDescriptorState.Values.PUBLISHED,
+    "2"
+  );
+  const draftDescriptor = baseDescriptor(
+    catalogApi.EServiceDescriptorState.Values.DRAFT,
+    "3"
+  );
+
+  const eService: catalogApi.EService = {
+    id: eServiceId,
+    name: "mockEService",
+    producerId: tenantId,
+    description: "mockDescription",
+    technology: catalogApi.EServiceTechnology.Values.REST,
+    descriptors: [deprecatedDescriptor, publishedDescriptor, draftDescriptor],
+    mode: catalogApi.EServiceMode.Values.RECEIVE,
+    riskAnalysis: [],
+    asyncExchange: true,
+  };
+
+  const mockGetEServiceById = vi.fn();
+  const mockCatalogProcessClient = {
+    getEServiceById: mockGetEServiceById,
+  } as unknown as catalogApi.CatalogProcessClient;
+
+  const mockTenantProcessClient = {
+    tenant: {
+      getTenant: vi.fn(({ params: { id } }) => ({
+        id,
+        name: "mockTenant",
+        attributes: [],
+        mails: [],
+      })),
+    },
+  } as unknown as TenantProcessClient;
+
+  const mockAgreementProcessClient =
+    {} as unknown as agreementApi.AgreementProcessClient;
+
+  const mockAttributeProcessClient =
+    {} as unknown as attributeRegistryApi.AttributeProcessClient;
+
+  const mockAuthorizationClient = {} as unknown as AuthorizationProcessClient;
+
+  const mockDelegationProcessClient = {
+    delegation: {
+      getDelegations: vi.fn().mockResolvedValue({ results: [], totalCount: 0 }),
+    },
+  } as unknown as DelegationProcessClient;
+
+  const mockEServiceTemplateProcessClient =
+    {} as unknown as eserviceTemplateApi.EServiceTemplateProcessClient;
+  const mockInAppNotificationManagerClient =
+    {} as unknown as inAppNotificationApi.InAppNotificationManagerClient;
+
+  const catalogService = catalogServiceBuilder(
+    mockCatalogProcessClient,
+    mockTenantProcessClient,
+    mockAgreementProcessClient,
+    mockAttributeProcessClient,
+    mockAuthorizationClient,
+    mockDelegationProcessClient,
+    mockEServiceTemplateProcessClient,
+    mockInAppNotificationManagerClient,
+    fileManager,
+    config
+  );
+
+  beforeEach(() => {
+    mockGetEServiceById.mockReset();
+  });
+
+  it("should map asyncExchange and latestActiveDescriptorId from the eservice, picking the latest active descriptor and ignoring drafts", async () => {
+    mockGetEServiceById.mockResolvedValue(eService);
+
+    const result = await catalogService.getProducerEServiceDetails(
+      eServiceId,
+      bffMockContext
+    );
+
+    expect(result.asyncExchange).toBe(true);
+    expect(result.latestActiveDescriptorId).toBe(publishedDescriptor.id);
+  });
+
+  it("should return undefined latestActiveDescriptorId when no active descriptor exists", async () => {
+    mockGetEServiceById.mockResolvedValue({
+      ...eService,
+      asyncExchange: false,
+      descriptors: [draftDescriptor],
+    });
+
+    const result = await catalogService.getProducerEServiceDetails(
+      eServiceId,
+      bffMockContext
+    );
+
+    expect(result.asyncExchange).toBe(false);
+    expect(result.latestActiveDescriptorId).toBeUndefined();
+  });
+});

--- a/packages/backend-for-frontend/test/mockUtils.ts
+++ b/packages/backend-for-frontend/test/mockUtils.ts
@@ -208,7 +208,7 @@ export const getMockBffApiProducerEServiceDetails =
     isConsumerDelegable: generateMock(z.boolean().optional()),
     isClientAccessDelegable: generateMock(z.boolean().optional()),
     asyncExchange: generateMock(z.boolean().optional()),
-    latestDescriptorId: generateId(),
+    latestActiveDescriptorId: generateId(),
   });
 
 export const getMockBffApiCatalogEServiceDescriptor =

--- a/packages/backend-for-frontend/test/mockUtils.ts
+++ b/packages/backend-for-frontend/test/mockUtils.ts
@@ -207,6 +207,8 @@ export const getMockBffApiProducerEServiceDetails =
     isSignalHubEnabled: generateMock(z.boolean().optional()),
     isConsumerDelegable: generateMock(z.boolean().optional()),
     isClientAccessDelegable: generateMock(z.boolean().optional()),
+    asyncExchange: generateMock(z.boolean().optional()),
+    latestDescriptorId: generateId(),
   });
 
 export const getMockBffApiCatalogEServiceDescriptor =


### PR DESCRIPTION
## Context

The FE needs to render descriptor-scoped actions on the producer e-service detail page knowing only the `eserviceId`. Today the `GET /producers/eservices/{eserviceId}` response does not expose any descriptor reference.

## Changes

- Add an optional `latestDescriptorId` field to the `ProducerEServiceDetails` in BFF schema.
- Propagate `eservice.asyncExchange` in the same handler: the flag was already declared in the `ProducerEServiceDetails` schema but it was never returned by the service.
- Update the BFF API test mock accordingly.