### PR TITLE
fix: block archiving of e-services with active or pending producer delegations (PIN-10320) 

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1247,6 +1247,12 @@ export function catalogServiceBuilder(
     ): Promise<WithMetadata<EService>> {
       logger.info(`Archiving EService ${eserviceId}`);
       const eservice = await retrieveEService(eserviceId, readModelService);
+
+      await assertNoExistingProducerDelegationInActiveOrPendingState(
+        eserviceId,
+        readModelService
+      );
+
       assertRequesterIsProducer(eservice.data.producerId, authData);
 
       assertEServiceArchivable(eservice.data);
@@ -2447,6 +2453,11 @@ export function catalogServiceBuilder(
     ): Promise<WithMetadata<EService>> {
       const eservice = await retrieveEService(eserviceId, readModelService);
       const descriptor = retrieveDescriptor(descriptorId, eservice);
+
+      await assertNoExistingProducerDelegationInActiveOrPendingState(
+        eserviceId,
+        readModelService
+      );
 
       assertRequesterIsProducer(eservice.data.producerId, authData);
 

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -1248,12 +1248,12 @@ export function catalogServiceBuilder(
       logger.info(`Archiving EService ${eserviceId}`);
       const eservice = await retrieveEService(eserviceId, readModelService);
 
+      assertRequesterIsProducer(eservice.data.producerId, authData);
+
       await assertNoExistingProducerDelegationInActiveOrPendingState(
         eserviceId,
         readModelService
       );
-
-      assertRequesterIsProducer(eservice.data.producerId, authData);
 
       assertEServiceArchivable(eservice.data);
 
@@ -2454,12 +2454,12 @@ export function catalogServiceBuilder(
       const eservice = await retrieveEService(eserviceId, readModelService);
       const descriptor = retrieveDescriptor(descriptorId, eservice);
 
+      assertRequesterIsProducer(eservice.data.producerId, authData);
+
       await assertNoExistingProducerDelegationInActiveOrPendingState(
         eserviceId,
         readModelService
       );
-
-      assertRequesterIsProducer(eservice.data.producerId, authData);
 
       assertDescriptorArchivable(descriptor, eservice.data);
 

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -781,6 +781,7 @@ export const updateEserviceDescriptorArchivingStatusErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)
+    .with("eserviceWithActiveOrPendingDelegation", () => HTTP_STATUS_CONFLICT)
     .with(
       "eServiceNotFound",
       "eServiceDescriptorNotFound",
@@ -799,6 +800,7 @@ export const updateEServiceArchivingStatusErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)
+    .with("eserviceWithActiveOrPendingDelegation", () => HTTP_STATUS_CONFLICT)
     .with("eServiceNotFound", () => HTTP_STATUS_NOT_FOUND)
     .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
     .with(

--- a/packages/catalog-process/test/integration/scheduleArchivingDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/scheduleArchivingDescriptor.test.ts
@@ -339,7 +339,7 @@ describe("schedule archiving of a descriptor", () => {
     await addOneEService(eservice);
     await addOneDelegation(delegation);
 
-    expect(
+    await expect(
       catalogService.scheduleEServiceDescriptorArchiving(
         eservice.id,
         descriptor.id,

--- a/packages/catalog-process/test/integration/scheduleArchivingDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/scheduleArchivingDescriptor.test.ts
@@ -4,6 +4,7 @@ import {
   decodeProtobufPayload,
   getMockContext,
   getMockAuthData,
+  getMockDelegation,
   getMockEService,
   getMockDescriptor,
   getMockDocument,
@@ -12,6 +13,8 @@ import {
 import {
   Descriptor,
   descriptorState,
+  delegationKind,
+  delegationState,
   EService,
   toEServiceV2,
   operationForbidden,
@@ -24,9 +27,11 @@ import { expect, describe, it, vi } from "vitest";
 import {
   eServiceNotFound,
   eServiceDescriptorNotFound,
+  eserviceWithActiveOrPendingDelegation,
   notValidDescriptorState,
 } from "../../src/model/domain/errors.js";
 import {
+  addOneDelegation,
   addOneEService,
   catalogService,
   readLastEserviceEvent,
@@ -314,6 +319,37 @@ describe("schedule archiving of a descriptor", () => {
         getMockContext({})
       )
     ).rejects.toThrowError(operationForbidden);
+  });
+
+  it("should throw eserviceWithActiveOrPendingDelegation if there is an active producer delegation", async () => {
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.deprecated,
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    const delegation = getMockDelegation({
+      kind: delegationKind.delegatedProducer,
+      eserviceId: eservice.id,
+      state: delegationState.active,
+    });
+
+    await addOneEService(eservice);
+    await addOneDelegation(delegation);
+
+    expect(
+      catalogService.scheduleEServiceDescriptorArchiving(
+        eservice.id,
+        descriptor.id,
+        getMockContext({
+          authData: getMockAuthData(eservice.producerId),
+        })
+      )
+    ).rejects.toThrowError(
+      eserviceWithActiveOrPendingDelegation(eservice.id, delegation.id)
+    );
   });
 
   it("should throw eServiceDescriptorNotFound if the descriptor doesn't exist", async () => {

--- a/packages/catalog-process/test/integration/scheduleArchivingEService.test.ts
+++ b/packages/catalog-process/test/integration/scheduleArchivingEService.test.ts
@@ -485,7 +485,7 @@ describe("schedule archiving of an EService", () => {
     await addOneEService(eservice);
     await addOneDelegation(delegation);
 
-    expect(
+    await expect(
       catalogService.scheduleEServiceArchiving(
         eservice.id,
         { archivingReason: mockArchivingReason },

--- a/packages/catalog-process/test/integration/scheduleArchivingEService.test.ts
+++ b/packages/catalog-process/test/integration/scheduleArchivingEService.test.ts
@@ -4,6 +4,7 @@ import {
   decodeProtobufPayload,
   getMockContext,
   getMockAuthData,
+  getMockDelegation,
   getMockEService,
   getMockDescriptor,
   getMockDocument,
@@ -12,6 +13,8 @@ import {
 import {
   Descriptor,
   descriptorState,
+  delegationKind,
+  delegationState,
   EService,
   toEServiceV2,
   operationForbidden,
@@ -21,9 +24,11 @@ import {
 import { expect, describe, it } from "vitest";
 import {
   eServiceNotFound,
+  eserviceWithActiveOrPendingDelegation,
   notValidEServiceState,
 } from "../../src/model/domain/errors.js";
 import {
+  addOneDelegation,
   addOneEService,
   catalogService,
   readLastEserviceEvent,
@@ -460,5 +465,36 @@ describe("schedule archiving of an EService", () => {
         getMockContext({})
       )
     ).rejects.toThrowError(operationForbidden);
+  });
+
+  it("should throw eserviceWithActiveOrPendingDelegation if there is an active producer delegation", async () => {
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    const delegation = getMockDelegation({
+      kind: delegationKind.delegatedProducer,
+      eserviceId: eservice.id,
+      state: delegationState.active,
+    });
+
+    await addOneEService(eservice);
+    await addOneDelegation(delegation);
+
+    expect(
+      catalogService.scheduleEServiceArchiving(
+        eservice.id,
+        { archivingReason: mockArchivingReason },
+        getMockContext({
+          authData: getMockAuthData(eservice.producerId),
+        })
+      )
+    ).rejects.toThrowError(
+      eserviceWithActiveOrPendingDelegation(eservice.id, delegation.id)
+    );
   });
 });


### PR DESCRIPTION
## Issue
- [PIN-10320](https://pagopa.atlassian.net/browse/PIN-10320)
- [SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2803302507/DRAFT+SRS+Archiviazione+manuale+e-service)

## Context

Adds a assert to prevent archiving e-services or their descriptors when an active or pending producer delegation exists.

## Scope
- `catalog-process`

[PIN-10320]: https://pagopa.atlassian.net/browse/PIN-10320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

