### PR TITLE
fix: validate async entityNumber maxResultSet in BFF `tools/validateTokenGeneration` (PIN-10299)

### DIFF
--- a/packages/backend-for-frontend/src/services/toolServiceUtils.ts
+++ b/packages/backend-for-frontend/src/services/toolServiceUtils.ts
@@ -362,6 +362,19 @@ export function buildProducerAsyncPlatformErrors(
     return errors;
   }
 
+  if (
+    jwt.payload.entityNumber !== undefined &&
+    jwt.payload.entityNumber > catalogEntry.asyncExchangeProperties.maxResultSet
+  ) {
+    errors.push(
+      makeDiagnosticError(
+        "invalidEntityNumber",
+        `entityNumber ${jwt.payload.entityNumber} exceeds maxResultSet ${catalogEntry.asyncExchangeProperties.maxResultSet} for client ${jwt.payload.sub}`,
+        "Invalid entityNumber"
+      )
+    );
+  }
+
   const elapsedMs =
     Date.now() - Date.parse(String(interaction.startInteractionTokenIssuedAt));
   const responseTimeMs =

--- a/packages/backend-for-frontend/test/validateAsyncTokenGeneration.test.ts
+++ b/packages/backend-for-frontend/test/validateAsyncTokenGeneration.test.ts
@@ -973,6 +973,106 @@ describe("validateTokenGeneration async validations", () => {
     ).toBe(true);
   });
 
+  it("invalidEntityNumber is detected for callback_invocation when entityNumber exceeds maxResultSet", async () => {
+    const producerKeychainId = generateId<ProducerKeychainId>();
+    const producerClientId = unsafeBrandId<ClientId>(producerKeychainId);
+
+    vi.spyOn(
+      clientAssertionValidation,
+      "verifyAsyncClientAssertion"
+    ).mockReturnValue({
+      errors: undefined,
+      data: {
+        header: { kid: mockKid, alg: "RS256", typ: "JWT" },
+        payload: {
+          sub: producerClientId,
+          jti: "jti",
+          iat: 1,
+          exp: 2,
+          iss: producerClientId,
+          aud: ["audience"],
+          scope: interactionState.callbackInvocation,
+          interactionId: mockInteractionId,
+          entityNumber: 51,
+        },
+      },
+    });
+
+    dynamoDBClient.send = vi.fn().mockResolvedValueOnce({
+      Items: [
+        marshall({
+          PK: `INTERACTION#${mockInteractionId}`,
+          interactionId: mockInteractionId,
+          clientId: mockClientId,
+          consumerId: mockAuthData.organizationId,
+          purposeId: mockPurposeId,
+          eServiceId: mockEServiceId,
+          descriptorId: mockDescriptorId,
+          state: interactionState.startInteraction,
+          startInteractionTokenIssuedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          ttl: 1,
+        }),
+      ],
+    });
+
+    mockClients.authorizationClient.producerKeychain.getProducerKeychain = vi
+      .fn()
+      .mockResolvedValue({
+        visibility: authorizationApi.Visibility.Values.FULL,
+        id: producerKeychainId,
+        producerId: generateId(),
+        name: "Producer keychain",
+        createdAt: new Date().toISOString(),
+        eservices: [mockEServiceId],
+        description: "Producer keychain description",
+        users: [],
+        keys: [],
+      });
+
+    mockClients.catalogProcessClient.getEServiceById = vi
+      .fn()
+      .mockResolvedValue({
+        id: mockEServiceId,
+        name: "Test eService",
+        asyncExchange: true,
+        descriptors: [
+          {
+            id: mockDescriptorId,
+            version: "1",
+            state: "PUBLISHED",
+            audience: ["audience"],
+            voucherLifespan: 3600,
+            asyncExchangeProperties: {
+              responseTime: 60,
+              resourceAvailableTime: 120,
+              confirmation: true,
+              bulk: false,
+              maxResultSet: 50,
+            },
+          },
+        ],
+      });
+
+    const result = await service.validateTokenGeneration(
+      producerClientId,
+      mockClientAssertion,
+      mockClientAssertionType,
+      mockGrantType,
+      true,
+      undefined,
+      ctx
+    );
+
+    expect(result.steps.platformStatesVerification.result).toBe("FAILED");
+    expect(result.steps.platformStatesVerification.failures).toEqual([
+      {
+        code: "invalidEntityNumber",
+        reason: `entityNumber 51 exceeds maxResultSet 50 for client ${producerClientId}`,
+      },
+    ]);
+  });
+
   it("interactionStateNotAllowed when interaction is in start_interaction state but scope is get_resource", async () => {
     vi.spyOn(
       clientAssertionValidation,


### PR DESCRIPTION
## Issue
- [PIN-10299](https://pagopa.atlassian.net/browse/PIN-10299)

## Context / Why
- The async token generation debugger did not report `invalidEntityNumber` when a `callback_invocation` assertion used an `entityNumber` greater than the descriptor `asyncExchangeProperties.maxResultSet`.
- This caused the validation steps to be reported as passed for cases that should fail, such as `entityNumber = 51` with `maxResultSet = 50`.

## Scope
- Added the missing `entityNumber > maxResultSet` validation in the BFF async token generation diagnostic flow.
- Added a focused unit test for the `callback_invocation` scenario.

## Testing / Validation
- [x] Lint
- [x] Type check
- [x] Unit tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [ ] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10299]: https://pagopa.atlassian.net/browse/PIN-10299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ