### PR TITLE
fix: map asyncExchangeBulkNotAllowedForSoap to 400 on draft template version update (PIN-10214)

### DIFF
--- a/packages/eservice-template-process/src/utilities/errorMappers.ts
+++ b/packages/eservice-template-process/src/utilities/errorMappers.ts
@@ -264,6 +264,7 @@ export const updateDraftTemplateVersionErrorMapper = (
       "notValidEServiceTemplateVersionState",
       "inconsistentDailyCalls",
       "attributeDuplicatedInGroup",
+      "asyncExchangeBulkNotAllowedForSoap",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/eservice-template-process/test/api/patchUpdateDraftTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/api/patchUpdateDraftTemplateVersion.test.ts
@@ -20,6 +20,7 @@ import { AuthRole, authRole } from "pagopa-interop-commons";
 import { eserviceTemplateApi } from "pagopa-interop-api-clients";
 import { api, eserviceTemplateService } from "../vitest.api.setup.js";
 import {
+  asyncExchangeBulkNotAllowedForSoap,
   attributeDuplicatedInGroup,
   attributeNotFound,
   eserviceTemplateNotFound,
@@ -212,6 +213,13 @@ describe("PATCH /templates/:templateId/versions/:templateVersionId router test",
     },
     {
       error: attributeDuplicatedInGroup(generateId()),
+      expectedStatus: 400,
+    },
+    {
+      error: asyncExchangeBulkNotAllowedForSoap(
+        mockEServiceTemplate.id,
+        templateVersion.id
+      ),
       expectedStatus: 400,
     },
   ])(

--- a/packages/eservice-template-process/test/api/updateDraftTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/api/updateDraftTemplateVersion.test.ts
@@ -17,6 +17,7 @@ import request from "supertest";
 import { eserviceTemplateApi } from "pagopa-interop-api-clients";
 import { api, eserviceTemplateService } from "../vitest.api.setup.js";
 import {
+  asyncExchangeBulkNotAllowedForSoap,
   attributeDuplicatedInGroup,
   attributeNotFound,
   eserviceTemplateNotFound,
@@ -109,6 +110,13 @@ describe("API POST /templates/:templateId/versions/:templateVersionId", () => {
     },
     {
       error: attributeDuplicatedInGroup(generateId()),
+      expectedStatus: 400,
+    },
+    {
+      error: asyncExchangeBulkNotAllowedForSoap(
+        mockEserviceTemplate.id,
+        mockEserviceTemplate.versions[0].id
+      ),
       expectedStatus: 400,
     },
   ])(


### PR DESCRIPTION
## PIN-10214 — Unexpected 500 on async SOAP descriptor/template update

### Context
A previous fix (#3428) mapped `asyncExchangeBulkNotAllowedForSoap` to HTTP 400 in `catalog-process` for `createDescriptor` and `updateDraftDescriptor`. QA verified the descriptor flow now returns 400 correctly (`001-0054`).

However, the same validation exists in `eservice-template-process`: `updateDraftEServiceTemplateVersion` throws `asyncExchangeBulkNotAllowedForSoap` (`011-0036`) when a draft template version with SOAP technology has `asyncExchangeProperties.bulk = true`. The route error mapper `updateDraftTemplateVersionErrorMapper` did **not** map this error code, so it fell through to `.otherwise(() => 500)`. The BFF (`forceGenericProblemOn500: true`) then masked it as the generic `008-9991 Unexpected error`.

QA reproduced the original 500 on the EService Template version-update flow on `release/2.19.0` (tag `2.19.0-RC2`), which is why the bug reappeared.

### Change
- Add `"asyncExchangeBulkNotAllowedForSoap"` to the `HTTP_STATUS_BAD_REQUEST` branch of `updateDraftTemplateVersionErrorMapper` (covers both the POST/full and PATCH/partial update routes).
- Add regression cases asserting status 400 in `updateDraftTemplateVersion.test.ts` and `patchUpdateDraftTemplateVersion.test.ts`.
