### PR TITLE
feature: add TenantCertifiedDiscreteAttribute events and in-app-notification refactoring (PIN-10185)

### DIFF
--- a/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantCertifiedAttributeUpdated.ts
+++ b/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantCertifiedAttributeUpdated.ts
@@ -13,10 +13,8 @@ import {
   getRecipientsForTenants,
   mapRecipientToEmailPayload,
   retrieveAttribute,
-  retrieveTenantByCertifierId,
   TenantHandlerParams,
 } from "../handlerCommons.js";
-import { certifierDatabaseOriginNames } from "../../config/constants.js";
 import { config } from "../../config/config.js";
 
 const notificationType: NotificationType =
@@ -72,11 +70,6 @@ export async function handleTenantCertifiedAttributeUpdated(
     return [];
   }
 
-  const certifierName = certifierDatabaseOriginNames.includes(attribute.origin)
-    ? attribute.origin
-    : (await retrieveTenantByCertifierId(attribute.origin, readModelService))
-        .name;
-
   return targets.map((t) => ({
     correlationId: correlationId ?? generateId(),
     email: {
@@ -86,7 +79,6 @@ export async function handleTenantCertifiedAttributeUpdated(
         notificationType,
         entityId: tenant.id,
         ...(t.type === "Tenant" ? { recipientName: tenant.name } : {}),
-        certifierName,
         attributeName: attribute.name,
         selfcareId: t.selfcareId,
         bffUrl: config.bffUrl,

--- a/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantCertifiedAttributeUpdated.ts
+++ b/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantCertifiedAttributeUpdated.ts
@@ -1,0 +1,98 @@
+import {
+  EmailNotificationMessagePayload,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+  fromTenantV2,
+} from "pagopa-interop-models";
+import {
+  eventMailTemplateType,
+  retrieveHTMLTemplate,
+} from "../../services/utils.js";
+import {
+  getRecipientsForTenants,
+  mapRecipientToEmailPayload,
+  retrieveAttribute,
+  retrieveTenantByCertifierId,
+  TenantHandlerParams,
+} from "../handlerCommons.js";
+import { certifierDatabaseOriginNames } from "../../config/constants.js";
+import { config } from "../../config/config.js";
+
+const notificationType: NotificationType =
+  "certifiedVerifiedAttributeAssignedRevokedToAssignee";
+
+export async function handleTenantCertifiedAttributeUpdated(
+  data: TenantHandlerParams
+): Promise<EmailNotificationMessagePayload[]> {
+  const {
+    tenantV2Msg,
+    attributeId,
+    readModelService,
+    logger,
+    templateService,
+    correlationId,
+  } = data;
+
+  if (!tenantV2Msg) {
+    throw missingKafkaMessageDataError(
+      "tenant",
+      "TenantCertifiedAttributeUpdated"
+    );
+  }
+
+  const tenant = fromTenantV2(tenantV2Msg);
+
+  const [htmlTemplate, attribute] = await Promise.all([
+    retrieveHTMLTemplate(
+      eventMailTemplateType.tenantCertifiedAttributeUpdatedMailTemplate
+    ),
+    retrieveAttribute(attributeId, readModelService),
+  ]);
+
+  if (!attribute.origin) {
+    logger.error(
+      `Origin of certified attribute ${attribute.id} cannot be undefined.`
+    );
+    return [];
+  }
+
+  const targets = await getRecipientsForTenants({
+    tenants: [tenant],
+    notificationType,
+    readModelService,
+    logger,
+    includeTenantContactEmails: false,
+  });
+
+  if (targets.length === 0) {
+    logger.info(
+      `No users with email notifications enabled for handleTenantCertifiedAttributeUpdated - entityId: ${tenant.id}, eventType: ${notificationType}`
+    );
+    return [];
+  }
+
+  const certifierName = certifierDatabaseOriginNames.includes(attribute.origin)
+    ? attribute.origin
+    : (await retrieveTenantByCertifierId(attribute.origin, readModelService))
+        .name;
+
+  return targets.map((t) => ({
+    correlationId: correlationId ?? generateId(),
+    email: {
+      subject: `Un tuo attributo certificato è stato aggiornato`,
+      body: templateService.compileHtml(htmlTemplate, {
+        title: `Un tuo attributo certificato è stato aggiornato`,
+        notificationType,
+        entityId: tenant.id,
+        ...(t.type === "Tenant" ? { recipientName: tenant.name } : {}),
+        certifierName,
+        attributeName: attribute.name,
+        selfcareId: t.selfcareId,
+        bffUrl: config.bffUrl,
+      }),
+    },
+    tenantId: t.tenantId,
+    ...mapRecipientToEmailPayload(t),
+  }));
+}

--- a/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantEvent.ts
+++ b/packages/email-notification-dispatcher/src/handlers/tenants/handleTenantEvent.ts
@@ -10,6 +10,7 @@ import { handleTenantCertifiedAttributeAssigned } from "./handleTenantCertifiedA
 import { handleTenantCertifiedAttributeRevoked } from "./handleTenantCertifiedAttributeRevoked.js";
 import { handleTenantVerifiedAttributeAssigned } from "./handleTenantVerifiedAttributeAssigned.js";
 import { handleTenantVerifiedAttributeRevoked } from "./handleTenantVerifiedAttributeRevoked.js";
+import { handleTenantCertifiedAttributeUpdated } from "./handleTenantCertifiedAttributeUpdated.js";
 
 export async function handleTenantEvent(
   params: HandlerParams<typeof TenantEvent>
@@ -28,6 +29,7 @@ export async function handleTenantEvent(
     })
     .with(
       { type: "TenantCertifiedAttributeAssigned" },
+      { type: "TenantCertifiedDiscreteAttributeAssigned" },
       ({ data: { tenant, attributeId } }) =>
         handleTenantCertifiedAttributeAssigned({
           tenantV2Msg: tenant,
@@ -40,8 +42,21 @@ export async function handleTenantEvent(
     )
     .with(
       { type: "TenantCertifiedAttributeRevoked" },
+      { type: "TenantCertifiedDiscreteAttributeRevoked" },
       ({ data: { tenant, attributeId } }) =>
         handleTenantCertifiedAttributeRevoked({
+          tenantV2Msg: tenant,
+          attributeId: unsafeBrandId<AttributeId>(attributeId),
+          logger,
+          readModelService,
+          templateService,
+          correlationId,
+        })
+    )
+    .with(
+      { type: "TenantCertifiedDiscreteAttributeUpdated" },
+      ({ data: { tenant, attributeId } }) =>
+        handleTenantCertifiedAttributeUpdated({
           tenantV2Msg: tenant,
           attributeId: unsafeBrandId<AttributeId>(attributeId),
           logger,
@@ -81,9 +96,6 @@ export async function handleTenantEvent(
           "TenantOnboardDetailsUpdated",
           "TenantDeclaredAttributeAssigned",
           "TenantDeclaredAttributeRevoked",
-          "TenantCertifiedDiscreteAttributeAssigned",
-          "TenantCertifiedDiscreteAttributeRevoked",
-          "TenantCertifiedDiscreteAttributeUpdated",
           "TenantVerifiedAttributeExpirationUpdated",
           "TenantVerifiedAttributeExtensionUpdated",
           "MaintenanceTenantDeleted",

--- a/packages/email-notification-dispatcher/src/resources/templates/tenant-certified-attribute-updated-mail.html
+++ b/packages/email-notification-dispatcher/src/resources/templates/tenant-certified-attribute-updated-mail.html
@@ -1,6 +1,6 @@
 {{> common-header }}
 <tr>
-  <td align="left" class="title" style="
+    <td align="left" class="title" style="
       font-size: 0px;
       padding: 10px 25px;
       padding-top: 24px;
@@ -9,7 +9,7 @@
       padding-left: 0px;
       word-break: break-word;
     ">
-    <div style="
+        <div style="
         font-family: Titillium Web, system-ui, sans-serif;
         font-size: 13px;
         font-weight: bold;
@@ -17,13 +17,13 @@
         text-align: left;
         color: #17324d;
       ">
-      <!-- H4 Desktop (from MUI Italia)-->
-      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
-    </div>
-  </td>
+            <!-- H4 Desktop (from MUI Italia)-->
+            <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+        </div>
+    </td>
 </tr>
 <tr>
-  <td align="left" class="text" style="
+    <td align="left" class="text" style="
       font-size: 0px;
       padding: 10px 25px;
       padding-top: 8px;
@@ -32,7 +32,7 @@
       padding-left: 0px;
       word-break: break-word;
     ">
-    <div style="
+        <div style="
         font-family: Titillium Web, system-ui, sans-serif;
         font-size: 16px;
         font-weight: regular;
@@ -40,16 +40,16 @@
         text-align: left;
         color: #17324d;
       ">
-      <p style="margin-bottom: 0px">
-        Gentile
-        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
-      </p>
-    </div>
-  </td>
+            <p style="margin-bottom: 0px">
+                Gentile
+                <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+            </p>
+        </div>
+    </td>
 </tr>
 <tr>
-  <td align="left" class="text" style="font-size: 0px; padding: 0px; word-break: break-word">
-    <div style="
+    <td align="left" class="text" style="font-size: 0px; padding: 0px; word-break: break-word">
+        <div style="
         font-family: Titillium Web, system-ui, sans-serif;
         font-size: 16px;
         font-weight: regular;
@@ -57,14 +57,12 @@
         text-align: left;
         color: #17324d;
       ">
-      <!-- Body 1 Desktop (from MUI Italia)-->
-      <p>
-        L'ente certificatore {{ certifierName }} ha revocato l'attributo certificato
-        "{{ attributeName }}". Tutte le richieste di fruizione con questo attributo
-        saranno sospese e in futuro non potrai più utilizzare questo attributo
-        per le richieste di fruizione.
-      </p>
-    </div>
-  </td>
+            <!-- Body 1 Desktop (from MUI Italia)-->
+            <p>
+                L'attributo certificato "{{ attributeName }}" conferito al tuo ente
+                è stato aggiornato. Puoi ora utilizzarlo nelle richieste di fruizione.
+            </p>
+        </div>
+    </td>
 </tr>
 {{> common-footer }}

--- a/packages/email-notification-dispatcher/src/resources/templates/tenant-certified-attribute-updated-mail.html
+++ b/packages/email-notification-dispatcher/src/resources/templates/tenant-certified-attribute-updated-mail.html
@@ -1,6 +1,6 @@
 {{> common-header }}
 <tr>
-    <td align="left" class="title" style="
+  <td align="left" class="title" style="
       font-size: 0px;
       padding: 10px 25px;
       padding-top: 24px;
@@ -9,7 +9,7 @@
       padding-left: 0px;
       word-break: break-word;
     ">
-        <div style="
+    <div style="
         font-family: Titillium Web, system-ui, sans-serif;
         font-size: 13px;
         font-weight: bold;
@@ -17,13 +17,13 @@
         text-align: left;
         color: #17324d;
       ">
-            <!-- H4 Desktop (from MUI Italia)-->
-            <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
-        </div>
-    </td>
+      <!-- H4 Desktop (from MUI Italia)-->
+      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+    </div>
+  </td>
 </tr>
 <tr>
-    <td align="left" class="text" style="
+  <td align="left" class="text" style="
       font-size: 0px;
       padding: 10px 25px;
       padding-top: 8px;
@@ -32,7 +32,7 @@
       padding-left: 0px;
       word-break: break-word;
     ">
-        <div style="
+    <div style="
         font-family: Titillium Web, system-ui, sans-serif;
         font-size: 16px;
         font-weight: regular;
@@ -40,16 +40,16 @@
         text-align: left;
         color: #17324d;
       ">
-            <p style="margin-bottom: 0px">
-                Gentile
-                <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
-            </p>
-        </div>
-    </td>
+      <p style="margin-bottom: 0px">
+        Gentile
+        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+      </p>
+    </div>
+  </td>
 </tr>
 <tr>
-    <td align="left" class="text" style="font-size: 0px; padding: 0px; word-break: break-word">
-        <div style="
+  <td align="left" class="text" style="font-size: 0px; padding: 0px; word-break: break-word">
+    <div style="
         font-family: Titillium Web, system-ui, sans-serif;
         font-size: 16px;
         font-weight: regular;
@@ -57,12 +57,12 @@
         text-align: left;
         color: #17324d;
       ">
-            <!-- Body 1 Desktop (from MUI Italia)-->
-            <p>
-                L'attributo certificato "{{ attributeName }}" conferito al tuo ente
-                è stato aggiornato. Puoi ora utilizzarlo nelle richieste di fruizione.
-            </p>
-        </div>
-    </td>
+      <!-- Body 1 Desktop (from MUI Italia)-->
+      <p>
+        L'attributo certificato "{{ attributeName }}" conferito al tuo ente
+        è stato aggiornato. Puoi ora utilizzarlo nelle richieste di fruizione.
+      </p>
+    </div>
+  </td>
 </tr>
 {{> common-footer }}

--- a/packages/email-notification-dispatcher/src/services/utils.ts
+++ b/packages/email-notification-dispatcher/src/services/utils.ts
@@ -95,6 +95,8 @@ export const eventMailTemplateType = {
     "tenant-certified-attribute-assigned-mail",
   tenantCertifiedAttributeRevokedMailTemplate:
     "tenant-certified-attribute-revoked-mail",
+  tenantCertifiedAttributeUpdatedMailTemplate:
+    "tenant-certified-attribute-updated-mail",
   tenantVerifiedAttributeAssignedMailTemplate:
     "tenant-verified-attribute-assigned-mail",
   tenantVerifiedAttributeRevokedMailTemplate:

--- a/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeAssigned.test.ts
+++ b/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeAssigned.test.ts
@@ -223,7 +223,6 @@ describe("handleTenantCertifiedAttributeAssigned", async () => {
         })
         .exhaustive();
       expect(message.email.body).toContain(attribute.name);
-      expect(message.email.body).toContain(attribute.name);
     });
   });
 });

--- a/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeRevoked.test.ts
+++ b/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeRevoked.test.ts
@@ -223,7 +223,6 @@ describe("handleTenantCertifiedAttributeRevoked", async () => {
         })
         .exhaustive();
       expect(message.email.body).toContain(attribute.name);
-      expect(message.email.body).toContain(attribute.name);
     });
   });
 });

--- a/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeUpdated.test.ts
+++ b/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeUpdated.test.ts
@@ -34,7 +34,6 @@ import {
 
 describe("handleTenantCertifiedAttributeUpdated", async () => {
   const targetTenantId = generateId<TenantId>();
-  const certifierTenantId = generateId<TenantId>();
   const certifierId = generateId();
   const attributeId = generateId<AttributeId>();
 
@@ -48,23 +47,12 @@ describe("handleTenantCertifiedAttributeUpdated", async () => {
     name: "Target Tenant",
     mails: [getMockTenantMail()],
   };
-  const certifierTenant: Tenant = {
-    ...getMockTenant(certifierTenantId),
-    name: "Certifier Tenant",
-    features: [
-      {
-        type: "PersistentCertifier",
-        certifierId,
-      },
-    ],
-  };
   const users = [getMockUser(targetTenantId), getMockUser(targetTenantId)];
 
   const { logger } = getMockContext({});
 
   beforeEach(async () => {
     await addOneTenant(targetTenant);
-    await addOneTenant(certifierTenant);
     await addOneAttribute(attribute);
     readModelService.getTenantNotificationConfigByTenantId = vi
       .fn()

--- a/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeUpdated.test.ts
+++ b/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeUpdated.test.ts
@@ -1,0 +1,229 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable sonarjs/no-identical-functions */
+import {
+    getMockAttribute,
+    getMockContext,
+    getMockTenant,
+    getMockTenantMail,
+} from "pagopa-interop-commons-test";
+import { authRole } from "pagopa-interop-commons";
+import {
+    Attribute,
+    AttributeId,
+    CorrelationId,
+    generateId,
+    missingKafkaMessageDataError,
+    NotificationType,
+    Tenant,
+    TenantId,
+    TenantNotificationConfigId,
+    toTenantV2,
+    unsafeBrandId,
+} from "pagopa-interop-models";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { match } from "ts-pattern";
+import { handleTenantCertifiedAttributeUpdated } from "../src/handlers/tenants/handleTenantCertifiedAttributeUpdated.js";
+import { attributeNotFound } from "../src/models/errors.js";
+import {
+    addOneAttribute,
+    addOneTenant,
+    getMockUser,
+    readModelService,
+    templateService,
+} from "./utils.js";
+
+describe("handleTenantCertifiedAttributeUpdated", async () => {
+    const targetTenantId = generateId<TenantId>();
+    const certifierTenantId = generateId<TenantId>();
+    const certifierId = generateId();
+    const attributeId = generateId<AttributeId>();
+
+    const attribute: Attribute = {
+        ...getMockAttribute("Certified", attributeId),
+        origin: certifierId,
+    };
+
+    const targetTenant: Tenant = {
+        ...getMockTenant(targetTenantId),
+        name: "Target Tenant",
+        mails: [getMockTenantMail()],
+    };
+    const certifierTenant: Tenant = {
+        ...getMockTenant(certifierTenantId),
+        name: "Certifier Tenant",
+        features: [
+            {
+                type: "PersistentCertifier",
+                certifierId,
+            },
+        ],
+    };
+    const users = [getMockUser(targetTenantId), getMockUser(targetTenantId)];
+
+    const { logger } = getMockContext({});
+
+    beforeEach(async () => {
+        await addOneTenant(targetTenant);
+        await addOneTenant(certifierTenant);
+        await addOneAttribute(attribute);
+        readModelService.getTenantNotificationConfigByTenantId = vi
+            .fn()
+            .mockResolvedValue({
+                id: generateId<TenantNotificationConfigId>(),
+                tenantId: targetTenantId,
+                enabled: true,
+                createAt: new Date(),
+            });
+        readModelService.getTenantUsersWithNotificationEnabled = vi
+            .fn()
+            .mockImplementation((tenantIds: TenantId[], _: NotificationType) =>
+                users
+                    .filter((user) =>
+                        tenantIds.includes(unsafeBrandId<TenantId>(user.tenantId))
+                    )
+                    .map((user) => ({
+                        userId: user.id,
+                        tenantId: user.tenantId,
+                        // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+                        userRoles: [authRole.ADMIN_ROLE],
+                    }))
+            );
+    });
+
+    it("should throw missingKafkaMessageDataError when tenant is undefined", async () => {
+        await expect(() =>
+            handleTenantCertifiedAttributeUpdated({
+                tenantV2Msg: undefined,
+                attributeId: generateId(),
+                logger,
+                templateService,
+                readModelService,
+                correlationId: generateId<CorrelationId>(),
+            })
+        ).rejects.toThrow(
+            missingKafkaMessageDataError("tenant", "TenantCertifiedAttributeUpdated")
+        );
+    });
+
+    it("should throw attributeNotFound when attribute is not found", async () => {
+        const unknownAttributeId = generateId<AttributeId>();
+
+        await expect(() =>
+            handleTenantCertifiedAttributeUpdated({
+                tenantV2Msg: toTenantV2(targetTenant),
+                attributeId: unknownAttributeId,
+                logger,
+                templateService,
+                readModelService,
+                correlationId: generateId<CorrelationId>(),
+            })
+        ).rejects.toThrow(attributeNotFound(unknownAttributeId));
+    });
+
+    it("should generate no messages when attribute has no origin", async () => {
+        const attributeWithNoOrigin: Attribute = {
+            ...getMockAttribute("Certified"),
+            origin: undefined,
+            code: undefined,
+        };
+        await addOneAttribute(attributeWithNoOrigin);
+
+        const messages = await handleTenantCertifiedAttributeUpdated({
+            tenantV2Msg: toTenantV2(targetTenant),
+            attributeId: attributeWithNoOrigin.id,
+            logger,
+            templateService,
+            readModelService,
+            correlationId: generateId<CorrelationId>(),
+        });
+
+        expect(messages.length).toEqual(0);
+    });
+
+    it("should generate one message per user of the tenant that is updated with the attribute", async () => {
+        const messages = await handleTenantCertifiedAttributeUpdated({
+            tenantV2Msg: toTenantV2(targetTenant),
+            attributeId,
+            logger,
+            templateService,
+            readModelService,
+            correlationId: generateId<CorrelationId>(),
+        });
+
+        expect(messages.length).toEqual(2);
+        expect(
+            messages.some(
+                (message) => message.type === "User" && message.userId === users[0].id
+            )
+        ).toBe(true);
+        expect(
+            messages.some(
+                (message) => message.type === "User" && message.userId === users[1].id
+            )
+        ).toBe(true);
+    });
+
+    it("should not generate a message if the user disabled this email notification", async () => {
+        readModelService.getTenantUsersWithNotificationEnabled = vi
+            .fn()
+            .mockResolvedValue([
+                {
+                    userId: users[0].id,
+                    tenantId: users[0].tenantId,
+                    // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+                    userRoles: [authRole.ADMIN_ROLE],
+                },
+            ]);
+
+        const messages = await handleTenantCertifiedAttributeUpdated({
+            tenantV2Msg: toTenantV2(targetTenant),
+            attributeId,
+            logger,
+            templateService,
+            readModelService,
+            correlationId: generateId<CorrelationId>(),
+        });
+
+        expect(messages.length).toEqual(1);
+        expect(
+            messages.some(
+                (message) => message.type === "User" && message.userId === users[0].id
+            )
+        ).toBe(true);
+        expect(
+            messages.some(
+                (message) => message.type === "User" && message.userId === users[1].id
+            )
+        ).toBe(false);
+    });
+
+    it("should generate a complete and correct message", async () => {
+        const messages = await handleTenantCertifiedAttributeUpdated({
+            tenantV2Msg: toTenantV2(targetTenant),
+            attributeId,
+            logger,
+            templateService,
+            readModelService,
+            correlationId: generateId<CorrelationId>(),
+        });
+
+        expect(messages.length).toBe(2);
+        messages.forEach((message) => {
+            expect(message.email.body).toContain("<!-- Footer -->");
+            expect(message.email.body).toContain("<!-- Title & Main Message -->");
+            expect(message.email.body).toContain(
+                `Un tuo attributo certificato è stato aggiornato`
+            );
+            match(message.type)
+                .with("User", () => {
+                    expect(message.email.body).toContain("{{ recipientName }}");
+                })
+                .with("Tenant", () => {
+                    expect(message.email.body).toContain(targetTenant.name);
+                })
+                .exhaustive();
+            expect(message.email.body).toContain(attribute.name);
+            expect(message.email.body).toContain(attribute.name);
+        });
+    });
+});

--- a/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeUpdated.test.ts
+++ b/packages/email-notification-dispatcher/test/handleTenantCertifiedAttributeUpdated.test.ts
@@ -1,229 +1,228 @@
 /* eslint-disable functional/immutable-data */
 /* eslint-disable sonarjs/no-identical-functions */
 import {
-    getMockAttribute,
-    getMockContext,
-    getMockTenant,
-    getMockTenantMail,
+  getMockAttribute,
+  getMockContext,
+  getMockTenant,
+  getMockTenantMail,
 } from "pagopa-interop-commons-test";
 import { authRole } from "pagopa-interop-commons";
 import {
-    Attribute,
-    AttributeId,
-    CorrelationId,
-    generateId,
-    missingKafkaMessageDataError,
-    NotificationType,
-    Tenant,
-    TenantId,
-    TenantNotificationConfigId,
-    toTenantV2,
-    unsafeBrandId,
+  Attribute,
+  AttributeId,
+  CorrelationId,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+  Tenant,
+  TenantId,
+  TenantNotificationConfigId,
+  toTenantV2,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { match } from "ts-pattern";
 import { handleTenantCertifiedAttributeUpdated } from "../src/handlers/tenants/handleTenantCertifiedAttributeUpdated.js";
 import { attributeNotFound } from "../src/models/errors.js";
 import {
-    addOneAttribute,
-    addOneTenant,
-    getMockUser,
-    readModelService,
-    templateService,
+  addOneAttribute,
+  addOneTenant,
+  getMockUser,
+  readModelService,
+  templateService,
 } from "./utils.js";
 
 describe("handleTenantCertifiedAttributeUpdated", async () => {
-    const targetTenantId = generateId<TenantId>();
-    const certifierTenantId = generateId<TenantId>();
-    const certifierId = generateId();
-    const attributeId = generateId<AttributeId>();
+  const targetTenantId = generateId<TenantId>();
+  const certifierTenantId = generateId<TenantId>();
+  const certifierId = generateId();
+  const attributeId = generateId<AttributeId>();
 
-    const attribute: Attribute = {
-        ...getMockAttribute("Certified", attributeId),
-        origin: certifierId,
+  const attribute: Attribute = {
+    ...getMockAttribute("Certified", attributeId),
+    origin: certifierId,
+  };
+
+  const targetTenant: Tenant = {
+    ...getMockTenant(targetTenantId),
+    name: "Target Tenant",
+    mails: [getMockTenantMail()],
+  };
+  const certifierTenant: Tenant = {
+    ...getMockTenant(certifierTenantId),
+    name: "Certifier Tenant",
+    features: [
+      {
+        type: "PersistentCertifier",
+        certifierId,
+      },
+    ],
+  };
+  const users = [getMockUser(targetTenantId), getMockUser(targetTenantId)];
+
+  const { logger } = getMockContext({});
+
+  beforeEach(async () => {
+    await addOneTenant(targetTenant);
+    await addOneTenant(certifierTenant);
+    await addOneAttribute(attribute);
+    readModelService.getTenantNotificationConfigByTenantId = vi
+      .fn()
+      .mockResolvedValue({
+        id: generateId<TenantNotificationConfigId>(),
+        tenantId: targetTenantId,
+        enabled: true,
+        createAt: new Date(),
+      });
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockImplementation((tenantIds: TenantId[], _: NotificationType) =>
+        users
+          .filter((user) =>
+            tenantIds.includes(unsafeBrandId<TenantId>(user.tenantId))
+          )
+          .map((user) => ({
+            userId: user.id,
+            tenantId: user.tenantId,
+            // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+            userRoles: [authRole.ADMIN_ROLE],
+          }))
+      );
+  });
+
+  it("should throw missingKafkaMessageDataError when tenant is undefined", async () => {
+    await expect(() =>
+      handleTenantCertifiedAttributeUpdated({
+        tenantV2Msg: undefined,
+        attributeId: generateId(),
+        logger,
+        templateService,
+        readModelService,
+        correlationId: generateId<CorrelationId>(),
+      })
+    ).rejects.toThrow(
+      missingKafkaMessageDataError("tenant", "TenantCertifiedAttributeUpdated")
+    );
+  });
+
+  it("should throw attributeNotFound when attribute is not found", async () => {
+    const unknownAttributeId = generateId<AttributeId>();
+
+    await expect(() =>
+      handleTenantCertifiedAttributeUpdated({
+        tenantV2Msg: toTenantV2(targetTenant),
+        attributeId: unknownAttributeId,
+        logger,
+        templateService,
+        readModelService,
+        correlationId: generateId<CorrelationId>(),
+      })
+    ).rejects.toThrow(attributeNotFound(unknownAttributeId));
+  });
+
+  it("should generate no messages when attribute has no origin", async () => {
+    const attributeWithNoOrigin: Attribute = {
+      ...getMockAttribute("Certified"),
+      origin: undefined,
+      code: undefined,
     };
+    await addOneAttribute(attributeWithNoOrigin);
 
-    const targetTenant: Tenant = {
-        ...getMockTenant(targetTenantId),
-        name: "Target Tenant",
-        mails: [getMockTenantMail()],
-    };
-    const certifierTenant: Tenant = {
-        ...getMockTenant(certifierTenantId),
-        name: "Certifier Tenant",
-        features: [
-            {
-                type: "PersistentCertifier",
-                certifierId,
-            },
-        ],
-    };
-    const users = [getMockUser(targetTenantId), getMockUser(targetTenantId)];
-
-    const { logger } = getMockContext({});
-
-    beforeEach(async () => {
-        await addOneTenant(targetTenant);
-        await addOneTenant(certifierTenant);
-        await addOneAttribute(attribute);
-        readModelService.getTenantNotificationConfigByTenantId = vi
-            .fn()
-            .mockResolvedValue({
-                id: generateId<TenantNotificationConfigId>(),
-                tenantId: targetTenantId,
-                enabled: true,
-                createAt: new Date(),
-            });
-        readModelService.getTenantUsersWithNotificationEnabled = vi
-            .fn()
-            .mockImplementation((tenantIds: TenantId[], _: NotificationType) =>
-                users
-                    .filter((user) =>
-                        tenantIds.includes(unsafeBrandId<TenantId>(user.tenantId))
-                    )
-                    .map((user) => ({
-                        userId: user.id,
-                        tenantId: user.tenantId,
-                        // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
-                        userRoles: [authRole.ADMIN_ROLE],
-                    }))
-            );
+    const messages = await handleTenantCertifiedAttributeUpdated({
+      tenantV2Msg: toTenantV2(targetTenant),
+      attributeId: attributeWithNoOrigin.id,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
     });
 
-    it("should throw missingKafkaMessageDataError when tenant is undefined", async () => {
-        await expect(() =>
-            handleTenantCertifiedAttributeUpdated({
-                tenantV2Msg: undefined,
-                attributeId: generateId(),
-                logger,
-                templateService,
-                readModelService,
-                correlationId: generateId<CorrelationId>(),
-            })
-        ).rejects.toThrow(
-            missingKafkaMessageDataError("tenant", "TenantCertifiedAttributeUpdated")
-        );
+    expect(messages.length).toEqual(0);
+  });
+
+  it("should generate one message per user of the tenant that is updated with the attribute", async () => {
+    const messages = await handleTenantCertifiedAttributeUpdated({
+      tenantV2Msg: toTenantV2(targetTenant),
+      attributeId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
     });
 
-    it("should throw attributeNotFound when attribute is not found", async () => {
-        const unknownAttributeId = generateId<AttributeId>();
+    expect(messages.length).toEqual(2);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[0].id
+      )
+    ).toBe(true);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[1].id
+      )
+    ).toBe(true);
+  });
 
-        await expect(() =>
-            handleTenantCertifiedAttributeUpdated({
-                tenantV2Msg: toTenantV2(targetTenant),
-                attributeId: unknownAttributeId,
-                logger,
-                templateService,
-                readModelService,
-                correlationId: generateId<CorrelationId>(),
-            })
-        ).rejects.toThrow(attributeNotFound(unknownAttributeId));
+  it("should not generate a message if the user disabled this email notification", async () => {
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockResolvedValue([
+        {
+          userId: users[0].id,
+          tenantId: users[0].tenantId,
+          // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+          userRoles: [authRole.ADMIN_ROLE],
+        },
+      ]);
+
+    const messages = await handleTenantCertifiedAttributeUpdated({
+      tenantV2Msg: toTenantV2(targetTenant),
+      attributeId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
     });
 
-    it("should generate no messages when attribute has no origin", async () => {
-        const attributeWithNoOrigin: Attribute = {
-            ...getMockAttribute("Certified"),
-            origin: undefined,
-            code: undefined,
-        };
-        await addOneAttribute(attributeWithNoOrigin);
+    expect(messages.length).toEqual(1);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[0].id
+      )
+    ).toBe(true);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[1].id
+      )
+    ).toBe(false);
+  });
 
-        const messages = await handleTenantCertifiedAttributeUpdated({
-            tenantV2Msg: toTenantV2(targetTenant),
-            attributeId: attributeWithNoOrigin.id,
-            logger,
-            templateService,
-            readModelService,
-            correlationId: generateId<CorrelationId>(),
-        });
-
-        expect(messages.length).toEqual(0);
+  it("should generate a complete and correct message", async () => {
+    const messages = await handleTenantCertifiedAttributeUpdated({
+      tenantV2Msg: toTenantV2(targetTenant),
+      attributeId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
     });
 
-    it("should generate one message per user of the tenant that is updated with the attribute", async () => {
-        const messages = await handleTenantCertifiedAttributeUpdated({
-            tenantV2Msg: toTenantV2(targetTenant),
-            attributeId,
-            logger,
-            templateService,
-            readModelService,
-            correlationId: generateId<CorrelationId>(),
-        });
-
-        expect(messages.length).toEqual(2);
-        expect(
-            messages.some(
-                (message) => message.type === "User" && message.userId === users[0].id
-            )
-        ).toBe(true);
-        expect(
-            messages.some(
-                (message) => message.type === "User" && message.userId === users[1].id
-            )
-        ).toBe(true);
+    expect(messages.length).toBe(2);
+    messages.forEach((message) => {
+      expect(message.email.body).toContain("<!-- Footer -->");
+      expect(message.email.body).toContain("<!-- Title & Main Message -->");
+      expect(message.email.body).toContain(
+        `Un tuo attributo certificato è stato aggiornato`
+      );
+      match(message.type)
+        .with("User", () => {
+          expect(message.email.body).toContain("{{ recipientName }}");
+        })
+        .with("Tenant", () => {
+          expect(message.email.body).toContain(targetTenant.name);
+        })
+        .exhaustive();
+      expect(message.email.body).toContain(attribute.name);
     });
-
-    it("should not generate a message if the user disabled this email notification", async () => {
-        readModelService.getTenantUsersWithNotificationEnabled = vi
-            .fn()
-            .mockResolvedValue([
-                {
-                    userId: users[0].id,
-                    tenantId: users[0].tenantId,
-                    // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
-                    userRoles: [authRole.ADMIN_ROLE],
-                },
-            ]);
-
-        const messages = await handleTenantCertifiedAttributeUpdated({
-            tenantV2Msg: toTenantV2(targetTenant),
-            attributeId,
-            logger,
-            templateService,
-            readModelService,
-            correlationId: generateId<CorrelationId>(),
-        });
-
-        expect(messages.length).toEqual(1);
-        expect(
-            messages.some(
-                (message) => message.type === "User" && message.userId === users[0].id
-            )
-        ).toBe(true);
-        expect(
-            messages.some(
-                (message) => message.type === "User" && message.userId === users[1].id
-            )
-        ).toBe(false);
-    });
-
-    it("should generate a complete and correct message", async () => {
-        const messages = await handleTenantCertifiedAttributeUpdated({
-            tenantV2Msg: toTenantV2(targetTenant),
-            attributeId,
-            logger,
-            templateService,
-            readModelService,
-            correlationId: generateId<CorrelationId>(),
-        });
-
-        expect(messages.length).toBe(2);
-        messages.forEach((message) => {
-            expect(message.email.body).toContain("<!-- Footer -->");
-            expect(message.email.body).toContain("<!-- Title & Main Message -->");
-            expect(message.email.body).toContain(
-                `Un tuo attributo certificato è stato aggiornato`
-            );
-            match(message.type)
-                .with("User", () => {
-                    expect(message.email.body).toContain("{{ recipientName }}");
-                })
-                .with("Tenant", () => {
-                    expect(message.email.body).toContain(targetTenant.name);
-                })
-                .exhaustive();
-            expect(message.email.body).toContain(attribute.name);
-            expect(message.email.body).toContain(attribute.name);
-        });
-    });
+  });
 });

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedAttributeAssignedRevokedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedAttributeAssignedRevokedToAssignee.ts
@@ -85,7 +85,7 @@ export async function handleCertifiedAttributeAssignedRevokedToAssignee(
   }));
 }
 
-export async function getAttributeAssignerOrRevokerName(
+async function getAttributeAssignerOrRevokerName(
   eventType: CertifiedAttributeAssignedRevokedEventType,
   attribute: Attribute,
   readModelService: ReadModelServiceSQL

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedAttributeAssignedRevokedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedAttributeAssignedRevokedToAssignee.ts
@@ -1,5 +1,6 @@
 import {
   AttributeId,
+  Attribute,
   fromTenantV2,
   missingKafkaMessageDataError,
   NewNotification,
@@ -12,7 +13,6 @@ import {
   retrieveTenantByCertifierId,
 } from "../handlerCommons.js";
 import { inAppTemplates } from "../../templates/inAppTemplates.js";
-import { Attribute } from "pagopa-interop-models";
 import { match, P } from "ts-pattern";
 import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
 import { attributeOriginUndefined } from "../../models/errors.js";

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedAttributeAssignedRevokedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedAttributeAssignedRevokedToAssignee.ts
@@ -1,0 +1,114 @@
+import {
+  AttributeId,
+  fromTenantV2,
+  missingKafkaMessageDataError,
+  NewNotification,
+  TenantV2,
+} from "pagopa-interop-models";
+import { Logger } from "pagopa-interop-commons";
+import {
+  getNotificationRecipients,
+  retrieveAttribute,
+  retrieveTenantByCertifierId,
+} from "../handlerCommons.js";
+import { inAppTemplates } from "../../templates/inAppTemplates.js";
+import { Attribute } from "pagopa-interop-models";
+import { match, P } from "ts-pattern";
+import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
+import { attributeOriginUndefined } from "../../models/errors.js";
+
+type CertifiedAttributeAssignedRevokedEventType =
+  | "TenantCertifiedAttributeAssigned"
+  | "TenantCertifiedAttributeRevoked";
+
+export async function handleCertifiedAttributeAssignedRevokedToAssignee(
+  tenantV2Msg: TenantV2 | undefined,
+  attributeId: AttributeId,
+  logger: Logger,
+  readModelService: ReadModelServiceSQL,
+  eventType: CertifiedAttributeAssignedRevokedEventType
+): Promise<NewNotification[]> {
+  if (!tenantV2Msg) {
+    throw missingKafkaMessageDataError("tenant", eventType);
+  }
+  logger.info(
+    `Sending in-app notification for handleCertifiedAttributeAssignedRevokedToAssignee - entityId: ${tenantV2Msg.id}, eventType: ${eventType}`
+  );
+
+  const tenant = fromTenantV2(tenantV2Msg);
+
+  const usersWithNotifications = await getNotificationRecipients(
+    [tenant.id],
+    "certifiedVerifiedAttributeAssignedRevokedToAssignee",
+    readModelService,
+    logger
+  );
+
+  if (usersWithNotifications.length === 0) {
+    logger.info(
+      `No users with notifications enabled for handleCertifiedAttributeAssignedRevokedToAssignee - entityId: ${tenant.id}, eventType: ${eventType}`
+    );
+    return [];
+  }
+
+  const attribute = await retrieveAttribute(attributeId, readModelService);
+
+  const assignerOrRevokerName = await getAttributeAssignerOrRevokerName(
+    eventType,
+    attribute,
+    readModelService
+  );
+
+  const body = match(eventType)
+    .with("TenantCertifiedAttributeAssigned", () =>
+      inAppTemplates.certifiedVerifiedAttributeAssignedToAssignee(
+        attribute.name,
+        "certificato",
+        assignerOrRevokerName
+      )
+    )
+    .with("TenantCertifiedAttributeRevoked", () =>
+      inAppTemplates.certifiedVerifiedAttributeRevokedToAssignee(
+        attribute.name,
+        "certificato",
+        assignerOrRevokerName
+      )
+    )
+    .exhaustive();
+
+  return usersWithNotifications.map(({ userId, tenantId }) => ({
+    userId,
+    tenantId,
+    body,
+    notificationType: "certifiedVerifiedAttributeAssignedRevokedToAssignee",
+    entityId: attribute.id,
+  }));
+}
+
+export async function getAttributeAssignerOrRevokerName(
+  eventType: CertifiedAttributeAssignedRevokedEventType,
+  attribute: Attribute,
+  readModelService: ReadModelServiceSQL
+): Promise<string> {
+  return match(eventType)
+    .with(
+      P.union(
+        "TenantCertifiedAttributeAssigned",
+        "TenantCertifiedAttributeRevoked"
+      ),
+      async () => {
+        if (!attribute.origin) {
+          throw attributeOriginUndefined(attribute.id);
+        }
+        return ["ANAC", "IPA", "IVASS"].includes(attribute.origin)
+          ? attribute.origin
+          : (
+              await retrieveTenantByCertifierId(
+                attribute.origin,
+                readModelService
+              )
+            ).name;
+      }
+    )
+    .exhaustive();
+}

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.ts
@@ -17,7 +17,7 @@ import { match, P } from "ts-pattern";
 import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
 import { attributeOriginUndefined } from "../../models/errors.js";
 
-export type CertifiedDiscreteAttributeAssignedRevokedUpdatedEventType =
+type CertifiedDiscreteAttributeAssignedRevokedUpdatedEventType =
   | "TenantCertifiedDiscreteAttributeAssigned"
   | "TenantCertifiedDiscreteAttributeRevoked"
   | "TenantCertifiedDiscreteAttributeUpdated";
@@ -93,7 +93,7 @@ export async function handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAs
   }));
 }
 
-export async function getAttributeAssignerOrRevokerOrUpdaterName(
+async function getAttributeAssignerOrRevokerOrUpdaterName(
   eventType: CertifiedDiscreteAttributeAssignedRevokedUpdatedEventType,
   attribute: Attribute,
   readModelService: ReadModelServiceSQL

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.ts
@@ -1,5 +1,6 @@
 import {
   AttributeId,
+  Attribute,
   fromTenantV2,
   missingKafkaMessageDataError,
   NewNotification,
@@ -12,7 +13,6 @@ import {
   retrieveTenantByCertifierId,
 } from "../handlerCommons.js";
 import { inAppTemplates } from "../../templates/inAppTemplates.js";
-import { Attribute } from "pagopa-interop-models";
 import { match, P } from "ts-pattern";
 import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
 import { attributeOriginUndefined } from "../../models/errors.js";
@@ -54,29 +54,34 @@ export async function handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAs
 
   const attribute = await retrieveAttribute(attributeId, readModelService);
 
-  const assignerOrRevokerOrUpdaterName =
-    await getAttributeAssignerOrRevokerOrUpdaterName(
-      eventType,
-      attribute,
-      readModelService
-    );
+  const body = await match(eventType)
+    .with("TenantCertifiedDiscreteAttributeAssigned", async () => {
+      const assignerName = await getAttributeAssignerOrRevokerOrUpdaterName(
+        eventType,
+        attribute,
+        readModelService
+      );
 
-  const body = match(eventType)
-    .with("TenantCertifiedDiscreteAttributeAssigned", () =>
-      inAppTemplates.certifiedVerifiedAttributeAssignedToAssignee(
+      return inAppTemplates.certifiedVerifiedAttributeAssignedToAssignee(
         attribute.name,
         "certificato",
-        assignerOrRevokerOrUpdaterName
-      )
-    )
-    .with("TenantCertifiedDiscreteAttributeRevoked", () =>
-      inAppTemplates.certifiedVerifiedAttributeRevokedToAssignee(
+        assignerName
+      );
+    })
+    .with("TenantCertifiedDiscreteAttributeRevoked", async () => {
+      const revokerName = await getAttributeAssignerOrRevokerOrUpdaterName(
+        eventType,
+        attribute,
+        readModelService
+      );
+
+      return inAppTemplates.certifiedVerifiedAttributeRevokedToAssignee(
         attribute.name,
         "certificato",
-        assignerOrRevokerOrUpdaterName
-      )
-    )
-    .with("TenantCertifiedDiscreteAttributeUpdated", () =>
+        revokerName
+      );
+    })
+    .with("TenantCertifiedDiscreteAttributeUpdated", async () =>
       inAppTemplates.certifiedVerifiedAttributeUpdatedToAssignee(
         attribute.name,
         "certificato"

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.ts
@@ -1,0 +1,123 @@
+import {
+  AttributeId,
+  fromTenantV2,
+  missingKafkaMessageDataError,
+  NewNotification,
+  TenantV2,
+} from "pagopa-interop-models";
+import { Logger } from "pagopa-interop-commons";
+import {
+  getNotificationRecipients,
+  retrieveAttribute,
+  retrieveTenantByCertifierId,
+} from "../handlerCommons.js";
+import { inAppTemplates } from "../../templates/inAppTemplates.js";
+import { Attribute } from "pagopa-interop-models";
+import { match, P } from "ts-pattern";
+import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
+import { attributeOriginUndefined } from "../../models/errors.js";
+
+export type CertifiedDiscreteAttributeAssignedRevokedUpdatedEventType =
+  | "TenantCertifiedDiscreteAttributeAssigned"
+  | "TenantCertifiedDiscreteAttributeRevoked"
+  | "TenantCertifiedDiscreteAttributeUpdated";
+
+export async function handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+  tenantV2Msg: TenantV2 | undefined,
+  attributeId: AttributeId,
+  logger: Logger,
+  readModelService: ReadModelServiceSQL,
+  eventType: CertifiedDiscreteAttributeAssignedRevokedUpdatedEventType
+): Promise<NewNotification[]> {
+  if (!tenantV2Msg) {
+    throw missingKafkaMessageDataError("tenant", eventType);
+  }
+  logger.info(
+    `Sending in-app notification for handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee - entityId: ${tenantV2Msg.id}, eventType: ${eventType}`
+  );
+
+  const tenant = fromTenantV2(tenantV2Msg);
+
+  const usersWithNotifications = await getNotificationRecipients(
+    [tenant.id],
+    "certifiedVerifiedAttributeAssignedRevokedToAssignee",
+    readModelService,
+    logger
+  );
+
+  if (usersWithNotifications.length === 0) {
+    logger.info(
+      `No users with notifications enabled for handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee - entityId: ${tenant.id}, eventType: ${eventType}`
+    );
+    return [];
+  }
+
+  const attribute = await retrieveAttribute(attributeId, readModelService);
+
+  const assignerOrRevokerOrUpdaterName =
+    await getAttributeAssignerOrRevokerOrUpdaterName(
+      eventType,
+      attribute,
+      readModelService
+    );
+
+  const body = match(eventType)
+    .with("TenantCertifiedDiscreteAttributeAssigned", () =>
+      inAppTemplates.certifiedVerifiedAttributeAssignedToAssignee(
+        attribute.name,
+        "certificato",
+        assignerOrRevokerOrUpdaterName
+      )
+    )
+    .with("TenantCertifiedDiscreteAttributeRevoked", () =>
+      inAppTemplates.certifiedVerifiedAttributeRevokedToAssignee(
+        attribute.name,
+        "certificato",
+        assignerOrRevokerOrUpdaterName
+      )
+    )
+    .with("TenantCertifiedDiscreteAttributeUpdated", () =>
+      inAppTemplates.certifiedVerifiedAttributeUpdatedToAssignee(
+        attribute.name,
+        "certificato"
+      )
+    )
+    .exhaustive();
+
+  return usersWithNotifications.map(({ userId, tenantId }) => ({
+    userId,
+    tenantId,
+    body,
+    notificationType: "certifiedVerifiedAttributeAssignedRevokedToAssignee",
+    entityId: attribute.id,
+  }));
+}
+
+export async function getAttributeAssignerOrRevokerOrUpdaterName(
+  eventType: CertifiedDiscreteAttributeAssignedRevokedUpdatedEventType,
+  attribute: Attribute,
+  readModelService: ReadModelServiceSQL
+): Promise<string> {
+  return match(eventType)
+    .with(
+      P.union(
+        "TenantCertifiedDiscreteAttributeAssigned",
+        "TenantCertifiedDiscreteAttributeRevoked",
+        "TenantCertifiedDiscreteAttributeUpdated"
+      ),
+      async () => {
+        if (!attribute.origin) {
+          throw attributeOriginUndefined(attribute.id);
+        }
+        return ["ISTAT"].includes(attribute.origin)
+          ? attribute.origin
+          : (
+              await retrieveTenantByCertifierId(
+                attribute.origin,
+                readModelService
+              )
+            ).name;
+      }
+    )
+    .exhaustive();
+}

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.ts
@@ -22,6 +22,10 @@ type CertifiedDiscreteAttributeAssignedRevokedUpdatedEventType =
   | "TenantCertifiedDiscreteAttributeRevoked"
   | "TenantCertifiedDiscreteAttributeUpdated";
 
+type CertifiedDiscreteAttributeAssignedRevokedEventType =
+  | "TenantCertifiedDiscreteAttributeAssigned"
+  | "TenantCertifiedDiscreteAttributeRevoked";
+
 export async function handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
   tenantV2Msg: TenantV2 | undefined,
   attributeId: AttributeId,
@@ -56,8 +60,8 @@ export async function handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAs
 
   const body = await match(eventType)
     .with("TenantCertifiedDiscreteAttributeAssigned", async () => {
-      const assignerName = await getAttributeAssignerOrRevokerOrUpdaterName(
-        eventType,
+      const assignerName = await getAttributeAssignerOrRevokerName(
+        "TenantCertifiedDiscreteAttributeAssigned",
         attribute,
         readModelService
       );
@@ -69,8 +73,8 @@ export async function handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAs
       );
     })
     .with("TenantCertifiedDiscreteAttributeRevoked", async () => {
-      const revokerName = await getAttributeAssignerOrRevokerOrUpdaterName(
-        eventType,
+      const revokerName = await getAttributeAssignerOrRevokerName(
+        "TenantCertifiedDiscreteAttributeRevoked",
         attribute,
         readModelService
       );
@@ -98,8 +102,8 @@ export async function handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAs
   }));
 }
 
-async function getAttributeAssignerOrRevokerOrUpdaterName(
-  eventType: CertifiedDiscreteAttributeAssignedRevokedUpdatedEventType,
+async function getAttributeAssignerOrRevokerName(
+  eventType: CertifiedDiscreteAttributeAssignedRevokedEventType,
   attribute: Attribute,
   readModelService: ReadModelServiceSQL
 ): Promise<string> {
@@ -107,8 +111,7 @@ async function getAttributeAssignerOrRevokerOrUpdaterName(
     .with(
       P.union(
         "TenantCertifiedDiscreteAttributeAssigned",
-        "TenantCertifiedDiscreteAttributeRevoked",
-        "TenantCertifiedDiscreteAttributeUpdated"
+        "TenantCertifiedDiscreteAttributeRevoked"
       ),
       async () => {
         if (!attribute.origin) {

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleTenantEvent.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleTenantEvent.ts
@@ -7,7 +7,9 @@ import {
 import { Logger } from "pagopa-interop-commons";
 import { P, match } from "ts-pattern";
 import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
-import { handleCertifiedVerifiedAttributeAssignedRevokedToAssignee } from "./handleCertifiedVerifiedAttributeAssignedRevokedToAssignee.js";
+import { handleCertifiedAttributeAssignedRevokedToAssignee } from "./handleCertifiedAttributeAssignedRevokedToAssignee.js";
+import { handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee } from "./handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.js";
+import { handleVerifiedAttributeAssignedRevokedToAssignee } from "./handleVerifiedAttributeAssignedRevokedToAssignee.js";
 
 export async function handleTenantEvent(
   decodedMessage: TenantEventEnvelope,
@@ -23,13 +25,44 @@ export async function handleTenantEvent(
       {
         type: P.union(
           "TenantCertifiedAttributeAssigned",
-          "TenantCertifiedAttributeRevoked",
+          "TenantCertifiedAttributeRevoked"
+        ),
+      },
+      ({ data: { tenant, attributeId }, type }) =>
+        handleCertifiedAttributeAssignedRevokedToAssignee(
+          tenant,
+          unsafeBrandId<AttributeId>(attributeId),
+          logger,
+          readModelService,
+          type
+        )
+    )
+    .with(
+      {
+        type: P.union(
+          "TenantCertifiedDiscreteAttributeAssigned",
+          "TenantCertifiedDiscreteAttributeRevoked",
+          "TenantCertifiedDiscreteAttributeUpdated"
+        ),
+      },
+      ({ data: { tenant, attributeId }, type }) =>
+        handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+          tenant,
+          unsafeBrandId<AttributeId>(attributeId),
+          logger,
+          readModelService,
+          type
+        )
+    )
+    .with(
+      {
+        type: P.union(
           "TenantVerifiedAttributeAssigned",
           "TenantVerifiedAttributeRevoked"
         ),
       },
       ({ data: { tenant, attributeId }, type }) =>
-        handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
+        handleVerifiedAttributeAssignedRevokedToAssignee(
           tenant,
           unsafeBrandId<AttributeId>(attributeId),
           logger,
@@ -44,9 +77,6 @@ export async function handleTenantEvent(
           "TenantOnboardDetailsUpdated",
           "TenantDeclaredAttributeAssigned",
           "TenantDeclaredAttributeRevoked",
-          "TenantCertifiedDiscreteAttributeAssigned",
-          "TenantCertifiedDiscreteAttributeRevoked",
-          "TenantCertifiedDiscreteAttributeUpdated",
           "TenantVerifiedAttributeExpirationUpdated",
           "TenantVerifiedAttributeExtensionUpdated",
           "MaintenanceTenantDeleted",

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleVerifiedAttributeAssignedRevokedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleVerifiedAttributeAssignedRevokedToAssignee.ts
@@ -1,9 +1,13 @@
 import {
   AttributeId,
+  Attribute,
   fromTenantV2,
   missingKafkaMessageDataError,
   NewNotification,
+  Tenant,
+  tenantAttributeType,
   TenantV2,
+  VerifiedTenantAttribute,
 } from "pagopa-interop-models";
 import { Logger } from "pagopa-interop-commons";
 import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
@@ -13,13 +17,6 @@ import {
   retrieveTenant,
 } from "../handlerCommons.js";
 import { inAppTemplates } from "../../templates/inAppTemplates.js";
-
-import {
-  Attribute,
-  Tenant,
-  tenantAttributeType,
-  VerifiedTenantAttribute,
-} from "pagopa-interop-models";
 import { match } from "ts-pattern";
 import { verifiedAttributeNotFoundInTenant } from "../../models/errors.js";
 

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleVerifiedAttributeAssignedRevokedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleVerifiedAttributeAssignedRevokedToAssignee.ts
@@ -1,47 +1,44 @@
 import {
-  Attribute,
   AttributeId,
   fromTenantV2,
   missingKafkaMessageDataError,
   NewNotification,
-  Tenant,
-  tenantAttributeType,
   TenantV2,
-  VerifiedTenantAttribute,
 } from "pagopa-interop-models";
 import { Logger } from "pagopa-interop-commons";
-import { match, P } from "ts-pattern";
 import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
 import {
   getNotificationRecipients,
   retrieveAttribute,
   retrieveTenant,
-  retrieveTenantByCertifierId,
 } from "../handlerCommons.js";
 import { inAppTemplates } from "../../templates/inAppTemplates.js";
-import {
-  attributeOriginUndefined,
-  verifiedAttributeNotFoundInTenant,
-} from "../../models/errors.js";
 
-type CertifiedVerifiedAttributeAssignedRevokedEventType =
-  | "TenantCertifiedAttributeAssigned"
-  | "TenantCertifiedAttributeRevoked"
+import {
+  Attribute,
+  Tenant,
+  tenantAttributeType,
+  VerifiedTenantAttribute,
+} from "pagopa-interop-models";
+import { match } from "ts-pattern";
+import { verifiedAttributeNotFoundInTenant } from "../../models/errors.js";
+
+export type VerifiedAttributeAssignedRevokedEventType =
   | "TenantVerifiedAttributeAssigned"
   | "TenantVerifiedAttributeRevoked";
 
-export async function handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
+export async function handleVerifiedAttributeAssignedRevokedToAssignee(
   tenantV2Msg: TenantV2 | undefined,
   attributeId: AttributeId,
   logger: Logger,
   readModelService: ReadModelServiceSQL,
-  eventType: CertifiedVerifiedAttributeAssignedRevokedEventType
+  eventType: VerifiedAttributeAssignedRevokedEventType
 ): Promise<NewNotification[]> {
   if (!tenantV2Msg) {
     throw missingKafkaMessageDataError("tenant", eventType);
   }
   logger.info(
-    `Sending in-app notification for handleCertifiedVerifiedAttributeAssignedRevokedToAssignee - entityId: ${tenantV2Msg.id}, eventType: ${eventType}`
+    `Sending in-app notification for handleVerifiedAttributeAssignedRevokedToAssignee - entityId: ${tenantV2Msg.id}, eventType: ${eventType}`
   );
 
   const tenant = fromTenantV2(tenantV2Msg);
@@ -55,7 +52,7 @@ export async function handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
 
   if (usersWithNotifications.length === 0) {
     logger.info(
-      `No users with notifications enabled for handleCertifiedVerifiedAttributeAssignedRevokedToAssignee - entityId: ${tenant.id}, eventType: ${eventType}`
+      `No users with notifications enabled for handleVerifiedAttributeAssignedRevokedToAssignee - entityId: ${tenant.id}, eventType: ${eventType}`
     );
     return [];
   }
@@ -70,20 +67,6 @@ export async function handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
   );
 
   const body = match(eventType)
-    .with("TenantCertifiedAttributeAssigned", () =>
-      inAppTemplates.certifiedVerifiedAttributeAssignedToAssignee(
-        attribute.name,
-        "certificato",
-        assignerOrRevokerName
-      )
-    )
-    .with("TenantCertifiedAttributeRevoked", () =>
-      inAppTemplates.certifiedVerifiedAttributeRevokedToAssignee(
-        attribute.name,
-        "certificato",
-        assignerOrRevokerName
-      )
-    )
     .with("TenantVerifiedAttributeAssigned", () =>
       inAppTemplates.certifiedVerifiedAttributeAssignedToAssignee(
         attribute.name,
@@ -109,32 +92,13 @@ export async function handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
   }));
 }
 
-async function getAttributeAssignerOrRevokerName(
-  eventType: CertifiedVerifiedAttributeAssignedRevokedEventType,
+export async function getAttributeAssignerOrRevokerName(
+  eventType: VerifiedAttributeAssignedRevokedEventType,
   tenant: Tenant,
   attribute: Attribute,
   readModelService: ReadModelServiceSQL
 ): Promise<string> {
   return match(eventType)
-    .with(
-      P.union(
-        "TenantCertifiedAttributeAssigned",
-        "TenantCertifiedAttributeRevoked"
-      ),
-      async () => {
-        if (!attribute.origin) {
-          throw attributeOriginUndefined(attribute.id);
-        }
-        return ["ANAC", "IPA", "IVASS"].includes(attribute.origin)
-          ? attribute.origin
-          : (
-              await retrieveTenantByCertifierId(
-                attribute.origin,
-                readModelService
-              )
-            ).name;
-      }
-    )
     .with("TenantVerifiedAttributeAssigned", async () => {
       const tenantAttribute = tenant.attributes.find(
         (attr): attr is VerifiedTenantAttribute =>

--- a/packages/in-app-notification-dispatcher/src/handlers/tenants/handleVerifiedAttributeAssignedRevokedToAssignee.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/tenants/handleVerifiedAttributeAssignedRevokedToAssignee.ts
@@ -23,7 +23,7 @@ import {
 import { match } from "ts-pattern";
 import { verifiedAttributeNotFoundInTenant } from "../../models/errors.js";
 
-export type VerifiedAttributeAssignedRevokedEventType =
+type VerifiedAttributeAssignedRevokedEventType =
   | "TenantVerifiedAttributeAssigned"
   | "TenantVerifiedAttributeRevoked";
 
@@ -92,7 +92,7 @@ export async function handleVerifiedAttributeAssignedRevokedToAssignee(
   }));
 }
 
-export async function getAttributeAssignerOrRevokerName(
+async function getAttributeAssignerOrRevokerName(
   eventType: VerifiedAttributeAssignedRevokedEventType,
   tenant: Tenant,
   attribute: Attribute,

--- a/packages/in-app-notification-dispatcher/src/templates/inAppTemplates.ts
+++ b/packages/in-app-notification-dispatcher/src/templates/inAppTemplates.ts
@@ -316,6 +316,11 @@ export const inAppTemplates = {
     revokerName: string
   ): string =>
     `Ti informiamo che l'ente certificatore  ${revokerName} ha revocato l'attributo ${attributeKind} "${attributeName}". Tutte le richieste di fruizione che utilizzano tale attributo subiranno una sospensione. Non potrai più utilizzare questo attributo per le future richieste di fruizione.`,
+  certifiedVerifiedAttributeUpdatedToAssignee: (
+    attributeName: string,
+    attributeKind: "certificato"
+  ): string =>
+    `L'attributo ${attributeKind} "${attributeName}" conferito al tuo ente è stato aggiornato. Puoi ora utilizzarlo nelle richieste di fruizione.`,
   producerKeychainEServiceAddedToConsumer: (
     producerName: string,
     eserviceName: string

--- a/packages/in-app-notification-dispatcher/test/handleCertifiedAttributeAssignedRevokedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleCertifiedAttributeAssignedRevokedToAssignee.test.ts
@@ -175,7 +175,7 @@ describe("handleCertifiedAttributeAssignedRevokedToAssignee", () => {
       attributeId: certifiedAttribute.id,
     },
   ])(
-    "should return empty array when no users have notifications enabled",
+    "should return empty array when no users have notifications enabled for event $eventType",
     async ({ eventType, attributeId }) => {
       mockGetNotificationRecipients.mockResolvedValue([]);
 
@@ -293,7 +293,7 @@ describe("handleCertifiedAttributeAssignedRevokedToAssignee", () => {
       attributeId: certifiedAttributeIPA.id,
     },
   ])(
-    "should generate notifications for multiple users",
+    "should generate notifications for multiple users for event $eventType",
     async ({ eventType, assigneeAttributes, attributeId }) => {
       const users = [
         { userId: generateId(), tenantId: assignee.id },

--- a/packages/in-app-notification-dispatcher/test/handleCertifiedAttributeAssignedRevokedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleCertifiedAttributeAssignedRevokedToAssignee.test.ts
@@ -4,7 +4,6 @@ import {
   getMockContext,
   getMockTenant,
   getMockAttribute,
-  getMockVerifiedTenantAttribute,
 } from "pagopa-interop-commons-test";
 import {
   generateId,
@@ -15,21 +14,18 @@ import {
   Attribute,
   attributeKind,
   TenantAttribute,
-  TenantId,
 } from "pagopa-interop-models";
-import { handleCertifiedVerifiedAttributeAssignedRevokedToAssignee } from "../src/handlers/tenants/handleCertifiedVerifiedAttributeAssignedRevokedToAssignee.js";
+import { handleCertifiedAttributeAssignedRevokedToAssignee } from "../src/handlers/tenants/handleCertifiedAttributeAssignedRevokedToAssignee.js";
 import {
   attributeNotFound,
   attributeOriginUndefined,
   certifierTenantNotFound,
-  tenantNotFound,
-  verifiedAttributeNotFoundInTenant,
 } from "../src/models/errors.js";
 import { getNotificationRecipients } from "../src/handlers/handlerCommons.js";
 import { inAppTemplates } from "../src/templates/inAppTemplates.js";
 import { addOneAttribute, addOneTenant, readModelService } from "./utils.js";
 
-describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
+describe("handleCertifiedAttributeAssignedRevokedToAssignee", () => {
   const certifierId = generateId();
 
   const assignee = getMockTenant();
@@ -37,10 +33,6 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
     ...getMockTenant(),
     name: "Certifier Name",
     features: [{ type: "PersistentCertifier", certifierId }],
-  };
-  const verifier: Tenant = {
-    ...getMockTenant(),
-    name: "Verifier Name",
   };
   const revoker: Tenant = {
     ...getMockTenant(),
@@ -67,10 +59,6 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
     name: "Certified IVASS Attribute",
     origin: "IVASS",
   };
-  const verifiedAttribute: Attribute = {
-    ...getMockAttribute(attributeKind.verified),
-    name: "Verified Attribute",
-  };
 
   const { logger } = getMockContext({});
 
@@ -81,18 +69,16 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
     // Setup test data
     await addOneTenant(assignee);
     await addOneTenant(certifier);
-    await addOneTenant(verifier);
     await addOneTenant(revoker);
     await addOneAttribute(certifiedAttribute);
     await addOneAttribute(certifiedAttributeANAC);
     await addOneAttribute(certifiedAttributeIPA);
     await addOneAttribute(certifiedAttributeIVASS);
-    await addOneAttribute(verifiedAttribute);
   });
 
   it("should throw missingKafkaMessageDataError when tenant is undefined", async () => {
     await expect(() =>
-      handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
+      handleCertifiedAttributeAssignedRevokedToAssignee(
         undefined,
         generateId(),
         logger,
@@ -113,7 +99,7 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
     ]);
 
     await expect(() =>
-      handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
+      handleCertifiedAttributeAssignedRevokedToAssignee(
         toTenantV2(assignee),
         unknownAttributeId,
         logger,
@@ -136,7 +122,7 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
     ]);
 
     await expect(() =>
-      handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
+      handleCertifiedAttributeAssignedRevokedToAssignee(
         toTenantV2(assignee),
         certifiedAttributeWithUndefinedOrigin.id,
         logger,
@@ -161,9 +147,11 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
       { userId: generateId(), tenantId: assignee.id },
     ]);
 
+    const tenant = toTenantV2(assignee);
+
     await expect(() =>
-      handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
-        toTenantV2(assignee),
+      handleCertifiedAttributeAssignedRevokedToAssignee(
+        tenant,
         certifiedAttributeWithUnknownCertifier.id,
         logger,
         readModelService,
@@ -172,75 +160,42 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
     ).rejects.toThrow(certifierTenantNotFound(unknownCertifierId));
   });
 
-  it("should throw verifiedAttributeNotFoundInTenant when the verified attribute is not found", async () => {
-    // Mock notification recipients so the check doesn't exit early
-    mockGetNotificationRecipients.mockResolvedValue([
-      { userId: generateId(), tenantId: assignee.id },
-    ]);
+  it.each<{
+    eventType:
+      | "TenantCertifiedAttributeAssigned"
+      | "TenantCertifiedAttributeRevoked";
+    attributeId: AttributeId;
+  }>([
+    {
+      eventType: "TenantCertifiedAttributeAssigned",
+      attributeId: certifiedAttribute.id,
+    },
+    {
+      eventType: "TenantCertifiedAttributeRevoked",
+      attributeId: certifiedAttribute.id,
+    },
+  ])(
+    "should return empty array when no users have notifications enabled",
+    async ({ eventType, attributeId }) => {
+      mockGetNotificationRecipients.mockResolvedValue([]);
 
-    await expect(() =>
-      handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
-        toTenantV2({ ...assignee, attributes: [] }),
-        verifiedAttribute.id,
-        logger,
-        readModelService,
-        "TenantVerifiedAttributeAssigned"
-      )
-    ).rejects.toThrow(
-      verifiedAttributeNotFoundInTenant(assignee.id, verifiedAttribute.id)
-    );
-  });
+      const notifications =
+        await handleCertifiedAttributeAssignedRevokedToAssignee(
+          toTenantV2(assignee),
+          attributeId,
+          logger,
+          readModelService,
+          eventType
+        );
 
-  it("should throw tenantNotFound when the verifier is not found", async () => {
-    const unknownVerifierId = generateId<TenantId>();
-
-    // Mock notification recipients so the check doesn't exit early
-    mockGetNotificationRecipients.mockResolvedValue([
-      { userId: generateId(), tenantId: assignee.id },
-    ]);
-
-    await expect(() =>
-      handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
-        toTenantV2({
-          ...assignee,
-          attributes: [
-            {
-              ...getMockVerifiedTenantAttribute(verifiedAttribute.id),
-              verifiedBy: [
-                { id: unknownVerifierId, verificationDate: new Date() },
-              ],
-            },
-          ],
-        }),
-        verifiedAttribute.id,
-        logger,
-        readModelService,
-        "TenantVerifiedAttributeAssigned"
-      )
-    ).rejects.toThrow(tenantNotFound(unknownVerifierId));
-  });
-
-  it("should return empty array when no users have notifications enabled", async () => {
-    mockGetNotificationRecipients.mockResolvedValue([]);
-
-    const notifications =
-      await handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
-        toTenantV2(assignee),
-        certifiedAttribute.id,
-        logger,
-        readModelService,
-        "TenantCertifiedAttributeAssigned"
-      );
-
-    expect(notifications).toEqual([]);
-  });
+      expect(notifications).toEqual([]);
+    }
+  );
 
   it.each<{
     eventType:
       | "TenantCertifiedAttributeAssigned"
-      | "TenantCertifiedAttributeRevoked"
-      | "TenantVerifiedAttributeAssigned"
-      | "TenantVerifiedAttributeRevoked";
+      | "TenantCertifiedAttributeRevoked";
     assigneeAttributes: TenantAttribute[];
     attributeId: AttributeId;
     expectedBody: string;
@@ -285,55 +240,6 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
         "IVASS"
       ),
     },
-    {
-      eventType: "TenantVerifiedAttributeAssigned",
-      assigneeAttributes: [
-        {
-          ...getMockVerifiedTenantAttribute(verifiedAttribute.id),
-          verifiedBy: [
-            { id: verifier.id, verificationDate: new Date() },
-            {
-              // older verifiedBy to be ignored
-              id: certifier.id,
-              verificationDate: new Date(Date.now() - 10000),
-            },
-          ],
-        },
-      ],
-      attributeId: verifiedAttribute.id,
-      expectedBody: inAppTemplates.certifiedVerifiedAttributeAssignedToAssignee(
-        verifiedAttribute.name,
-        "verificato",
-        "Verifier Name"
-      ),
-    },
-    {
-      eventType: "TenantVerifiedAttributeRevoked",
-      assigneeAttributes: [
-        {
-          ...getMockVerifiedTenantAttribute(verifiedAttribute.id),
-          revokedBy: [
-            {
-              id: revoker.id,
-              verificationDate: new Date(Date.now() - 10000),
-              revocationDate: new Date(),
-            },
-            {
-              // older revokedBy to be ignored
-              id: certifier.id,
-              verificationDate: new Date(Date.now() - 20000),
-              revocationDate: new Date(Date.now() - 10000),
-            },
-          ],
-        },
-      ],
-      attributeId: verifiedAttribute.id,
-      expectedBody: inAppTemplates.certifiedVerifiedAttributeRevokedToAssignee(
-        verifiedAttribute.name,
-        "verificato",
-        "Revoker Name"
-      ),
-    },
   ])(
     "should handle $eventType event correctly",
     async ({ eventType, assigneeAttributes, attributeId, expectedBody }) => {
@@ -345,7 +251,7 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
       mockGetNotificationRecipients.mockResolvedValue(assigneeUsers);
 
       const notifications =
-        await handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
+        await handleCertifiedAttributeAssignedRevokedToAssignee(
           toTenantV2({ ...assignee, attributes: assigneeAttributes }),
           attributeId,
           logger,
@@ -369,29 +275,49 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
     }
   );
 
-  it("should generate notifications for multiple users", async () => {
-    const users = [
-      { userId: generateId(), tenantId: assignee.id },
-      { userId: generateId(), tenantId: assignee.id },
-      { userId: generateId(), tenantId: assignee.id },
-    ];
-    mockGetNotificationRecipients.mockResolvedValue(users);
+  it.each<{
+    eventType:
+      | "TenantCertifiedAttributeAssigned"
+      | "TenantCertifiedAttributeRevoked";
+    assigneeAttributes: TenantAttribute[];
+    attributeId: AttributeId;
+  }>([
+    {
+      eventType: "TenantCertifiedAttributeAssigned",
+      assigneeAttributes: [],
+      attributeId: certifiedAttribute.id,
+    },
+    {
+      eventType: "TenantCertifiedAttributeRevoked",
+      assigneeAttributes: [],
+      attributeId: certifiedAttributeIPA.id,
+    },
+  ])(
+    "should generate notifications for multiple users",
+    async ({ eventType, assigneeAttributes, attributeId }) => {
+      const users = [
+        { userId: generateId(), tenantId: assignee.id },
+        { userId: generateId(), tenantId: assignee.id },
+        { userId: generateId(), tenantId: assignee.id },
+      ];
+      mockGetNotificationRecipients.mockResolvedValue(users);
 
-    const notifications =
-      await handleCertifiedVerifiedAttributeAssignedRevokedToAssignee(
-        toTenantV2(assignee),
-        certifiedAttribute.id,
-        logger,
-        readModelService,
-        "TenantCertifiedAttributeAssigned"
-      );
+      const notifications =
+        await handleCertifiedAttributeAssignedRevokedToAssignee(
+          toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+          attributeId,
+          logger,
+          readModelService,
+          eventType
+        );
 
-    expect(notifications).toHaveLength(3);
+      expect(notifications).toHaveLength(3);
 
-    // Check that all users got notifications
-    const userIds = notifications.map((n) => n.userId);
-    expect(userIds).toContain(users[0].userId);
-    expect(userIds).toContain(users[1].userId);
-    expect(userIds).toContain(users[2].userId);
-  });
+      // Check that all users got notifications
+      const userIds = notifications.map((n) => n.userId);
+      expect(userIds).toContain(users[0].userId);
+      expect(userIds).toContain(users[1].userId);
+      expect(userIds).toContain(users[2].userId);
+    }
+  );
 });

--- a/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
@@ -1,0 +1,401 @@
+/* eslint-disable functional/immutable-data */
+import { describe, it, expect, beforeEach, Mock } from "vitest";
+import { match } from "ts-pattern";
+import {
+  getMockContext,
+  getMockTenant,
+  getMockAttribute,
+} from "pagopa-interop-commons-test";
+import {
+  generateId,
+  missingKafkaMessageDataError,
+  toTenantV2,
+  AttributeId,
+  Tenant,
+  Attribute,
+  attributeKind,
+  TenantAttribute,
+} from "pagopa-interop-models";
+
+import { handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee } from "../src/handlers/tenants/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.js";
+import {
+  attributeNotFound,
+  attributeOriginUndefined,
+  certifierTenantNotFound,
+} from "../src/models/errors.js";
+import { getNotificationRecipients } from "../src/handlers/handlerCommons.js";
+import { inAppTemplates } from "../src/templates/inAppTemplates.js";
+import { addOneAttribute, addOneTenant, readModelService } from "./utils.js";
+
+describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () => {
+  const certifierId = generateId();
+
+  const assignee = getMockTenant();
+  const certifier: Tenant = {
+    ...getMockTenant(),
+    name: "Certifier Name",
+    features: [{ type: "PersistentCertifier", certifierId }],
+  };
+  const revoker: Tenant = {
+    ...getMockTenant(),
+    name: "Revoker Name",
+  };
+
+  const certifiedAttribute: Attribute = {
+    ...getMockAttribute(attributeKind.certified),
+    name: "Certified Attribute",
+    origin: certifierId,
+  };
+  const certifiedAttributeANAC: Attribute = {
+    ...getMockAttribute(attributeKind.certified),
+    name: "Certified ANAC Attribute",
+    origin: "ANAC",
+  };
+  const certifiedAttributeIPA: Attribute = {
+    ...getMockAttribute(attributeKind.certified),
+    name: "Certified IPA Attribute",
+    origin: "IPA",
+  };
+  const certifiedAttributeIVASS: Attribute = {
+    ...getMockAttribute(attributeKind.certified),
+    name: "Certified IVASS Attribute",
+    origin: "IVASS",
+  };
+  const verifiedAttribute: Attribute = {
+    ...getMockAttribute(attributeKind.verified),
+    name: "Verified Attribute",
+  };
+  const certifiedAttributeISTAT: Attribute = {
+    ...getMockAttribute(attributeKind.certified),
+    name: "Certified ISTAT Attribute",
+    origin: "ISTAT",
+  };
+
+  const { logger } = getMockContext({});
+
+  const mockGetNotificationRecipients = getNotificationRecipients as Mock;
+
+  beforeEach(async () => {
+    mockGetNotificationRecipients.mockReset();
+    // Setup test data
+    await addOneTenant(assignee);
+    await addOneTenant(certifier);
+    await addOneTenant(revoker);
+    await addOneAttribute(certifiedAttribute);
+    await addOneAttribute(certifiedAttributeANAC);
+    await addOneAttribute(certifiedAttributeIPA);
+    await addOneAttribute(certifiedAttributeIVASS);
+    await addOneAttribute(certifiedAttributeISTAT);
+    await addOneAttribute(verifiedAttribute);
+  });
+
+  it("should throw missingKafkaMessageDataError when tenant is undefined", async () => {
+    await expect(() =>
+      handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+        undefined,
+        generateId(),
+        logger,
+        readModelService,
+        "TenantCertifiedDiscreteAttributeAssigned"
+      )
+    ).rejects.toThrow(
+      missingKafkaMessageDataError(
+        "tenant",
+        "TenantCertifiedDiscreteAttributeAssigned"
+      )
+    );
+  });
+
+  it("should throw attributeNotFound when attribute is not found", async () => {
+    const unknownAttributeId = generateId<AttributeId>();
+
+    // Mock notification recipients so the check doesn't exit early
+    mockGetNotificationRecipients.mockResolvedValue([
+      { userId: generateId(), tenantId: assignee.id },
+    ]);
+
+    await expect(() =>
+      handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+        toTenantV2(assignee),
+        unknownAttributeId,
+        logger,
+        readModelService,
+        "TenantCertifiedDiscreteAttributeAssigned"
+      )
+    ).rejects.toThrow(attributeNotFound(unknownAttributeId));
+  });
+
+  it("should throw attributeOriginUndefined when the certified discrete attribute has undefined origin", async () => {
+    const certifiedAttributeWithUndefinedOrigin: Attribute = {
+      ...getMockAttribute(attributeKind.certified),
+      origin: undefined,
+    };
+    await addOneAttribute(certifiedAttributeWithUndefinedOrigin);
+
+    // Mock notification recipients so the check doesn't exit early
+    mockGetNotificationRecipients.mockResolvedValue([
+      { userId: generateId(), tenantId: assignee.id },
+    ]);
+
+    await expect(() =>
+      handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+        toTenantV2(assignee),
+        certifiedAttributeWithUndefinedOrigin.id,
+        logger,
+        readModelService,
+        "TenantCertifiedDiscreteAttributeAssigned"
+      )
+    ).rejects.toThrow(
+      attributeOriginUndefined(certifiedAttributeWithUndefinedOrigin.id)
+    );
+  });
+
+  it("should throw certifierTenantNotFound when the certifier tenant is not found", async () => {
+    const unknownCertifierId = generateId();
+    const certifiedAttributeWithUnknownCertifier: Attribute = {
+      ...getMockAttribute(attributeKind.certified),
+      origin: unknownCertifierId,
+    };
+    await addOneAttribute(certifiedAttributeWithUnknownCertifier);
+
+    // Mock notification recipients so the check doesn't exit early
+    mockGetNotificationRecipients.mockResolvedValue([
+      { userId: generateId(), tenantId: assignee.id },
+    ]);
+
+    await expect(() =>
+      handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+        toTenantV2(assignee),
+        certifiedAttributeWithUnknownCertifier.id,
+        logger,
+        readModelService,
+        "TenantCertifiedDiscreteAttributeAssigned"
+      )
+    ).rejects.toThrow(certifierTenantNotFound(unknownCertifierId));
+  });
+
+  it.each<{
+    eventType:
+      | "TenantCertifiedDiscreteAttributeAssigned"
+      | "TenantCertifiedDiscreteAttributeRevoked"
+      | "TenantCertifiedDiscreteAttributeUpdated";
+    attributeId: AttributeId;
+  }>([
+    {
+      eventType: "TenantCertifiedDiscreteAttributeAssigned",
+      attributeId: certifiedAttributeISTAT.id,
+    },
+    {
+      eventType: "TenantCertifiedDiscreteAttributeRevoked",
+      attributeId: certifiedAttributeISTAT.id,
+    },
+    {
+      eventType: "TenantCertifiedDiscreteAttributeUpdated",
+      attributeId: certifiedAttributeISTAT.id,
+    },
+  ])(
+    "should return empty array when no users have notifications enabled",
+    async ({ eventType, attributeId }) => {
+      mockGetNotificationRecipients.mockResolvedValue([]);
+
+      const notifications = await match(eventType)
+        .with("TenantCertifiedDiscreteAttributeAssigned", () =>
+          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+            toTenantV2(assignee),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .with("TenantCertifiedDiscreteAttributeRevoked", () =>
+          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+            toTenantV2(assignee),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .with("TenantCertifiedDiscreteAttributeUpdated", () =>
+          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+            toTenantV2(assignee),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .exhaustive();
+
+      expect(notifications).toEqual([]);
+    }
+  );
+
+  it.each<{
+    eventType:
+      | "TenantCertifiedDiscreteAttributeAssigned"
+      | "TenantCertifiedDiscreteAttributeRevoked"
+      | "TenantCertifiedDiscreteAttributeUpdated";
+    assigneeAttributes: TenantAttribute[];
+    attributeId: AttributeId;
+    expectedBody: string;
+  }>([
+    {
+      eventType: "TenantCertifiedDiscreteAttributeAssigned",
+      assigneeAttributes: [],
+      attributeId: certifiedAttributeISTAT.id,
+      expectedBody: inAppTemplates.certifiedVerifiedAttributeAssignedToAssignee(
+        certifiedAttributeISTAT.name,
+        "certificato",
+        "ISTAT"
+      ),
+    },
+    {
+      eventType: "TenantCertifiedDiscreteAttributeRevoked",
+      assigneeAttributes: [],
+      attributeId: certifiedAttributeISTAT.id,
+      expectedBody: inAppTemplates.certifiedVerifiedAttributeRevokedToAssignee(
+        certifiedAttributeISTAT.name,
+        "certificato",
+        "ISTAT"
+      ),
+    },
+    {
+      eventType: "TenantCertifiedDiscreteAttributeUpdated",
+      assigneeAttributes: [],
+      attributeId: certifiedAttributeISTAT.id,
+      expectedBody: inAppTemplates.certifiedVerifiedAttributeUpdatedToAssignee(
+        certifiedAttributeISTAT.name,
+        "certificato"
+      ),
+    },
+  ])(
+    "should handle $eventType event correctly",
+    async ({ eventType, assigneeAttributes, attributeId, expectedBody }) => {
+      const assigneeUsers = [
+        { userId: generateId(), tenantId: assignee.id },
+        { userId: generateId(), tenantId: assignee.id },
+      ];
+
+      mockGetNotificationRecipients.mockResolvedValue(assigneeUsers);
+
+      const notifications = await match(eventType)
+        .with("TenantCertifiedDiscreteAttributeAssigned", () =>
+          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .with("TenantCertifiedDiscreteAttributeRevoked", () =>
+          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .with("TenantCertifiedDiscreteAttributeUpdated", () =>
+          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .exhaustive();
+
+      expect(notifications).toHaveLength(assigneeUsers.length);
+
+      const expectedNotifications = assigneeUsers.map((user) => ({
+        userId: user.userId,
+        tenantId: user.tenantId,
+        body: expectedBody,
+        notificationType: "certifiedVerifiedAttributeAssignedRevokedToAssignee",
+        entityId: attributeId,
+      }));
+
+      expect(notifications).toEqual(
+        expect.arrayContaining(expectedNotifications)
+      );
+    }
+  );
+
+  it.each<{
+    eventType:
+      | "TenantCertifiedDiscreteAttributeAssigned"
+      | "TenantCertifiedDiscreteAttributeRevoked"
+      | "TenantCertifiedDiscreteAttributeUpdated";
+    assigneeAttributes: TenantAttribute[];
+    attributeId: AttributeId;
+  }>([
+    {
+      eventType: "TenantCertifiedDiscreteAttributeAssigned",
+      assigneeAttributes: [],
+      attributeId: certifiedAttributeISTAT.id,
+    },
+    {
+      eventType: "TenantCertifiedDiscreteAttributeRevoked",
+      assigneeAttributes: [],
+      attributeId: certifiedAttributeISTAT.id,
+    },
+    {
+      eventType: "TenantCertifiedDiscreteAttributeUpdated",
+      assigneeAttributes: [],
+      attributeId: certifiedAttributeISTAT.id,
+    },
+  ])(
+    "should generate notifications for multiple users",
+    async ({ eventType, assigneeAttributes, attributeId }) => {
+      const users = [
+        { userId: generateId(), tenantId: assignee.id },
+        { userId: generateId(), tenantId: assignee.id },
+        { userId: generateId(), tenantId: assignee.id },
+      ];
+      mockGetNotificationRecipients.mockResolvedValue(users);
+
+      const notifications = await match(eventType)
+        .with("TenantCertifiedDiscreteAttributeAssigned", () =>
+          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .with("TenantCertifiedDiscreteAttributeRevoked", () =>
+          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .with("TenantCertifiedDiscreteAttributeUpdated", () =>
+          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .exhaustive();
+
+      expect(notifications).toHaveLength(3);
+
+      // Check that all users got notifications
+      const userIds = notifications.map((n) => n.userId);
+      expect(userIds).toContain(users[0].userId);
+      expect(userIds).toContain(users[1].userId);
+      expect(userIds).toContain(users[2].userId);
+    }
+  );
+});

--- a/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
@@ -41,10 +41,6 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
     name: "Revoker Name",
   };
 
-  const verifiedAttribute: Attribute = {
-    ...getMockAttribute(attributeKind.verified),
-    name: "Verified Attribute",
-  };
   const certifiedAttributeISTAT: Attribute = {
     ...getMockAttribute(attributeKind.certified),
     name: "Certified ISTAT Attribute",
@@ -62,7 +58,6 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
     await addOneTenant(certifier);
     await addOneTenant(revoker);
     await addOneAttribute(certifiedAttributeISTAT);
-    await addOneAttribute(verifiedAttribute);
   });
 
   it("should throw missingKafkaMessageDataError when tenant is undefined", async () => {

--- a/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
@@ -11,7 +11,6 @@ import {
   missingKafkaMessageDataError,
   toTenantV2,
   AttributeId,
-  Tenant,
   Attribute,
   attributeKind,
   TenantAttribute,
@@ -28,18 +27,7 @@ import { inAppTemplates } from "../src/templates/inAppTemplates.js";
 import { addOneAttribute, addOneTenant, readModelService } from "./utils.js";
 
 describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () => {
-  const certifierId = generateId();
-
   const assignee = getMockTenant();
-  const certifier: Tenant = {
-    ...getMockTenant(),
-    name: "Certifier Name",
-    features: [{ type: "PersistentCertifier", certifierId }],
-  };
-  const revoker: Tenant = {
-    ...getMockTenant(),
-    name: "Revoker Name",
-  };
 
   const certifiedAttributeISTAT: Attribute = {
     ...getMockAttribute(attributeKind.certified),
@@ -55,8 +43,6 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
     mockGetNotificationRecipients.mockReset();
     // Setup test data
     await addOneTenant(assignee);
-    await addOneTenant(certifier);
-    await addOneTenant(revoker);
     await addOneAttribute(certifiedAttributeISTAT);
   });
 

--- a/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
@@ -41,26 +41,6 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
     name: "Revoker Name",
   };
 
-  const certifiedAttribute: Attribute = {
-    ...getMockAttribute(attributeKind.certified),
-    name: "Certified Attribute",
-    origin: certifierId,
-  };
-  const certifiedAttributeANAC: Attribute = {
-    ...getMockAttribute(attributeKind.certified),
-    name: "Certified ANAC Attribute",
-    origin: "ANAC",
-  };
-  const certifiedAttributeIPA: Attribute = {
-    ...getMockAttribute(attributeKind.certified),
-    name: "Certified IPA Attribute",
-    origin: "IPA",
-  };
-  const certifiedAttributeIVASS: Attribute = {
-    ...getMockAttribute(attributeKind.certified),
-    name: "Certified IVASS Attribute",
-    origin: "IVASS",
-  };
   const verifiedAttribute: Attribute = {
     ...getMockAttribute(attributeKind.verified),
     name: "Verified Attribute",
@@ -81,10 +61,6 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
     await addOneTenant(assignee);
     await addOneTenant(certifier);
     await addOneTenant(revoker);
-    await addOneAttribute(certifiedAttribute);
-    await addOneAttribute(certifiedAttributeANAC);
-    await addOneAttribute(certifiedAttributeIPA);
-    await addOneAttribute(certifiedAttributeIVASS);
     await addOneAttribute(certifiedAttributeISTAT);
     await addOneAttribute(verifiedAttribute);
   });
@@ -194,7 +170,7 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
       attributeId: certifiedAttributeISTAT.id,
     },
   ])(
-    "should return empty array when no users have notifications enabled",
+    "should return empty array when no users have notifications enabled for event $eventType",
     async ({ eventType, attributeId }) => {
       mockGetNotificationRecipients.mockResolvedValue([]);
 
@@ -350,7 +326,7 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
       attributeId: certifiedAttributeISTAT.id,
     },
   ])(
-    "should generate notifications for multiple users",
+    "should generate notifications for multiple users for event $eventType",
     async ({ eventType, assigneeAttributes, attributeId }) => {
       const users = [
         { userId: generateId(), tenantId: assignee.id },

--- a/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable functional/immutable-data */
 import { describe, it, expect, beforeEach, Mock } from "vitest";
-import { match } from "ts-pattern";
 import {
   getMockContext,
   getMockTenant,
@@ -155,35 +154,14 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
     async ({ eventType, attributeId }) => {
       mockGetNotificationRecipients.mockResolvedValue([]);
 
-      const notifications = await match(eventType)
-        .with("TenantCertifiedDiscreteAttributeAssigned", () =>
-          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
-            toTenantV2(assignee),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .with("TenantCertifiedDiscreteAttributeRevoked", () =>
-          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
-            toTenantV2(assignee),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .with("TenantCertifiedDiscreteAttributeUpdated", () =>
-          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
-            toTenantV2(assignee),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .exhaustive();
+      const notifications =
+        await handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+          toTenantV2(assignee),
+          attributeId,
+          logger,
+          readModelService,
+          eventType
+        );
 
       expect(notifications).toEqual([]);
     }
@@ -237,35 +215,14 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
 
       mockGetNotificationRecipients.mockResolvedValue(assigneeUsers);
 
-      const notifications = await match(eventType)
-        .with("TenantCertifiedDiscreteAttributeAssigned", () =>
-          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .with("TenantCertifiedDiscreteAttributeRevoked", () =>
-          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .with("TenantCertifiedDiscreteAttributeUpdated", () =>
-          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .exhaustive();
+      const notifications =
+        await handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+          toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+          attributeId,
+          logger,
+          readModelService,
+          eventType
+        );
 
       expect(notifications).toHaveLength(assigneeUsers.length);
 
@@ -316,35 +273,14 @@ describe("handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee", () 
       ];
       mockGetNotificationRecipients.mockResolvedValue(users);
 
-      const notifications = await match(eventType)
-        .with("TenantCertifiedDiscreteAttributeAssigned", () =>
-          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .with("TenantCertifiedDiscreteAttributeRevoked", () =>
-          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .with("TenantCertifiedDiscreteAttributeUpdated", () =>
-          handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .exhaustive();
+      const notifications =
+        await handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee(
+          toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+          attributeId,
+          logger,
+          readModelService,
+          eventType
+        );
 
       expect(notifications).toHaveLength(3);
 

--- a/packages/in-app-notification-dispatcher/test/handleVerifiedAttributeAssignedRevokedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleVerifiedAttributeAssignedRevokedToAssignee.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable functional/immutable-data */
 import { describe, it, expect, beforeEach, Mock } from "vitest";
-import { match } from "ts-pattern";
 import {
   getMockContext,
   getMockTenant,
@@ -166,26 +165,14 @@ describe("handleVerifiedAttributeAssignedRevokedToAssignee", () => {
     async ({ eventType, attributeId }) => {
       mockGetNotificationRecipients.mockResolvedValue([]);
 
-      const notifications = await match(eventType)
-        .with("TenantVerifiedAttributeAssigned", () =>
-          handleVerifiedAttributeAssignedRevokedToAssignee(
-            toTenantV2(assignee),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .with("TenantVerifiedAttributeRevoked", () =>
-          handleVerifiedAttributeAssignedRevokedToAssignee(
-            toTenantV2(assignee),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .exhaustive();
+      const notifications =
+        await handleVerifiedAttributeAssignedRevokedToAssignee(
+          toTenantV2(assignee),
+          attributeId,
+          logger,
+          readModelService,
+          eventType
+        );
 
       expect(notifications).toEqual([]);
     }
@@ -258,26 +245,14 @@ describe("handleVerifiedAttributeAssignedRevokedToAssignee", () => {
 
       mockGetNotificationRecipients.mockResolvedValue(assigneeUsers);
 
-      const notifications = await match(eventType)
-        .with("TenantVerifiedAttributeAssigned", () =>
-          handleVerifiedAttributeAssignedRevokedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .with("TenantVerifiedAttributeRevoked", () =>
-          handleVerifiedAttributeAssignedRevokedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .exhaustive();
+      const notifications =
+        await handleVerifiedAttributeAssignedRevokedToAssignee(
+          toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+          attributeId,
+          logger,
+          readModelService,
+          eventType
+        );
 
       expect(notifications).toHaveLength(assigneeUsers.length);
 
@@ -351,26 +326,14 @@ describe("handleVerifiedAttributeAssignedRevokedToAssignee", () => {
       ];
       mockGetNotificationRecipients.mockResolvedValue(users);
 
-      const notifications = await match(eventType)
-        .with("TenantVerifiedAttributeAssigned", () =>
-          handleVerifiedAttributeAssignedRevokedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .with("TenantVerifiedAttributeRevoked", () =>
-          handleVerifiedAttributeAssignedRevokedToAssignee(
-            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
-            attributeId,
-            logger,
-            readModelService,
-            eventType
-          )
-        )
-        .exhaustive();
+      const notifications =
+        await handleVerifiedAttributeAssignedRevokedToAssignee(
+          toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+          attributeId,
+          logger,
+          readModelService,
+          eventType
+        );
 
       expect(notifications).toHaveLength(3);
 

--- a/packages/in-app-notification-dispatcher/test/handleVerifiedAttributeAssignedRevokedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleVerifiedAttributeAssignedRevokedToAssignee.test.ts
@@ -28,7 +28,7 @@ import { getNotificationRecipients } from "../src/handlers/handlerCommons.js";
 import { inAppTemplates } from "../src/templates/inAppTemplates.js";
 import { addOneAttribute, addOneTenant, readModelService } from "./utils.js";
 
-describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
+describe("handleVerifiedAttributeAssignedRevokedToAssignee", () => {
   const certifierId = generateId();
 
   const assignee = getMockTenant();
@@ -162,7 +162,7 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
       attributeId: verifiedAttribute.id,
     },
   ])(
-    "should return empty array when no users have notifications enabled",
+    "should return empty array when no users have notifications enabled for event $eventType",
     async ({ eventType, attributeId }) => {
       mockGetNotificationRecipients.mockResolvedValue([]);
 
@@ -342,7 +342,7 @@ describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
       attributeId: verifiedAttribute.id,
     },
   ])(
-    "should generate notifications for multiple users",
+    "should generate notifications for multiple users for event $eventType",
     async ({ eventType, assigneeAttributes, attributeId }) => {
       const users = [
         { userId: generateId(), tenantId: assignee.id },

--- a/packages/in-app-notification-dispatcher/test/handleVerifiedAttributeAssignedRevokedToAssignee.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleVerifiedAttributeAssignedRevokedToAssignee.test.ts
@@ -1,0 +1,384 @@
+/* eslint-disable functional/immutable-data */
+import { describe, it, expect, beforeEach, Mock } from "vitest";
+import { match } from "ts-pattern";
+import {
+  getMockContext,
+  getMockTenant,
+  getMockAttribute,
+  getMockVerifiedTenantAttribute,
+} from "pagopa-interop-commons-test";
+import {
+  generateId,
+  missingKafkaMessageDataError,
+  toTenantV2,
+  AttributeId,
+  Tenant,
+  Attribute,
+  attributeKind,
+  TenantAttribute,
+  TenantId,
+} from "pagopa-interop-models";
+import { handleVerifiedAttributeAssignedRevokedToAssignee } from "../src/handlers/tenants/handleVerifiedAttributeAssignedRevokedToAssignee.js";
+import {
+  attributeNotFound,
+  tenantNotFound,
+  verifiedAttributeNotFoundInTenant,
+} from "../src/models/errors.js";
+import { getNotificationRecipients } from "../src/handlers/handlerCommons.js";
+import { inAppTemplates } from "../src/templates/inAppTemplates.js";
+import { addOneAttribute, addOneTenant, readModelService } from "./utils.js";
+
+describe("handleCertifiedVerifiedAttributeAssignedRevokedToAssignee", () => {
+  const certifierId = generateId();
+
+  const assignee = getMockTenant();
+  const certifier: Tenant = {
+    ...getMockTenant(),
+    name: "Certifier Name",
+    features: [{ type: "PersistentCertifier", certifierId }],
+  };
+  const verifier: Tenant = {
+    ...getMockTenant(),
+    name: "Verifier Name",
+  };
+  const revoker: Tenant = {
+    ...getMockTenant(),
+    name: "Revoker Name",
+  };
+
+  const verifiedAttribute: Attribute = {
+    ...getMockAttribute(attributeKind.verified),
+    name: "Verified Attribute",
+  };
+
+  const { logger } = getMockContext({});
+
+  const mockGetNotificationRecipients = getNotificationRecipients as Mock;
+
+  beforeEach(async () => {
+    mockGetNotificationRecipients.mockReset();
+    // Setup test data
+    await addOneTenant(assignee);
+    await addOneTenant(certifier);
+    await addOneTenant(verifier);
+    await addOneTenant(revoker);
+    await addOneAttribute(verifiedAttribute);
+  });
+
+  // Certified Attribute
+  it("should throw missingKafkaMessageDataError when tenant is undefined", async () => {
+    await expect(() =>
+      handleVerifiedAttributeAssignedRevokedToAssignee(
+        undefined,
+        generateId(),
+        logger,
+        readModelService,
+        "TenantVerifiedAttributeAssigned"
+      )
+    ).rejects.toThrow(
+      missingKafkaMessageDataError("tenant", "TenantVerifiedAttributeAssigned")
+    );
+  });
+
+  it("should throw attributeNotFound when attribute is not found", async () => {
+    const unknownAttributeId = generateId<AttributeId>();
+
+    // Mock notification recipients so the check doesn't exit early
+    mockGetNotificationRecipients.mockResolvedValue([
+      { userId: generateId(), tenantId: assignee.id },
+    ]);
+
+    await expect(() =>
+      handleVerifiedAttributeAssignedRevokedToAssignee(
+        toTenantV2(assignee),
+        unknownAttributeId,
+        logger,
+        readModelService,
+        "TenantVerifiedAttributeAssigned"
+      )
+    ).rejects.toThrow(attributeNotFound(unknownAttributeId));
+  });
+
+  it("should throw verifiedAttributeNotFoundInTenant when the verified attribute is not found", async () => {
+    // Mock notification recipients so the check doesn't exit early
+    mockGetNotificationRecipients.mockResolvedValue([
+      { userId: generateId(), tenantId: assignee.id },
+    ]);
+
+    await expect(() =>
+      handleVerifiedAttributeAssignedRevokedToAssignee(
+        toTenantV2({ ...assignee, attributes: [] }),
+        verifiedAttribute.id,
+        logger,
+        readModelService,
+        "TenantVerifiedAttributeAssigned"
+      )
+    ).rejects.toThrow(
+      verifiedAttributeNotFoundInTenant(assignee.id, verifiedAttribute.id)
+    );
+  });
+
+  it("should throw tenantNotFound when the verifier is not found", async () => {
+    const unknownVerifierId = generateId<TenantId>();
+
+    // Mock notification recipients so the check doesn't exit early
+    mockGetNotificationRecipients.mockResolvedValue([
+      { userId: generateId(), tenantId: assignee.id },
+    ]);
+
+    await expect(() =>
+      handleVerifiedAttributeAssignedRevokedToAssignee(
+        toTenantV2({
+          ...assignee,
+          attributes: [
+            {
+              ...getMockVerifiedTenantAttribute(verifiedAttribute.id),
+              verifiedBy: [
+                { id: unknownVerifierId, verificationDate: new Date() },
+              ],
+            },
+          ],
+        }),
+        verifiedAttribute.id,
+        logger,
+        readModelService,
+        "TenantVerifiedAttributeAssigned"
+      )
+    ).rejects.toThrow(tenantNotFound(unknownVerifierId));
+  });
+
+  it.each<{
+    eventType:
+      | "TenantVerifiedAttributeAssigned"
+      | "TenantVerifiedAttributeRevoked";
+    attributeId: AttributeId;
+  }>([
+    {
+      eventType: "TenantVerifiedAttributeAssigned",
+      attributeId: verifiedAttribute.id,
+    },
+    {
+      eventType: "TenantVerifiedAttributeRevoked",
+      attributeId: verifiedAttribute.id,
+    },
+  ])(
+    "should return empty array when no users have notifications enabled",
+    async ({ eventType, attributeId }) => {
+      mockGetNotificationRecipients.mockResolvedValue([]);
+
+      const notifications = await match(eventType)
+        .with("TenantVerifiedAttributeAssigned", () =>
+          handleVerifiedAttributeAssignedRevokedToAssignee(
+            toTenantV2(assignee),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .with("TenantVerifiedAttributeRevoked", () =>
+          handleVerifiedAttributeAssignedRevokedToAssignee(
+            toTenantV2(assignee),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .exhaustive();
+
+      expect(notifications).toEqual([]);
+    }
+  );
+
+  it.each<{
+    eventType:
+      | "TenantVerifiedAttributeAssigned"
+      | "TenantVerifiedAttributeRevoked";
+    assigneeAttributes: TenantAttribute[];
+    attributeId: AttributeId;
+    expectedBody: string;
+  }>([
+    {
+      eventType: "TenantVerifiedAttributeAssigned",
+      assigneeAttributes: [
+        {
+          ...getMockVerifiedTenantAttribute(verifiedAttribute.id),
+          verifiedBy: [
+            { id: verifier.id, verificationDate: new Date() },
+            {
+              // older verifiedBy to be ignored
+              id: certifier.id,
+              verificationDate: new Date(Date.now() - 10000),
+            },
+          ],
+        },
+      ],
+      attributeId: verifiedAttribute.id,
+      expectedBody: inAppTemplates.certifiedVerifiedAttributeAssignedToAssignee(
+        verifiedAttribute.name,
+        "verificato",
+        "Verifier Name"
+      ),
+    },
+    {
+      eventType: "TenantVerifiedAttributeRevoked",
+      assigneeAttributes: [
+        {
+          ...getMockVerifiedTenantAttribute(verifiedAttribute.id),
+          revokedBy: [
+            {
+              id: revoker.id,
+              verificationDate: new Date(Date.now() - 10000),
+              revocationDate: new Date(),
+            },
+            {
+              // older revokedBy to be ignored
+              id: certifier.id,
+              verificationDate: new Date(Date.now() - 20000),
+              revocationDate: new Date(Date.now() - 10000),
+            },
+          ],
+        },
+      ],
+      attributeId: verifiedAttribute.id,
+      expectedBody: inAppTemplates.certifiedVerifiedAttributeRevokedToAssignee(
+        verifiedAttribute.name,
+        "verificato",
+        "Revoker Name"
+      ),
+    },
+  ])(
+    "should handle $eventType event correctly",
+    async ({ eventType, assigneeAttributes, attributeId, expectedBody }) => {
+      const assigneeUsers = [
+        { userId: generateId(), tenantId: assignee.id },
+        { userId: generateId(), tenantId: assignee.id },
+      ];
+
+      mockGetNotificationRecipients.mockResolvedValue(assigneeUsers);
+
+      const notifications = await match(eventType)
+        .with("TenantVerifiedAttributeAssigned", () =>
+          handleVerifiedAttributeAssignedRevokedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .with("TenantVerifiedAttributeRevoked", () =>
+          handleVerifiedAttributeAssignedRevokedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .exhaustive();
+
+      expect(notifications).toHaveLength(assigneeUsers.length);
+
+      const expectedNotifications = assigneeUsers.map((user) => ({
+        userId: user.userId,
+        tenantId: user.tenantId,
+        body: expectedBody,
+        notificationType: "certifiedVerifiedAttributeAssignedRevokedToAssignee",
+        entityId: attributeId,
+      }));
+
+      expect(notifications).toEqual(
+        expect.arrayContaining(expectedNotifications)
+      );
+    }
+  );
+
+  it.each<{
+    eventType:
+      | "TenantVerifiedAttributeAssigned"
+      | "TenantVerifiedAttributeRevoked";
+    assigneeAttributes: TenantAttribute[];
+    attributeId: AttributeId;
+  }>([
+    {
+      eventType: "TenantVerifiedAttributeAssigned",
+      assigneeAttributes: [
+        {
+          ...getMockVerifiedTenantAttribute(verifiedAttribute.id),
+          verifiedBy: [
+            { id: verifier.id, verificationDate: new Date() },
+            {
+              // older verifiedBy to be ignored
+              id: certifier.id,
+              verificationDate: new Date(Date.now() - 10000),
+            },
+          ],
+        },
+      ],
+      attributeId: verifiedAttribute.id,
+    },
+    {
+      eventType: "TenantVerifiedAttributeRevoked",
+      assigneeAttributes: [
+        {
+          ...getMockVerifiedTenantAttribute(verifiedAttribute.id),
+          revokedBy: [
+            {
+              id: revoker.id,
+              verificationDate: new Date(Date.now() - 10000),
+              revocationDate: new Date(),
+            },
+            {
+              // older revokedBy to be ignored
+              id: certifier.id,
+              verificationDate: new Date(Date.now() - 20000),
+              revocationDate: new Date(Date.now() - 10000),
+            },
+          ],
+        },
+      ],
+      attributeId: verifiedAttribute.id,
+    },
+  ])(
+    "should generate notifications for multiple users",
+    async ({ eventType, assigneeAttributes, attributeId }) => {
+      const users = [
+        { userId: generateId(), tenantId: assignee.id },
+        { userId: generateId(), tenantId: assignee.id },
+        { userId: generateId(), tenantId: assignee.id },
+      ];
+      mockGetNotificationRecipients.mockResolvedValue(users);
+
+      const notifications = await match(eventType)
+        .with("TenantVerifiedAttributeAssigned", () =>
+          handleVerifiedAttributeAssignedRevokedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .with("TenantVerifiedAttributeRevoked", () =>
+          handleVerifiedAttributeAssignedRevokedToAssignee(
+            toTenantV2({ ...assignee, attributes: assigneeAttributes }),
+            attributeId,
+            logger,
+            readModelService,
+            eventType
+          )
+        )
+        .exhaustive();
+
+      expect(notifications).toHaveLength(3);
+
+      // Check that all users got notifications
+      const userIds = notifications.map((n) => n.userId);
+      expect(userIds).toContain(users[0].userId);
+      expect(userIds).toContain(users[1].userId);
+      expect(userIds).toContain(users[2].userId);
+    }
+  );
+});

--- a/packages/tenant-process/src/model/domain/toEvent.ts
+++ b/packages/tenant-process/src/model/domain/toEvent.ts
@@ -390,3 +390,64 @@ export function toCreateEventTenantRemoteIdAssigned(
     correlationId,
   };
 }
+
+export const toCreateEventTenantCertifiedDiscreteAttributeAssigned = (
+  version: number,
+  updatedTenant: Tenant,
+  attributeId: AttributeId,
+  correlationId: CorrelationId
+): CreateEvent<TenantEvent> => ({
+  streamId: updatedTenant.id,
+  version,
+  event: {
+    type: "TenantCertifiedDiscreteAttributeAssigned",
+    event_version: 2,
+    data: {
+      attributeId,
+      tenant: toTenantV2(updatedTenant),
+    },
+  },
+  correlationId,
+});
+
+export const toCreateEventTenantCertifiedDiscreteAttributeRevoked = (
+  version: number,
+  updatedTenant: Tenant,
+  attributeId: AttributeId,
+  correlationId: CorrelationId
+): CreateEvent<TenantEvent> => ({
+  streamId: updatedTenant.id,
+  version,
+  event: {
+    type: "TenantCertifiedDiscreteAttributeRevoked",
+    event_version: 2,
+    data: {
+      attributeId,
+      tenant: toTenantV2(updatedTenant),
+    },
+  },
+  correlationId,
+});
+
+export const toCreateEventTenantCertifiedDiscreteAttributeUpdated = (
+  version: number,
+  updatedTenant: Tenant,
+  attributeId: AttributeId,
+  previousValue: number,
+  newValue: number,
+  correlationId: CorrelationId
+): CreateEvent<TenantEvent> => ({
+  streamId: updatedTenant.id,
+  version,
+  event: {
+    type: "TenantCertifiedDiscreteAttributeUpdated",
+    event_version: 2,
+    data: {
+      attributeId,
+      tenant: toTenantV2(updatedTenant),
+      previousValue: previousValue,
+      newValue: newValue,
+    },
+  },
+  correlationId,
+});

--- a/packages/tenant-process/src/model/domain/toEvent.ts
+++ b/packages/tenant-process/src/model/domain/toEvent.ts
@@ -448,8 +448,8 @@ export const toCreateEventTenantCertifiedDiscreteAttributeUpdated = (
     data: {
       attributeId,
       tenant: toTenantV2(updatedTenant),
-      previousValue: previousValue,
-      newValue: newValue,
+      previousValue,
+      newValue,
     },
   },
   correlationId,

--- a/packages/tenant-process/src/model/domain/toEvent.ts
+++ b/packages/tenant-process/src/model/domain/toEvent.ts
@@ -391,6 +391,7 @@ export function toCreateEventTenantRemoteIdAssigned(
   };
 }
 
+/** @public */ // TO-BE-USED in PIN-9886
 export const toCreateEventTenantCertifiedDiscreteAttributeAssigned = (
   version: number,
   updatedTenant: Tenant,
@@ -410,6 +411,7 @@ export const toCreateEventTenantCertifiedDiscreteAttributeAssigned = (
   correlationId,
 });
 
+/** @public */ // TO-BE-USED in PIN-9886
 export const toCreateEventTenantCertifiedDiscreteAttributeRevoked = (
   version: number,
   updatedTenant: Tenant,
@@ -429,6 +431,7 @@ export const toCreateEventTenantCertifiedDiscreteAttributeRevoked = (
   correlationId,
 });
 
+/** @public */ // TO-BE-USED in PIN-9886
 export const toCreateEventTenantCertifiedDiscreteAttributeUpdated = (
   version: number,
   updatedTenant: Tenant,
@@ -451,6 +454,7 @@ export const toCreateEventTenantCertifiedDiscreteAttributeUpdated = (
   },
   correlationId,
 });
+
 export function toCreateEventMaintenanceTenantRemoteIdDeleted(
   version: number,
   tenant: Tenant,


### PR DESCRIPTION
## Jira Issue
[PIN-10185](https://pagopa.atlassian.net/browse/PIN-10185)

## Context/Why
This PR manages TenantCertifiedDiscreteAttribute events in the email and in-app message notifications

Refactoring: Separation of Concerns with Dedicated Handlers
The handleCertifiedVerifiedAttributeAssignedRevokedToAssignee function has undergone a partial refactoring to improve separation of concerns. 
Logic has been distributed across new dedicated handlers, each focused on a specific attribute kind (Certified, CertifiedDiscrete, Verified).

Motivation
- each handler has a well-defined responsibility
- specific logic is isolated and independently testable

Notes
This is a partial refactoring. A more comprehensive refactoring in the future could extend the separation to other aspects of the notification flow.

## Services Impacted
- in-app-notification-dispatcher
- email-notification-dispatcher
- tenant-process

## Key Changes
 - handleCertifiedVerifiedAttributeAssignedRevokedToAssignee splitted in :
	- handleCertifiedAttributeAssignedRevokedToAssignee
	- handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee
	- handleVerifiedAttributeAssignedRevokedToAssignee
 - handleCertifiedVerifiedAttributeAssignedRevokedToAssignee.test splitted in :
	- handleCertifiedAttributeAssignedRevokedToAssignee.test
	- handleCertifiedDiscreteAttributeAssignedRevokedUpdatedToAssignee.test
	- handleVerifiedAttributeAssignedRevokedToAssignee.test

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard (type(scope): descrizione (KEY))
- [x] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated

[PIN-10185]: https://pagopa.atlassian.net/browse/PIN-10185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ