### PR TITLE
feat: update outbound async exchange models (PIN-9380)

### DIFF
--- a/packages/agreement-outbound-writer/package.json
+++ b/packages/agreement-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
+    "@pagopa/interop-outbound-models": "1.7.0",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/agreement-outbound-writer/package.json
+++ b/packages/agreement-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.7.0",
+    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/catalog-outbound-writer/package.json
+++ b/packages/catalog-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.14",
+    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/catalog-outbound-writer/src/converters/toOutboundEventV2.ts
+++ b/packages/catalog-outbound-writer/src/converters/toOutboundEventV2.ts
@@ -1,4 +1,5 @@
 import {
+  AsyncExchangePropertiesV2,
   EServiceEventEnvelopeV2,
   EServiceV2,
   EServiceDescriptorV2,
@@ -7,6 +8,7 @@ import {
   TemplateInstanceInterfaceMetadataV2,
 } from "pagopa-interop-models";
 import {
+  AsyncExchangePropertiesV2 as OutboundAsyncExchangePropertiesV2,
   EServiceEvent as OutboundEServiceEvent,
   EServiceV2 as OutboundEServiceV2,
   EServiceDescriptorV2 as OutboundEServiceDescriptorV2,
@@ -40,6 +42,12 @@ function toOutboundTemplateInstanceInterfaceMetadataV2(
   };
 }
 
+function toOutboundAsyncExchangePropertiesV2(
+  properties: AsyncExchangePropertiesV2
+): Exact<OutboundAsyncExchangePropertiesV2, AsyncExchangePropertiesV2> {
+  return { ...properties };
+}
+
 function toOutboundEServiceTemplateVersionRefV2(
   templateVersionRef: EServiceTemplateVersionRefV2
 ): Exact<OutboundEServiceTemplateVersionRefV2, EServiceTemplateVersionRefV2> {
@@ -65,8 +73,12 @@ function toOutboundDescriptorV2(
     templateVersionRef:
       descriptor.templateVersionRef &&
       toOutboundEServiceTemplateVersionRefV2(descriptor.templateVersionRef),
-    asyncExchangeCallbackInterface: undefined,
-    asyncExchangeProperties: undefined,
+    asyncExchangeCallbackInterface:
+      descriptor.asyncExchangeCallbackInterface &&
+      toOutboundEServiceDocumentV2(descriptor.asyncExchangeCallbackInterface),
+    asyncExchangeProperties:
+      descriptor.asyncExchangeProperties &&
+      toOutboundAsyncExchangePropertiesV2(descriptor.asyncExchangeProperties),
   };
 }
 
@@ -76,7 +88,6 @@ function toOutboundEServiceV2(
   return {
     ...eservice,
     riskAnalysis: undefined,
-    asyncExchange: undefined,
     instanceLabel: undefined,
     descriptors: eservice.descriptors.map(toOutboundDescriptorV2),
     templateId: eservice.templateId,
@@ -183,6 +194,9 @@ export function toOutboundEventV2(
       { type: "EServiceDescriptorDocumentAddedByTemplateUpdate" },
       { type: "EServiceDescriptorDocumentUpdatedByTemplateUpdate" },
       { type: "EServiceDescriptorDocumentDeletedByTemplateUpdate" },
+      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded" },
+      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated" },
+      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceDeleted" },
       (msg) => ({
         event_version: msg.event_version,
         type: msg.type,
@@ -220,10 +234,6 @@ export function toOutboundEventV2(
       { type: "EServiceRiskAnalysisAdded" },
       { type: "EServiceRiskAnalysisDeleted" },
       { type: "EServiceRiskAnalysisUpdated" },
-      // TODO: Propagate async exchange callback interface events when @pagopa/interop-outbound-models is updated
-      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded" },
-      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated" },
-      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceDeleted" },
       () => undefined
     )
     .exhaustive();

--- a/packages/delegation-outbound-writer/package.json
+++ b/packages/delegation-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
+    "@pagopa/interop-outbound-models": "1.7.0",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/delegation-outbound-writer/package.json
+++ b/packages/delegation-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.7.0",
+    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/eservice-template-outbound-writer/package.json
+++ b/packages/eservice-template-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.8",
+    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/eservice-template-outbound-writer/src/converters/toOutboundEventV2.ts
+++ b/packages/eservice-template-outbound-writer/src/converters/toOutboundEventV2.ts
@@ -1,4 +1,5 @@
 import {
+  AsyncExchangePropertiesV2,
   EServiceDocumentV2,
   EServiceTemplateEventEnvelopeV2,
   EServiceTemplateV2,
@@ -7,6 +8,7 @@ import {
 import { match } from "ts-pattern";
 import { Exact } from "pagopa-interop-commons";
 import {
+  AsyncExchangePropertiesV2 as OutboundAsyncExchangePropertiesV2,
   EServiceTemplateEvent as OutboundEServiceTemplateEvent,
   EServiceTemplateV2 as OutboundEServiceTemplateV2,
   EServiceTemplateVersionV2 as OutboundEServiceTemplateVersionV2,
@@ -22,6 +24,12 @@ function toOuboundEServiceDocumentV2(
   };
 }
 
+function toOutboundAsyncExchangePropertiesV2(
+  properties: AsyncExchangePropertiesV2
+): Exact<OutboundAsyncExchangePropertiesV2, AsyncExchangePropertiesV2> {
+  return { ...properties };
+}
+
 function toOutboundEServiceTemplateVersionV2(
   template: EServiceTemplateVersionV2
 ): Exact<OutboundEServiceTemplateVersionV2, EServiceTemplateVersionV2> {
@@ -30,8 +38,12 @@ function toOutboundEServiceTemplateVersionV2(
     docs: template.docs.map(toOuboundEServiceDocumentV2),
     interface:
       template.interface && toOuboundEServiceDocumentV2(template.interface),
-    asyncExchangeCallbackInterface: undefined,
-    asyncExchangeProperties: undefined,
+    asyncExchangeCallbackInterface:
+      template.asyncExchangeCallbackInterface &&
+      toOuboundEServiceDocumentV2(template.asyncExchangeCallbackInterface),
+    asyncExchangeProperties:
+      template.asyncExchangeProperties &&
+      toOutboundAsyncExchangePropertiesV2(template.asyncExchangeProperties),
   };
 }
 
@@ -42,7 +54,6 @@ function toOutboundEServiceTemplateV2(
     ...template,
     versions: template.versions.map(toOutboundEServiceTemplateVersionV2),
     riskAnalysis: undefined,
-    asyncExchange: undefined,
   };
 }
 
@@ -101,6 +112,9 @@ export function toOutboundEventV2(
       { type: "EServiceTemplateVersionInterfaceAdded" },
       { type: "EServiceTemplateVersionInterfaceDeleted" },
       { type: "EServiceTemplateVersionInterfaceUpdated" },
+      { type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded" },
+      { type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdated" },
+      { type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeleted" },
       (msg) => ({
         event_version: msg.event_version,
         type: msg.type,
@@ -134,9 +148,6 @@ export function toOutboundEventV2(
       { type: "EServiceTemplateRiskAnalysisAdded" },
       { type: "EServiceTemplateRiskAnalysisDeleted" },
       { type: "EServiceTemplateRiskAnalysisUpdated" },
-      { type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded" },
-      { type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdated" },
-      { type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeleted" },
       () => undefined
     )
     .exhaustive();

--- a/packages/purpose-outbound-writer/package.json
+++ b/packages/purpose-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.1",
+    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/purpose-outbound-writer/package.json
+++ b/packages/purpose-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
+    "@pagopa/interop-outbound-models": "1.8.1",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/purpose-template-outbound-writer/package.json
+++ b/packages/purpose-template-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
+    "@pagopa/interop-outbound-models": "1.8.10",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/purpose-template-outbound-writer/package.json
+++ b/packages/purpose-template-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.10",
+    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/tenant-outbound-writer/package.json
+++ b/packages/tenant-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
+    "@pagopa/interop-outbound-models": "1.8.12",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/packages/tenant-outbound-writer/package.json
+++ b/packages/tenant-outbound-writer/package.json
@@ -20,7 +20,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@pagopa/interop-outbound-models": "1.8.12",
+    "@pagopa/interop-outbound-models": "1.8.18-scambi.async.purpose.template.0",
     "dotenv-flow": "catalog:",
     "kafka-iam-auth": "workspace:*",
     "kafkajs": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
   packages/agreement-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.7.0
-        version: 1.7.0
+        specifier: 1.8.18-scambi.async.purpose.template.0
+        version: 1.8.18-scambi.async.purpose.template.0
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -1434,8 +1434,8 @@ importers:
   packages/catalog-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.14
-        version: 1.8.14
+        specifier: 1.8.18-scambi.async.purpose.template.0
+        version: 1.8.18-scambi.async.purpose.template.0
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -2342,8 +2342,8 @@ importers:
   packages/delegation-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.7.0
-        version: 1.7.0
+        specifier: 1.8.18-scambi.async.purpose.template.0
+        version: 1.8.18-scambi.async.purpose.template.0
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -3099,8 +3099,8 @@ importers:
   packages/eservice-template-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.8
-        version: 1.8.8
+        specifier: 1.8.18-scambi.async.purpose.template.0
+        version: 1.8.18-scambi.async.purpose.template.0
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -5004,8 +5004,8 @@ importers:
   packages/purpose-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.1
-        version: 1.8.1
+        specifier: 1.8.18-scambi.async.purpose.template.0
+        version: 1.8.18-scambi.async.purpose.template.0
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -5233,8 +5233,8 @@ importers:
   packages/purpose-template-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.10
-        version: 1.8.10
+        specifier: 1.8.18-scambi.async.purpose.template.0
+        version: 1.8.18-scambi.async.purpose.template.0
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -5652,8 +5652,8 @@ importers:
   packages/tenant-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.12
-        version: 1.8.12
+        specifier: 1.8.18-scambi.async.purpose.template.0
+        version: 1.8.18-scambi.async.purpose.template.0
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -7315,23 +7315,8 @@ packages:
     peerDependencies:
       eslint: ^9.39.2
 
-  '@pagopa/interop-outbound-models@1.7.0':
-    resolution: {integrity: sha512-Y6Nf2ZyN8qFftmG0pBIctrFKQ/oC/a8IlKBlD03qNxYilB0ok7AB08QVpngEYcc7D3zlxhSDH35EVrRcjDj7gw==}
-
-  '@pagopa/interop-outbound-models@1.8.1':
-    resolution: {integrity: sha512-WOxbvxvc03fKYn/I1cxucbhvak+h5NFGFAu3ESV/3Y15mDWDEO4ZZz+Ybm+v4dxb54OuOQME8JSVot9tExr+pQ==}
-
-  '@pagopa/interop-outbound-models@1.8.10':
-    resolution: {integrity: sha512-amx3SsrQG06QmV1uS5uchpjs8midHoY8T4mvly6sBKCDIfgUto5M/JH+6O2PqoO6FGMSponOTfKWO5O/y5X75w==}
-
-  '@pagopa/interop-outbound-models@1.8.12':
-    resolution: {integrity: sha512-+m2RRwz0sxTYFPwG+9mjFKtC49f0r3O0at/OCNjVcHJELvJyO58bYF2jGQszmRB/TPyV5ZM6FlTGX2TvVgPGbw==}
-
-  '@pagopa/interop-outbound-models@1.8.14':
-    resolution: {integrity: sha512-ZbWHhkv/6efGd2jOYtDB5c30jaUgpXZVn815+96fVgM0brhArnkCx+2kxhJJ5GEsr/vNNaFogRPq3y9eliT5tw==}
-
-  '@pagopa/interop-outbound-models@1.8.8':
-    resolution: {integrity: sha512-Qzmle24iM/Kf44zf9Tmq/Bft1NECHVT4QoNGcRTeq2+QQW0d7np247iriz8xd46G2AoOBkXju13cNDFHlr/nMg==}
+  '@pagopa/interop-outbound-models@1.8.18-scambi.async.purpose.template.0':
+    resolution: {integrity: sha512-46mge7b5FFqThB2MocvEOOoaceStERp3rLBKKBU/8IBxrx3JsdXno97ZmtWcxyvgSehpMeYhAavO4X9EAerF+w==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -13819,37 +13804,7 @@ snapshots:
       - supports-color
       - vitest
 
-  '@pagopa/interop-outbound-models@1.7.0':
-    dependencies:
-      '@protobuf-ts/runtime': 2.9.4
-      ts-pattern: 5.2.0
-      zod: 3.23.8
-
-  '@pagopa/interop-outbound-models@1.8.1':
-    dependencies:
-      '@protobuf-ts/runtime': 2.9.4
-      ts-pattern: 5.2.0
-      zod: 3.23.8
-
-  '@pagopa/interop-outbound-models@1.8.10':
-    dependencies:
-      '@protobuf-ts/runtime': 2.9.4
-      ts-pattern: 5.2.0
-      zod: 3.23.8
-
-  '@pagopa/interop-outbound-models@1.8.12':
-    dependencies:
-      '@protobuf-ts/runtime': 2.9.4
-      ts-pattern: 5.2.0
-      zod: 3.23.8
-
-  '@pagopa/interop-outbound-models@1.8.14':
-    dependencies:
-      '@protobuf-ts/runtime': 2.9.4
-      ts-pattern: 5.2.0
-      zod: 3.23.8
-
-  '@pagopa/interop-outbound-models@1.8.8':
+  '@pagopa/interop-outbound-models@1.8.18-scambi.async.purpose.template.0':
     dependencies:
       '@protobuf-ts/runtime': 2.9.4
       ts-pattern: 5.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
   packages/agreement-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.18-scambi.async.purpose.template.0
-        version: 1.8.18-scambi.async.purpose.template.0
+        specifier: 1.7.0
+        version: 1.7.0
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -2342,8 +2342,8 @@ importers:
   packages/delegation-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.18-scambi.async.purpose.template.0
-        version: 1.8.18-scambi.async.purpose.template.0
+        specifier: 1.7.0
+        version: 1.7.0
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -5004,8 +5004,8 @@ importers:
   packages/purpose-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.18-scambi.async.purpose.template.0
-        version: 1.8.18-scambi.async.purpose.template.0
+        specifier: 1.8.1
+        version: 1.8.1
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -5233,8 +5233,8 @@ importers:
   packages/purpose-template-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.18-scambi.async.purpose.template.0
-        version: 1.8.18-scambi.async.purpose.template.0
+        specifier: 1.8.10
+        version: 1.8.10
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -5652,8 +5652,8 @@ importers:
   packages/tenant-outbound-writer:
     dependencies:
       '@pagopa/interop-outbound-models':
-        specifier: 1.8.18-scambi.async.purpose.template.0
-        version: 1.8.18-scambi.async.purpose.template.0
+        specifier: 1.8.12
+        version: 1.8.12
       dotenv-flow:
         specifier: 'catalog:'
         version: 4.1.0
@@ -7314,6 +7314,18 @@ packages:
     resolution: {integrity: sha512-7Byb+K51xcWKjk9oWDU0GeHPpdRm3Y1zgLSP0NZ0wnijxmD4GGe3DNLMhbu3q7MOCrHbbJXWR4jqR3BqE6P7dw==}
     peerDependencies:
       eslint: ^9.39.2
+
+  '@pagopa/interop-outbound-models@1.7.0':
+    resolution: {integrity: sha512-Y6Nf2ZyN8qFftmG0pBIctrFKQ/oC/a8IlKBlD03qNxYilB0ok7AB08QVpngEYcc7D3zlxhSDH35EVrRcjDj7gw==}
+
+  '@pagopa/interop-outbound-models@1.8.1':
+    resolution: {integrity: sha512-WOxbvxvc03fKYn/I1cxucbhvak+h5NFGFAu3ESV/3Y15mDWDEO4ZZz+Ybm+v4dxb54OuOQME8JSVot9tExr+pQ==}
+
+  '@pagopa/interop-outbound-models@1.8.10':
+    resolution: {integrity: sha512-amx3SsrQG06QmV1uS5uchpjs8midHoY8T4mvly6sBKCDIfgUto5M/JH+6O2PqoO6FGMSponOTfKWO5O/y5X75w==}
+
+  '@pagopa/interop-outbound-models@1.8.12':
+    resolution: {integrity: sha512-+m2RRwz0sxTYFPwG+9mjFKtC49f0r3O0at/OCNjVcHJELvJyO58bYF2jGQszmRB/TPyV5ZM6FlTGX2TvVgPGbw==}
 
   '@pagopa/interop-outbound-models@1.8.18-scambi.async.purpose.template.0':
     resolution: {integrity: sha512-46mge7b5FFqThB2MocvEOOoaceStERp3rLBKKBU/8IBxrx3JsdXno97ZmtWcxyvgSehpMeYhAavO4X9EAerF+w==}
@@ -13803,6 +13815,30 @@ snapshots:
       - prettier
       - supports-color
       - vitest
+
+  '@pagopa/interop-outbound-models@1.7.0':
+    dependencies:
+      '@protobuf-ts/runtime': 2.9.4
+      ts-pattern: 5.2.0
+      zod: 3.23.8
+
+  '@pagopa/interop-outbound-models@1.8.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.9.4
+      ts-pattern: 5.2.0
+      zod: 3.23.8
+
+  '@pagopa/interop-outbound-models@1.8.10':
+    dependencies:
+      '@protobuf-ts/runtime': 2.9.4
+      ts-pattern: 5.2.0
+      zod: 3.23.8
+
+  '@pagopa/interop-outbound-models@1.8.12':
+    dependencies:
+      '@protobuf-ts/runtime': 2.9.4
+      ts-pattern: 5.2.0
+      zod: 3.23.8
 
   '@pagopa/interop-outbound-models@1.8.18-scambi.async.purpose.template.0':
     dependencies:


### PR DESCRIPTION
## Context

- Bump `@pagopa/interop-outbound-models` to (test version) `1.8.18-scambi.async.purpose.template.0` across all async exchange `*-outbound-writer` packages.
- Propagate async exchange fields on the outbound `EServiceV2` / `EServiceDescriptorV2` in `catalog-outbound-writer` (`asyncExchange`,`asyncExchangeCallbackInterface`, `asyncExchangeProperties`).
- Propagate the same fields on the outbound `EServiceTemplateV2` / `EServiceTemplateVersionV2` in `eservice-template-outbound-writer`.
- Emit the 6 new async exchange events instead of dropping them:
  - `EServiceDescriptorAsyncExchangeCallbackInterface{Added,Updated,Deleted}`
  - `EServiceTemplateVersionAsyncExchangeCallbackInterface{Added,Updated,Deleted}`

## Refs
[PIN-9380](https://pagopa.atlassian.net/browse/PIN-9380)
[pagopa/interop-outbound-models#74](https://github.com/pagopa/interop-outbound-models/pull/74).

[PIN-9380]: https://pagopa.atlassian.net/browse/PIN-9380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ