### PR TITLE
fix: suggest purpose templates linked to e-service template for template instances (PIN-10221)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -12151,7 +12151,10 @@ paths:
           explode: false
         - in: query
           name: eserviceIds
-          description: comma separated sequence of e-service IDs
+          description: >-
+            comma separated sequence of e-service IDs. For e-services that are
+            instances of an e-service template, purpose templates linked to the
+            originating e-service template are also returned.
           schema:
             type: array
             items:

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -16423,7 +16423,11 @@ paths:
           explode: false
         - in: query
           name: eserviceIds
-          description: Filter Purpose Templates by E-Service IDs. If not specified, return Purpose Templates for any E-Service.
+          description: >-
+            Filter Purpose Templates by E-Service IDs. If not specified, return
+            Purpose Templates for any E-Service. For e-services that are
+            instances of an e-service template, purpose templates linked to the
+            originating e-service template are also returned.
           schema:
             type: array
             items:

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -10292,7 +10292,11 @@ components:
     EserviceIdsParam:
       in: query
       name: eserviceIds
-      description: Filter by E-Service IDs. If not specified, return results for any E-Service
+      description: >-
+        Filter by E-Service IDs. If not specified, return results for any
+        E-Service. For e-services that are instances of an e-service template,
+        purpose templates linked to the originating e-service template are also
+        returned.
       required: false
       explode: false
       schema:

--- a/packages/api-clients/open-api/purposeTemplateApi.yml
+++ b/packages/api-clients/open-api/purposeTemplateApi.yml
@@ -69,7 +69,10 @@ paths:
           explode: false
         - in: query
           name: eserviceIds
-          description: comma separated sequence of e-service IDs
+          description: >-
+            comma separated sequence of e-service IDs. For e-services that are
+            instances of an e-service template, purpose templates linked to the
+            originating e-service template are also returned.
           schema:
             type: array
             items:

--- a/packages/purpose-template-process/src/services/readModelServiceSQL.ts
+++ b/packages/purpose-template-process/src/services/readModelServiceSQL.ts
@@ -99,7 +99,8 @@ export type GetPurposeTemplateEServiceTemplatesFilters = {
 
 const getPurposeTemplatesFilters = (
   filters: GetPurposeTemplatesFilters,
-  authData: UIAuthData | M2MAuthData | M2MAdminAuthData
+  authData: UIAuthData | M2MAuthData | M2MAdminAuthData,
+  resolvedEServiceTemplateIds: EServiceTemplateId[]
 ): SQL | undefined => {
   const {
     purposeTitle,
@@ -123,12 +124,25 @@ const getPurposeTemplatesFilters = (
       ? inArray(purposeTemplateInReadmodelPurposeTemplate.creatorId, creatorIds)
       : undefined;
 
-  const eserviceIdsFilter =
+  const concreteEserviceMatch =
     eserviceIds.length > 0
       ? inArray(
           purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate.eserviceId,
           eserviceIds
         )
+      : undefined;
+
+  const templateEserviceMatch =
+    resolvedEServiceTemplateIds.length > 0
+      ? inArray(
+          eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate.eserviceTemplateId,
+          resolvedEServiceTemplateIds
+        )
+      : undefined;
+
+  const eserviceIdsFilter =
+    concreteEserviceMatch || templateEserviceMatch
+      ? or(concreteEserviceMatch, templateEserviceMatch)
       : undefined;
 
   const statesFilter =
@@ -258,6 +272,22 @@ export function readModelServiceBuilderSQL({
       { limit, offset }: { limit: number; offset: number },
       authData: UIAuthData | M2MAuthData | M2MAdminAuthData
     ): Promise<ListResult<PurposeTemplate>> {
+      const resolvedEServiceTemplateIds: EServiceTemplateId[] =
+        filters.eserviceIds.length > 0
+          ? (
+              await Promise.all(
+                filters.eserviceIds.map((id) =>
+                  catalogReadModelServiceSQL.getEServiceById(id)
+                )
+              )
+            )
+              .map((e) => e?.data.templateId)
+              .filter(
+                (templateId): templateId is EServiceTemplateId =>
+                  templateId !== undefined
+              )
+          : [];
+
       const subquery = readModelDB
         .select(
           withTotalCount({
@@ -273,13 +303,26 @@ export function readModelServiceBuilderSQL({
           )
         )
         .leftJoin(
+          eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate,
+          eq(
+            purposeTemplateInReadmodelPurposeTemplate.id,
+            eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate.purposeTemplateId
+          )
+        )
+        .leftJoin(
           purposeTemplateRiskAnalysisFormInReadmodelPurposeTemplate,
           eq(
             purposeTemplateInReadmodelPurposeTemplate.id,
             purposeTemplateRiskAnalysisFormInReadmodelPurposeTemplate.purposeTemplateId
           )
         )
-        .where(getPurposeTemplatesFilters(filters, authData))
+        .where(
+          getPurposeTemplatesFilters(
+            filters,
+            authData,
+            resolvedEServiceTemplateIds
+          )
+        )
         .groupBy(purposeTemplateInReadmodelPurposeTemplate.id)
         .orderBy(
           ascLower(purposeTemplateInReadmodelPurposeTemplate.purposeTitle)

--- a/packages/purpose-template-process/src/services/readModelServiceSQL.ts
+++ b/packages/purpose-template-process/src/services/readModelServiceSQL.ts
@@ -140,10 +140,7 @@ const getPurposeTemplatesFilters = (
         )
       : undefined;
 
-  const eserviceIdsFilter =
-    concreteEserviceMatch || templateEserviceMatch
-      ? or(concreteEserviceMatch, templateEserviceMatch)
-      : undefined;
+  const eserviceIdsFilter = or(concreteEserviceMatch, templateEserviceMatch);
 
   const statesFilter =
     states.length > 0

--- a/packages/purpose-template-process/test/integration/getPurposeTemplates.test.ts
+++ b/packages/purpose-template-process/test/integration/getPurposeTemplates.test.ts
@@ -4,6 +4,7 @@ import {
   getMockContext,
   getMockDescriptor,
   getMockEService,
+  getMockEServiceTemplate,
   getMockPurposeTemplate,
   getMockValidRiskAnalysisFormTemplate,
   sortPurposeTemplate,
@@ -12,6 +13,10 @@ import {
   descriptorState,
   EService,
   EServiceDescriptorPurposeTemplate,
+  EServiceTemplate,
+  EServiceTemplateId,
+  EServiceTemplateVersionId,
+  EServiceTemplateVersionPurposeTemplate,
   generateId,
   PurposeTemplate,
   purposeTemplateState,
@@ -20,6 +25,9 @@ import {
 } from "pagopa-interop-models";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  addOneEService,
+  addOneEServiceTemplate,
+  addOneEServiceTemplateVersionPurposeTemplate,
   addOnePurposeTemplate,
   addOnePurposeTemplateEServiceDescriptor,
   expectSinglePageListResult,
@@ -519,5 +527,206 @@ describe("getPurposeTemplates", async () => {
     );
 
     expectSinglePageListResult(result, [suspendedPurposeTemplateByCreator2]);
+  });
+});
+
+describe("getPurposeTemplates - e-service template instance resolution", async () => {
+  const creatorId = generateId<TenantId>();
+  const otherCreatorId = generateId<TenantId>();
+
+  const linkedEServiceTemplate: EServiceTemplate = {
+    ...getMockEServiceTemplate(generateId<EServiceTemplateId>(), creatorId),
+  };
+  const unlinkedEServiceTemplate: EServiceTemplate = {
+    ...getMockEServiceTemplate(generateId<EServiceTemplateId>(), creatorId),
+  };
+
+  const instanceEService: EService = {
+    ...getMockEService(),
+    name: "instance of linked template",
+    templateId: linkedEServiceTemplate.id,
+    descriptors: [getMockDescriptor(descriptorState.published)],
+  };
+  const standaloneEService: EService = {
+    ...getMockEService(),
+    name: "standalone eservice",
+    descriptors: [getMockDescriptor(descriptorState.published)],
+  };
+  const instanceOfUnlinkedTemplate: EService = {
+    ...getMockEService(),
+    name: "instance of unlinked template",
+    templateId: unlinkedEServiceTemplate.id,
+    descriptors: [getMockDescriptor(descriptorState.published)],
+  };
+
+  const ptViaTemplate: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    purposeTitle: "A - linked via template",
+    state: purposeTemplateState.published,
+    creatorId,
+  };
+  const ptViaConcrete: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    purposeTitle: "B - linked via concrete eservice",
+    state: purposeTemplateState.published,
+    creatorId,
+  };
+  const ptViaBoth: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    purposeTitle: "C - linked via both",
+    state: purposeTemplateState.published,
+    creatorId,
+  };
+  const draftPtViaTemplate: PurposeTemplate = {
+    ...getMockPurposeTemplate(),
+    purposeTitle: "D - draft linked via template",
+    state: purposeTemplateState.draft,
+    creatorId,
+  };
+
+  const concreteLinkViaConcrete: EServiceDescriptorPurposeTemplate = {
+    purposeTemplateId: ptViaConcrete.id,
+    eserviceId: standaloneEService.id,
+    descriptorId: standaloneEService.descriptors[0].id,
+    createdAt: new Date(),
+  };
+  const concreteLinkViaBoth: EServiceDescriptorPurposeTemplate = {
+    purposeTemplateId: ptViaBoth.id,
+    eserviceId: standaloneEService.id,
+    descriptorId: standaloneEService.descriptors[0].id,
+    createdAt: new Date(),
+  };
+
+  const templateLinkViaTemplate: EServiceTemplateVersionPurposeTemplate = {
+    purposeTemplateId: ptViaTemplate.id,
+    eserviceTemplateId: linkedEServiceTemplate.id,
+    eserviceTemplateVersionId: generateId<EServiceTemplateVersionId>(),
+    createdAt: new Date(),
+  };
+  const templateLinkViaBoth: EServiceTemplateVersionPurposeTemplate = {
+    purposeTemplateId: ptViaBoth.id,
+    eserviceTemplateId: linkedEServiceTemplate.id,
+    eserviceTemplateVersionId: linkedEServiceTemplate.versions[0].id,
+    createdAt: new Date(),
+  };
+  const templateLinkViaDraft: EServiceTemplateVersionPurposeTemplate = {
+    purposeTemplateId: draftPtViaTemplate.id,
+    eserviceTemplateId: linkedEServiceTemplate.id,
+    eserviceTemplateVersionId: linkedEServiceTemplate.versions[0].id,
+    createdAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    await addOneEServiceTemplate(linkedEServiceTemplate);
+    await addOneEServiceTemplate(unlinkedEServiceTemplate);
+    await addOneEService(instanceEService);
+    await addOneEService(standaloneEService);
+    await addOneEService(instanceOfUnlinkedTemplate);
+
+    await addOnePurposeTemplate(ptViaTemplate);
+    await addOnePurposeTemplate(ptViaConcrete);
+    await addOnePurposeTemplate(ptViaBoth);
+    await addOnePurposeTemplate(draftPtViaTemplate);
+
+    await addOnePurposeTemplateEServiceDescriptor(concreteLinkViaConcrete);
+    await addOnePurposeTemplateEServiceDescriptor(concreteLinkViaBoth);
+
+    await addOneEServiceTemplateVersionPurposeTemplate(templateLinkViaTemplate);
+    await addOneEServiceTemplateVersionPurposeTemplate(templateLinkViaBoth);
+    await addOneEServiceTemplateVersionPurposeTemplate(templateLinkViaDraft);
+  });
+
+  it("should suggest purpose templates linked to the originating e-service template when the queried e-service is an instance (version-independent)", async () => {
+    const result = await purposeTemplateService.getPurposeTemplates(
+      {
+        eserviceIds: [instanceEService.id],
+        creatorIds: [],
+        states: [],
+      },
+      { offset: 0, limit: 50 },
+      getMockContext({ authData: getMockAuthData(creatorId) })
+    );
+
+    expectSinglePageListResult(result, [
+      ptViaTemplate,
+      ptViaBoth,
+      draftPtViaTemplate,
+    ]);
+  });
+
+  it("should still match concrete links, and match resources linked via either kind (OR)", async () => {
+    const result = await purposeTemplateService.getPurposeTemplates(
+      {
+        eserviceIds: [standaloneEService.id],
+        creatorIds: [],
+        states: [],
+      },
+      { offset: 0, limit: 50 },
+      getMockContext({ authData: getMockAuthData(creatorId) })
+    );
+
+    expectSinglePageListResult(result, [ptViaConcrete, ptViaBoth]);
+  });
+
+  it("should match across multiple e-service ids (template instance + standalone concrete)", async () => {
+    const result = await purposeTemplateService.getPurposeTemplates(
+      {
+        eserviceIds: [instanceEService.id, standaloneEService.id],
+        creatorIds: [],
+        states: [],
+      },
+      { offset: 0, limit: 50 },
+      getMockContext({ authData: getMockAuthData(creatorId) })
+    );
+
+    expect(result.totalCount).toBe(4);
+    expectSinglePageListResult(result, [
+      ptViaTemplate,
+      ptViaConcrete,
+      ptViaBoth,
+      draftPtViaTemplate,
+    ]);
+  });
+
+  it("should not suggest purpose templates for an instance whose template has no linked purpose template", async () => {
+    const result = await purposeTemplateService.getPurposeTemplates(
+      {
+        eserviceIds: [instanceOfUnlinkedTemplate.id],
+        creatorIds: [],
+        states: [],
+      },
+      { offset: 0, limit: 50 },
+      getMockContext({ authData: getMockAuthData(creatorId) })
+    );
+
+    expectSinglePageListResult(result, []);
+  });
+
+  it("should not error and return empty for a non-existent e-service id", async () => {
+    const result = await purposeTemplateService.getPurposeTemplates(
+      {
+        eserviceIds: [generateId()],
+        creatorIds: [],
+        states: [],
+      },
+      { offset: 0, limit: 50 },
+      getMockContext({ authData: getMockAuthData(creatorId) })
+    );
+
+    expectSinglePageListResult(result, []);
+  });
+
+  it("should keep draft template-linked purpose templates hidden from non-creators", async () => {
+    const result = await purposeTemplateService.getPurposeTemplates(
+      {
+        eserviceIds: [instanceEService.id],
+        creatorIds: [],
+        states: [],
+      },
+      { offset: 0, limit: 50 },
+      getMockContext({ authData: getMockAuthData(otherCreatorId) })
+    );
+
+    expectSinglePageListResult(result, [ptViaTemplate, ptViaBoth]);
   });
 });


### PR DESCRIPTION
## Issue
- [PIN-10221](https://pagopa.atlassian.net/browse/PIN-10221)

## Context / Why
- When a consumer creates a purpose by selecting an e-service that is an instance of an e-service template, the purpose templates linked to that originating template were not being suggested.
- The query only matched purpose templates linked to concrete e-services, never resolving the instance → parent-template chain.

## Scope
- `GET /purposeTemplates` filtering by `eserviceIds` now also returns purpose templates linked to the originating e-service template for instance e-services.

## Key Changes
- Resolve the originating e-service template IDs for the requested `eserviceIds` and OR-match them against `eserviceTemplateVersionPurposeTemplate`, alongside the existing concrete e-service match.
- Added a left join on `eserviceTemplateVersionPurposeTemplate` in the read model query.
- Updated the `eserviceIds` parameter description across `bffApi`, `m2mGatewayApi`, `m2mGatewayApiV3`, and `purposeTemplateApi` specs.
- Added integration tests covering instance/template/concrete link resolution.

## Testing / Validation
- [x] Lint
- [x] Type check
- [x] Integration tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [ ] Service labels applied
- [x] API and integration tests updated
- [x] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10221]: https://pagopa.atlassian.net/browse/PIN-10221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
