### PR TITLE
fix: allow confirmation scope from callback_invocation in authorization-server (PIN-10199)

### DIFF
--- a/packages/authorization-server/src/services/scopeHandlers/callbackInvocationHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/callbackInvocationHandler.ts
@@ -2,6 +2,7 @@ import {
   clientKindTokenGenStates,
   genericInternalError,
   interactionState,
+  isInteractionStateAllowedForScope,
   unsafeBrandId,
   ProducerKeychainId,
 } from "pagopa-interop-models";
@@ -28,7 +29,6 @@ import {
 } from "../../utilities/tokenServiceHelpers.js";
 import {
   readInteraction,
-  isInteractionStateAllowedForScope,
   updateInteractionState,
 } from "../../utilities/interactionsUtils.js";
 import type {

--- a/packages/authorization-server/src/services/scopeHandlers/confirmationHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/confirmationHandler.ts
@@ -7,6 +7,7 @@ import {
   clientKindTokenGenStates,
   genericInternalError,
   interactionState,
+  isInteractionStateAllowedForScope,
   makeTokenGenerationStatesClientKidPurposePK,
 } from "pagopa-interop-models";
 import {
@@ -28,7 +29,6 @@ import {
   retrieveKey,
 } from "../../utilities/tokenServiceHelpers.js";
 import {
-  isInteractionStateAllowedForScope,
   readInteraction,
   updateInteractionState,
 } from "../../utilities/interactionsUtils.js";

--- a/packages/authorization-server/src/services/scopeHandlers/getResourceHandler.ts
+++ b/packages/authorization-server/src/services/scopeHandlers/getResourceHandler.ts
@@ -7,6 +7,7 @@ import {
   clientKindTokenGenStates,
   genericInternalError,
   interactionState,
+  isInteractionStateAllowedForScope,
   makeTokenGenerationStatesClientKidPurposePK,
 } from "pagopa-interop-models";
 import {
@@ -27,7 +28,6 @@ import {
   retrieveKey,
 } from "../../utilities/tokenServiceHelpers.js";
 import {
-  isInteractionStateAllowedForScope,
   readInteraction,
   updateInteractionState,
 } from "../../utilities/interactionsUtils.js";

--- a/packages/authorization-server/src/utilities/interactionsUtils.ts
+++ b/packages/authorization-server/src/utilities/interactionsUtils.ts
@@ -40,6 +40,7 @@ const interactionStateAllowedByScope: Record<
     interactionState.getResource,
   ],
   [interactionState.confirmation]: [
+    interactionState.callbackInvocation,
     interactionState.getResource,
     interactionState.confirmation,
   ],

--- a/packages/authorization-server/src/utilities/interactionsUtils.ts
+++ b/packages/authorization-server/src/utilities/interactionsUtils.ts
@@ -27,10 +27,6 @@ import {
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
-// Re-exported from pagopa-interop-models so existing call sites keep importing
-// it from here; the single source of truth lives in models.
-export { isInteractionStateAllowedForScope };
-
 export const createInteraction = async ({
   dynamoDBClient,
   interactionsTable,

--- a/packages/authorization-server/src/utilities/interactionsUtils.ts
+++ b/packages/authorization-server/src/utilities/interactionsUtils.ts
@@ -19,6 +19,7 @@ import {
   InteractionId,
   interactionState,
   InteractionState,
+  isInteractionStateAllowedForScope,
   makeGSIPKInteractionId,
   makeInteractionPK,
   PurposeId,
@@ -26,25 +27,9 @@ import {
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
-const interactionStateAllowedByScope: Record<
-  InteractionState,
-  InteractionState[]
-> = {
-  [interactionState.startInteraction]: [],
-  [interactionState.callbackInvocation]: [
-    interactionState.startInteraction,
-    interactionState.callbackInvocation,
-  ],
-  [interactionState.getResource]: [
-    interactionState.callbackInvocation,
-    interactionState.getResource,
-  ],
-  [interactionState.confirmation]: [
-    interactionState.callbackInvocation,
-    interactionState.getResource,
-    interactionState.confirmation,
-  ],
-};
+// Re-exported from pagopa-interop-models so existing call sites keep importing
+// it from here; the single source of truth lives in models.
+export { isInteractionStateAllowedForScope };
 
 export const createInteraction = async ({
   dynamoDBClient,
@@ -225,11 +210,3 @@ export const updateInteractionState = async ({
 
   await dynamoDBClient.send(new UpdateItemCommand(input));
 };
-
-export const isInteractionStateAllowedForScope = ({
-  currentState,
-  scope,
-}: {
-  currentState: InteractionState;
-  scope: InteractionState;
-}): boolean => interactionStateAllowedByScope[scope].includes(currentState);

--- a/packages/authorization-server/test/integration/confirmationHandler.integration.test.ts
+++ b/packages/authorization-server/test/integration/confirmationHandler.integration.test.ts
@@ -112,7 +112,8 @@ const overrideTokenGenStatesFields = async (
 
 /**
  * Full confirmation scenario: start_interaction, force interaction into
- * `get_resource` (the only valid predecessor) with callback_invocation
+ * `get_resource` (the default valid predecessor; `callback_invocation` is
+ * also allowed) with callback_invocation
  * timestamp set, update catalog entry `confirmation` flag as requested,
  * then issue a fresh consumer JWS for scope=confirmation and align the
  * consumer token-gen-states publicKey.
@@ -248,7 +249,7 @@ const setupConfirmationScenario = async (overrides?: {
   const interactionId = (startResult.token.payload as { interactionId: string })
     .interactionId as InteractionId;
 
-  // Confirmation can only be reached from get_resource; put interaction there.
+  // Confirmation is reachable from get_resource (default) or callback_invocation.
   const targetState =
     overrides?.interactionStateOverride ?? interactionState.getResource;
   await forceInteractionState(dynamoDBClient, interactionId, targetState, {
@@ -560,7 +561,7 @@ describe("async token service - confirmation", () => {
     ).rejects.toThrowError(/was not started by the requesting client/);
   });
 
-  it("should throw interactionStateNotAllowed when interaction is still in callback_invocation", async () => {
+  it("should generate token for confirmation scope from callback_invocation (PIN-10199)", async () => {
     mockProducer.send.mockImplementation(async () => [
       { topic: config.tokenAuditingTopic, partition: 0, errorCode: 0 },
     ]);
@@ -568,12 +569,14 @@ describe("async token service - confirmation", () => {
     const { consumerJws, consumerClientId } = await setupConfirmationScenario({
       interactionStateOverride: interactionState.callbackInvocation,
     });
+    const result = await callAsyncTokenService(consumerJws, consumerClientId);
 
-    await expect(
-      callAsyncTokenService(consumerJws, consumerClientId)
-    ).rejects.toThrowError(
-      /Interaction .* in state callback_invocation does not allow scope confirmation/
-    );
+    expect(result.limitReached).toBe(false);
+    if (result.limitReached || !result.tokenGenerated) {
+      fail();
+    }
+    expect(result.token.serialized).toBeDefined();
+    expect(result.isDPoP).toBe(false);
   });
 
   it("should throw callbackInvocationTokenIssuedAtMissing when the timestamp is absent", async () => {

--- a/packages/authorization-server/test/interactionsUtils.unit.test.ts
+++ b/packages/authorization-server/test/interactionsUtils.unit.test.ts
@@ -251,7 +251,7 @@ describe("interactions utils", () => {
         currentState: "callback_invocation",
         scope: "confirmation",
       })
-    ).toBe(false);
+    ).toBe(true);
 
     expect(
       isInteractionStateAllowedForScope({

--- a/packages/authorization-server/test/interactionsUtils.unit.test.ts
+++ b/packages/authorization-server/test/interactionsUtils.unit.test.ts
@@ -159,8 +159,8 @@ describe("interactions utils", () => {
       consumerId: generateId<TenantId>(),
       eServiceId,
       descriptorId: generateId<DescriptorId>(),
-      state: "callback_invocation",
-      callbackInvocationTokenIssuedAt: new Date().toISOString(),
+      state: "start_interaction",
+      startInteractionTokenIssuedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       ttl: dateToSeconds(new Date()) + ttlSeconds,
     };

--- a/packages/authorization-server/test/interactionsUtils.unit.test.ts
+++ b/packages/authorization-server/test/interactionsUtils.unit.test.ts
@@ -12,6 +12,7 @@ import {
   generateId,
   Interaction,
   InteractionId,
+  isInteractionStateAllowedForScope,
   makeInteractionPK,
   PurposeId,
   TenantId,
@@ -19,7 +20,6 @@ import {
 import { dateToSeconds } from "pagopa-interop-commons";
 import {
   createInteraction,
-  isInteractionStateAllowedForScope,
   readInteraction,
   updateInteractionState,
 } from "../src/utilities/interactionsUtils.js";

--- a/packages/backend-for-frontend/src/services/toolServiceUtils.ts
+++ b/packages/backend-for-frontend/src/services/toolServiceUtils.ts
@@ -13,7 +13,7 @@ import {
   Interaction,
   InteractionId,
   interactionState,
-  InteractionState,
+  isInteractionStateAllowedForScope,
   ItemState,
   makeGSIPKInteractionId,
   makeInteractionPK,
@@ -23,26 +23,6 @@ import {
   AsyncCatalogValidationContext,
   RetrievedInteractionValidationResult,
 } from "./toolService.types.js";
-
-const asyncInteractionStateAllowedByScope: Record<
-  InteractionState,
-  InteractionState[]
-> = {
-  [interactionState.startInteraction]: [],
-  [interactionState.callbackInvocation]: [
-    interactionState.startInteraction,
-    interactionState.callbackInvocation,
-  ],
-  [interactionState.getResource]: [
-    interactionState.callbackInvocation,
-    interactionState.getResource,
-  ],
-  [interactionState.confirmation]: [
-    interactionState.callbackInvocation,
-    interactionState.getResource,
-    interactionState.confirmation,
-  ],
-};
 
 export function validateAsyncScopeClaims(
   jwt: AsyncClientAssertion
@@ -196,7 +176,10 @@ export async function retrieveInteractionForAsyncScope(
   }
 
   if (
-    !isInteractionStateAllowedForScope(interaction.state, jwt.payload.scope)
+    !isInteractionStateAllowedForScope({
+      currentState: interaction.state,
+      scope: jwt.payload.scope,
+    })
   ) {
     return {
       interaction: undefined,
@@ -410,13 +393,6 @@ export function toAsyncCatalogValidationContext(
     asyncExchange: eservice.asyncExchange,
     asyncExchangeProperties: descriptor.asyncExchangeProperties,
   };
-}
-
-function isInteractionStateAllowedForScope(
-  currentState: InteractionState,
-  scope: InteractionState
-): boolean {
-  return asyncInteractionStateAllowedByScope[scope].includes(currentState);
 }
 
 export function makeDiagnosticError(

--- a/packages/models/src/token-generation-readmodel/interactions-entry.ts
+++ b/packages/models/src/token-generation-readmodel/interactions-entry.ts
@@ -40,3 +40,37 @@ export const Interaction = z.object({
   ttl: z.number(),
 });
 export type Interaction = z.infer<typeof Interaction>;
+
+/**
+ * For a given requested scope, the interaction states from which that scope
+ * may be requested. This is the single source of truth for async interaction
+ * state-transition validation, shared by every service that validates async
+ * token requests (authorization-server, backend-for-frontend).
+ */
+const interactionStateAllowedByScope: Record<
+  InteractionState,
+  InteractionState[]
+> = {
+  [interactionState.startInteraction]: [],
+  [interactionState.callbackInvocation]: [
+    interactionState.startInteraction,
+    interactionState.callbackInvocation,
+  ],
+  [interactionState.getResource]: [
+    interactionState.callbackInvocation,
+    interactionState.getResource,
+  ],
+  [interactionState.confirmation]: [
+    interactionState.callbackInvocation,
+    interactionState.getResource,
+    interactionState.confirmation,
+  ],
+};
+
+export const isInteractionStateAllowedForScope = ({
+  currentState,
+  scope,
+}: {
+  currentState: InteractionState;
+  scope: InteractionState;
+}): boolean => interactionStateAllowedByScope[scope].includes(currentState);


### PR DESCRIPTION
## Context

The PIN-10199 fix (PR #3402) added `callbackInvocation` to the states allowed for the `confirmation` scope, but **only in the backend-for-frontend** (`toolServiceUtils.ts`, the portal's validation "tool").

The same async state-transition validation logic was however **duplicated** in the `authorization-server`, which is the service that actually serves the `POST /token.oauth2.async` endpoint. Its map (`interactionsUtils.ts`) was not updated, so the `callback_invocation → confirmation` flow (skipping `get_resource`) kept returning **HTTP 400 / `015-0008`** — the bug persisted even with the deployed `2.19.0-RC1` image, despite the tag correctly containing the merge of #3402.

## Changes

**Fix**
- `authorization-server/src/utilities/interactionsUtils.ts`: added `callbackInvocation` to the states allowed for the `confirmation` scope (mirrors the BFF fix).
- `interactionsUtils.unit.test.ts`: fixed the assertion that expected `false` for `callback_invocation → confirmation` (now `true`).
- `confirmationHandler.integration.test.ts`: converted the test that expected `interactionStateNotAllowed` into a **success** test for the PIN-10199 scenario; updated stale comments.

**Unification (prevents this class of bug recurring)**
- Moved the duplicated state-transition map and `isInteractionStateAllowedForScope` into `pagopa-interop-models` (`token-generation-readmodel/interactions-entry.ts`), next to the `interactionState` enum and `Interaction` model — now the single source of truth.
- `authorization-server` and `backend-for-frontend` now import the shared helper from `pagopa-interop-models` instead of maintaining their own copies.

## Notes

- This PR targets `release/2.19.0`. `develop` will receive these changes through the backmerge from `main` after the production release — no separate action needed.
