### PR TITLE
PIN-10284 Fix bulk attribute endpoint

### DIFF
--- a/packages/attribute-registry-process/src/routers/AttributeRouter.ts
+++ b/packages/attribute-registry-process/src/routers/AttributeRouter.ts
@@ -79,6 +79,8 @@ const attributeRouter = (
     M2M_ADMIN_ROLE,
     INTERNAL_ROLE,
     SUPPORT_ROLE,
+    REVIEWER_ROLE,
+    VIEWER_ROLE,
   } = authRole;
 
   attributeRouter
@@ -234,6 +236,8 @@ const attributeRouter = (
           SECURITY_ROLE,
           M2M_ROLE,
           M2M_ADMIN_ROLE,
+          REVIEWER_ROLE,
+          VIEWER_ROLE,
         ]);
 
         const attributes = await attributeRegistryService.getAttributesByIds(

--- a/packages/attribute-registry-process/test/api/getAttributesByIds.test.ts
+++ b/packages/attribute-registry-process/test/api/getAttributesByIds.test.ts
@@ -48,6 +48,8 @@ describe("API /bulk/attributes authorization test", () => {
     authRole.M2M_ROLE,
     authRole.SUPPORT_ROLE,
     authRole.M2M_ADMIN_ROLE,
+    authRole.REVIEWER_ROLE,
+    authRole.VIEWER_ROLE,
   ];
   it.each(authorizedRoles)(
     "Should return 200 for user with role %s",


### PR DESCRIPTION
This PR is for allowing viewer and reviewer in the endpoint to retrieve bulk attributes, which is required to get the tenant.