### PR TITLE
fix(bff): parse form-urlencoded async flag in token debugger (PIN-10157)

### DIFF
--- a/collections/bff/tools/Validate token generation request.bru
+++ b/collections/bff/tools/Validate token generation request.bru
@@ -19,7 +19,7 @@ body:form-urlencoded {
   client_assertion_type: <string>
   grant_type: <string>
   client_id: <string>
-  is_async: false
+  is_async: "false"
   dpop_proof: <optional dpop proof>
 }
 

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -26138,8 +26138,11 @@ components:
         grant_type:
           type: string
         is_async:
-          type: boolean
-          default: false
+          type: string
+          enum:
+            - "true"
+            - "false"
+          default: "false"
           description: Set to true to validate the client assertion as an async token generation request
         dpop_proof:
           type: string

--- a/packages/backend-for-frontend/src/routers/toolRouter.ts
+++ b/packages/backend-for-frontend/src/routers/toolRouter.ts
@@ -36,7 +36,7 @@ const toolRouter = (
         req.body.client_assertion,
         req.body.client_assertion_type,
         req.body.grant_type,
-        req.body.is_async ?? false,
+        req.body.is_async === "true",
         req.body.dpop_proof,
         ctx
       );

--- a/packages/backend-for-frontend/test/api/toolRouter/validateTokenGeneration.test.ts
+++ b/packages/backend-for-frontend/test/api/toolRouter/validateTokenGeneration.test.ts
@@ -15,7 +15,7 @@ describe("API POST /tools/validateTokenGeneration", () => {
     client_assertion_type:
       "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
     grant_type: "client_credentials",
-    is_async: false,
+    is_async: "false",
   };
   const mockRequestWithDPoP: bffApi.AccessTokenRequest = {
     ...mockRequest,
@@ -23,7 +23,7 @@ describe("API POST /tools/validateTokenGeneration", () => {
   };
   const mockAsyncRequest: bffApi.AccessTokenRequest = {
     ...mockRequest,
-    is_async: true,
+    is_async: "true",
   };
   const mockResult: bffApi.TokenGenerationValidationResult = {
     clientKind: "CONSUMER",
@@ -79,6 +79,15 @@ describe("API POST /tools/validateTokenGeneration", () => {
       .set("Authorization", `Bearer ${token}`)
       .set("X-Correlation-Id", generateId())
       .send(body);
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  const makeFormRequest = async (token: string, body: Record<string, string>) =>
+    request(api)
+      .post(`${appBasePath}/tools/validateTokenGeneration`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .set("Content-Type", "application/x-www-form-urlencoded")
+      .send(new URLSearchParams(body).toString());
 
   it.each([authRole.ADMIN_ROLE, authRole.SECURITY_ROLE, authRole.SUPPORT_ROLE])(
     "Should return 200 with validation result for valid request (role %s)",
@@ -144,6 +153,35 @@ describe("API POST /tools/validateTokenGeneration", () => {
       expect.anything()
     );
   });
+
+  it.each([
+    { isAsync: "true", expectedIsAsync: true },
+    { isAsync: "false", expectedIsAsync: false },
+  ])(
+    "Should parse async validation mode $isAsync from form-urlencoded body",
+    async ({ isAsync, expectedIsAsync }) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeFormRequest(token, {
+        client_id: mockAsyncRequest.client_id ?? "",
+        client_assertion: mockAsyncRequest.client_assertion,
+        client_assertion_type: mockAsyncRequest.client_assertion_type,
+        grant_type: mockAsyncRequest.grant_type,
+        is_async: isAsync,
+      });
+      expect(res.status).toBe(200);
+      expect(
+        services.toolsService.validateTokenGeneration
+      ).toHaveBeenCalledWith(
+        mockAsyncRequest.client_id,
+        mockAsyncRequest.client_assertion,
+        mockAsyncRequest.client_assertion_type,
+        mockAsyncRequest.grant_type,
+        expectedIsAsync,
+        undefined,
+        expect.anything()
+      );
+    }
+  );
 
   it.each([
     { body: {} },


### PR DESCRIPTION
## Issue
- [PIN-10157](https://pagopa.atlassian.net/browse/PIN-10157)

## Context / Why
- `application/x-www-form-urlencoded` bodies carry all values as strings, but the `is_async` field was declared as `boolean` in the OpenAPI schema, so form-encoded requests always received the string `"true"` or `"false"` instead of a native boolean.
- The previous fallback `req.body.is_async ?? false` never fired for `"false"` (non-empty string is truthy), making it impossible to explicitly disable async mode when calling the token debugger via form encoding.

## Scope
- Changed `AccessTokenRequest.is_async` in `bffApi.yml` from `type: boolean` to `type: string` with `enum: ["true", "false"]` and `default: "false"`. The schema now reflects what form encoding can actually carry, and Zodios rejects any other value with 400.
- Updated `toolRouter.ts` to convert the field with `req.body.is_async === "true"` instead of `req.body.is_async ?? false`.
- Updated test

## Testing / Validation
- [x] Lint
- [x] Type Check
- [x] Unit tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [x] OpenAPI spec updated
- [x] Bruno endpoint definition updated

[PIN-10157]: https://pagopa.atlassian.net/browse/PIN-10157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ