### PR TITLE
fix: allow confirmation scope from callback_invocation (PIN-10199)

### DIFF
--- a/packages/backend-for-frontend/src/services/toolServiceUtils.ts
+++ b/packages/backend-for-frontend/src/services/toolServiceUtils.ts
@@ -38,6 +38,7 @@ const asyncInteractionStateAllowedByScope: Record<
     interactionState.getResource,
   ],
   [interactionState.confirmation]: [
+    interactionState.callbackInvocation,
     interactionState.getResource,
     interactionState.confirmation,
   ],

--- a/packages/backend-for-frontend/test/validateAsyncTokenGeneration.test.ts
+++ b/packages/backend-for-frontend/test/validateAsyncTokenGeneration.test.ts
@@ -1111,4 +1111,141 @@ describe("validateTokenGeneration async validations", () => {
       )
     ).toBe(true);
   });
+
+  it("should validate confirmation when interaction is in callback_invocation state", async () => {
+    vi.spyOn(
+      clientAssertionValidation,
+      "verifyAsyncClientAssertion"
+    ).mockReturnValue({
+      errors: undefined,
+      data: {
+        header: { kid: mockKid, alg: "RS256", typ: "JWT" },
+        payload: {
+          sub: mockClientId,
+          jti: "jti",
+          iat: 1,
+          exp: 2,
+          iss: mockClientId,
+          aud: ["audience"],
+          scope: interactionState.confirmation,
+          interactionId: mockInteractionId,
+        },
+      },
+    });
+
+    dynamoDBClient.send = vi.fn().mockResolvedValueOnce({
+      Items: [
+        marshall({
+          PK: `INTERACTION#${mockInteractionId}`,
+          GSIPK_interactionId: makeGSIPKInteractionId(mockInteractionId),
+          interactionId: mockInteractionId,
+          clientId: mockClientId,
+          consumerId: mockAuthData.organizationId,
+          purposeId: mockPurposeId,
+          eServiceId: mockEServiceId,
+          descriptorId: mockDescriptorId,
+          state: interactionState.callbackInvocation,
+          callbackInvocationTokenIssuedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          ttl: 1,
+        }),
+      ],
+    });
+
+    mockClients.catalogProcessClient.getEServiceById = vi
+      .fn()
+      .mockResolvedValue({
+        id: mockEServiceId,
+        name: "Test eService",
+        asyncExchange: true,
+        descriptors: [
+          {
+            id: mockDescriptorId,
+            version: "1",
+            state: "PUBLISHED",
+            audience: ["audience"],
+            voucherLifespan: 3600,
+            asyncExchangeProperties: {
+              responseTime: 60,
+              resourceAvailableTime: 120,
+              confirmation: true,
+              bulk: false,
+              maxResultSet: 100,
+            },
+          },
+        ],
+      });
+
+    const result = await service.validateTokenGeneration(
+      mockClientId,
+      mockClientAssertion,
+      mockClientAssertionType,
+      mockGrantType,
+      true,
+      undefined,
+      ctx
+    );
+
+    expect(result.steps.clientAssertionValidation.result).toBe("PASSED");
+    expect(result.steps.publicKeyRetrieve.result).toBe("PASSED");
+    expect(result.steps.platformStatesVerification.result).toBe("PASSED");
+  });
+
+  it("interactionStateNotAllowed when interaction is in start_interaction state but scope is confirmation", async () => {
+    vi.spyOn(
+      clientAssertionValidation,
+      "verifyAsyncClientAssertion"
+    ).mockReturnValue({
+      errors: undefined,
+      data: {
+        header: { kid: mockKid, alg: "RS256", typ: "JWT" },
+        payload: {
+          sub: mockClientId,
+          jti: "jti",
+          iat: 1,
+          exp: 2,
+          iss: mockClientId,
+          aud: ["audience"],
+          scope: interactionState.confirmation,
+          interactionId: mockInteractionId,
+        },
+      },
+    });
+
+    dynamoDBClient.send = vi.fn().mockResolvedValueOnce({
+      Items: [
+        marshall({
+          PK: `INTERACTION#${mockInteractionId}`,
+          interactionId: mockInteractionId,
+          clientId: mockClientId,
+          consumerId: mockAuthData.organizationId,
+          purposeId: mockPurposeId,
+          eServiceId: mockEServiceId,
+          descriptorId: mockDescriptorId,
+          state: interactionState.startInteraction,
+          startInteractionTokenIssuedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          ttl: 1,
+        }),
+      ],
+    });
+
+    const result = await service.validateTokenGeneration(
+      mockClientId,
+      mockClientAssertion,
+      mockClientAssertionType,
+      mockGrantType,
+      true,
+      undefined,
+      ctx
+    );
+
+    expect(result.steps.publicKeyRetrieve.result).toBe("FAILED");
+    expect(result.steps.publicKeyRetrieve.failures).toEqual([
+      {
+        code: "interactionStateNotAllowed",
+        reason: `Interaction ${mockInteractionId} in state ${interactionState.startInteraction} does not allow scope ${interactionState.confirmation}`,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `callback_invocation` to the allowed states for the `confirmation` scope in `asyncInteractionStateAllowedByScope` (`packages/backend-for-frontend/src/services/toolServiceUtils.ts`).
- Fixes [PIN-10199](https://pagopa.atlassian.net/browse/PIN-10199): a voucher request with scope `confirmation` starting from state `callback_invocation` was returning 400 (`015-0008 - Unable to generate a token for the given request`) instead of 200.

## Rationale

Per the [SRS - Scambi massivi asincroni](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2512683132), step 33, PDND validations for issuing `TokenPDND_async_confirmation` allow:

> lo stato di `InteractionID` sia uguale a `callback_invocation` o `get_resource`

Skipping `get_resource` is an explicit use case: when the Provider delivers the `resultset` inline in the callback (cardinality 1), the Consumer does not receive an `id_resource`, so the `OPT1` block is not triggered and the flow goes directly to `confirmation` (when `[OPT_CONFIRMATION]` is enabled).

`confirmation` is kept as a self-loop, consistent with the re-issue pattern of the other scopes (`callback_invocation` and `get_resource` both accept themselves).

## Tests

Added in `packages/backend-for-frontend/test/validateAsyncTokenGeneration.test.ts`:

- `should validate confirmation when interaction is in callback_invocation state` — direct regression test for the bug.
- `interactionStateNotAllowed when interaction is in start_interaction state but scope is confirmation` — ensures non-allowed states (e.g. `start_interaction`) remain blocked.

[PIN-10199]: https://pagopa.atlassian.net/browse/PIN-10199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ