### PR TITLE
fix: allow API role to list producer keychains (PIN-10225)

### DIFF
--- a/packages/authorization-process/src/routers/AuthorizationRouter.ts
+++ b/packages/authorization-process/src/routers/AuthorizationRouter.ts
@@ -684,6 +684,7 @@ const authorizationRouter = (
       try {
         validateAuthorization(ctx, [
           ADMIN_ROLE,
+          API_ROLE,
           SECURITY_ROLE,
           M2M_ROLE,
           SUPPORT_ROLE,

--- a/packages/authorization-process/test/api/getProducerKeychains.test.ts
+++ b/packages/authorization-process/test/api/getProducerKeychains.test.ts
@@ -73,6 +73,7 @@ describe("API /producerKeychains authorization test", () => {
 
   const authorizedRoles: AuthRole[] = [
     authRole.ADMIN_ROLE,
+    authRole.API_ROLE,
     authRole.SECURITY_ROLE,
     authRole.SUPPORT_ROLE,
     authRole.M2M_ROLE,

--- a/packages/backend-for-frontend/test/api/producerKeychainRouter/getProducerKeychains.test.ts
+++ b/packages/backend-for-frontend/test/api/producerKeychainRouter/getProducerKeychains.test.ts
@@ -54,6 +54,13 @@ describe("API GET /producerKeychains test", () => {
     expect(res.body).toEqual(mockCompactProducerKeychains);
   });
 
+  it("Should return 200 for user with role API", async () => {
+    const token = generateToken(authRole.API_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockCompactProducerKeychains);
+  });
+
   it.each([
     { query: {} },
     { query: { ...defaultQuery, offset: undefined } },


### PR DESCRIPTION
## Issue
- [PIN-10225](https://pagopa.atlassian.net/browse/PIN-10225)

## Context / Why
- Async e-service draft summary needs to read producer keychains associated with an e-service through `/producerKeychains?eserviceId=...`.
- Users with API role were receiving `403 Invalid roles ["api"] for this operation` from the authorization process.

## Scope
- Allow `API_ROLE` on authorization process `GET /producerKeychains`.
- Add API tests covering the API role on authorization process and BFF producer keychain list routes.

## Key Changes
- Added `API_ROLE` to the authorized roles for listing producer keychains.
- Extended producer keychain list API tests to prevent regressions for API-role users.

## Testing / Validation
- [x] Lint
- [x] Type check
- [x] Api tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10225]: https://pagopa.atlassian.net/browse/PIN-10225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ