### PR TITLE
fix: return discrete certified attributes from BFF tenant endpoints (PIN-10309)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -29695,11 +29695,14 @@ components:
           format: uuid
         attributeName:
           type: string
+        kind:
+          $ref: "#/components/schemas/AttributeKind"
       required:
         - tenantId
         - tenantName
         - attributeId
         - attributeName
+        - kind
     RequesterCertifiedAttributes:
       type: object
       additionalProperties: false
@@ -29993,14 +29996,7 @@ components:
         certified:
           type: array
           items:
-            oneOf:
-              - $ref: "#/components/schemas/CertifiedTenantAttribute"
-              - $ref: "#/components/schemas/CertifiedDiscreteTenantAttribute"
-            discriminator:
-              propertyName: kind
-              mapping:
-                CERTIFIED: "#/components/schemas/CertifiedTenantAttribute"
-                CERTIFIED_DISCRETE: "#/components/schemas/CertifiedDiscreteTenantAttribute"
+            $ref: "#/components/schemas/CertifiedTenantAttribute"
         verified:
           type: array
           items:
@@ -30085,6 +30081,15 @@ components:
         - isDelegatedConsumerFeatureEnabled
         - isDelegatedProducerFeatureEnabled
     CertifiedTenantAttribute:
+      oneOf:
+        - $ref: "#/components/schemas/StandardCertifiedTenantAttribute"
+        - $ref: "#/components/schemas/CertifiedDiscreteTenantAttribute"
+      discriminator:
+        propertyName: kind
+        mapping:
+          CERTIFIED: "#/components/schemas/StandardCertifiedTenantAttribute"
+          CERTIFIED_DISCRETE: "#/components/schemas/CertifiedDiscreteTenantAttribute"
+    StandardCertifiedTenantAttribute:
       type: object
       additionalProperties: false
       properties:

--- a/packages/backend-for-frontend/src/api/tenantApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/tenantApiConverter.ts
@@ -101,6 +101,7 @@ export const toBffApiRequesterCertifiedAttributes = (
   tenantName: input.name,
   attributeId: input.attributeId,
   attributeName: input.attributeName,
+  kind: tenantAttributeKind.certified,
 });
 
 export type RegistryAttributesMap = Map<
@@ -185,12 +186,23 @@ const toBffApiVerifiedTenantAttribute = (
 };
 
 export function toBffApiCertifiedTenantAttributes(
-  certifiedAttributes: tenantApi.CertifiedTenantAttribute[],
+  certifiedAttributes: Array<
+    | tenantApi.CertifiedTenantAttribute
+    | tenantApi.CertifiedDiscreteTenantAttribute
+  >,
   registryAttributesMap: RegistryAttributesMap
-): bffApi.CertifiedTenantAttribute[] {
+): bffApi.CertifiedAttributesResponse["attributes"] {
   return certifiedAttributes
     .map((tenantAttribute) =>
-      toBffApiCertifiedTenantAttribute(tenantAttribute, registryAttributesMap)
+      "discreteValue" in tenantAttribute
+        ? toBffApiCertifiedDiscreteTenantAttribute(
+            tenantAttribute,
+            registryAttributesMap
+          )
+        : toBffApiCertifiedTenantAttribute(
+            tenantAttribute,
+            registryAttributesMap
+          )
     )
     .filter(isDefined);
 }

--- a/packages/backend-for-frontend/src/api/tenantApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/tenantApiConverter.ts
@@ -241,26 +241,6 @@ export function toBffApiTenant(
       attribute.certifiedDiscrete ? [attribute.certifiedDiscrete] : []
     );
 
-  const toBffApiMergedCertifiedTenantAttributes =
-    (): bffApi.TenantAttributes["certified"] => {
-      const certifiedDiscrete = certifiedDiscreteAttributes
-        .map((tenantAttribute) =>
-          toBffApiCertifiedDiscreteTenantAttribute(
-            tenantAttribute,
-            registryAttributesMap
-          )
-        )
-        .filter(isDefined);
-
-      return [
-        ...toBffApiCertifiedTenantAttributes(
-          certifiedAttributes,
-          registryAttributesMap
-        ),
-        ...certifiedDiscrete,
-      ];
-    };
-
   return {
     id: tenant.id,
     selfcareId: tenant.selfcareId,
@@ -276,7 +256,10 @@ export function toBffApiTenant(
     selfcareInstitutionType: tenant.selfcareInstitutionType,
     contactMail: getLatestTenantContactEmail(tenant),
     attributes: {
-      certified: toBffApiMergedCertifiedTenantAttributes(),
+      certified: toBffApiCertifiedTenantAttributes(
+        [...certifiedAttributes, ...certifiedDiscreteAttributes],
+        registryAttributesMap
+      ),
       declared: toBffApiDeclaredTenantAttributes(
         declaredAttributes,
         registryAttributesMap

--- a/packages/backend-for-frontend/src/services/tenantService.ts
+++ b/packages/backend-for-frontend/src/services/tenantService.ts
@@ -258,15 +258,20 @@ export function tenantServiceBuilder(
       const certifiedAttributes = tenant.attributes
         .map((v) => v.certified)
         .filter(isDefined);
+      const certifiedDiscreteAttributes = tenant.attributes
+        .map((v) => v.certifiedDiscrete)
+        .filter(isDefined);
 
       const registryAttributesMap = await getRegistryAttributesMap(
-        certifiedAttributes.map((v) => v.id),
+        [...certifiedAttributes, ...certifiedDiscreteAttributes].map(
+          (v) => v.id
+        ),
         attributeRegistryProcessClient,
         headers
       );
 
       const attributes = toBffApiCertifiedTenantAttributes(
-        certifiedAttributes,
+        [...certifiedAttributes, ...certifiedDiscreteAttributes],
         registryAttributesMap
       );
 

--- a/packages/backend-for-frontend/test/mockUtils.ts
+++ b/packages/backend-for-frontend/test/mockUtils.ts
@@ -914,14 +914,31 @@ export const getMockBffApiCertifiedAttributesResponse =
   (): bffApi.CertifiedAttributesResponse => ({
     attributes: generateMock(
       z.array(
-        z.object({
-          kind: z.literal(tenantAttributeKind.certified),
-          id: z.string().uuid(),
-          name: z.string(),
-          description: z.string(),
-          assignmentTimestamp: z.string().datetime({ offset: true }),
-          revocationTimestamp: z.string().datetime({ offset: true }).optional(),
-        })
+        z.union([
+          z.object({
+            kind: z.literal(tenantAttributeKind.certified),
+            id: z.string().uuid(),
+            name: z.string(),
+            description: z.string(),
+            assignmentTimestamp: z.string().datetime({ offset: true }),
+            revocationTimestamp: z
+              .string()
+              .datetime({ offset: true })
+              .optional(),
+          }),
+          z.object({
+            kind: z.literal(tenantAttributeKind.certifiedDiscrete),
+            id: z.string().uuid(),
+            name: z.string(),
+            description: z.string(),
+            assignmentTimestamp: z.string().datetime({ offset: true }),
+            revocationTimestamp: z
+              .string()
+              .datetime({ offset: true })
+              .optional(),
+            discreteValue: z.number().int().gte(1).lte(1000000000),
+          }),
+        ])
       )
     ),
   });
@@ -932,6 +949,7 @@ export const getMockBffApiRequesterCertifiedAttribute =
     tenantName: generateMock(z.string()),
     attributeId: generateId(),
     attributeName: generateMock(z.string()),
+    kind: tenantAttributeKind.certified,
   });
 
 export const getMockBffApiCompactOrganization =

--- a/packages/backend-for-frontend/test/tenantService.test.ts
+++ b/packages/backend-for-frontend/test/tenantService.test.ts
@@ -3,11 +3,18 @@ import {
   getMockedApiAttribute,
   getMockedApiTenant,
 } from "pagopa-interop-commons-test";
-import { attributeRegistryApi, tenantApi } from "pagopa-interop-api-clients";
+import {
+  attributeRegistryApi,
+  bffApi,
+  tenantApi,
+} from "pagopa-interop-api-clients";
 import { AttributeId, TenantId, generateId } from "pagopa-interop-models";
 import { describe, expect, it, vi } from "vitest";
 import { tenantServiceBuilder } from "../src/services/tenantService.js";
-import { tenantAttributeKind } from "../src/api/tenantApiConverter.js";
+import {
+  tenantAttributeKind,
+  toBffApiRequesterCertifiedAttributes,
+} from "../src/api/tenantApiConverter.js";
 import { BffAppContext } from "../src/utilities/context.js";
 
 describe("tenantServiceBuilder.getTenant", () => {
@@ -271,5 +278,115 @@ describe("tenantServiceBuilder.getTenant", () => {
         revokedBy: [],
       },
     ]);
+  });
+});
+
+describe("tenantServiceBuilder.getCertifiedAttributes", () => {
+  it("should return certified and certified discrete attributes with their kind discriminator", async () => {
+    const tenantId = generateId<TenantId>();
+    const certifiedAttributeId = generateId<AttributeId>();
+    const certifiedDiscreteAttributeId = generateId<AttributeId>();
+    const assignmentTimestamp = new Date().toISOString();
+
+    const tenant: tenantApi.Tenant = {
+      ...getMockedApiTenant({
+        attributes: [
+          {
+            certified: {
+              id: certifiedAttributeId,
+              assignmentTimestamp,
+            },
+          },
+          {
+            certifiedDiscrete: {
+              id: certifiedDiscreteAttributeId,
+              assignmentTimestamp,
+              discreteValue: 42,
+            },
+          },
+        ],
+      }),
+      id: tenantId,
+      mails: [],
+      features: [],
+    };
+
+    const registryCertifiedAttribute: attributeRegistryApi.Attribute = {
+      ...getMockedApiAttribute({
+        kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED,
+      }),
+      id: certifiedAttributeId,
+    };
+    const registryCertifiedDiscreteAttribute: attributeRegistryApi.Attribute = {
+      ...getMockedApiAttribute({
+        kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+      }),
+      id: certifiedDiscreteAttributeId,
+    };
+
+    const service = tenantServiceBuilder(
+      {
+        tenant: {
+          getTenant: vi.fn().mockResolvedValue(tenant),
+        },
+      } as never,
+      {
+        getBulkedAttributes: vi.fn().mockResolvedValue({
+          results: [
+            registryCertifiedAttribute,
+            registryCertifiedDiscreteAttribute,
+          ],
+          totalCount: 2,
+        }),
+      } as never,
+      {} as never
+    );
+
+    const ctx = {
+      authData: { organizationId: tenantId },
+      headers: {
+        "X-Correlation-Id": generateId(),
+        Authorization: "authorization",
+        "X-Forwarded-For": "x-forwarded-for",
+      },
+      logger: genericLogger,
+    } as WithLogger<BffAppContext>;
+
+    const result = await service.getCertifiedAttributes(tenantId, ctx);
+    bffApi.CertifiedAttributesResponse.parse(result);
+
+    expect(result.attributes).toStrictEqual([
+      expect.objectContaining({
+        id: certifiedAttributeId,
+        kind: tenantAttributeKind.certified,
+      }),
+      expect.objectContaining({
+        id: certifiedDiscreteAttributeId,
+        kind: tenantAttributeKind.certifiedDiscrete,
+        discreteValue: 42,
+      }),
+    ]);
+  });
+});
+
+describe("toBffApiRequesterCertifiedAttributes", () => {
+  it("should add the certified kind discriminator", () => {
+    const input: tenantApi.CertifiedAttribute = {
+      id: generateId(),
+      name: "tenant",
+      attributeId: generateId(),
+      attributeName: "attribute",
+    };
+
+    const result = toBffApiRequesterCertifiedAttributes(input);
+    bffApi.RequesterCertifiedAttribute.parse(result);
+
+    expect(result).toStrictEqual({
+      tenantId: input.id,
+      tenantName: input.name,
+      attributeId: input.attributeId,
+      attributeName: input.attributeName,
+      kind: tenantAttributeKind.certified,
+    });
   });
 });


### PR DESCRIPTION
## Jira Issue
[PIN-10309](https://pagopa.atlassian.net/browse/PIN-10309)

## Context
- BFF tenant endpoints returning certified attributes did not consistently include certified discrete attributes and the attribute kind discriminator.

## Services Affected
- `backend-for-frontend`
- BFF OpenAPI contract in `api-clients`

## Key Changes
- Reuse a single discriminated BFF certified tenant attribute response for standard and discrete certified attributes.
- Aggregate certified and certified discrete tenant attributes only in the BFF tenant service.
- Return the existing `kind` discriminator from the BFF tenant attribute mappers.
- Add regression coverage for both certified attribute types and the discriminator.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [x] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)


[PIN-10309]: https://pagopa.atlassian.net/browse/PIN-10309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ