### PR TITLE
feat(authorization-server): add interaction data to async flow audit logs (PIN-9529)

### DIFF
--- a/packages/authorization-server/src/services/scopeHandlers/callbackInvocationHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/callbackInvocationHandler.ts
@@ -255,6 +255,12 @@ export const handleCallbackInvocation = async (
     correlationId,
     fileManager,
     logger,
+    interaction: {
+      interactionId: interaction.interactionId,
+      state: scope,
+      startInteractionTokenIssuedAt: interaction.startInteractionTokenIssuedAt,
+      callbackInvocationTokenIssuedAt: issuedAt,
+    },
   });
 
   // 12. Log and return

--- a/packages/authorization-server/src/services/scopeHandlers/callbackInvocationHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/callbackInvocationHandler.ts
@@ -257,9 +257,11 @@ export const handleCallbackInvocation = async (
     logger,
     interaction: {
       interactionId: interaction.interactionId,
-      state: scope,
+      state: interactionState.callbackInvocation,
       startInteractionTokenIssuedAt: interaction.startInteractionTokenIssuedAt,
-      callbackInvocationTokenIssuedAt: issuedAt,
+      callbackInvocationTokenIssuedAt: new Date(
+        token.payload.iat * 1000
+      ).toISOString(),
     },
   });
 

--- a/packages/authorization-server/src/services/scopeHandlers/confirmationHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/confirmationHandler.ts
@@ -242,11 +242,13 @@ export const handleConfirmation = async (
     logger,
     interaction: {
       interactionId: interaction.interactionId,
-      state: scope,
+      state: interactionState.confirmation,
       startInteractionTokenIssuedAt: interaction.startInteractionTokenIssuedAt,
       callbackInvocationTokenIssuedAt:
         interaction.callbackInvocationTokenIssuedAt,
-      confirmationTokenIssuedAt: issuedAt,
+      confirmationTokenIssuedAt: new Date(
+        token.payload.iat * 1000
+      ).toISOString(),
     },
   });
 

--- a/packages/authorization-server/src/services/scopeHandlers/confirmationHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/confirmationHandler.ts
@@ -240,6 +240,14 @@ export const handleConfirmation = async (
     correlationId,
     fileManager,
     logger,
+    interaction: {
+      interactionId: interaction.interactionId,
+      state: scope,
+      startInteractionTokenIssuedAt: interaction.startInteractionTokenIssuedAt,
+      callbackInvocationTokenIssuedAt:
+        interaction.callbackInvocationTokenIssuedAt,
+      confirmationTokenIssuedAt: issuedAt,
+    },
   });
 
   logTokenGenerationInfo({

--- a/packages/authorization-server/src/services/scopeHandlers/getResourceHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/getResourceHandler.ts
@@ -235,7 +235,7 @@ export const handleGetResource = async (
     logger,
     interaction: {
       interactionId: interaction.interactionId,
-      state: scope,
+      state: interactionState.getResource,
       startInteractionTokenIssuedAt: interaction.startInteractionTokenIssuedAt,
       callbackInvocationTokenIssuedAt:
         interaction.callbackInvocationTokenIssuedAt,

--- a/packages/authorization-server/src/services/scopeHandlers/getResourceHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/getResourceHandler.ts
@@ -233,6 +233,13 @@ export const handleGetResource = async (
     correlationId,
     fileManager,
     logger,
+    interaction: {
+      interactionId: interaction.interactionId,
+      state: scope,
+      startInteractionTokenIssuedAt: interaction.startInteractionTokenIssuedAt,
+      callbackInvocationTokenIssuedAt:
+        interaction.callbackInvocationTokenIssuedAt,
+    },
   });
 
   logTokenGenerationInfo({

--- a/packages/authorization-server/src/services/scopeHandlers/startInteractionHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/startInteractionHandler.ts
@@ -199,7 +199,7 @@ export const handleStartInteraction = async (
     logger,
     interaction: {
       interactionId,
-      state: scope,
+      state: interactionState.startInteraction,
       startInteractionTokenIssuedAt: issuedAt,
     },
   });

--- a/packages/authorization-server/src/services/scopeHandlers/startInteractionHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/startInteractionHandler.ts
@@ -197,6 +197,11 @@ export const handleStartInteraction = async (
     correlationId,
     fileManager,
     logger,
+    interaction: {
+      interactionId,
+      state: scope,
+      startInteractionTokenIssuedAt: issuedAt,
+    },
   });
 
   // 11. Log and return

--- a/packages/authorization-server/src/utilities/tokenServiceHelpers.ts
+++ b/packages/authorization-server/src/utilities/tokenServiceHelpers.ts
@@ -11,6 +11,7 @@ import {
   EServiceId,
   FullTokenGenerationStatesConsumerClient,
   GeneratedTokenAuditDetails,
+  InteractionAuditDetails,
   generateId,
   genericInternalError,
   GSIPKEServiceIdDescriptorId,
@@ -222,6 +223,7 @@ const buildAuditMessageBody = ({
   descriptorId,
   purposeId,
   purposeVersionId,
+  interaction,
 }: {
   generatedToken: InteropConsumerToken | InteropAsyncConsumerToken;
   clientAssertion: ClientAssertion | AsyncClientAssertion;
@@ -233,6 +235,7 @@ const buildAuditMessageBody = ({
   descriptorId: DescriptorId;
   purposeId: string;
   purposeVersionId: string;
+  interaction?: InteractionAuditDetails;
 }): GeneratedTokenAuditDetails => ({
   jwtId: generatedToken.payload.jti,
   correlationId,
@@ -274,6 +277,7 @@ const buildAuditMessageBody = ({
         },
       }
     : {}),
+  ...(interaction ? { interaction } : {}),
 });
 
 const sendAuditMessage = async ({
@@ -320,6 +324,7 @@ export const publishAudit = async ({
   correlationId,
   fileManager,
   logger,
+  interaction,
 }: {
   producer: Awaited<ReturnType<typeof initProducer>>;
   generatedToken: InteropConsumerToken | InteropAsyncConsumerToken;
@@ -334,6 +339,7 @@ export const publishAudit = async ({
   correlationId: CorrelationId;
   fileManager: FileManager;
   logger: Logger;
+  interaction?: InteractionAuditDetails;
 }): Promise<void> => {
   const messageBody = buildAuditMessageBody({
     generatedToken,
@@ -346,6 +352,7 @@ export const publishAudit = async ({
     descriptorId,
     purposeId: key.GSIPK_purposeId,
     purposeVersionId: key.purposeVersionId,
+    interaction,
   });
 
   await sendAuditMessage({ messageBody, producer, fileManager, logger });
@@ -394,6 +401,7 @@ export const publishProducerAudit = async ({
   correlationId,
   fileManager,
   logger,
+  interaction,
 }: {
   producer: Awaited<ReturnType<typeof initProducer>>;
   generatedToken: InteropAsyncConsumerToken;
@@ -408,6 +416,7 @@ export const publishProducerAudit = async ({
   correlationId: CorrelationId;
   fileManager: FileManager;
   logger: Logger;
+  interaction?: InteractionAuditDetails;
 }): Promise<void> => {
   const messageBody = buildAuditMessageBody({
     generatedToken,
@@ -420,6 +429,7 @@ export const publishProducerAudit = async ({
     descriptorId,
     purposeId,
     purposeVersionId,
+    interaction,
   });
 
   await sendAuditMessage({ messageBody, producer, fileManager, logger });

--- a/packages/models/src/token-generation-audit/audit.ts
+++ b/packages/models/src/token-generation-audit/audit.ts
@@ -4,11 +4,13 @@ import {
   ClientId,
   DescriptorId,
   EServiceId,
+  InteractionId,
   PurposeId,
   PurposeVersionId,
   TenantId,
 } from "../brandedIds.js";
 import { JWKKeyRS256, JWKKeyES256 } from "../authorization/key.js";
+import { InteractionState } from "../token-generation-readmodel/interactions-entry.js";
 
 export const ClientAssertionAuditDetails = z.object({
   jwtId: z.string(),
@@ -35,6 +37,15 @@ export const DPoPAuditDetails = z.object({
 });
 export type DPoPAuditDetails = z.infer<typeof DPoPAuditDetails>;
 
+export const InteractionAuditDetails = z.object({
+  interactionId: InteractionId,
+  state: InteractionState,
+  startInteractionTokenIssuedAt: z.string().datetime().optional(),
+  callbackInvocationTokenIssuedAt: z.string().datetime().optional(),
+  confirmationTokenIssuedAt: z.string().datetime().optional(),
+});
+export type InteractionAuditDetails = z.infer<typeof InteractionAuditDetails>;
+
 export const GeneratedTokenAuditDetails = z.object({
   jwtId: z.string(),
   correlationId: z.string(),
@@ -55,6 +66,7 @@ export const GeneratedTokenAuditDetails = z.object({
   issuer: z.string(),
   clientAssertion: ClientAssertionAuditDetails,
   dpop: DPoPAuditDetails.optional(),
+  interaction: InteractionAuditDetails.optional(),
 });
 export type GeneratedTokenAuditDetails = z.infer<
   typeof GeneratedTokenAuditDetails


### PR DESCRIPTION
## Summary

- Add optional InteractionAuditDetails to GeneratedTokenAuditDetails audit schema (interactionId, state, and phase timestamps)
- Each async scope handler now passes interaction data at audit time, enabling correlation of the 4 audit records of a single async exchange
- Sync flow is unaffected (field is optional and absent)


## Issue
[PIN-9529](https://pagopa.atlassian.net/browse/PIN-9529)

[PIN-9529]: https://pagopa.atlassian.net/browse/PIN-9529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ