### PR TITLE
fix: map asyncExchangeBulkNotAllowedForSoap to 400 on descriptor create/update (PIN-10214)

### DIFF
--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -198,6 +198,7 @@ export const createDescriptorErrorMapper = (
       "attributeDuplicatedInGroup",
       "attributeDailyCallsNotAllowed",
       "templateInstanceNotAllowed",
+      "asyncExchangeBulkNotAllowedForSoap",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
@@ -233,6 +234,7 @@ export const updateDraftDescriptorErrorMapper = (
       "templateInstanceNotAllowed",
       "attributeDuplicatedInGroup",
       "attributeDailyCallsNotAllowed",
+      "asyncExchangeBulkNotAllowedForSoap",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/catalog-process/test/api/createDescriptor.test.ts
+++ b/packages/catalog-process/test/api/createDescriptor.test.ts
@@ -21,6 +21,7 @@ import { api, catalogService } from "../vitest.api.setup.js";
 import { buildCreateDescriptorSeed } from "../mockUtils.js";
 import { eServiceToApiEService } from "../../src/model/domain/apiConverter.js";
 import {
+  asyncExchangeBulkNotAllowedForSoap,
   attributeDailyCallsNotAllowed,
   attributeDuplicatedInGroup,
   attributeNotFound,
@@ -153,6 +154,10 @@ describe("API /eservices/{eServiceId}/descriptors authorization test", () => {
     },
     {
       error: attributeDailyCallsNotAllowed(generateId()),
+      expectedStatus: 400,
+    },
+    {
+      error: asyncExchangeBulkNotAllowedForSoap(eservice.id, newDescriptor.id),
       expectedStatus: 400,
     },
   ])(

--- a/packages/catalog-process/test/api/updateDraftDescriptor.test.ts
+++ b/packages/catalog-process/test/api/updateDraftDescriptor.test.ts
@@ -23,6 +23,7 @@ import { api, catalogService } from "../vitest.api.setup.js";
 import { buildUpdateDescriptorSeed } from "../mockUtils.js";
 import { eServiceToApiEService } from "../../src/model/domain/apiConverter.js";
 import {
+  asyncExchangeBulkNotAllowedForSoap,
   attributeDailyCallsNotAllowed,
   attributeDuplicatedInGroup,
   attributeNotFound,
@@ -137,6 +138,10 @@ describe("PUT /eservices/{eServiceId}/descriptors/{descriptorId} router test", (
     },
     {
       error: attributeDailyCallsNotAllowed(generateId()),
+      expectedStatus: 400,
+    },
+    {
+      error: asyncExchangeBulkNotAllowedForSoap(mockEService.id, descriptor.id),
       expectedStatus: 400,
     },
   ])(


### PR DESCRIPTION
## Description

Fixes [PIN-10214](https://pagopa.atlassian.net/browse/PIN-10214).

Given an **async** e-service with **SOAP** technology and `asyncExchangeProperties.bulk = true`, updating a draft descriptor (`PUT /eservices/{eServiceId}/descriptors/{descriptorId}`) returned a generic **500** (`008-9991` "Unexpected error" from the BFF) instead of the expected **400**.

### Root cause

The domain validation `assertAsyncExchangeBulkAllowedForDescriptor` correctly throws the `asyncExchangeBulkNotAllowedForSoap` domain error, but `updateDraftDescriptorErrorMapper` did not map this error code, so it fell through to `HTTP_STATUS_INTERNAL_SERVER_ERROR` (500). The BFF (`problemErrorsPassthrough` + `forceGenericProblemOn500`) then forwarded that 500 as the generic `008-9991` problem.

The same gap existed in `createDescriptorErrorMapper`, which also invokes the same validation (new descriptor / version creation path), so it is fixed for consistency.

### Changes

- Map `asyncExchangeBulkNotAllowedForSoap` to **400** in both `updateDraftDescriptorErrorMapper` and `createDescriptorErrorMapper` (`packages/catalog-process/src/utilities/errorMappers.ts`).
- Add API-level tests asserting the **400** status for this error code in `updateDraftDescriptor` and `createDescriptor` router tests.

No BFF change is required: with the catalog-process now returning 400, the BFF passthrough forwards the correct status and error code.


[PIN-10214]: https://pagopa.atlassian.net/browse/PIN-10214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ