### PR TITLE
feature: update BFF attribute contracts (PIN-10233)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -29065,20 +29065,17 @@ components:
         certified:
           type: array
           items:
-            $ref: "#/components/schemas/CertifiedTenantAttribute"
+            oneOf:
+              - $ref: "#/components/schemas/CertifiedTenantAttribute"
+              - $ref: "#/components/schemas/CertifiedDiscreteTenantAttribute"
         verified:
           type: array
           items:
             $ref: "#/components/schemas/VerifiedTenantAttribute"
-        certifiedDiscrete:
-          type: array
-          items:
-            $ref: "#/components/schemas/CertifiedDiscreteTenantAttribute"
       required:
         - declared
         - certified
         - verified
-        - certifiedDiscrete
     DeclaredTenantAttribute:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -26961,9 +26961,12 @@ components:
           format: uuid
         name:
           type: string
+        kind:
+          $ref: "#/components/schemas/AttributeKind"
       required:
         - id
         - name
+        - kind
     CompactAgreement:
       type: object
       additionalProperties: false

--- a/packages/backend-for-frontend/src/api/attributeApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/attributeApiConverter.ts
@@ -13,4 +13,5 @@ export const toCompactAttribute = (
 ): bffApi.CompactAttribute => ({
   id: attribute.id,
   name: attribute.name,
+  kind: attribute.kind,
 });

--- a/packages/backend-for-frontend/src/api/tenantApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/tenantApiConverter.ts
@@ -184,6 +184,29 @@ export function toBffApiCertifiedTenantAttributes(
     .filter(isDefined);
 }
 
+function toBffApiTenantCertifiedAttributes(
+  certifiedAttributes: tenantApi.CertifiedTenantAttribute[],
+  certifiedDiscreteAttributes: tenantApi.CertifiedDiscreteTenantAttribute[],
+  registryAttributesMap: RegistryAttributesMap
+): bffApi.TenantAttributes["certified"] {
+  const certifiedDiscrete = certifiedDiscreteAttributes
+    .map((tenantAttribute) =>
+      toBffApiCertifiedDiscreteTenantAttribute(
+        tenantAttribute,
+        registryAttributesMap
+      )
+    )
+    .filter(isDefined);
+
+  return [
+    ...toBffApiCertifiedTenantAttributes(
+      certifiedAttributes,
+      registryAttributesMap
+    ),
+    ...certifiedDiscrete,
+  ];
+}
+
 export function toBffApiDeclaredTenantAttributes(
   declaredAttributes: tenantApi.DeclaredTenantAttribute[],
   registryAttributesMap: RegistryAttributesMap
@@ -202,20 +225,6 @@ export function toBffApiVerifiedTenantAttributes(
   return verifiedAttributes
     .map((tenantAttribute) =>
       toBffApiVerifiedTenantAttribute(tenantAttribute, registryAttributesMap)
-    )
-    .filter(isDefined);
-}
-
-function toBffApiCertifiedDiscreteTenantAttributes(
-  certifiedDiscreteAttributes: tenantApi.CertifiedDiscreteTenantAttribute[],
-  registryAttributesMap: RegistryAttributesMap
-): bffApi.CertifiedDiscreteTenantAttribute[] {
-  return certifiedDiscreteAttributes
-    .map((tenantAttribute) =>
-      toBffApiCertifiedDiscreteTenantAttribute(
-        tenantAttribute,
-        registryAttributesMap
-      )
     )
     .filter(isDefined);
 }
@@ -246,8 +255,9 @@ export function toBffApiTenant(
     remoteIds: tenant.remoteIds,
     contactMail: getLatestTenantContactEmail(tenant),
     attributes: {
-      certified: toBffApiCertifiedTenantAttributes(
+      certified: toBffApiTenantCertifiedAttributes(
         certifiedAttributes,
+        certifiedDiscreteAttributes,
         registryAttributesMap
       ),
       declared: toBffApiDeclaredTenantAttributes(
@@ -256,10 +266,6 @@ export function toBffApiTenant(
       ),
       verified: toBffApiVerifiedTenantAttributes(
         verifiedAttributes,
-        registryAttributesMap
-      ),
-      certifiedDiscrete: toBffApiCertifiedDiscreteTenantAttributes(
-        certifiedDiscreteAttributes,
         registryAttributesMap
       ),
     },

--- a/packages/backend-for-frontend/src/services/tenantService.ts
+++ b/packages/backend-for-frontend/src/services/tenantService.ts
@@ -497,25 +497,23 @@ export function enhanceTenantAttributes(
     .map((attr) => getDeclaredTenantAttribute(attr, registryAttributesMap))
     .filter(isDefined);
 
-  const certified = tenantAttributes
+  const certifiedAttributes = tenantAttributes
     .map((attr) => getCertifiedTenantAttribute(attr, registryAttributesMap))
+    .filter(isDefined);
+  const certifiedDiscreteAttributes = tenantAttributes
+    .map((attr) =>
+      getCertifiedDiscreteTenantAttribute(attr, registryAttributesMap)
+    )
     .filter(isDefined);
 
   const verified = tenantAttributes
     .map((attr) => toApiVerifiedTenantAttribute(attr, registryAttributesMap))
     .filter(isDefined);
 
-  const certifiedDiscrete = tenantAttributes
-    .map((attr) =>
-      getCertifiedDiscreteTenantAttribute(attr, registryAttributesMap)
-    )
-    .filter(isDefined);
-
   return {
-    certified,
+    certified: [...certifiedAttributes, ...certifiedDiscreteAttributes],
     declared,
     verified,
-    certifiedDiscrete,
   };
 }
 

--- a/packages/backend-for-frontend/test/api/attributeRouter/getAttributes.test.ts
+++ b/packages/backend-for-frontend/test/api/attributeRouter/getAttributes.test.ts
@@ -8,6 +8,7 @@ import { attributeRegistryApi, bffApi } from "pagopa-interop-api-clients";
 import { api, clients } from "../../vitest.api.setup.js";
 import { appBasePath } from "../../../src/config/appBasePath.js";
 import { getMockBffApiAttribute } from "../../mockUtils.js";
+import { toCompactAttribute } from "../../../src/api/attributeApiConverter.js";
 
 describe("API GET /attributes", () => {
   const defaultQuery = {
@@ -24,11 +25,7 @@ describe("API GET /attributes", () => {
     totalCount: 3,
   };
   const mockResponse: bffApi.Attributes = {
-    results: mockAttributes.results.map(({ id, name, kind }) => ({
-      id,
-      name,
-      kind,
-    })),
+    results: mockAttributes.results.map(toCompactAttribute),
     pagination: {
       offset: defaultQuery.offset,
       limit: defaultQuery.limit,

--- a/packages/backend-for-frontend/test/api/attributeRouter/getAttributes.test.ts
+++ b/packages/backend-for-frontend/test/api/attributeRouter/getAttributes.test.ts
@@ -8,7 +8,6 @@ import { attributeRegistryApi, bffApi } from "pagopa-interop-api-clients";
 import { api, clients } from "../../vitest.api.setup.js";
 import { appBasePath } from "../../../src/config/appBasePath.js";
 import { getMockBffApiAttribute } from "../../mockUtils.js";
-import { toCompactAttribute } from "../../../src/api/attributeApiConverter.js";
 
 describe("API GET /attributes", () => {
   const defaultQuery = {
@@ -25,7 +24,11 @@ describe("API GET /attributes", () => {
     totalCount: 3,
   };
   const mockResponse: bffApi.Attributes = {
-    results: mockAttributes.results.map(toCompactAttribute),
+    results: mockAttributes.results.map(({ id, name, kind }) => ({
+      id,
+      name,
+      kind,
+    })),
     pagination: {
       offset: defaultQuery.offset,
       limit: defaultQuery.limit,

--- a/packages/backend-for-frontend/test/enrichAgreement.test.ts
+++ b/packages/backend-for-frontend/test/enrichAgreement.test.ts
@@ -166,18 +166,19 @@ describe("enrichAgreement", () => {
         creationTime: agreementCertifiedDiscreteRegistryAttribute.creationTime,
       },
     ]);
-    expect(actualAgreement.consumer.attributes.certifiedDiscrete).toStrictEqual(
-      [
-        {
-          id: tenantCertifiedDiscreteAttributeId,
-          name: tenantCertifiedDiscreteRegistryAttribute.name,
-          description: tenantCertifiedDiscreteRegistryAttribute.description,
-          assignmentTimestamp:
-            consumer.attributes[0].certifiedDiscrete?.assignmentTimestamp,
-          revocationTimestamp: undefined,
-          discreteValue: 42,
-        },
-      ]
+    expect(actualAgreement.consumer.attributes.certified).toStrictEqual([
+      {
+        id: tenantCertifiedDiscreteAttributeId,
+        name: tenantCertifiedDiscreteRegistryAttribute.name,
+        description: tenantCertifiedDiscreteRegistryAttribute.description,
+        assignmentTimestamp:
+          consumer.attributes[0].certifiedDiscrete?.assignmentTimestamp,
+        revocationTimestamp: undefined,
+        discreteValue: 42,
+      },
+    ]);
+    expect(actualAgreement.consumer.attributes).not.toHaveProperty(
+      "certifiedDiscrete"
     );
     expect(
       clients.attributeProcessClient.getBulkedAttributes

--- a/packages/backend-for-frontend/test/tenantService.test.ts
+++ b/packages/backend-for-frontend/test/tenantService.test.ts
@@ -10,14 +10,21 @@ import { tenantServiceBuilder } from "../src/services/tenantService.js";
 import { BffAppContext } from "../src/utilities/context.js";
 
 describe("tenantServiceBuilder.getTenant", () => {
-  it("should include certified discrete attributes in tenant details", async () => {
+  it("should include certified and certified discrete attributes in tenant certified attributes", async () => {
     const tenantId = generateId<TenantId>();
+    const certifiedAttributeId = generateId<AttributeId>();
     const certifiedDiscreteAttributeId = generateId<AttributeId>();
     const assignmentTimestamp = new Date().toISOString();
 
     const tenant = {
       ...getMockedApiTenant({
         attributes: [
+          {
+            certified: {
+              id: certifiedAttributeId,
+              assignmentTimestamp,
+            },
+          },
           {
             certifiedDiscrete: {
               id: certifiedDiscreteAttributeId,
@@ -32,7 +39,15 @@ describe("tenantServiceBuilder.getTenant", () => {
       features: [],
     };
 
-    const registryAttribute = {
+    const registryCertifiedAttribute = {
+      ...getMockedApiAttribute({
+        kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED,
+        name: "tenant certified",
+        description: "tenant certified description",
+      }),
+      id: certifiedAttributeId,
+    };
+    const registryCertifiedDiscreteAttribute = {
       ...getMockedApiAttribute({
         kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
         name: "tenant certified discrete",
@@ -50,9 +65,10 @@ describe("tenantServiceBuilder.getTenant", () => {
     const attributeProcessClient = {
       getBulkedAttributes: vi.fn((attributeIds: string[]) =>
         Promise.resolve({
-          results: [registryAttribute].filter((attribute) =>
-            attributeIds.includes(attribute.id)
-          ),
+          results: [
+            registryCertifiedAttribute,
+            registryCertifiedDiscreteAttribute,
+          ].filter((attribute) => attributeIds.includes(attribute.id)),
           totalCount: attributeIds.length,
         })
       ),
@@ -76,18 +92,29 @@ describe("tenantServiceBuilder.getTenant", () => {
 
     const result = await service.getTenant(tenantId, ctx);
 
-    expect(result.attributes.certifiedDiscrete).toStrictEqual([
+    expect(result.attributes.certified).toStrictEqual([
+      {
+        id: certifiedAttributeId,
+        name: registryCertifiedAttribute.name,
+        description: registryCertifiedAttribute.description,
+        assignmentTimestamp,
+        revocationTimestamp: undefined,
+      },
       {
         id: certifiedDiscreteAttributeId,
-        name: registryAttribute.name,
-        description: registryAttribute.description,
+        name: registryCertifiedDiscreteAttribute.name,
+        description: registryCertifiedDiscreteAttribute.description,
         assignmentTimestamp,
         revocationTimestamp: undefined,
         discreteValue: 42,
       },
     ]);
+    expect(result.attributes).not.toHaveProperty("certifiedDiscrete");
     expect(attributeProcessClient.getBulkedAttributes).toHaveBeenCalledWith(
-      expect.arrayContaining([certifiedDiscreteAttributeId]),
+      expect.arrayContaining([
+        certifiedAttributeId,
+        certifiedDiscreteAttributeId,
+      ]),
       expect.any(Object)
     );
   });


### PR DESCRIPTION
## Jira Issue
[PIN-10233](https://pagopa.atlassian.net/browse/PIN-10233)

## Context
- This PR updates the BFF attribute contracts for certified discrete attributes.

## Services Affected
- `pagopa-interop-api-clients`
- `pagopa-interop-backend-for-frontend`

## Key Changes
- Add `kind` to `CompactAttribute` returned by the BFF attributes list.
- Merge certified and certified discrete tenant attributes in `TenantAttributes.certified`.
- Remove `TenantAttributes.certifiedDiscrete` from the BFF contract.
- Update BFF mappers and focused tests for tenant details and agreement enrichment.


[PIN-10233]: https://pagopa.atlassian.net/browse/PIN-10233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ