### PR TITLE
fix: add scheduled-notification-db-models to notification dispatcher Dockerfiles

### DIFF
--- a/packages/email-notification-dispatcher/Dockerfile
+++ b/packages/email-notification-dispatcher/Dockerfile
@@ -18,6 +18,7 @@ COPY ./packages/models/package.json /app/packages/models/package.json
 COPY ./packages/kafka-iam-auth/package.json /app/packages/kafka-iam-auth/package.json
 COPY ./packages/readmodel/package.json /app/packages/readmodel/package.json
 COPY ./packages/readmodel-models/package.json /app/packages/readmodel-models/package.json
+COPY ./packages/scheduled-notification-db-models/package.json /app/packages/scheduled-notification-db-models/package.json
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
@@ -31,6 +32,7 @@ COPY ./packages/models /app/packages/models
 COPY ./packages/kafka-iam-auth /app/packages/kafka-iam-auth
 COPY ./packages/readmodel /app/packages/readmodel
 COPY ./packages/readmodel-models /app/packages/readmodel-models
+COPY ./packages/scheduled-notification-db-models /app/packages/scheduled-notification-db-models
 
 ARG NODE_HEAP_SIZE=4096
 RUN NODE_OPTIONS="--max-old-space-size=${NODE_HEAP_SIZE}" pnpm build && \
@@ -46,6 +48,7 @@ RUN NODE_OPTIONS="--max-old-space-size=${NODE_HEAP_SIZE}" pnpm build && \
   packages/kafka-iam-auth \
   packages/readmodel/ \
   packages/readmodel-models/ \
+  packages/scheduled-notification-db-models/ \
   packages/email-notification-dispatcher/dist && \
   find /out -exec touch -h --date=@0 {} \;
 

--- a/packages/in-app-notification-dispatcher/Dockerfile
+++ b/packages/in-app-notification-dispatcher/Dockerfile
@@ -19,6 +19,7 @@ COPY ./packages/kafka-iam-auth/package.json /app/packages/kafka-iam-auth/package
 COPY ./packages/readmodel/package.json /app/packages/readmodel/package.json
 COPY ./packages/readmodel-models/package.json /app/packages/readmodel-models/package.json
 COPY ./packages/in-app-notification-db-models/package.json /app/packages/in-app-notification-db-models/package.json
+COPY ./packages/scheduled-notification-db-models/package.json /app/packages/scheduled-notification-db-models/package.json
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
@@ -33,6 +34,7 @@ COPY ./packages/kafka-iam-auth /app/packages/kafka-iam-auth
 COPY ./packages/readmodel /app/packages/readmodel
 COPY ./packages/readmodel-models /app/packages/readmodel-models
 COPY ./packages/in-app-notification-db-models /app/packages/in-app-notification-db-models
+COPY ./packages/scheduled-notification-db-models /app/packages/scheduled-notification-db-models
 
 ARG NODE_HEAP_SIZE=4096
 RUN NODE_OPTIONS="--max-old-space-size=${NODE_HEAP_SIZE}" pnpm build && \
@@ -49,6 +51,7 @@ RUN NODE_OPTIONS="--max-old-space-size=${NODE_HEAP_SIZE}" pnpm build && \
   packages/readmodel/ \
   packages/readmodel-models/ \
   packages/in-app-notification-db-models/ \
+  packages/scheduled-notification-db-models/ \
   packages/in-app-notification-dispatcher/dist && \
   find /out -exec touch -h --date=@0 {} \;
 


### PR DESCRIPTION
## Context

After merging PIN-9754 (#3431), the `develop` Docker image builds for `email-notification-dispatcher` and `in-app-notification-dispatcher` started failing:

```
pagopa-interop-notification-commons:build: src/scheduled/runScheduledDeliveryBatch.ts(2,39): error TS2307: Cannot find module 'pagopa-interop-scheduled-notification-db-models' or its corresponding type declarations.
pagopa-interop-notification-commons:build: src/scheduled/types.ts(6,8): error TS2307: Cannot find module 'pagopa-interop-scheduled-notification-db-models' or its corresponding type declarations.
```

(failing run: https://github.com/pagopa/interop-be-monorepo/actions/runs/27191425384)

## Cause

PIN-9754 added a dependency from `notification-commons` on the `pagopa-interop-scheduled-notification-db-models` workspace package. Both dispatcher Dockerfiles build `notification-commons` but did not copy that new package into the build context, so `pnpm build` could not resolve the module.

## Fix

Add `scheduled-notification-db-models` to both Dockerfiles in the three required places: the package.json copy before `pnpm install`, the source copy before `pnpm build`, and the `/out` copy for the final stage. Mirrors the existing pattern already used by `scheduled-notification-cleaner`.