### PR TITLE
fix: align eservice template async exchange callback interface upload (PIN-10163 follow-up)

### DIFF
--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -1710,13 +1710,6 @@ export function eserviceTemplateServiceBuilder(
           );
         }
 
-        if (version.asyncExchangeProperties === undefined) {
-          throw missingAsyncExchangeProperties(
-            eserviceTemplate.data.id,
-            version.id
-          );
-        }
-
         if (version.asyncExchangeCallbackInterface !== undefined) {
           throw asyncExchangeCallbackInterfaceAlreadyExists(version.id);
         }

--- a/packages/eservice-template-process/src/utilities/errorMappers.ts
+++ b/packages/eservice-template-process/src/utilities/errorMappers.ts
@@ -294,7 +294,6 @@ export const createEServiceTemplateDocumentErrorMapper = (
       "interfaceAlreadyExists",
       "asyncExchangeCallbackInterfaceAlreadyExists",
       "eserviceTemplateAsyncExchangeNotEnabled",
-      "missingAsyncExchangeProperties",
       "asyncExchangeBulkNotAllowedForSoap",
       () => HTTP_STATUS_BAD_REQUEST
     )

--- a/packages/eservice-template-process/test/api/createEServiceTemplateDocument.test.ts
+++ b/packages/eservice-template-process/test/api/createEServiceTemplateDocument.test.ts
@@ -26,7 +26,6 @@ import {
   eserviceTemplateVersionNotFound,
   interfaceAlreadyExists,
   notValidEServiceTemplateVersionState,
-  missingAsyncExchangeProperties,
   asyncExchangeBulkNotAllowedForSoap,
 } from "../../src/model/domain/errors.js";
 import { buildDocumentSeed } from "../mockUtils.js";
@@ -135,13 +134,6 @@ describe("API POST /templates/:templateId/versions/:templateVersionId/documents"
         eserviceTemplateVersionState.published
       ),
       expectedStatus: 409,
-    },
-    {
-      error: missingAsyncExchangeProperties(
-        mockEserviceTemplate.id,
-        mockEserviceTemplate.versions[0].id
-      ),
-      expectedStatus: 400,
     },
     {
       error: asyncExchangeBulkNotAllowedForSoap(

--- a/packages/eservice-template-process/test/integration/uploadDocument.test.ts
+++ b/packages/eservice-template-process/test/integration/uploadDocument.test.ts
@@ -33,7 +33,6 @@ import {
   notValidEServiceTemplateVersionState,
   eserviceTemplateAsyncExchangeNotEnabled,
   asyncExchangeCallbackInterfaceAlreadyExists,
-  missingAsyncExchangeProperties,
 } from "../../src/model/domain/errors.js";
 import { config } from "../../src/config/config.js";
 import {
@@ -595,7 +594,7 @@ describe("upload Document", () => {
     }
   );
 
-  it("should throw missingAsyncExchangeProperties when uploading asyncExchangeCallbackInterface without asyncExchangeProperties configured", async () => {
+  it("should write on event-store for the upload of an asyncExchangeCallbackInterface even when the version has no asyncExchangeProperties set yet", async () => {
     const version: EServiceTemplateVersion = {
       ...mockVersion,
       state: eserviceTemplateVersionState.draft,
@@ -608,18 +607,69 @@ describe("upload Document", () => {
     };
     await addOneEServiceTemplate(eserviceTemplate);
 
-    await expect(
-      eserviceTemplateService.createEServiceTemplateDocument(
+    const returnedDocument =
+      await eserviceTemplateService.createEServiceTemplateDocument(
         eserviceTemplate.id,
         version.id,
         buildAsyncExchangeCallbackInterfaceSeed(),
         getMockContext({
           authData: getMockAuthData(eserviceTemplate.creatorId),
         })
-      )
-    ).rejects.toThrowError(
-      missingAsyncExchangeProperties(eserviceTemplate.id, version.id)
+      );
+
+    const writtenEvent = await readLastEserviceTemplateEvent(
+      eserviceTemplate.id
     );
+
+    expect(writtenEvent).toMatchObject({
+      stream_id: eserviceTemplate.id,
+      version: "1",
+      type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded",
+      event_version: 2,
+    });
+
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceTemplateVersionAsyncExchangeCallbackInterfaceAddedV2,
+      payload: writtenEvent.data,
+    });
+
+    const expectedDocument: Document = {
+      ...mockDocument,
+      id: unsafeBrandId(
+        writtenPayload.eserviceTemplate!.versions[0]!
+          .asyncExchangeCallbackInterface!.id
+      ),
+      checksum:
+        writtenPayload.eserviceTemplate!.versions[0]!
+          .asyncExchangeCallbackInterface!.checksum,
+      uploadDate: new Date(
+        writtenPayload.eserviceTemplate!.versions[0]!
+          .asyncExchangeCallbackInterface!.uploadDate
+      ),
+    };
+
+    const expectedEserviceTemplate = toEServiceTemplateV2({
+      ...eserviceTemplate,
+      versions: [
+        {
+          ...version,
+          asyncExchangeCallbackInterface: expectedDocument,
+        },
+      ],
+    });
+
+    expect(writtenPayload.eserviceTemplateVersionId).toEqual(version.id);
+    expect(writtenPayload).toEqual({
+      eserviceTemplateVersionId: version.id,
+      documentId: expectedDocument.id,
+      eserviceTemplate: expectedEserviceTemplate,
+    });
+    expect(returnedDocument).toEqual({
+      data: expectedDocument,
+      metadata: {
+        version: 1,
+      },
+    });
   });
 
   it("should throw featureFlagNotEnabled when uploading asyncExchangeCallbackInterface with feature flag disabled", async () => {


### PR DESCRIPTION
## Context

Follow-up to [PIN-10163](https://pagopa.atlassian.net/browse/PIN-10163) (#3397), which unblocked the async exchange callback
interface upload in `catalog-process`. The same fix was not propagated to
`eservice-template-process`


[PIN-10163]: https://pagopa.atlassian.net/browse/PIN-10163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ