### PR TITLE
fix: validate async exchange limits (PIN-10237)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -30132,9 +30132,11 @@ components:
         responseTime:
           type: integer
           format: int32
+          maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          maximum: 999999
         confirmation:
           type: boolean
         bulk:
@@ -30142,6 +30144,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          maximum: 99999
     AsyncExchangePropertiesInstanceSeed:
       type: object
       additionalProperties: false
@@ -30149,12 +30152,15 @@ components:
         responseTime:
           type: integer
           format: int32
+          maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          maximum: 999999
         maxResultSet:
           type: integer
           format: int32
+          maximum: 99999
     EServiceTemplateVersionDetails:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -30132,10 +30132,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -30144,6 +30146,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     AsyncExchangePropertiesInstanceSeed:
       type: object
@@ -30152,14 +30155,17 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     EServiceTemplateVersionDetails:
       type: object

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -3964,10 +3964,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -3976,6 +3978,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     AsyncExchangePropertiesInstanceSeed:
       type: object
@@ -3984,14 +3987,17 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     EServiceTechnology:
       type: string

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -3964,9 +3964,11 @@ components:
         responseTime:
           type: integer
           format: int32
+          maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          maximum: 999999
         confirmation:
           type: boolean
         bulk:
@@ -3974,6 +3976,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          maximum: 99999
     AsyncExchangePropertiesInstanceSeed:
       type: object
       additionalProperties: false
@@ -3981,12 +3984,15 @@ components:
         responseTime:
           type: integer
           format: int32
+          maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          maximum: 999999
         maxResultSet:
           type: integer
           format: int32
+          maximum: 99999
     EServiceTechnology:
       type: string
       description: API Technology

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -2310,10 +2310,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -2322,6 +2324,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     CompactOrganization:
       type: object

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -2310,9 +2310,11 @@ components:
         responseTime:
           type: integer
           format: int32
+          maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          maximum: 999999
         confirmation:
           type: boolean
         bulk:
@@ -2320,6 +2322,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          maximum: 99999
     CompactOrganization:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -21008,9 +21008,11 @@ components:
         responseTime:
           type: integer
           format: int32
+          maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          maximum: 999999
         confirmation:
           type: boolean
         bulk:
@@ -21018,6 +21020,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          maximum: 99999
     EServiceTechnology:
       type: string
       description: API Technology

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -21008,10 +21008,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -21020,6 +21022,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     EServiceTechnology:
       type: string

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -12087,10 +12087,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -12099,6 +12101,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     EServiceTechnology:
       type: string

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -12087,9 +12087,11 @@ components:
         responseTime:
           type: integer
           format: int32
+          maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          maximum: 999999
         confirmation:
           type: boolean
         bulk:
@@ -12097,6 +12099,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          maximum: 99999
     EServiceTechnology:
       type: string
       description: API Technology

--- a/packages/backend-for-frontend/test/api/catalogRouter/updateDraftDescriptor.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/updateDraftDescriptor.test.ts
@@ -72,6 +72,42 @@ describe("API PUT /eservices/:eServiceId/descriptors/:descriptorId", () => {
         attributes: "invalid",
       },
     },
+    {
+      body: {
+        ...mockUpdateEServiceDescriptorSeed,
+        asyncExchangeProperties: {
+          responseTime: 2_147_483_648,
+          resourceAvailableTime: 999_999,
+          confirmation: true,
+          bulk: true,
+          maxResultSet: 99_999,
+        },
+      },
+    },
+    {
+      body: {
+        ...mockUpdateEServiceDescriptorSeed,
+        asyncExchangeProperties: {
+          responseTime: 999_999,
+          resourceAvailableTime: 1_000_000,
+          confirmation: true,
+          bulk: true,
+          maxResultSet: 99_999,
+        },
+      },
+    },
+    {
+      body: {
+        ...mockUpdateEServiceDescriptorSeed,
+        asyncExchangeProperties: {
+          responseTime: 999_999,
+          resourceAvailableTime: 999_999,
+          confirmation: true,
+          bulk: true,
+          maxResultSet: 100_000,
+        },
+      },
+    },
   ])(
     "Should return 400 if passed an invalid parameter",
     async ({ eServiceId, descriptorId, body }) => {

--- a/packages/catalog-process/test/api/createDescriptor.test.ts
+++ b/packages/catalog-process/test/api/createDescriptor.test.ts
@@ -174,6 +174,45 @@ describe("API /eservices/{eServiceId}/descriptors authorization test", () => {
     [{ ...descriptorSeed, dailyCallsTotal: -1 }, eservice.id],
     [{ ...descriptorSeed, attributes: undefined }, eservice.id],
     [{ ...descriptorSeed, docs: [{}] }, eservice.id],
+    [
+      {
+        ...descriptorSeed,
+        asyncExchangeProperties: {
+          responseTime: 1_000_000,
+          resourceAvailableTime: 999_999,
+          confirmation: true,
+          bulk: true,
+          maxResultSet: 99_999,
+        },
+      },
+      eservice.id,
+    ],
+    [
+      {
+        ...descriptorSeed,
+        asyncExchangeProperties: {
+          responseTime: 999_999,
+          resourceAvailableTime: 1_000_000,
+          confirmation: true,
+          bulk: true,
+          maxResultSet: 99_999,
+        },
+      },
+      eservice.id,
+    ],
+    [
+      {
+        ...descriptorSeed,
+        asyncExchangeProperties: {
+          responseTime: 999_999,
+          resourceAvailableTime: 999_999,
+          confirmation: true,
+          bulk: true,
+          maxResultSet: 100_000,
+        },
+      },
+      eservice.id,
+    ],
     [{}, "invalidId"],
     // dailyCalls validation tests on attributes
     [

--- a/packages/catalog-process/test/api/updateDraftDescriptor.test.ts
+++ b/packages/catalog-process/test/api/updateDraftDescriptor.test.ts
@@ -163,6 +163,48 @@ describe("PUT /eservices/{eServiceId}/descriptors/{descriptorId} router test", (
       descriptor.id,
     ],
     [
+      {
+        ...descriptorSeed,
+        asyncExchangeProperties: {
+          responseTime: 1_000_000,
+          resourceAvailableTime: 999_999,
+          confirmation: true,
+          bulk: true,
+          maxResultSet: 99_999,
+        },
+      },
+      mockEService.id,
+      descriptor.id,
+    ],
+    [
+      {
+        ...descriptorSeed,
+        asyncExchangeProperties: {
+          responseTime: 999_999,
+          resourceAvailableTime: 1_000_000,
+          confirmation: true,
+          bulk: true,
+          maxResultSet: 99_999,
+        },
+      },
+      mockEService.id,
+      descriptor.id,
+    ],
+    [
+      {
+        ...descriptorSeed,
+        asyncExchangeProperties: {
+          responseTime: 999_999,
+          resourceAvailableTime: 999_999,
+          confirmation: true,
+          bulk: true,
+          maxResultSet: 100_000,
+        },
+      },
+      mockEService.id,
+      descriptor.id,
+    ],
+    [
       { ...descriptorSeed, attributes: { certified: [], declared: [] } },
       mockEService.id,
       descriptor.id,


### PR DESCRIPTION
## Issue
- [PIN-10237](https://pagopa.atlassian.net/browse/PIN-10237)
- [SRS Scambi asincroni massivi](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2512683132/SRSScambiasincroni+massivi#Ciclo-di-vita-di-un-e-service)

## Context / Why
- Backend validation was missing for async/massive exchange limits, allowing oversized values to reach downstream conversion and produce 500 errors.

## Scope
- Added OpenAPI maximum constraints for async exchange fields in BFF, catalog, e-service template, and M2M gateway APIs.
- Added API tests for catalog descriptor create/update and BFF descriptor update validation.

## Testing / Validation
- [x] Lint
- [x] Type check
- [x] Unit tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [x] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10237]: https://pagopa.atlassian.net/browse/PIN-10237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ