### PR TITLE
fix: validate async exchange properties minimum value (PIN-10217)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -30132,10 +30132,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -30144,6 +30146,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     AsyncExchangePropertiesInstanceSeed:
       type: object
@@ -30152,14 +30155,17 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     EServiceTemplateVersionDetails:
       type: object

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -3964,10 +3964,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -3976,6 +3978,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     AsyncExchangePropertiesInstanceSeed:
       type: object
@@ -3984,14 +3987,17 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     EServiceTechnology:
       type: string

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -2310,10 +2310,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -2322,6 +2324,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     CompactOrganization:
       type: object

--- a/packages/api-clients/open-api/m2mGatewayApi.yml
+++ b/packages/api-clients/open-api/m2mGatewayApi.yml
@@ -21008,10 +21008,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -21020,6 +21022,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     EServiceTechnology:
       type: string

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -12087,10 +12087,12 @@ components:
         responseTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         resourceAvailableTime:
           type: integer
           format: int32
+          minimum: 1
           maximum: 999999
         confirmation:
           type: boolean
@@ -12099,6 +12101,7 @@ components:
         maxResultSet:
           type: integer
           format: int32
+          minimum: 1
           maximum: 99999
     EServiceTechnology:
       type: string


### PR DESCRIPTION
Based on #3427

## Context

[PIN-10217](https://pagopa.atlassian.net/browse/PIN-10217)

When updating the async exchange parameters of an e-service, negative/invalid values for `responseTime`, `resourceAvailableTime` and `maxResultSet` were accepted instead of being rejected. A `PUT /eservices/{eserviceId}/descriptors/{descriptorId}` with e.g. `responseTime: -30` returned `200 OK` instead of `400 Bad Request`.

## Root cause

The three numeric fields of `asyncExchangeProperties` were declared as `integer/int32` with **no `minimum` constraint** across all OpenAPI specs. Since HTTP body validation is driven by the Zod schemas generated from these specs, negative values passed validation and the descriptor update copied the seed verbatim with no application-level checks.

## Change

This PR is stacked on top of #3427, which adds the `maximum` constraints for the same async exchange fields. On top of those, it adds `minimum: 1` to `responseTime`, `resourceAvailableTime` and `maxResultSet` in the `AsyncExchangeProperties` and `AsyncExchangePropertiesInstanceSeed` schemas across all specs that define them:

- `bffApi.yml`
- `catalogApi.yml`
- `eserviceTemplateApi.yml`
- `m2mGatewayApi.yml`
- `m2mGatewayApiV3.yml`

The generated Zod schemas now produce `z.number().int().gte(1).lte(...)`, so values `< 1` are rejected with `400` at request-body validation, consistent with how `voucherLifespan` and `dailyCalls*` are already constrained.

[PIN-10217]: https://pagopa.atlassian.net/browse/PIN-10217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ