### PR TITLE
fix(bff): normalize async callback interface document (PIN-10153)

### DIFF
--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -516,7 +516,10 @@ export function catalogServiceBuilder(
         },
         asyncExchangeProperties: descriptor.asyncExchangeProperties,
         asyncExchangeCallbackInterface:
-          descriptor.asyncExchangeCallbackInterface,
+          descriptor.asyncExchangeCallbackInterface &&
+          toBffCatalogApiDescriptorDoc(
+            descriptor.asyncExchangeCallbackInterface
+          ),
         delegation:
           delegation !== undefined && delegate !== undefined
             ? {
@@ -997,7 +1000,10 @@ export function catalogServiceBuilder(
         docs: descriptor.docs.map(toBffCatalogApiDescriptorDoc),
         asyncExchangeProperties: descriptor.asyncExchangeProperties,
         asyncExchangeCallbackInterface:
-          descriptor.asyncExchangeCallbackInterface,
+          descriptor.asyncExchangeCallbackInterface &&
+          toBffCatalogApiDescriptorDoc(
+            descriptor.asyncExchangeCallbackInterface
+          ),
         eservice: await toBffCatalogDescriptorEService(
           eservice,
           descriptor,

--- a/packages/backend-for-frontend/test/getCatalogEServiceDescriptor.test.ts
+++ b/packages/backend-for-frontend/test/getCatalogEServiceDescriptor.test.ts
@@ -29,6 +29,7 @@ import * as delegationService from "../src/services/delegationService.js";
 import * as agreementService from "../src/services/agreementService.js";
 import * as catalogApiConverter from "../src/api/catalogApiConverter.js";
 import { fileManager, getBffMockContext } from "./utils.js";
+import { getMockCatalogApiEServiceDoc, toApiEServiceDoc } from "./mockUtils.js";
 
 describe("getCatalogEServiceDescriptor", () => {
   const eServiceId: EServiceId = generateId<EServiceId>();
@@ -357,6 +358,34 @@ describe("getCatalogEServiceDescriptor", () => {
       true,
       true
     );
+  });
+
+  it("should convert the async exchange callback interface to the BFF document shape", async () => {
+    const asyncExchangeCallbackInterface = getMockCatalogApiEServiceDoc();
+    vi.spyOn(mockCatalogProcessClient, "getEServiceById").mockResolvedValueOnce(
+      {
+        ...eService,
+        descriptors: [
+          {
+            ...eServiceDescriptor,
+            asyncExchangeCallbackInterface,
+          },
+        ],
+      }
+    );
+
+    const result = await catalogService.getCatalogEServiceDescriptor(
+      eServiceId,
+      mockDescriptorId,
+      bffMockContext
+    );
+
+    expect(result.asyncExchangeCallbackInterface).toEqual(
+      toApiEServiceDoc(asyncExchangeCallbackInterface)
+    );
+    expect(() =>
+      bffApi.EServiceDoc.parse(result.asyncExchangeCallbackInterface)
+    ).not.toThrow();
   });
 
   it("should throw eserviceDescriptorNotFound if descriptorId cannot be found in eservice's descriptors", async () => {

--- a/packages/backend-for-frontend/test/getProducerEServiceDescriptor.test.ts
+++ b/packages/backend-for-frontend/test/getProducerEServiceDescriptor.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   attributeRegistryApi,
+  bffApi,
   catalogApi,
   agreementApi,
   eserviceTemplateApi,
@@ -23,7 +24,11 @@ import type {
 import { catalogServiceBuilder } from "../src/services/catalogService.js";
 import { config } from "../src/config/config.js";
 import { fileManager, getBffMockContext } from "./utils.js";
-import { getMockDelegationApiDelegation } from "./mockUtils.js";
+import {
+  getMockCatalogApiEServiceDoc,
+  getMockDelegationApiDelegation,
+  toApiEServiceDoc,
+} from "./mockUtils.js";
 
 describe("getProducerEServiceDescriptor", () => {
   const tenantId: TenantId = generateId<TenantId>();
@@ -171,6 +176,33 @@ describe("getProducerEServiceDescriptor", () => {
 
     expect(result.eservice.hasProducerKeychain).toBe(false);
     expect(result.eservice.hasProducerKeychainKeys).toBe(false);
+  });
+
+  it("should convert the async exchange callback interface to the BFF document shape", async () => {
+    const asyncExchangeCallbackInterface = getMockCatalogApiEServiceDoc();
+    vi.spyOn(mockCatalogProcessClient, "getEServiceById").mockResolvedValueOnce(
+      {
+        ...eService,
+        descriptors: [
+          {
+            ...descriptor,
+            asyncExchangeCallbackInterface,
+          },
+        ],
+      }
+    );
+    mockProducerKeychainEServiceFlagsResponse(false, false);
+
+    const result = await catalogService.getProducerEServiceDescriptor(
+      eServiceId,
+      descriptorId,
+      bffMockContext
+    );
+
+    expect(result.asyncExchangeCallbackInterface).toEqual(
+      toApiEServiceDoc(asyncExchangeCallbackInterface)
+    );
+    expect(() => bffApi.ProducerEServiceDescriptor.parse(result)).not.toThrow();
   });
 
   it("should distinguish a producer keychain without keys", async () => {


### PR DESCRIPTION
## Issue
- [PIN-10153](https://pagopa.atlassian.net/browse/PIN-10153)

## Context / Why
- The BFF returned 500 when an e-service descriptor included `asyncExchangeCallbackInterface`.
- The callback interface document was returned with Catalog API fields such as `path` and `uploadDate`, while the BFF `EServiceDoc` response schema is strict.

## Scope
- Normalize `asyncExchangeCallbackInterface` to the BFF document shape in producer descriptor responses.
- Apply the same normalization to catalog descriptor responses.
- Add regression tests for both descriptor retrieval flows.

## Testing / Validation
- [x] Lint
- [x] Type check
- [x] Unit tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10153]: https://pagopa.atlassian.net/browse/PIN-10153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ