### PR TITLE
Attempt to repair generator

### DIFF
--- a/packages/api-clients/src/catalogApi.ts
+++ b/packages/api-clients/src/catalogApi.ts
@@ -4,7 +4,9 @@ import { QueryParametersByAlias } from "./utils.js";
 
 type CatalogApi = typeof catalogApi.processEndpoints;
 
-export type CatalogProcessClient = ZodiosInstance<typeof catalogApi.processEndpoints>;
+export type CatalogProcessClient = ZodiosInstance<
+  typeof catalogApi.processEndpoints
+>;
 
 export type GetEServicesQueryParams = QueryParametersByAlias<
   CatalogApi,

--- a/packages/api-clients/src/catalogApi.ts
+++ b/packages/api-clients/src/catalogApi.ts
@@ -1,11 +1,10 @@
 import * as catalogApi from "./generated/catalogApi.js";
+import { ZodiosInstance } from "@zodios/core";
 import { QueryParametersByAlias } from "./utils.js";
 
-type CatalogApi = typeof catalogApi.processApi.api;
+type CatalogApi = typeof catalogApi.processEndpoints;
 
-export type CatalogProcessClient = ReturnType<
-  typeof catalogApi.createProcessApiClient
->;
+export type CatalogProcessClient = ZodiosInstance<typeof catalogApi.processEndpoints>;
 
 export type GetEServicesQueryParams = QueryParametersByAlias<
   CatalogApi,

--- a/packages/api-clients/template-bff.hbs
+++ b/packages/api-clients/template-bff.hbs
@@ -8,137 +8,150 @@ import { AxiosInstance } from "axios";
 export const {{@key}} = {{{this}}};
 export type {{@key}} = z.infer<typeof {{@key}}>;
 
-{{/each}}
+	{{/each}}
 
-{{#each endpointsGroups}}
-export const {{@key}}Endpoints = makeApi([
-{{#each this.endpoints}}
+	{{#each endpointsGroups}}
+	export const {{@key}}Endpoints = makeApi([
+	{{#each this.endpoints}}
 	{
-		method: "{{method}}",
-		path: "{{path}}",
-		{{#if @root.options.withAlias}}
-		{{#if alias}}
-		alias: "{{alias}}",
-		{{/if}}
-		{{/if}}
-		{{#if description}}
-		description: `{{description}}`,
-		{{/if}}
-		{{#if requestFormat}}
-		requestFormat: "{{requestFormat}}",
-		{{/if}}
-		{{#if parameters}}
-		parameters: [
-			{{#each parameters}}
-			{
-				name: "{{name}}",
-				{{#if description}}
-				description: `{{description}}`,
-				{{/if}}
-				{{#if type}}
-				type: "{{type}}",
-				{{/if}}
-				{{#if (and (eq type "Query") (eq schema "z.array(z.string()).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string()).optional().default([])), z.array(z.string()).optional().default([])]),
-				{{else if (and (eq type "Query") (eq schema "z.array(z.string().uuid()).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string().uuid()).optional().default([])), z.array(z.string().uuid()).optional().default([])]),
-				{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind)"))}}
-						schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)), z.array(AttributeKind)])
-				{{else if (and (eq type "Query") (eq schema "z.array(AgreementState).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(AgreementState).optional().default([])),z.array(AgreementState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(EServiceDescriptorState).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(EServiceDescriptorState).optional().default([])), z.array(EServiceDescriptorState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(PurposeVersionState).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeVersionState).optional().default([])), z.array(PurposeVersionState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(DelegationState).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(DelegationState).optional().default([])), z.array(DelegationState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(TenantFeatureType).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(TenantFeatureType).optional().default([])), z.array(TenantFeatureType).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(PurposeTemplateState).optional().default([])"))}}
-					schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeTemplateState).optional().default([])), z.array(PurposeTemplateState).optional().default([])])
-				{{else}}
-					schema: {{{schema}}},
-				{{/if}}
-			},
-			{{/each}}
-		],
-		{{/if}}
-		{{#if (and (eq method "get") (eq path "/agreements/:agreementId/consumer-documents/:documentId"))}}
-			response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/privacyNotices/:consentType"))}}
-			response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/purposes/:purposeId/versions/:versionId/documents/:documentId"))}}
-			response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/eservices/:eServiceId/consumers"))}}
-			response: z.instanceof(Buffer),
-		{{else if (and (eq method "post") (eq path "/agreements/:agreementId/consumer-documents"))}}
-			response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/agreements/:agreementId/consumer-documents"))}}
-			response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/agreements/:agreementId/contract"))}}
-			response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/eservices/:eServiceId/descriptors/:descriptorId/documents/:documentId"))}}
-			response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/delegations/:delegationId/contracts/:contractId"))}}
-			response: z.instanceof(Buffer),
-        {{else if (and (eq method "get") (eq path "/eservices/templates/:eServiceTemplateId/versions/:eServiceTemplateVersionId/documents/:documentId"))}}
-            response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation/documents/:documentId"))}}
-            response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/agreements/:agreementId/signedContract"))}}
-            response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/delegations/:delegationId/signedContract/:contractId"))}}
-            response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/purposes/:purposeId/versions/:versionId/signedDocuments/:documentId"))}}
-            response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/purposeTemplates/:purposeTemplateId/riskAnalysisDocument"))}}
-            response: z.instanceof(Buffer),
-		{{else if (and (eq method "get") (eq path "/purposeTemplates/:purposeTemplateId/riskAnalysisDocument/signed"))}}
-            response: z.instanceof(Buffer),
-		{{else}}
-			response: {{{response}}},
-		{{/if}}
-		{{#if errors.length}}
-		errors: [
-			{{#each errors}}
-			{
-				{{#if (eq status "default") }}
-				status: "default",
-				{{else}}
-				status: {{status}},
-				{{/if}}
-				{{#if description}}
-				description: `{{description}}`,
-				{{/if}}
-				schema: {{{schema}}}
-			},
-			{{/each}}
-		]
-		{{/if}}
+	method: "{{method}}",
+	path: "{{path}}",
+	{{#if @root.options.withAlias}}
+	{{#if alias}}
+	alias: "{{alias}}",
+	{{/if}}
+	{{/if}}
+	{{#if description}}
+	description: `{{description}}`,
+	{{/if}}
+	{{#if requestFormat}}
+	requestFormat: "{{requestFormat}}",
+	{{/if}}
+	{{#if parameters}}
+	parameters: [
+	{{#each parameters}}
+	{
+	name: "{{name}}",
+	{{#if description}}
+	description: `{{description}}`,
+	{{/if}}
+	{{#if type}}
+	type: "{{type}}",
+	{{/if}}
+	{{#if (and (eq type "Query") (eq schema "z.array(z.string()).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") :
+	undefined).pipe(z.array(z.string()).optional().default([])), z.array(z.string()).optional().default([])]),
+	{{else if (and (eq type "Query") (eq schema "z.array(z.string().uuid()).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") :
+	undefined).pipe(z.array(z.string().uuid()).optional().default([])),
+	z.array(z.string().uuid()).optional().default([])]),
+	{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind)"))}}
+	schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)), z.array(AttributeKind)])
+	{{else if (and (eq type "Query") (eq schema "z.array(AgreementState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(AgreementState).optional().default([])),z.array(AgreementState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(EServiceDescriptorState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(EServiceDescriptorState).optional().default([])),
+	z.array(EServiceDescriptorState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(PurposeVersionState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(PurposeVersionState).optional().default([])), z.array(PurposeVersionState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(DelegationState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(DelegationState).optional().default([])), z.array(DelegationState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(TenantFeatureType).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(TenantFeatureType).optional().default([])), z.array(TenantFeatureType).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(PurposeTemplateState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(PurposeTemplateState).optional().default([])), z.array(PurposeTemplateState).optional().default([])])
+	{{else}}
+	schema: {{{schema}}},
+	{{/if}}
 	},
-{{/each}}
-]);
+	{{/each}}
+	],
+	{{/if}}
+	{{#if (and (eq method "get") (eq path "/agreements/:agreementId/consumer-documents/:documentId"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/privacyNotices/:consentType"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/purposes/:purposeId/versions/:versionId/documents/:documentId"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/eservices/:eServiceId/consumers"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "post") (eq path "/agreements/:agreementId/consumer-documents"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/agreements/:agreementId/consumer-documents"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/agreements/:agreementId/contract"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path
+	"/eservices/:eServiceId/descriptors/:descriptorId/documents/:documentId"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/delegations/:delegationId/contracts/:contractId"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path
+	"/eservices/templates/:eServiceTemplateId/versions/:eServiceTemplateVersionId/documents/:documentId"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path
+	"/purposeTemplates/:purposeTemplateId/riskAnalysis/answers/:answerId/annotation/documents/:documentId"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/agreements/:agreementId/signedContract"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/delegations/:delegationId/signedContract/:contractId"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/purposes/:purposeId/versions/:versionId/signedDocuments/:documentId"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/purposeTemplates/:purposeTemplateId/riskAnalysisDocument"))}}
+	response: z.instanceof(Buffer),
+	{{else if (and (eq method "get") (eq path "/purposeTemplates/:purposeTemplateId/riskAnalysisDocument/signed"))}}
+	response: z.instanceof(Buffer),
+	{{else}}
+	response: {{{response}}},
+	{{/if}}
+	{{#if errors.length}}
+	errors: [
+	{{#each errors}}
+	{
+	{{#if (eq status "default") }}
+	status: "default",
+	{{else}}
+	status: {{status}},
+	{{/if}}
+	{{#if description}}
+	description: `{{description}}`,
+	{{/if}}
+	schema: {{{schema}}}
+	},
+	{{/each}}
+	]
+	{{/if}}
+	},
+	{{/each}}
+	]);
 
-export const {{@key}}Api = new Zodios({{#if options.baseUrl}}"{{options.baseUrl}}", {{/if}}{{@key}}Endpoints);
+	export const {{@key}}Api = new Zodios({{#if options.baseUrl}}"{{options.baseUrl}}", {{/if}}{{@key}}Endpoints);
 
-export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: ZodiosOptions) {
-		const zodiosClient = new Zodios(baseUrl, {{@key}}Endpoints, {
-			...options,
-			validate: false,
-			axiosConfig: {
-				...options?.axiosConfig,
-				// This configuration is used to serialize correctly array query parameters.
-				// The default serialization produces a query param name appending "[]" after the equals:
-				// eg: ids[]=1,2,3 instead of ids=1,2,3
-				paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
-			},
-		});
+	export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: ZodiosOptions) {
+	const zodiosClient = new Zodios(baseUrl, {{@key}}Endpoints, {
+	...options,
+	validate: false,
+	axiosConfig: {
+	...options?.axiosConfig,
+	// This configuration is used to serialize correctly array query parameters.
+	// The default serialization produces a query param name appending "[]" after the equals:
+	// eg: ids[]=1,2,3 instead of ids=1,2,3
+	paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
+	},
+	});
 
-		configureAxiosLogInterceptors(
-			zodiosClient.axios as AxiosInstance,
-			"{{pascalcase @root.options.apiClientName}} {{pascalcase @key}} Client"
-		);
-		return zodiosClient;
-}
+	configureAxiosLogInterceptors(
+	zodiosClient.axios as AxiosInstance,
+	"{{pascalcase @root.options.apiClientName}} {{pascalcase @key}} Client"
+	);
+	return zodiosClient;
+	}
 
-{{/each}}
+	{{/each}}

--- a/packages/api-clients/template.hbs
+++ b/packages/api-clients/template.hbs
@@ -1,10 +1,7 @@
 import {
 makeApi,
 Zodios,
-{{#if (eq @root.options.apiClientName "catalogApi")}}
-type ZodiosEndpointDefinitions,
 type ZodiosInstance,
-{{/if}}
 type ZodiosOptions,
 } from "@zodios/core";
 import { z } from "zod";
@@ -19,8 +16,7 @@ export type {{@key}} = z.infer<typeof {{@key}}>;
 	{{/each}}
 
 	{{#each endpointsGroups}}
-	export const {{@key}}Endpoints{{#if (and (eq @root.options.apiClientName "catalogApi") (eq @key "process"))}}:
-	ZodiosEndpointDefinitions{{/if}} = makeApi([
+	export const {{@key}}Endpoints = makeApi([
 	{{#each this.endpoints}}
 	{
 	method: "{{method}}",
@@ -113,30 +109,28 @@ export type {{@key}} = z.infer<typeof {{@key}}>;
 	{{/each}}
 	]);
 
-	export const {{@key}}Api{{#if (and (eq @root.options.apiClientName "catalogApi") (eq @key "process"))}}:
-	ZodiosInstance<ZodiosEndpointDefinitions>{{/if}} = new Zodios({{#if options.baseUrl}}"{{options.baseUrl}}",
-		{{/if}}{{@key}}Endpoints);
+	export const {{@key}}Api = new Zodios({{#if options.baseUrl}}"{{options.baseUrl}}",
+	{{/if}}{{@key}}Endpoints);
 
-		export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: ZodiosOptions){{#if (and (eq
-		@root.options.apiClientName "catalogApi") (eq @key "process"))}}: ZodiosInstance<ZodiosEndpointDefinitions>
-			{{/if}} {
-			const zodiosClient = new Zodios(baseUrl, {{@key}}Endpoints, {
-			...options,
-			validate: false,
-			axiosConfig: {
-			...options?.axiosConfig,
-			// This configuration is used to serialize correctly array query parameters.
-			// The default serialization produces a query param name appending "[]" after the equals:
-			// eg: ids[]=1,2,3 instead of ids=1,2,3
-			paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
-			},
-			});
+	export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: ZodiosOptions): ZodiosInstance<typeof
+		{{@key}}Endpoints> {
+		const zodiosClient = new Zodios(baseUrl, {{@key}}Endpoints, {
+		...options,
+		validate: false,
+		axiosConfig: {
+		...options?.axiosConfig,
+		// This configuration is used to serialize correctly array query parameters.
+		// The default serialization produces a query param name appending "[]" after the equals:
+		// eg: ids[]=1,2,3 instead of ids=1,2,3
+		paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
+		},
+		});
 
-			configureAxiosLogInterceptors(
-			zodiosClient.axios as AxiosInstance,
-			"{{pascalcase @root.options.apiClientName}} {{pascalcase @key}} Client"
-			);
-			return zodiosClient;
-			}
+		configureAxiosLogInterceptors(
+		zodiosClient.axios as AxiosInstance,
+		"{{pascalcase @root.options.apiClientName}} {{pascalcase @key}} Client"
+		);
+		return zodiosClient;
+		}
 
-			{{/each}}
+		{{/each}}

--- a/packages/api-clients/template.hbs
+++ b/packages/api-clients/template.hbs
@@ -1,4 +1,12 @@
-import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
+import {
+makeApi,
+Zodios,
+{{#if (eq @root.options.apiClientName "catalogApi")}}
+type ZodiosEndpointDefinitions,
+type ZodiosInstance,
+{{/if}}
+type ZodiosOptions,
+} from "@zodios/core";
 import { z } from "zod";
 import qs from "qs";
 import { configureAxiosLogInterceptors } from "../axiosLogInterceptors.js";
@@ -8,110 +16,127 @@ import { AxiosInstance } from "axios";
 export const {{@key}} = {{{this}}};
 export type {{@key}} = z.infer<typeof {{@key}}>;
 
-{{/each}}
+	{{/each}}
 
-{{#each endpointsGroups}}
-export const {{@key}}Endpoints = makeApi([
-{{#each this.endpoints}}
+	{{#each endpointsGroups}}
+	export const {{@key}}Endpoints{{#if (and (eq @root.options.apiClientName "catalogApi") (eq @key "process"))}}:
+	ZodiosEndpointDefinitions{{/if}} = makeApi([
+	{{#each this.endpoints}}
 	{
-		method: "{{method}}",
-		path: "{{path}}",
-		{{#if @root.options.withAlias}}
-		{{#if alias}}
-		alias: "{{alias}}",
-		{{/if}}
-		{{/if}}
-		{{#if description}}
-		description: `{{description}}`,
-		{{/if}}
-		{{#if requestFormat}}
-		requestFormat: "{{requestFormat}}",
-		{{/if}}
-		{{#if parameters}}
-		parameters: [
-			{{#each parameters}}
-			{
-				name: "{{name}}",
-				{{#if description}}
-				description: `{{description}}`,
-				{{/if}}
-				{{#if type}}
-				type: "{{type}}",
-				{{/if}}
-				{{#if (and (eq type "Query") (eq schema "z.array(z.string()).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string()).optional().default([])), z.array(z.string()).optional().default([])]),
-				{{else if (and (eq type "Query") (eq schema "z.array(z.string().uuid()).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined).pipe(z.array(z.string().uuid()).optional().default([])), z.array(z.string().uuid()).optional().default([])]),
-				{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind)"))}}
-						schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)), z.array(AttributeKind)])
-				{{else if (and (eq type "Query") (eq schema "z.array(AgreementState).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(AgreementState).optional().default([])),z.array(AgreementState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(EServiceDescriptorState).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(EServiceDescriptorState).optional().default([])), z.array(EServiceDescriptorState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(PurposeVersionState).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeVersionState).optional().default([])), z.array(PurposeVersionState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(DelegationState).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(DelegationState).optional().default([])), z.array(DelegationState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(TenantFeatureType).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(TenantFeatureType).optional().default([])), z.array(TenantFeatureType).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(EServiceTemplateVersionState).optional().default([])"))}}
-						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(EServiceTemplateVersionState).optional().default([])), z.array(EServiceTemplateVersionState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.array(PurposeTemplateState).optional().default([])"))}}
-					schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeTemplateState).optional().default([])), z.array(PurposeTemplateState).optional().default([])])
-				{{else if (and (eq type "Query") (eq schema "z.string().uuid().nullish()"))}}
-					schema: z.union([z.string().uuid(), z.null(), z.undefined()])
-				{{else if (and (eq type "Query") (eq schema "z.array(NotificationType).optional().default([])"))}}
-					schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(NotificationType).optional().default([])), z.array(NotificationType).optional().default([])])
-				{{else}}
-					schema: {{{schema}}},
-				{{/if}}
-			},
-			{{/each}}
-		],
-		{{/if}}
-		response: {{{response}}},
-		{{#if errors.length}}
-		errors: [
-			{{#each errors}}
-			{
-				{{#if (eq status "default") }}
-				status: "default",
-				{{else}}
-				status: {{status}},
-				{{/if}}
-				{{#if description}}
-				description: `{{description}}`,
-				{{/if}}
-				schema: {{{schema}}}
-			},
-			{{/each}}
-		]
-		{{/if}}
+	method: "{{method}}",
+	path: "{{path}}",
+	{{#if @root.options.withAlias}}
+	{{#if alias}}
+	alias: "{{alias}}",
+	{{/if}}
+	{{/if}}
+	{{#if description}}
+	description: `{{description}}`,
+	{{/if}}
+	{{#if requestFormat}}
+	requestFormat: "{{requestFormat}}",
+	{{/if}}
+	{{#if parameters}}
+	parameters: [
+	{{#each parameters}}
+	{
+	name: "{{name}}",
+	{{#if description}}
+	description: `{{description}}`,
+	{{/if}}
+	{{#if type}}
+	type: "{{type}}",
+	{{/if}}
+	{{#if (and (eq type "Query") (eq schema "z.array(z.string()).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") :
+	undefined).pipe(z.array(z.string()).optional().default([])), z.array(z.string()).optional().default([])]),
+	{{else if (and (eq type "Query") (eq schema "z.array(z.string().uuid()).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") :
+	undefined).pipe(z.array(z.string().uuid()).optional().default([])),
+	z.array(z.string().uuid()).optional().default([])]),
+	{{else if (and (eq type "Query") (eq schema "z.array(AttributeKind)"))}}
+	schema: z.union([z.string().transform(v => v.split(",")).pipe(z.array(AttributeKind)), z.array(AttributeKind)])
+	{{else if (and (eq type "Query") (eq schema "z.array(AgreementState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(AgreementState).optional().default([])),z.array(AgreementState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(EServiceDescriptorState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(EServiceDescriptorState).optional().default([])),
+	z.array(EServiceDescriptorState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(PurposeVersionState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(PurposeVersionState).optional().default([])), z.array(PurposeVersionState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(DelegationState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(DelegationState).optional().default([])), z.array(DelegationState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(TenantFeatureType).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(TenantFeatureType).optional().default([])), z.array(TenantFeatureType).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(EServiceTemplateVersionState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(EServiceTemplateVersionState).optional().default([])),
+	z.array(EServiceTemplateVersionState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.array(PurposeTemplateState).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(PurposeTemplateState).optional().default([])), z.array(PurposeTemplateState).optional().default([])])
+	{{else if (and (eq type "Query") (eq schema "z.string().uuid().nullish()"))}}
+	schema: z.union([z.string().uuid(), z.null(), z.undefined()])
+	{{else if (and (eq type "Query") (eq schema "z.array(NotificationType).optional().default([])"))}}
+	schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined
+	).pipe(z.array(NotificationType).optional().default([])), z.array(NotificationType).optional().default([])])
+	{{else}}
+	schema: {{{schema}}},
+	{{/if}}
 	},
-{{/each}}
-]);
+	{{/each}}
+	],
+	{{/if}}
+	response: {{{response}}},
+	{{#if errors.length}}
+	errors: [
+	{{#each errors}}
+	{
+	{{#if (eq status "default") }}
+	status: "default",
+	{{else}}
+	status: {{status}},
+	{{/if}}
+	{{#if description}}
+	description: `{{description}}`,
+	{{/if}}
+	schema: {{{schema}}}
+	},
+	{{/each}}
+	]
+	{{/if}}
+	},
+	{{/each}}
+	]);
 
-export const {{@key}}Api = new Zodios({{#if options.baseUrl}}"{{options.baseUrl}}", {{/if}}{{@key}}Endpoints);
+	export const {{@key}}Api{{#if (and (eq @root.options.apiClientName "catalogApi") (eq @key "process"))}}:
+	ZodiosInstance<ZodiosEndpointDefinitions>{{/if}} = new Zodios({{#if options.baseUrl}}"{{options.baseUrl}}",
+		{{/if}}{{@key}}Endpoints);
 
-export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: ZodiosOptions) {
-		const zodiosClient = new Zodios(baseUrl, {{@key}}Endpoints, {
+		export function create{{pascalcase @key}}ApiClient(baseUrl: string, options?: ZodiosOptions){{#if (and (eq
+		@root.options.apiClientName "catalogApi") (eq @key "process"))}}: ZodiosInstance<ZodiosEndpointDefinitions>
+			{{/if}} {
+			const zodiosClient = new Zodios(baseUrl, {{@key}}Endpoints, {
 			...options,
 			validate: false,
 			axiosConfig: {
-				...options?.axiosConfig,
-				// This configuration is used to serialize correctly array query parameters.
-				// The default serialization produces a query param name appending "[]" after the equals:
-				// eg: ids[]=1,2,3 instead of ids=1,2,3
-				paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
+			...options?.axiosConfig,
+			// This configuration is used to serialize correctly array query parameters.
+			// The default serialization produces a query param name appending "[]" after the equals:
+			// eg: ids[]=1,2,3 instead of ids=1,2,3
+			paramsSerializer: (params) => qs.stringify(params, { arrayFormat: "comma" }),
 			},
-		});
+			});
 
-		configureAxiosLogInterceptors(
+			configureAxiosLogInterceptors(
 			zodiosClient.axios as AxiosInstance,
 			"{{pascalcase @root.options.apiClientName}} {{pascalcase @key}} Client"
-		);
-		return zodiosClient;
-}
+			);
+			return zodiosClient;
+			}
 
-{{/each}}
-
+			{{/each}}


### PR DESCRIPTION
La build di `pagopa-interop-api-clients` falliva con `TS7056` durante la compilazione di `src/generated/catalogApi.ts.` Il problema non era nella logica runtime del client, ma nella quantità di tipo che TypeScript era costretto a inferire e serializzare per alcuni export generati da Zodios, in particolare nel gruppo process del client Catalog.

Il file che andava in errore è generato, quindi la correzione è stata fatta a monte, nel generatore, e nel wrapper tipizzato del client Catalog.

Cosa cambia

In `template.hbs` viene importato `ZodiosInstance`e la factory generata riceve un tipo di ritorno esplicito `ZodiosInstance<typeof {{@key}}Endpoints>`
In questo modo non lasciamo più a TypeScript l’inferenza completa del tipo del client generato.
In `catalogApi.ts` il wrapper del Catalog smette di basarsi su `typeof catalogApi.processApi.api` e su `ReturnType<typeof catalogApi.createProcessApiClient>`, che costringevano il compilatore a materializzare tipi molto grandi. Al loro posto usa direttamente `typeof catalogApi.processEndpoints` e `ZodiosInstance<typeof catalogApi.processEndpoints>`.

Risultato:
La PR riduce la pressione sull’inferenza dei tipi nei client generati, elimina il TS7056 emerso sul client Catalog e rende più stabile la generazione dei client API in fase di build.