### PR TITLE
fix: reset async callback on technology change (PIN-10287)

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -4766,9 +4766,13 @@ async function updateDraftEService(
     await Promise.all(
       eservice.data.descriptors.map(async (d) => {
         if (d.interface !== undefined) {
-          return await fileManager.delete(
+          await fileManager.delete(config.s3Bucket, d.interface.path, logger);
+        }
+
+        if (d.asyncExchangeCallbackInterface !== undefined) {
+          await fileManager.delete(
             config.s3Bucket,
-            d.interface.path,
+            d.asyncExchangeCallbackInterface.path,
             logger
           );
         }
@@ -4848,6 +4852,7 @@ async function updateDraftEService(
       ? eservice.data.descriptors.map((d) => ({
           ...d,
           interface: undefined,
+          asyncExchangeCallbackInterface: undefined,
           serverUrls: [],
         }))
       : eservice.data.descriptors,

--- a/packages/catalog-process/test/integration/patchUpdateEservice.test.ts
+++ b/packages/catalog-process/test/integration/patchUpdateEservice.test.ts
@@ -306,11 +306,18 @@ describe("patch update eService", () => {
       name: `${mockDocument.name}`,
       path: `${config.eserviceDocumentsPath}/${mockDocument.id}/${mockDocument.name}`,
     };
+    const mockAsyncExchangeCallbackInterfaceDocument = getMockDocument();
+    const asyncExchangeCallbackInterfaceDocument = {
+      ...mockAsyncExchangeCallbackInterfaceDocument,
+      name: `${mockDocument.name}_callback`,
+      path: `${config.eserviceDocumentsPath}/${mockAsyncExchangeCallbackInterfaceDocument.id}/${mockDocument.name}_callback`,
+    };
 
     const descriptor: Descriptor = {
       ...getMockDescriptor(),
       state: descriptorState.draft,
       interface: interfaceDocument,
+      asyncExchangeCallbackInterface: asyncExchangeCallbackInterfaceDocument,
     };
     const eservice: EService = {
       ...mockEService,
@@ -329,10 +336,23 @@ describe("patch update eService", () => {
       },
       genericLogger
     );
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.eserviceDocumentsPath,
+        resourceId: asyncExchangeCallbackInterfaceDocument.id,
+        name: asyncExchangeCallbackInterfaceDocument.name,
+        content: Buffer.from("testtest"),
+      },
+      genericLogger
+    );
 
     expect(
       await fileManager.listFiles(config.s3Bucket, genericLogger)
     ).toContain(interfaceDocument.path);
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).toContain(asyncExchangeCallbackInterfaceDocument.path);
 
     const updateEServiceReturn = await catalogService.patchUpdateEService(
       eservice.id,
@@ -348,6 +368,7 @@ describe("patch update eService", () => {
       descriptors: eservice.descriptors.map((d) => ({
         ...d,
         interface: undefined,
+        asyncExchangeCallbackInterface: undefined,
         serverUrls: [],
       })),
     };

--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -2259,9 +2259,13 @@ async function updateDraftEServiceTemplate(
     await Promise.all(
       eserviceTemplate.data.versions.map(async (d) => {
         if (d.interface !== undefined) {
-          return await fileManager.delete(
+          await fileManager.delete(config.s3Bucket, d.interface.path, logger);
+        }
+
+        if (d.asyncExchangeCallbackInterface !== undefined) {
+          await fileManager.delete(
             config.s3Bucket,
-            d.interface.path,
+            d.asyncExchangeCallbackInterface.path,
             logger
           );
         }
@@ -2322,6 +2326,7 @@ async function updateDraftEServiceTemplate(
       ? eserviceTemplate.data.versions.map((d) => ({
           ...d,
           interface: undefined,
+          asyncExchangeCallbackInterface: undefined,
         }))
       : eserviceTemplate.data.versions,
     isSignalHubEnabled: updatedIsSignalHubEnabled,

--- a/packages/eservice-template-process/test/integration/updateEServiceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/updateEServiceTemplate.test.ts
@@ -101,11 +101,18 @@ describe("update EService template", () => {
       name: mockDocument.name,
       path: `${config.eserviceTemplateDocumentsPath}/${mockDocument.id}/${mockDocument.name}`,
     };
+    const mockAsyncExchangeCallbackInterfaceDocument = getMockDocument();
+    const asyncExchangeCallbackInterfaceDocument = {
+      ...mockAsyncExchangeCallbackInterfaceDocument,
+      name: `${mockDocument.name}_callback`,
+      path: `${config.eserviceTemplateDocumentsPath}/${mockAsyncExchangeCallbackInterfaceDocument.id}/${mockDocument.name}_callback`,
+    };
 
     const version: EServiceTemplateVersion = {
       ...mockVersion,
       state: eserviceTemplateVersionState.draft,
       interface: interfaceDocument,
+      asyncExchangeCallbackInterface: asyncExchangeCallbackInterfaceDocument,
     };
     const eserviceTemplate: EServiceTemplate = {
       ...mockEServiceTemplate,
@@ -125,6 +132,16 @@ describe("update EService template", () => {
       },
       genericLogger
     );
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.eserviceTemplateDocumentsPath,
+        resourceId: asyncExchangeCallbackInterfaceDocument.id,
+        name: asyncExchangeCallbackInterfaceDocument.name,
+        content: Buffer.from("testtest"),
+      },
+      genericLogger
+    );
 
     const updatedEServiceTemplate: EServiceTemplate = {
       ...eserviceTemplate,
@@ -133,12 +150,16 @@ describe("update EService template", () => {
       versions: eserviceTemplate.versions.map((v) => ({
         ...v,
         interface: undefined,
+        asyncExchangeCallbackInterface: undefined,
       })),
     };
 
     expect(
       await fileManager.listFiles(config.s3Bucket, genericLogger)
     ).toContain(interfaceDocument.path);
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).toContain(asyncExchangeCallbackInterfaceDocument.path);
 
     const returnedEServiceTemplate =
       await eserviceTemplateService.updateEServiceTemplate(


### PR DESCRIPTION
# Issue

- [PIN-10287](https://pagopa.atlassian.net/browse/PIN-10287)

## Context / Why

- When a draft e-service or e-service template changes technology between REST and SOAP, the main interface is reset, but the async exchange callback interface was kept.
- This allowed drafts to retain a callback interface uploaded for the previous technology and proceed with inconsistent technical specifications.

## Scope

- Reset async exchange callback interfaces when technology changes for draft e-services.
- Reset async exchange callback interfaces when technology changes for draft e-service templates.

## Key Changes

- Delete the async exchange callback interface file from storage when technology changes.
- Clear `asyncExchangeCallbackInterface` from descriptors/template versions together with the main `interface`.
- Extend integration tests for technology-change flows to cover callback interface cleanup.

## Testing / Validation

- [x] Type check
- [x] Lint
- [x] Integration tests

## Traceability Checklist

- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10287]: https://pagopa.atlassian.net/browse/PIN-10287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ