### PR TITLE
fix: reject async receive template creation (PIN-10261)

### DIFF
--- a/packages/eservice-template-process/src/model/domain/errors.ts
+++ b/packages/eservice-template-process/src/model/domain/errors.ts
@@ -45,6 +45,7 @@ const errorCodes = {
   missingAsyncExchangeProperties: "0035",
   asyncExchangeBulkNotAllowedForSoap: "0036",
   tenantKindNotFound: "0037",
+  asyncExchangeReceiveTemplateNotAllowed: "0038",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -406,5 +407,13 @@ export function asyncExchangeBulkNotAllowedForSoap(
     detail: `Async exchange bulk is not allowed for SOAP technology in version ${eserviceTemplateVersionId} of EService Template ${eserviceTemplateId}`,
     code: "asyncExchangeBulkNotAllowedForSoap",
     title: "Async exchange bulk not allowed for SOAP",
+  });
+}
+
+export function asyncExchangeReceiveTemplateNotAllowed(): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Async exchange cannot be enabled for EService templates in receive mode`,
+    code: "asyncExchangeReceiveTemplateNotAllowed",
+    title: "Async exchange receive template not allowed",
   });
 }

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -130,6 +130,7 @@ import {
   assertUpdatedNameDiffersFromCurrent,
   assertUpdatedDescriptionDiffersFromCurrent,
   versionStatesNotAllowingInterfaceOperations,
+  assertAsyncExchangeReceiveTemplateNotAllowed,
 } from "./validators.js";
 import { ReadModelServiceSQL } from "./readModelServiceSQL.js";
 
@@ -1355,6 +1356,13 @@ export function eserviceTemplateServiceBuilder(
       await assertEServiceTemplateNameAvailable(seed.name, readModelService);
 
       assertConsistentDailyCalls(seed.version);
+
+      if (isFeatureFlagEnabled(config, "featureFlagAsyncExchange")) {
+        assertAsyncExchangeReceiveTemplateNotAllowed({
+          mode: apiEServiceModeToEServiceMode(seed.mode),
+          asyncExchange: seed.asyncExchange,
+        });
+      }
 
       const creationDate = new Date();
       const draftVersion: EServiceTemplateVersion = {

--- a/packages/eservice-template-process/src/services/validators.ts
+++ b/packages/eservice-template-process/src/services/validators.ts
@@ -16,6 +16,7 @@ import {
   operationForbidden,
   TenantId,
   eserviceMode,
+  EServiceMode,
   RiskAnalysisId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
@@ -31,6 +32,7 @@ import {
   riskAnalysisNotFound,
   eServiceTemplateUpdateSameNameConflict,
   eServiceTemplateUpdateSameDescriptionConflict,
+  asyncExchangeReceiveTemplateNotAllowed,
 } from "../model/domain/errors.js";
 import { ReadModelServiceSQL } from "./readModelServiceSQL.js";
 
@@ -109,6 +111,18 @@ export function assertConsistentDailyCalls({
     dailyCallsPerConsumer > dailyCallsTotal
   ) {
     throw inconsistentDailyCalls();
+  }
+}
+
+export function assertAsyncExchangeReceiveTemplateNotAllowed({
+  mode,
+  asyncExchange,
+}: {
+  mode: EServiceMode;
+  asyncExchange: boolean | undefined;
+}): void {
+  if (mode === eserviceMode.receive && asyncExchange === true) {
+    throw asyncExchangeReceiveTemplateNotAllowed();
   }
 }
 

--- a/packages/eservice-template-process/src/utilities/errorMappers.ts
+++ b/packages/eservice-template-process/src/utilities/errorMappers.ts
@@ -232,7 +232,11 @@ export const createEServiceTemplateErrorMapper = (
   match(error.code)
     .with("originNotCompliant", () => HTTP_STATUS_FORBIDDEN)
     .with("eserviceTemplateDuplicate", () => HTTP_STATUS_CONFLICT)
-    .with("inconsistentDailyCalls", () => HTTP_STATUS_BAD_REQUEST)
+    .with(
+      "inconsistentDailyCalls",
+      "asyncExchangeReceiveTemplateNotAllowed",
+      () => HTTP_STATUS_BAD_REQUEST
+    )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
 export const updateEServiceTemplateErrorMapper = (

--- a/packages/eservice-template-process/test/api/createEServiceTemplate.test.ts
+++ b/packages/eservice-template-process/test/api/createEServiceTemplate.test.ts
@@ -16,6 +16,7 @@ import {
   eserviceTemplateDuplicate,
   inconsistentDailyCalls,
   originNotCompliant,
+  asyncExchangeReceiveTemplateNotAllowed,
 } from "../../src/model/domain/errors.js";
 
 describe("API POST /templates", () => {
@@ -132,6 +133,10 @@ describe("API POST /templates", () => {
     },
     {
       error: inconsistentDailyCalls(),
+      expectedStatus: 400,
+    },
+    {
+      error: asyncExchangeReceiveTemplateNotAllowed(),
       expectedStatus: 400,
     },
   ])(

--- a/packages/eservice-template-process/test/integration/createEServiceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/createEServiceTemplate.test.ts
@@ -13,12 +13,14 @@ import {
   toEServiceTemplateV2,
   EServiceTemplateAddedV2,
   generateId,
+  eserviceMode,
 } from "pagopa-interop-models";
 import { expect, describe, it, beforeAll, vi, afterAll } from "vitest";
 import {
   eserviceTemplateDuplicate,
   inconsistentDailyCalls,
   originNotCompliant,
+  asyncExchangeReceiveTemplateNotAllowed,
 } from "../../src/model/domain/errors.js";
 import { config } from "../../src/config/config.js";
 import {
@@ -47,6 +49,7 @@ describe("create eservice template", () => {
           ...mockEServiceTemplate,
           isSignalHubEnabled,
           asyncExchange,
+          mode: eserviceMode.deliver,
         }),
         getMockContext({
           authData: getMockAuthData(mockEServiceTemplate.creatorId),
@@ -89,6 +92,7 @@ describe("create eservice template", () => {
       ],
       isSignalHubEnabled,
       asyncExchange,
+      mode: eserviceMode.deliver,
     };
 
     expect(eserviceCreationPayload).toEqual({
@@ -113,6 +117,21 @@ describe("create eservice template", () => {
         })
       )
     ).rejects.toThrowError(originNotCompliant("not-allowed-origin"));
+  });
+
+  it("should throw asyncExchangeReceiveTemplateNotAllowed when creating a receive template with asyncExchange enabled", async () => {
+    await expect(
+      eserviceTemplateService.createEServiceTemplate(
+        eserviceTemplateToApiEServiceTemplateSeed({
+          ...mockEServiceTemplate,
+          mode: eserviceMode.receive,
+          asyncExchange: true,
+        }),
+        getMockContext({
+          authData: getMockAuthData(mockEServiceTemplate.creatorId),
+        })
+      )
+    ).rejects.toThrowError(asyncExchangeReceiveTemplateNotAllowed());
   });
 
   it("should throw eserviceTemplateDuplicate if an eservice template with the same name already exists, case insensitive", async () => {


### PR DESCRIPTION
## Issue
- [PIN-10261](https://pagopa.atlassian.net/browse/PIN-10261)

## Context / Why
- Creating an e-service template with `mode: RECEIVE` and `asyncExchange: true` was accepted.
- The expected behavior is to reject this invalid async template configuration.

## Scope
- Added a domain validation to reject async exchange on receive-mode e-service template creation.
- Added a dedicated domain error and mapped it to HTTP 400.
- Added API and integration coverage for the rejected creation flow.

## Testing / Validation
- [x] Lint
- [x] Typecheck
- [x] API tests
- [x] Integration tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10261]: https://pagopa.atlassian.net/browse/PIN-10261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ