### PR TITLE
PIN-10212 fix: install Puppeteer Chrome in CI test job

### DIFF
--- a/.github/workflows/pr-app-validation.yaml
+++ b/.github/workflows/pr-app-validation.yaml
@@ -287,6 +287,8 @@ jobs:
     permissions:
       contents: read
     needs: [packages_sharding, build]
+    env:
+      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
     strategy:
       fail-fast: false
       matrix:
@@ -310,7 +312,7 @@ jobs:
         if: contains(toJson(matrix.shard.packages), 'pagopa-interop-documents-generator')
         uses: actions/cache@b7e8d49f17405cc70c1c120101943203c98d3a4b
         with:
-          path: ~/.cache/puppeteer
+          path: ${{ env.PUPPETEER_CACHE_DIR }}
           key: ${{ runner.os }}-puppeteer-chrome-${{ hashFiles('pnpm-workspace.yaml') }}
       # `puppeteer browsers install chrome` is bypassed because on this runner
       # its zip extraction completes only partially (a handful of entries out of
@@ -320,8 +322,6 @@ jobs:
       # installed Puppeteer package so a puppeteer bump is followed automatically.
       - name: Install Puppeteer browser
         if: contains(toJson(matrix.shard.packages), 'pagopa-interop-documents-generator')
-        env:
-          PUPPETEER_CACHE_DIR: /home/runner/.cache/puppeteer
         run: |
           CHROME_VERSION="$(pnpm --filter pagopa-interop-documents-generator exec node --input-type=module -e 'import puppeteer from "puppeteer"; console.log(puppeteer.browserRevision ?? "")')"
           if [ -z "$CHROME_VERSION" ]; then
@@ -353,8 +353,6 @@ jobs:
           fi
           echo "Chrome ready at: $CHROME_BIN"
       - name: Run tests for shard
-        env:
-          PUPPETEER_CACHE_DIR: /home/runner/.cache/puppeteer
         run: |
           PACKAGES_JSON='${{ toJson(matrix.shard.packages) }}'
           COMMAND='${{ matrix.shard.command }}'

--- a/.github/workflows/pr-app-validation.yaml
+++ b/.github/workflows/pr-app-validation.yaml
@@ -306,7 +306,55 @@ jobs:
         with:
           name: build-output
           path: .
+      - name: Cache Puppeteer browsers
+        if: contains(toJson(matrix.shard.packages), 'pagopa-interop-documents-generator')
+        uses: actions/cache@b7e8d49f17405cc70c1c120101943203c98d3a4b
+        with:
+          path: ~/.cache/puppeteer
+          key: ${{ runner.os }}-puppeteer-chrome-${{ hashFiles('pnpm-workspace.yaml') }}
+      # `puppeteer browsers install chrome` is bypassed because on this runner
+      # its zip extraction completes only partially (a handful of entries out of
+      # thousands), leaving the cache directory without the chrome executable.
+      # We fetch the official Chrome-for-Testing zip and unpack it with system
+      # `unzip`, which is reliable. The Chrome version is derived from the
+      # installed Puppeteer package so a puppeteer bump is followed automatically.
+      - name: Install Puppeteer browser
+        if: contains(toJson(matrix.shard.packages), 'pagopa-interop-documents-generator')
+        env:
+          PUPPETEER_CACHE_DIR: /home/runner/.cache/puppeteer
+        run: |
+          CHROME_VERSION="$(pnpm --filter pagopa-interop-documents-generator exec node --input-type=module -e 'import puppeteer from "puppeteer"; console.log(puppeteer.browserRevision ?? "")')"
+          if [ -z "$CHROME_VERSION" ]; then
+            echo "::error::Unable to derive Chrome version from Puppeteer"
+            exit 1
+          fi
+          echo "Chrome version derived from puppeteer-core: $CHROME_VERSION"
+          CHROME_DIR="$PUPPETEER_CACHE_DIR/chrome/linux-$CHROME_VERSION/chrome-linux64"
+          CHROME_BIN="$CHROME_DIR/chrome"
+          if [ -x "$CHROME_BIN" ]; then
+            echo "Chrome already installed at $CHROME_BIN"
+            if "$CHROME_BIN" --version; then
+              exit 0
+            fi
+            echo "Cached Chrome cannot run, reinstalling..."
+            rm -rf "$PUPPETEER_CACHE_DIR/chrome/linux-$CHROME_VERSION"
+          fi
+          echo "Chrome not installed. Downloading $CHROME_VERSION from Chrome-for-Testing..."
+          rm -rf "$PUPPETEER_CACHE_DIR/chrome/linux-$CHROME_VERSION"
+          mkdir -p "$PUPPETEER_CACHE_DIR/chrome/linux-$CHROME_VERSION"
+          curl -fSL -o /tmp/chrome.zip \
+            "https://storage.googleapis.com/chrome-for-testing-public/$CHROME_VERSION/linux64/chrome-linux64.zip"
+          unzip -q /tmp/chrome.zip -d "$PUPPETEER_CACHE_DIR/chrome/linux-$CHROME_VERSION"
+          rm /tmp/chrome.zip
+          chmod +x "$CHROME_BIN"
+          if ! "$CHROME_BIN" --version; then
+            echo "::error::Chrome install failed: $CHROME_BIN cannot run"
+            exit 1
+          fi
+          echo "Chrome ready at: $CHROME_BIN"
       - name: Run tests for shard
+        env:
+          PUPPETEER_CACHE_DIR: /home/runner/.cache/puppeteer
         run: |
           PACKAGES_JSON='${{ toJson(matrix.shard.packages) }}'
           COMMAND='${{ matrix.shard.command }}'


### PR DESCRIPTION
## Jira Issue
N/A — CI infrastructure fix.

## Context
The CI shard running `pagopa-interop-documents-generator` failed because Puppeteer could not find Chrome in `~/.cache/puppeteer` on GitHub runners. Two further issues surfaced while iterating: the cache action sometimes stored the Chrome directory **without** its executable, and `puppeteer browsers install chrome` itself extracted only a handful of entries from the 160 MB zip, leaving the cache without the `chrome` binary.

## Services Affected
CI workflow only (`.github/workflows/pr-app-validation.yaml`).

## Key Changes
- Install Chrome before tests, gated to the shard that actually needs it.
- Cache `~/.cache/puppeteer` keyed on `pnpm-workspace.yaml` to skip the download when the Puppeteer version is unchanged.
- Bypass `puppeteer browsers install chrome` (broken zip extraction on this runner): download the official Chrome-for-Testing zip with `curl` and extract with system `unzip`.
- Derive `CHROME_VERSION` from `puppeteer.browserRevision` so a puppeteer bump in the catalog is followed automatically.
- Verify the binary with `--version` after install (and on cache hit) and `chmod +x` defensively.
- Set `PUPPETEER_CACHE_DIR` on both the install and the test step to keep install location and runtime lookup in sync.

## Checklist
- [ ] Documents-generator shard passes in CI on this branch.