### PR TITLE
bugfix(notifier-seeder): async callback interface event conversion (PIN-10154)

### DIFF
--- a/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationConverter.ts
+++ b/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationConverter.ts
@@ -95,9 +95,7 @@ const getAsyncExchangeCallbackInterface = (
   }
 
   const eservice = fromEServiceV2(event.data.eservice);
-  const descriptor = eservice.descriptors.find(
-    (d) => d.id === descriptorId
-  );
+  const descriptor = eservice.descriptors.find((d) => d.id === descriptorId);
 
   if (!descriptor) {
     throw eventV1ConversionError(

--- a/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationConverter.ts
+++ b/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationConverter.ts
@@ -19,7 +19,10 @@ import {
   CatalogItemRiskAnalysisNotification,
   CatalogItemV1Notification,
 } from "./catalogItemEventNotification.js";
-import { toCatalogItemV1 } from "./catalogItemEventNotificationMappers.js";
+import {
+  toCatalogDocumentV1,
+  toCatalogItemV1,
+} from "./catalogItemEventNotificationMappers.js";
 
 const getCatalogItem = (
   event: EServiceEventEnvelopeV2
@@ -80,6 +83,43 @@ const getCatalogItemInterface = (
   }
 
   return descriptor.interface;
+};
+
+const getAsyncExchangeCallbackInterface = (
+  event: EServiceEventEnvelopeV2,
+  descriptorId: string,
+  documentId: string
+): CatalogDocumentV1Notification => {
+  if (!event.data.eservice) {
+    throw missingKafkaMessageDataError("eservice", event.type);
+  }
+
+  const eservice = fromEServiceV2(event.data.eservice);
+  const descriptor = eservice.descriptors.find(
+    (d) => d.id === descriptorId
+  );
+
+  if (!descriptor) {
+    throw eventV1ConversionError(
+      `Expected descriptor ${descriptorId} in eservice ${eservice.id} during eventV1 conversion`
+    );
+  }
+
+  const asyncExchangeCallbackInterface =
+    descriptor.asyncExchangeCallbackInterface;
+  if (!asyncExchangeCallbackInterface) {
+    throw eventV1ConversionError(
+      `Expected async exchange callback interface ${documentId} in descriptor ${descriptor.id} during eventV1 conversion`
+    );
+  }
+
+  if (asyncExchangeCallbackInterface.id !== documentId) {
+    throw eventV1ConversionError(
+      `Expected async exchange callback interface with same ID ${documentId} in descriptor ${descriptor.id} during eventV1 conversion`
+    );
+  }
+
+  return toCatalogDocumentV1(asyncExchangeCallbackInterface);
 };
 
 export const toCatalogItemEventNotification = (
@@ -174,7 +214,6 @@ export const toCatalogItemEventNotification = (
     )
     .with(
       { type: "EServiceDescriptorInterfaceAdded" }, // CatalogItemDocumentAddedV1
-      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded" },
       (e): CatalogItemDocumentAddedNotification => {
         const catalogItem = getCatalogItem(e);
         const catalogItemDescriptor = getCatalogItemDescriptor(
@@ -192,6 +231,28 @@ export const toCatalogItemEventNotification = (
           document: catalogItemInterface,
           isInterface: true,
           serverUrls: catalogItemDescriptor.serverUrls,
+        };
+      }
+    )
+    .with(
+      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded" },
+      (e): CatalogItemDocumentAddedNotification => {
+        const catalogItem = getCatalogItem(e);
+        const catalogItemDescriptor = getCatalogItemDescriptor(
+          catalogItem,
+          e.data.descriptorId
+        );
+
+        return {
+          eServiceId: catalogItem.id,
+          descriptorId: catalogItemDescriptor.id,
+          document: getAsyncExchangeCallbackInterface(
+            e,
+            e.data.descriptorId,
+            e.data.documentId
+          ),
+          isInterface: true,
+          serverUrls: [],
         };
       }
     )
@@ -214,7 +275,6 @@ export const toCatalogItemEventNotification = (
     )
     .with(
       { type: "EServiceDescriptorInterfaceUpdated" }, // CatalogItemDocumentUpdatedV1
-      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated" },
       (e): CatalogItemDocumentUpdateNotification => {
         const eserviceV1 = getCatalogItem(e);
         const descriptorV1 = getCatalogItemDescriptor(
@@ -232,6 +292,30 @@ export const toCatalogItemEventNotification = (
           documentId: interfaceV1.id,
           updatedDocument: interfaceV1,
           serverUrls: descriptorV1.serverUrls,
+        };
+      }
+    )
+    .with(
+      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated" },
+      (e): CatalogItemDocumentUpdateNotification => {
+        const eserviceV1 = getCatalogItem(e);
+        const descriptorV1 = getCatalogItemDescriptor(
+          eserviceV1,
+          e.data.descriptorId
+        );
+        const asyncExchangeCallbackInterface =
+          getAsyncExchangeCallbackInterface(
+            e,
+            e.data.descriptorId,
+            e.data.documentId
+          );
+
+        return {
+          eServiceId: eserviceV1.id,
+          descriptorId: descriptorV1.id,
+          documentId: asyncExchangeCallbackInterface.id,
+          updatedDocument: asyncExchangeCallbackInterface,
+          serverUrls: [],
         };
       }
     )

--- a/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationMappers.ts
+++ b/packages/notifier-seeder/src/models/catalog/catalogItemEventNotificationMappers.ts
@@ -80,7 +80,9 @@ const toCatalogAttributeValueV1 = (
   return input ? input.map((a) => a.map(toCatalogAttributeValue)) : [];
 };
 
-const toCatalogDocumentV1 = (doc: Document): CatalogDocumentV1Notification => ({
+export const toCatalogDocumentV1 = (
+  doc: Document
+): CatalogDocumentV1Notification => ({
   id: doc.id,
   name: doc.name,
   contentType: doc.contentType,

--- a/packages/notifier-seeder/test/catalogItemEventNotificationConverter.test.ts
+++ b/packages/notifier-seeder/test/catalogItemEventNotificationConverter.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  DescriptorId,
+  EServiceDocumentId,
+  EServiceEventEnvelopeV2,
+  EServiceId,
+  TenantId,
+  descriptorState,
+  eserviceMode,
+  generateId,
+  technology,
+  toEServiceV2,
+} from "pagopa-interop-models";
+import { toCatalogItemEventNotification } from "../src/models/catalog/catalogItemEventNotificationConverter.js";
+
+const descriptorId: DescriptorId = generateId();
+const eserviceId: EServiceId = generateId();
+const producerId: TenantId = generateId();
+const interfaceId: EServiceDocumentId = generateId();
+const asyncExchangeCallbackInterfaceId: EServiceDocumentId = generateId();
+
+const interfaceDocument = {
+  id: interfaceId,
+  name: "interface.yaml",
+  contentType: "application/yaml",
+  prettyName: "Interface",
+  path: `eservices/docs/${interfaceId}/interface.yaml`,
+  checksum: "interface-checksum",
+  uploadDate: new Date("2026-05-22T08:00:00.000Z"),
+};
+
+const asyncExchangeCallbackInterfaceDocument = {
+  id: asyncExchangeCallbackInterfaceId,
+  name: "callback.yaml",
+  contentType: "application/yaml",
+  prettyName: "Callback interface",
+  path: `eservices/docs/${asyncExchangeCallbackInterfaceId}/callback.yaml`,
+  checksum: "callback-checksum",
+  uploadDate: new Date("2026-05-22T08:05:00.000Z"),
+};
+
+const eservice = toEServiceV2({
+  id: eserviceId,
+  producerId,
+  name: "eservice name",
+  description: "eservice description",
+  technology: technology.rest,
+  descriptors: [
+    {
+      id: descriptorId,
+      version: "1",
+      interface: interfaceDocument,
+      asyncExchangeCallbackInterface: asyncExchangeCallbackInterfaceDocument,
+      docs: [],
+      state: descriptorState.draft,
+      audience: [],
+      voucherLifespan: 60,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1,
+      agreementApprovalPolicy: "Automatic",
+      createdAt: new Date("2026-05-22T07:50:00.000Z"),
+      serverUrls: ["https://example.com/callback"],
+      attributes: {
+        certified: [],
+        declared: [],
+        verified: [],
+      },
+    },
+  ],
+  createdAt: new Date("2026-05-22T07:45:00.000Z"),
+  riskAnalysis: [],
+  mode: eserviceMode.deliver,
+});
+
+const getEnvelope = (
+  type:
+    | "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded"
+    | "EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated"
+): EServiceEventEnvelopeV2 => ({
+  sequence_num: 1,
+  stream_id: eserviceId,
+  version: 1,
+  correlation_id: generateId(),
+  log_date: new Date("2026-05-22T08:10:00.000Z"),
+  event_version: 2,
+  type,
+  data: {
+    descriptorId,
+    documentId: asyncExchangeCallbackInterfaceId,
+    eservice,
+  },
+});
+
+describe("toCatalogItemEventNotification", () => {
+  it("should convert async exchange callback interface added events using the callback interface document", () => {
+    const result = toCatalogItemEventNotification(
+      getEnvelope("EServiceDescriptorAsyncExchangeCallbackInterfaceAdded")
+    );
+
+    expect(result).toEqual({
+      eServiceId: eserviceId,
+      descriptorId,
+      document: {
+        ...asyncExchangeCallbackInterfaceDocument,
+        uploadDate:
+          asyncExchangeCallbackInterfaceDocument.uploadDate.toISOString(),
+      },
+      isInterface: true,
+      serverUrls: [],
+    });
+  });
+
+  it("should convert async exchange callback interface updated events using the callback interface document", () => {
+    const result = toCatalogItemEventNotification(
+      getEnvelope("EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated")
+    );
+
+    expect(result).toEqual({
+      eServiceId: eserviceId,
+      descriptorId,
+      documentId: asyncExchangeCallbackInterfaceId,
+      updatedDocument: {
+        ...asyncExchangeCallbackInterfaceDocument,
+        uploadDate:
+          asyncExchangeCallbackInterfaceDocument.uploadDate.toISOString(),
+      },
+      serverUrls: [],
+    });
+  });
+});


### PR DESCRIPTION
## Issue
- [PIN-10154](https://pagopa.atlassian.net/browse/PIN-10154)

## Context / Why
- The notifier-seeder crashed while converting `EServiceDescriptorAsyncExchangeCallbackInterfaceAdded` events.
- Async callback interface events were handled like regular interface events, so the converter looked up the callback document in `descriptor.interface`.

## Scope
- Handle async exchange callback interface added/updated events separately.
- Read callback documents from `descriptor.asyncExchangeCallbackInterface`.
- Keep `serverUrls` empty for async callback interface events since `serverUrls` are not needed for `asyncExchangeCallbackInterface`: the callback endpoint is provided during the async exchange interaction in the `start_interaction` flow, not through descriptor interface server URLs.
- Add regression tests for added and updated callback interface events.

## Testing / Validation
- [x] Lint
- [x] Typecheck
- [x] Unit tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [ ] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10154]: https://pagopa.atlassian.net/browse/PIN-10154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ