### PR TITLE
fix: align template instance seed (PIN-10248)

### DIFF
--- a/collections/bff/catalog/Create EService Instance From Template.bru
+++ b/collections/bff/catalog/Create EService Instance From Template.bru
@@ -18,6 +18,16 @@ headers {
   Authorization: {{JWT}}
 }
 
+body:json {
+  {
+      "asyncExchangeProperties": {
+          "responseTime": 60,
+          "resourceAvailableTime": 120,
+          "maxResultSet": 100
+      }
+  }
+}
+
 script:pre-request {
   const { v4 } = require('uuid');
   bru.setVar("randomUuid", v4() );

--- a/collections/catalog/Create EService from existing Template.bru
+++ b/collections/catalog/Create EService from existing Template.bru
@@ -15,3 +15,12 @@ headers {
   X-Correlation-Id: {{correlation-id}}
 }
 
+body:json {
+  {
+      "asyncExchangeProperties": {
+          "responseTime": 60,
+          "resourceAvailableTime": 120,
+          "maxResultSet": 100
+      }
+  }
+}

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -30343,8 +30343,8 @@ components:
           type: string
           minLength: 1
           maxLength: 12
-        asyncExchange:
-          type: boolean
+        asyncExchangeProperties:
+          $ref: "#/components/schemas/AsyncExchangePropertiesInstanceSeed"
     VersionSeedForEServiceTemplateCreation:
       required:
         - voucherLifespan

--- a/packages/backend-for-frontend/test/api/catalogRouter/createEServiceInstanceFromTemplate.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/createEServiceInstanceFromTemplate.test.ts
@@ -59,11 +59,18 @@ describe("API POST /templates/:templateId/eservices", () => {
   it.each([
     { templateId: "invalid" as EServiceTemplateId },
     { body: { ...mockInstanceEServiceSeed, extraField: 1 } },
+    { body: { ...mockInstanceEServiceSeed, asyncExchange: false } },
     {
       body: { ...mockInstanceEServiceSeed, isClientAccessDelegable: "invalid" },
     },
     { body: { ...mockInstanceEServiceSeed, isConsumerDelegable: "invalid" } },
     { body: { ...mockInstanceEServiceSeed, isSignalHubEnabled: "invalid" } },
+    {
+      body: {
+        ...mockInstanceEServiceSeed,
+        asyncExchangeProperties: { responseTime: "invalid" },
+      },
+    },
   ])(
     "Should return 400 if passed an invalid parameter: %s",
     async ({ templateId, body }) => {

--- a/packages/backend-for-frontend/test/mockUtils.ts
+++ b/packages/backend-for-frontend/test/mockUtils.ts
@@ -358,6 +358,9 @@ export const getMockBffApiInstanceEServiceSeed =
     isSignalHubEnabled: generateMock(z.boolean().optional()),
     isClientAccessDelegable: generateMock(z.boolean().optional()),
     isConsumerDelegable: generateMock(z.boolean().optional()),
+    asyncExchangeProperties: generateMock(
+      bffApi.AsyncExchangePropertiesInstanceSeed.optional()
+    ),
   });
 
 export const getMockBffApiEServicePersonalDataFlagUpdateSeed =


### PR DESCRIPTION
## Issue
- [PIN-10248](https://pagopa.atlassian.net/browse/PIN-10248)

## Context / Why
- The BFF OpenAPI contract allowed `asyncExchange` when creating an e-service instance from a template.
- The catalog-process contract rejects `asyncExchange` for this endpoint and only allows template-instantiation parameters, including modifiable async exchange properties.

## Scope
- Align BFF `InstanceEServiceSeed` with catalog-process by replacing `asyncExchange` with `asyncExchangeProperties`.
- Update BFF API tests to reject `asyncExchange` and validate invalid `asyncExchangeProperties`.

## Testing / Validation
- [x] Lint
- [x] Type Check
- [x] Api tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [x] OpenAPI spec updated
- [x] Bruno endpoint definition updated

[PIN-10248]: https://pagopa.atlassian.net/browse/PIN-10248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ