### PR TITLE
(fix): Retrieving tenant by remoteIds to ISTAT importer (PIN-10325)

### DIFF
--- a/packages/istat-certified-attributes-importer/src/model/istatModel.ts
+++ b/packages/istat-certified-attributes-importer/src/model/istatModel.ts
@@ -6,6 +6,7 @@ export type JobStats = {
   created: number;
   updated: number;
   revoked: number;
+  skipped: number;
   errors: number;
 };
 

--- a/packages/istat-certified-attributes-importer/src/service/processor.ts
+++ b/packages/istat-certified-attributes-importer/src/service/processor.ts
@@ -68,6 +68,10 @@ export async function importAttributes(
   );
   const entries = Array.from(populationByMunicipality.entries());
   const chunks = sliceIntoChunks(entries, csvChunkSize);
+  logger.info("Pre-fetching valid ISTAT tenants from database...");
+  const validIstatCodesArray = await readModel.getAllIstatRemoteIds();
+  const validIstatCodes = new Set(validIstatCodesArray);
+  logger.info(`Found ${validIstatCodes.size} valid ISTAT tenants.`);
 
   for (const chunk of chunks) {
     await Promise.all(
@@ -81,14 +85,9 @@ export async function importAttributes(
           };
 
           try {
-            const tenant = await readModel.getTenantByRemoteId({
-              origin: ISTAT_ATTRIBUTE_SEED.origin,
-              value: municipalityCode,
-            });
-
-            if (!tenant) {
+            if (!validIstatCodes.has(municipalityCode)) {
               logger.debug(
-                `Tenant with remoteId: ${municipalityCode} not found. Skipping.`
+                `Tenant with remoteId: ${municipalityCode} not found in DB. Skipping.`
               );
               stats.skipped++;
               return;

--- a/packages/istat-certified-attributes-importer/src/service/processor.ts
+++ b/packages/istat-certified-attributes-importer/src/service/processor.ts
@@ -74,16 +74,15 @@ export async function importAttributes(
   logger.info(`Found ${validIstatCodes.size} valid ISTAT tenants.`);
 
   for (const chunk of chunks) {
+    const token = await refreshableToken.get();
+    const context: InteropContext = {
+      correlationId,
+      bearerToken: token.serialized,
+    };
     await Promise.all(
       chunk.map(async ([municipalityCode, totalCount]) => {
         stats.processed++;
         try {
-          const token = await refreshableToken.get();
-          const context: InteropContext = {
-            correlationId,
-            bearerToken: token.serialized,
-          };
-
           try {
             if (!validIstatCodes.has(municipalityCode)) {
               logger.debug(

--- a/packages/istat-certified-attributes-importer/src/service/processor.ts
+++ b/packages/istat-certified-attributes-importer/src/service/processor.ts
@@ -45,6 +45,7 @@ export async function importAttributes(
     processed: 0,
     created: 0,
     updated: 0,
+    skipped: 0,
     revoked: 0,
     errors: 0,
   };
@@ -80,6 +81,18 @@ export async function importAttributes(
           };
 
           try {
+            const tenant = await readModel.getTenantByRemoteId({
+              origin: ISTAT_ATTRIBUTE_SEED.origin,
+              value: municipalityCode,
+            });
+
+            if (!tenant) {
+              logger.debug(
+                `Tenant with remoteId: ${municipalityCode} not found. Skipping.`
+              );
+              stats.skipped++;
+              return;
+            }
             await tenantProcess.internalAssignCertifiedDiscreteAttribute(
               ISTAT_ATTRIBUTE_SEED.origin,
               municipalityCode,
@@ -132,7 +145,7 @@ export async function importAttributes(
   );
 
   logger.info(
-    `Process complete. Processed: ${stats.processed}, Success: ${stats.created}, Updated: ${stats.updated}, Revoked: ${stats.revoked}, Error: ${stats.errors}`
+    `Process complete. Processed: ${stats.processed}, Success: ${stats.created}, Updated: ${stats.updated}, Skipped: ${stats.skipped}, Revoked: ${stats.revoked}, Error: ${stats.errors}`
   );
 }
 

--- a/packages/istat-certified-attributes-importer/src/service/readModelServiceSQL.ts
+++ b/packages/istat-certified-attributes-importer/src/service/readModelServiceSQL.ts
@@ -96,26 +96,13 @@ export function readModelQueriesBuilderSQL(
       );
     },
 
-    async getTenantByRemoteId(remoteId: {
-      origin: string;
-      value: string;
-    }): Promise<WithMetadata<Tenant> | undefined> {
-      const tenantSQL = await readModelDB
-        .select()
+    async getAllIstatRemoteIds(): Promise<string[]> {
+      const records = await readModelDB
+        .select({ value: tenantRemoteIdInReadmodelTenant.value })
         .from(tenantRemoteIdInReadmodelTenant)
-        .where(
-          and(
-            eq(tenantRemoteIdInReadmodelTenant.origin, remoteId.origin),
-            eq(tenantRemoteIdInReadmodelTenant.value, remoteId.value)
-          )
-        );
+        .where(eq(tenantRemoteIdInReadmodelTenant.origin, "ISTAT"));
 
-      if (tenantSQL.length === 0) {
-        return undefined;
-      }
-      return await tenantReadModelService.getTenantById(
-        unsafeBrandId(tenantSQL[0].tenantId)
-      );
+      return records.map((r) => r.value);
     },
   };
 }

--- a/packages/istat-certified-attributes-importer/src/service/readModelServiceSQL.ts
+++ b/packages/istat-certified-attributes-importer/src/service/readModelServiceSQL.ts
@@ -13,7 +13,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import {
   attributeInReadmodelAttribute,
   DrizzleReturnType,
-  tenantCertifiedAttributeInReadmodelTenant,
+  tenantCertifiedDiscreteAttributeInReadmodelTenant,
   tenantInReadmodelTenant,
   tenantRemoteIdInReadmodelTenant,
 } from "pagopa-interop-readmodel-models";
@@ -55,23 +55,23 @@ export function readModelQueriesBuilderSQL(
         .selectDistinct({ id: tenantInReadmodelTenant.id })
         .from(tenantInReadmodelTenant)
         .innerJoin(
-          tenantCertifiedAttributeInReadmodelTenant,
+          tenantCertifiedDiscreteAttributeInReadmodelTenant,
           eq(
             tenantInReadmodelTenant.id,
-            tenantCertifiedAttributeInReadmodelTenant.tenantId
+            tenantCertifiedDiscreteAttributeInReadmodelTenant.tenantId
           )
         )
         .innerJoin(
           attributeInReadmodelAttribute,
           and(
             eq(
-              tenantCertifiedAttributeInReadmodelTenant.attributeId,
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.attributeId,
               attributeInReadmodelAttribute.id
             ),
             eq(attributeInReadmodelAttribute.origin, certifierId),
             eq(attributeInReadmodelAttribute.code, attributeCode),
             isNull(
-              tenantCertifiedAttributeInReadmodelTenant.revocationTimestamp
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.revocationTimestamp
             )
           )
         );

--- a/packages/istat-certified-attributes-importer/src/service/readModelServiceSQL.ts
+++ b/packages/istat-certified-attributes-importer/src/service/readModelServiceSQL.ts
@@ -15,6 +15,7 @@ import {
   DrizzleReturnType,
   tenantCertifiedAttributeInReadmodelTenant,
   tenantInReadmodelTenant,
+  tenantRemoteIdInReadmodelTenant,
 } from "pagopa-interop-readmodel-models";
 import { IstatReadModelTenant } from "../model/istatModel.js";
 
@@ -92,6 +93,28 @@ export function readModelQueriesBuilderSQL(
     ): Promise<WithMetadata<Tenant> | undefined> {
       return tenantReadModelService.getTenantById(
         unsafeBrandId<TenantId>(tenantId)
+      );
+    },
+
+    async getTenantByRemoteId(remoteId: {
+      origin: string;
+      value: string;
+    }): Promise<WithMetadata<Tenant> | undefined> {
+      const tenantSQL = await readModelDB
+        .select()
+        .from(tenantRemoteIdInReadmodelTenant)
+        .where(
+          and(
+            eq(tenantRemoteIdInReadmodelTenant.origin, remoteId.origin),
+            eq(tenantRemoteIdInReadmodelTenant.value, remoteId.value)
+          )
+        );
+
+      if (tenantSQL.length === 0) {
+        return undefined;
+      }
+      return await tenantReadModelService.getTenantById(
+        unsafeBrandId(tenantSQL[0].tenantId)
       );
     },
   };

--- a/packages/istat-certified-attributes-importer/test/processor.test.ts
+++ b/packages/istat-certified-attributes-importer/test/processor.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import {
   Tenant,
   TenantId,
@@ -42,6 +42,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     getAttributeByExternalId: vi.fn(),
     getTenantsWithDiscreteAttribute: vi.fn(),
     getTenantByIdWithMetadata: vi.fn(),
+    getTenantByRemoteId: vi.fn(),
   } as any;
 
   const refreshableTokenMock = {
@@ -49,6 +50,12 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
   } as any;
 
   const csvChunkSize = 100;
+
+  beforeEach(() => {
+    readModelQueriesMock.getTenantByRemoteId.mockResolvedValue({
+      data: { id: generateId() },
+    });
+  });
 
   afterEach(() => {
     vi.clearAllMocks();
@@ -64,6 +71,42 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     };
 
     await addOneAttribute(persistentAttribute);
+    const t1: Tenant = {
+      id: unsafeBrandId<TenantId>(generateId()),
+      externalId: { origin: "ISTAT", value: "015146" },
+      name: "Comune 015146",
+      attributes: [],
+      features: [],
+      createdAt: new Date(),
+      mails: [],
+      remoteIds: [
+        { origin: "ISTAT", value: "015146", assignmentTimestamp: new Date() },
+      ],
+    };
+    const t2: Tenant = {
+      id: unsafeBrandId<TenantId>(generateId()),
+      externalId: { origin: "ISTAT", value: "090001" },
+      name: "Comune 090001",
+      attributes: [],
+      features: [],
+      createdAt: new Date(),
+      mails: [],
+      remoteIds: [
+        { origin: "ISTAT", value: "090001", assignmentTimestamp: new Date() },
+      ],
+    };
+    const t3: Tenant = {
+      id: unsafeBrandId<TenantId>(generateId()),
+      externalId: { origin: "ISTAT", value: "028001" },
+      name: "Comune 028001",
+      attributes: [],
+      features: [],
+      createdAt: new Date(),
+      mails: [],
+      remoteIds: [
+        { origin: "ISTAT", value: "028001", assignmentTimestamp: new Date() },
+      ],
+    };
 
     const obsoleteTenantId = generateId();
     const obsoleteTenant: Tenant = {
@@ -97,7 +140,9 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     await cleanup();
     await addOneAttribute(persistentAttribute);
     await addOneTenant(obsoleteTenantWithAttribute);
-
+    await addOneTenant(t1);
+    await addOneTenant(t2);
+    await addOneTenant(t3);
     await importAttributes(
       istatClientMock as any,
       readModelService,
@@ -367,6 +412,84 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything()
     );
   });
+  it("should skip assignment if the tenant is not found in the read model", async () => {
+    const debugSpy = vi.spyOn(genericLogger, "debug");
+    const infoSpy = vi.spyOn(genericLogger, "info");
+    readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
+      data: { id: generateId() },
+      metadata: { version: 1 },
+    });
+    readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValue([]);
+
+    readModelQueriesMock.getTenantByRemoteId.mockImplementation(
+      async (remoteId: { value: string }) => {
+        if (remoteId.value === "001001") {
+          return { data: { id: "tenant-id-1" } };
+        }
+        return undefined;
+      }
+    );
+
+    tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
+      internalAssignCertifiedDiscreteAttributeMock
+    );
+
+    const csvContent = `"Popolazione residente per età e sesso"
+    "Codice comune";"Comune";"Età";"Totale maschi";"Totale femmine";"Totale"
+    "001001";"Trapani";999;50;50;100
+    "001002";"Roma";999;200;200;400`;
+
+    istatClientMock.downloadNationalDataset.mockResolvedValueOnce(csvContent);
+
+    await importAttributes(
+      istatClientMock as any,
+      readModelQueriesMock as any,
+      tenantProcessMock as any,
+      attributeProcessMock as any,
+      refreshableTokenMock,
+      { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
+      csvChunkSize,
+      genericLogger,
+      generateId()
+    );
+
+    expect(
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+    ).toHaveBeenCalledTimes(1);
+
+    expect(
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+    ).toHaveBeenCalledWith(
+      ISTAT_ATTRIBUTE_SEED.origin,
+      "001001",
+      expect.anything(),
+      expect.anything(),
+      100,
+      expect.anything(),
+      expect.anything()
+    );
+
+    expect(
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+    ).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "001002",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Tenant with remoteId: 001002 not found. Skipping."
+    );
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Process complete. Processed: 2, Success: 1, Updated: 0, Skipped: 1, Revoked: 0, Error: 0"
+      )
+    );
+  });
   it("should revoke attribute for municipalities not in CSV", async () => {
     readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
       data: { id: generateId() },
@@ -414,7 +537,6 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything()
     );
   });
-
   it("should throw a timeout error if attribute polling max retries are reached", async () => {
     readModelQueriesMock.getAttributeByExternalId.mockResolvedValue(undefined);
 
@@ -436,7 +558,6 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).not.toHaveBeenCalled();
   });
-
   it("should continue processing other municipalities if one assignment fails", async () => {
     readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
       data: { id: generateId() },
@@ -464,7 +585,6 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledTimes(8);
   });
-
   it("should revoke a tenant if it possesses the attribute but lacks a valid ISTAT remoteId", async () => {
     readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
       data: { id: generateId() },
@@ -512,7 +632,6 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything()
     );
   });
-
   it("should continue revoking other tenants if one revocation fails", async () => {
     readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
       data: { id: generateId() },

--- a/packages/istat-certified-attributes-importer/test/processor.test.ts
+++ b/packages/istat-certified-attributes-importer/test/processor.test.ts
@@ -136,8 +136,9 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       attributes: [
         {
           id: persistentAttribute.id,
-          type: "PersistentCertifiedAttribute",
+          type: "PersistentCertifiedDiscreteAttribute",
           assignmentTimestamp: new Date(),
+          discreteValue: 100,
         } as any,
       ],
     };

--- a/packages/istat-certified-attributes-importer/test/processor.test.ts
+++ b/packages/istat-certified-attributes-importer/test/processor.test.ts
@@ -42,7 +42,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     getAttributeByExternalId: vi.fn(),
     getTenantsWithDiscreteAttribute: vi.fn(),
     getTenantByIdWithMetadata: vi.fn(),
-    getTenantByRemoteId: vi.fn(),
+    getAllIstatRemoteIds: vi.fn(),
   } as any;
 
   const refreshableTokenMock = {
@@ -52,9 +52,13 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
   const csvChunkSize = 100;
 
   beforeEach(() => {
-    readModelQueriesMock.getTenantByRemoteId.mockResolvedValue({
-      data: { id: generateId() },
-    });
+    readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue([
+      "015146",
+      "090001",
+      "028001",
+      "001001",
+      "001002",
+    ]);
   });
 
   afterEach(() => {
@@ -318,7 +322,10 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
       internalAssignCertifiedDiscreteAttributeMock
     );
-
+    const fakeIds = Array.from({ length: 1200 }, (_, i) =>
+      String(i).padStart(6, "0")
+    );
+    readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue(fakeIds);
     const largePopulationMap = new Map<string, number>();
     for (let i = 0; i < 1200; i++) {
       largePopulationMap.set(`COMUNE_${i}`, 1000 + i);
@@ -421,14 +428,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     });
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValue([]);
 
-    readModelQueriesMock.getTenantByRemoteId.mockImplementation(
-      async (remoteId: { value: string }) => {
-        if (remoteId.value === "001001") {
-          return { data: { id: "tenant-id-1" } };
-        }
-        return undefined;
-      }
-    );
+    readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue(["001001"]);
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
       internalAssignCertifiedDiscreteAttributeMock
@@ -481,7 +481,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything()
     );
     expect(debugSpy).toHaveBeenCalledWith(
-      "Tenant with remoteId: 001002 not found. Skipping."
+      "Tenant with remoteId: 001002 not found in DB. Skipping."
     );
 
     expect(infoSpy).toHaveBeenCalledWith(
@@ -569,6 +569,16 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       .mockRejectedValueOnce(new Error("Internal Server Error on API"))
       .mockImplementation(internalAssignCertifiedDiscreteAttributeMock);
 
+    readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue([
+      "028001",
+      "001002",
+      "003003",
+      "004004",
+      "015146",
+      "102050",
+      "090001",
+      "048017",
+    ]);
     await importAttributes(
       istatClientMock as any,
       readModelQueriesMock as any,


### PR DESCRIPTION
## Jira Issue
[PIN-10325](https://pagopa.atlassian.net/browse/PIN-10325)

## Context
The `istat-certified-discrete-attributes-importer` was causing database connection pool exhaustion and `500 Internal Server Error` / `ECONNREFUSED` crashes on `tenant-process`. This occurred because the job attempted to process all 80,000 municipalities from the ISTAT CSV, triggering massive 404 errors on the `remoteId` field for municipalities without remoteIds

## Services Affected
- `istat-certified-discrete-attributes-importer`

## Key Changes
- **Loading tenant by remoteId** Added a bulk read-model query (`getAllIstatRemoteIds`) at the start of the job to load all valid ISTAT `remoteId`s into an in-memory `Set`.
- **Test Suite Update:** Updated Unit and Integration test to validate the new skip/early-exit logic and the updated read-model queries.

## Traceability Checklist
- [X] Branch name contain the Jira key
- [X] PR title is compliant with the standard (type(scope): descrizione (KEY))
- [X] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated

[PIN-10325]: https://pagopa.atlassian.net/browse/PIN-10325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ