### PR TITLE
fix(bff): align interactions GSI name to deployed infrastructure (PIN-10208)

### DIFF
--- a/docker/dynamo-db/schema/interactions-dynamo-db.json
+++ b/docker/dynamo-db/schema/interactions-dynamo-db.json
@@ -18,7 +18,7 @@
   ],
   "GlobalSecondaryIndexes": [
     {
-      "IndexName": "GSIPK_interactionId-index",
+      "IndexName": "interactionId",
       "KeySchema": [
         {
           "AttributeName": "GSIPK_interactionId",

--- a/packages/backend-for-frontend/src/services/toolServiceUtils.ts
+++ b/packages/backend-for-frontend/src/services/toolServiceUtils.ts
@@ -129,7 +129,7 @@ async function readInteractionById(
   const queryResult = await dynamoDBClient.send(
     new QueryCommand({
       TableName: interactionsTable,
-      IndexName: "GSIPK_interactionId-index",
+      IndexName: "interactionId",
       KeyConditionExpression: "GSIPK_interactionId = :interactionId",
       ExpressionAttributeValues: {
         ":interactionId": { S: makeGSIPKInteractionId(interactionId) },


### PR DESCRIPTION
## Summary

The async client assertion validation in `POST /backend-for-frontend/tools/validateTokenGeneration` was returning **500 (008-9991)** in `dev` with the underlying DynamoDB error:

```
ValidationException: The table does not have the specified index: GSIPK_interactionId-index
```

The endpoint goes through `validateAsyncTokenGeneration` → `retrieveInteractionForAsyncScope` → `readInteractionById`, which queries the `interactions` table via a GSI whose name was hardcoded to `GSIPK_interactionId-index`. The GSI on the deployed table is named **`interactionId`**.

This PR aligns the BFF code and the local docker schema to the deployed GSI name:

- `packages/backend-for-frontend/src/services/toolServiceUtils.ts:132` — `IndexName: "GSIPK_interactionId-index"` → `IndexName: "interactionId"`
- `docker/dynamo-db/schema/interactions-dynamo-db.json` — rename the local GSI accordingly to keep dev-local and dev-AWS in sync.

`KeyConditionExpression` and `ExpressionAttributeValues` stay unchanged: the GSI partition key remains `GSIPK_interactionId`, which is already populated on item creation by `authorization-server/src/utilities/interactionsUtils.ts:92` (merged with PIN-9594 via #3116).

## Infra change required (blocking this PR)

Direct inspection of `interop-async-exchanges-interactions-dev` (account `505630707203`, eu-south-1) shows that the GSI deployed today is built with **`PK`** as hash key instead of `GSIPK_interactionId`:

```json
"GlobalSecondaryIndexes": [
  {
    "IndexName": "interactionId",
    "KeySchema": [{ "AttributeName": "PK", "KeyType": "HASH" }],
    "Projection": { "ProjectionType": "ALL" }
  }
]
```

`GSIPK_interactionId` is not even declared in `AttributeDefinitions`, despite being populated on every new item by `authorization-server`. The most likely explanation is that the GSI was provisioned before PIN-9594 introduced reliable writes of the `GSIPK_interactionId` attribute, and `PK` was used as a safe fallback hash key.

DevOps action needed to make this PR work end-to-end:

1. Add `GSIPK_interactionId` to the table `AttributeDefinitions` in the IaC for the `interactions` table.
2. Recreate the `interactionId` GSI with `KeySchema: AttributeName=GSIPK_interactionId, KeyType=HASH` (and `ProjectionType: ALL`). The GSI cannot be altered in place — it has to be dropped and recreated.
3. Roll out across `dev` → `test` → `qa` → `prod`. Backfill is automatic: every item created since the PIN-9594 merge already carries `GSIPK_interactionId`.

This PR can be merged once the GSI is recreated in the target environment.

Jira: [PIN-10208](https://pagopa.atlassian.net/browse/PIN-10208)

[PIN-10208]: https://pagopa.atlassian.net/browse/PIN-10208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ