### PR TITLE
fix: require template callback interface before publication (PIN-10270)

### DIFF
--- a/packages/eservice-template-process/src/model/domain/errors.ts
+++ b/packages/eservice-template-process/src/model/domain/errors.ts
@@ -46,6 +46,7 @@ const errorCodes = {
   asyncExchangeBulkNotAllowedForSoap: "0036",
   tenantKindNotFound: "0037",
   asyncExchangeReceiveTemplateNotAllowed: "0038",
+  missingAsyncExchangeCallbackInterface: "0039",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -396,6 +397,17 @@ export function missingAsyncExchangeProperties(
     detail: `Async exchange properties are missing for version ${eserviceTemplateVersionId} of EService Template ${eserviceTemplateId}`,
     code: "missingAsyncExchangeProperties",
     title: "Missing async exchange properties",
+  });
+}
+
+export function missingAsyncExchangeCallbackInterface(
+  eserviceTemplateId: EServiceTemplateId,
+  eserviceTemplateVersionId: EServiceTemplateVersionId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `EService Template ${eserviceTemplateId} version ${eserviceTemplateVersionId} can't be published because asyncExchangeCallbackInterface must be set when async exchange is enabled`,
+    code: "missingAsyncExchangeCallbackInterface",
+    title: "Async exchange callback interface must be set before publication",
   });
 }
 

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -76,6 +76,7 @@ import {
   eserviceTemplateAsyncExchangeNotEnabled,
   asyncExchangeCallbackInterfaceAlreadyExists,
   missingAsyncExchangeProperties,
+  missingAsyncExchangeCallbackInterface,
   asyncExchangeBulkNotAllowedForSoap,
 } from "../model/domain/errors.js";
 import {
@@ -549,6 +550,15 @@ export function eserviceTemplateServiceBuilder(
       ) {
         if (eserviceTemplateVersion.asyncExchangeProperties === undefined) {
           throw missingAsyncExchangeProperties(
+            eserviceTemplateId,
+            eserviceTemplateVersionId
+          );
+        }
+
+        if (
+          eserviceTemplateVersion.asyncExchangeCallbackInterface === undefined
+        ) {
+          throw missingAsyncExchangeCallbackInterface(
             eserviceTemplateId,
             eserviceTemplateVersionId
           );

--- a/packages/eservice-template-process/src/utilities/errorMappers.ts
+++ b/packages/eservice-template-process/src/utilities/errorMappers.ts
@@ -71,6 +71,7 @@ export const publishEServiceTemplateVersionErrorMapper = (
       "riskAnalysisValidationFailed",
       "missingPersonalDataFlag",
       "missingAsyncExchangeProperties",
+      "missingAsyncExchangeCallbackInterface",
       "asyncExchangeBulkNotAllowedForSoap",
       () => HTTP_STATUS_BAD_REQUEST
     )

--- a/packages/eservice-template-process/test/api/publishEServiceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/api/publishEServiceTemplateVersion.test.ts
@@ -28,6 +28,7 @@ import {
   riskAnalysisValidationFailed,
   missingRiskAnalysis,
   missingAsyncExchangeProperties,
+  missingAsyncExchangeCallbackInterface,
   asyncExchangeBulkNotAllowedForSoap,
 } from "../../src/model/domain/errors.js";
 
@@ -138,6 +139,13 @@ describe("API POST /templates/:templateId/versions/:templateVersionId/publish", 
     },
     {
       error: missingAsyncExchangeProperties(
+        mockEserviceTemplate.id,
+        mockEserviceTemplate.versions[0].id
+      ),
+      expectedStatus: 400,
+    },
+    {
+      error: missingAsyncExchangeCallbackInterface(
         mockEserviceTemplate.id,
         mockEserviceTemplate.versions[0].id
       ),

--- a/packages/eservice-template-process/test/integration/publishEServiceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/integration/publishEServiceTemplateVersion.test.ts
@@ -35,6 +35,7 @@ import {
   notValidEServiceTemplateVersionState,
   riskAnalysisValidationFailed,
   missingAsyncExchangeProperties,
+  missingAsyncExchangeCallbackInterface,
 } from "../../src/model/domain/errors.js";
 import {
   eserviceTemplateService,
@@ -487,6 +488,49 @@ describe("publishEServiceTemplateVersion", () => {
     );
   });
 
+  it("should throw missingAsyncExchangeCallbackInterface if asyncExchange is true but asyncExchangeCallbackInterface is undefined", async () => {
+    const eserviceTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      interface: getMockDocument(),
+      state: descriptorState.draft,
+      asyncExchangeProperties: {
+        responseTime: 3600,
+        resourceAvailableTime: 7200,
+        confirmation: true,
+        bulk: false,
+        maxResultSet: 1000,
+      },
+    };
+
+    const eserviceTemplate: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      versions: [eserviceTemplateVersion],
+      asyncExchange: true,
+      personalData: false,
+    };
+
+    await addOneTenant({
+      ...getMockTenant(eserviceTemplate.creatorId),
+      kind: tenantKind.PA,
+    });
+    await addOneEServiceTemplate(eserviceTemplate);
+
+    await expect(
+      eserviceTemplateService.publishEServiceTemplateVersion(
+        eserviceTemplate.id,
+        eserviceTemplateVersion.id,
+        getMockContext({
+          authData: getMockAuthData(eserviceTemplate.creatorId),
+        })
+      )
+    ).rejects.toThrowError(
+      missingAsyncExchangeCallbackInterface(
+        eserviceTemplate.id,
+        eserviceTemplateVersion.id
+      )
+    );
+  });
+
   it("should succeed publishing when asyncExchange is true and asyncExchangeProperties is valid", async () => {
     const eserviceTemplateVersion: EServiceTemplateVersion = {
       ...getMockEServiceTemplateVersion(),
@@ -499,6 +543,7 @@ describe("publishEServiceTemplateVersion", () => {
         bulk: false,
         maxResultSet: 1000,
       },
+      asyncExchangeCallbackInterface: getMockDocument(),
     };
 
     const eserviceTemplate: EServiceTemplate = {


### PR DESCRIPTION
# Issue

- [PIN-10270](https://pagopa.atlassian.net/browse/PIN-10270)

## Context / Why

- Publishing an async exchange e-service template currently succeeds even when the template version has no callback interface.
- The expected behavior is to reject publication when `asyncExchange=true` and `asyncExchangeCallbackInterface` is missing.

## Scope

- Add a template-process domain error for missing async exchange callback interface.
- Validate callback interface presence during e-service template version publication.
- Map the new publish error to HTTP 400.
- Add API and integration coverage for the new validation.

## Key Changes

- `publishEServiceTemplateVersion` now requires both `asyncExchangeProperties` and `asyncExchangeCallbackInterface` when async exchange is enabled.
- Added a positive integration test proving publication still succeeds when the callback interface is present.

## Testing / Validation

- [x] Type check
- [x] Lint:
- [x] Api tests
- [x] Integration tests

## Traceability Checklist

- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10270]: https://pagopa.atlassian.net/browse/PIN-10270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ