### PR TITLE
bugfix: manual archive: Include Archived state in BFF getProducerEServices (PIN-10268)

### DIFF
--- a/packages/backend-for-frontend/src/model/modelMappingUtils.ts
+++ b/packages/backend-for-frontend/src/model/modelMappingUtils.ts
@@ -30,10 +30,15 @@ const invalidDescriptorState: catalogApi.EServiceDescriptorState[] = [
 ];
 
 export function getLatestActiveDescriptor(
-  eservice: catalogApi.EService
+  eservice: catalogApi.EService,
+  includeArchived: boolean = false
 ): catalogApi.EServiceDescriptor | undefined {
   return eservice.descriptors
-    .filter((d) => activeDescriptorStatesFilter.includes(d.state))
+    .filter(
+      (d) =>
+        activeDescriptorStatesFilter.includes(d.state) ||
+        (includeArchived && d.state === catalogApiDescriptorState.ARCHIVED)
+    )
     .sort((a, b) => Number(a.version) - Number(b.version))
     .at(-1);
 }

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -182,7 +182,7 @@ const enhanceProducerEService = (
   eserviceTemplates: eserviceTemplateApi.EServiceTemplate[],
   hasNotifications: boolean
 ): bffApi.ProducerEService => {
-  const activeDescriptor = getLatestActiveDescriptor(eservice);
+  const activeDescriptor = getLatestActiveDescriptor(eservice, true);
   const draftDescriptor = eservice.descriptors.find(isInvalidDescriptor);
 
   const isRequesterDelegateProducer = requesterId !== eservice.producerId;


### PR DESCRIPTION
## Issue
- [PIN-10268](https://pagopa.atlassian.net/browse/PIN-10268)
- [SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2803302507/DRAFT+SRS+Archiviazione+manuale+e-service)

## Context

Added ARCHIVED states to `activeDescriptor` in bff for `getProducerEServices` so as to manage the eservice when it is fully archived.

We have opted for adding this optional boolean in the `getLatestActiveDescriptor` so as not to include the archived EServices when they might be wrong (for instance in the boolean for `templateRef.isNewTemplateVersionAvailable`, in [`packages/backend-for-frontend/src/services/catalogService.ts` line 510](./../blob/develop/packages/backend-for-frontend/src/services/catalogService.ts)).

This will fix this error in the frontend, when a fully-archived E-Service will not show up in `activeDescriptor` under "My E-Services" list:

<img width="1443" height="252" alt="Screenshot From 2026-06-05 15-16-20" src="https://github.com/user-attachments/assets/166b980f-9384-4571-a6f7-a57ddf87c5a0" />


## Scope
- `backend-for-frontend`

## Traceability Checklist
- [X] Branch contains Jira key
- [X] PR title compliant (type(scope): description (KEY))
- [X] Service labels applied


[PIN-10268]: https://pagopa.atlassian.net/browse/PIN-10268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ