### PR TITLE
fix: return 400 for template instance discrete config updates (PIN-10333)

### DIFF
--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -820,12 +820,14 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
         - name: descriptorId
           in: path
           description: The Descriptor Id
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
         description: An E-Service Descriptor seed
         content:

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -256,6 +256,7 @@ export const updateDraftDescriptorTemplateInstanceErrorMapper = (
       "attributeNotFound",
       "eServiceNotAnInstance",
       "attributeDiscreteConfigNotAllowed",
+      "templateInstanceNotAllowed",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -738,6 +739,7 @@ export const updateTemplateInstanceDescriptorErrorMapper = (
       "inconsistentDailyCalls",
       "attributeDailyCallsNotAllowed",
       "attributeDiscreteConfigNotAllowed",
+      "templateInstanceNotAllowed",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/catalog-process/test/api/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/catalog-process/test/api/updateDraftDescriptorTemplateInstance.test.ts
@@ -27,6 +27,7 @@ import {
   eServiceNotFound,
   inconsistentDailyCalls,
   notValidDescriptorState,
+  templateInstanceNotAllowed,
 } from "../../src/model/domain/errors.js";
 
 describe("API /templates/eservices/{eServiceId}/descriptors/{descriptorId} authorization test", () => {
@@ -114,6 +115,14 @@ describe("API /templates/eservices/{eServiceId}/descriptors/{descriptorId} autho
     },
     {
       error: attributeNotFound(generateId()),
+      expectedStatus: 400,
+    },
+    {
+      error: templateInstanceNotAllowed(
+        mockEService.id,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        mockEService.templateId!
+      ),
       expectedStatus: 400,
     },
     {

--- a/packages/catalog-process/test/api/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/catalog-process/test/api/updateDraftDescriptorTemplateInstance.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import request from "supertest";
 import {
   Descriptor,
@@ -54,9 +54,11 @@ describe("API /templates/eservices/{eServiceId}/descriptors/{descriptorId} autho
       agreementApprovalPolicy: "AUTOMATIC",
     };
 
-  catalogService.updateDraftDescriptorTemplateInstance = vi
-    .fn()
-    .mockResolvedValue(mockEService);
+  beforeEach(() => {
+    catalogService.updateDraftDescriptorTemplateInstance = vi
+      .fn()
+      .mockResolvedValue(mockEService);
+  });
 
   const makeRequest = async (
     token: string,

--- a/packages/catalog-process/test/api/updateTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/api/updateTemplateInstanceDescriptor.test.ts
@@ -21,6 +21,7 @@ import { eServiceToApiEService } from "../../src/model/domain/apiConverter.js";
 import {
   eServiceDescriptorNotFound,
   eServiceNotFound,
+  templateInstanceNotAllowed,
 } from "../../src/model/domain/errors.js";
 
 describe("API /templates/eservices/{eServiceId}/descriptors/{descriptorId}/update authorization test", () => {
@@ -90,6 +91,10 @@ describe("API /templates/eservices/{eServiceId}/descriptors/{descriptorId}/updat
     {
       error: eServiceDescriptorNotFound(mockEService.id, descriptor.id),
       expectedStatus: 404,
+    },
+    {
+      error: templateInstanceNotAllowed(mockEService.id, generateId()),
+      expectedStatus: 400,
     },
   ])(
     "Should return $expectedStatus for $error.code",

--- a/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/catalog-process/test/integration/updateDraftDescriptorTemplateInstance.test.ts
@@ -29,6 +29,7 @@ import {
   AttributeId,
   unsafeBrandId,
   attributeKind,
+  attributeCertifiedDiscreteComparator,
 } from "pagopa-interop-models";
 import { expect, describe, it } from "vitest";
 import {
@@ -39,6 +40,7 @@ import {
   eServiceNotAnInstance,
   attributeDailyCallsNotAllowed,
   attributeDiscreteConfigNotAllowed,
+  templateInstanceNotAllowed,
 } from "../../src/model/domain/errors.js";
 import {
   addOneEService,
@@ -49,6 +51,7 @@ import {
   addOneEServiceTemplate,
 } from "../integrationUtils.js";
 import { buildUpdateDescriptorSeed } from "../mockUtils.js";
+import { config } from "../../src/config/config.js";
 
 describe("update draft descriptor instance", () => {
   const mockDescriptor = getMockDescriptor();
@@ -1084,4 +1087,72 @@ describe("update draft descriptor instance", () => {
       );
     }
   );
+
+  it("should throw templateInstanceNotAllowed when changing inherited discreteConfig", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const template = getMockEServiceTemplate();
+    const certifiedDiscreteAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: {
+                threshold: 10,
+                comparator: attributeCertifiedDiscreteComparator.GTE,
+              },
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+      name: `${template.name} test`,
+      templateId: template.id,
+    };
+
+    await addOneEServiceTemplate(template);
+    await addOneAttribute(certifiedDiscreteAttribute);
+    await addOneEService(eservice);
+
+    await expect(
+      catalogService.updateDraftDescriptorTemplateInstance(
+        eservice.id,
+        descriptor.id,
+        {
+          ...buildUpdateDescriptorSeed(descriptor),
+          attributes: {
+            certified: [
+              [
+                {
+                  id: certifiedDiscreteAttribute.id,
+                  explicitAttributeVerification: false,
+                  discreteConfig: {
+                    threshold: 20,
+                    comparator: attributeCertifiedDiscreteComparator.GTE,
+                  },
+                },
+              ],
+            ],
+            declared: [],
+            verified: [],
+          },
+        },
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      templateInstanceNotAllowed(eservice.id, template.id)
+    );
+  });
 });

--- a/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
@@ -20,6 +20,7 @@ import {
   delegationState,
   delegationKind,
   attributeKind,
+  attributeCertifiedDiscreteComparator,
 } from "pagopa-interop-models";
 import { catalogApi } from "pagopa-interop-api-clients";
 import { expect, describe, it } from "vitest";
@@ -41,6 +42,7 @@ import {
   readLastEserviceEvent,
   addOneDelegation,
 } from "../integrationUtils.js";
+import { config } from "../../src/config/config.js";
 
 describe("update descriptor", () => {
   const mockEService = getMockEService();
@@ -646,6 +648,77 @@ describe("update descriptor", () => {
         eservice.id,
         descriptor.id,
         descriptorQuotasSeed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      templateInstanceNotAllowed(eservice.id, mockTemplate.id)
+    );
+  });
+
+  it("should throw templateInstanceNotAllowed when changing inherited discreteConfig", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const certifiedDiscreteAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+    await addOneAttribute(certifiedDiscreteAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: {
+                threshold: 10,
+                comparator: attributeCertifiedDiscreteComparator.GTE,
+              },
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      templateId: mockTemplate.id,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+    await addOneEServiceTemplate(mockTemplate);
+
+    const seed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+      {
+        dailyCallsPerConsumer: descriptor.dailyCallsPerConsumer,
+        dailyCallsTotal: descriptor.dailyCallsTotal,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedDiscreteAttribute.id,
+                explicitAttributeVerification: false,
+                discreteConfig: {
+                  threshold: 20,
+                  comparator: attributeCertifiedDiscreteComparator.GTE,
+                },
+              },
+            ],
+          ],
+          declared: [],
+          verified: [],
+        },
+      };
+
+    await expect(
+      catalogService.updateTemplateInstanceDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
     ).rejects.toThrowError(


### PR DESCRIPTION
## Jira Issue
[PIN-10333](https://pagopa.atlassian.net/browse/PIN-10333)

## Context
- Template instance descriptors inherit certified discrete attribute configuration from their template.
- Attempts to change the inherited `discreteConfig` were correctly rejected by the domain validator, but the resulting `templateInstanceNotAllowed` error was returned as HTTP 500.
- The draft template instance descriptor endpoint also lacked UUID validation for its path parameters, making two API tests depend on mock execution order.

## Services Affected
- `catalog-process`
- `api-clients`

## Key Changes
- Map `templateInstanceNotAllowed` to HTTP 400 for draft and published template instance descriptor updates.
- Add API and integration regression coverage for attempts to change inherited certified discrete configuration.
- Validate draft template instance descriptor path IDs as UUIDs and reset the API service mock before each test.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira
- [x] API and integration tests updated
- [x] OpenAPI spec updated


[PIN-10333]: https://pagopa.atlassian.net/browse/PIN-10333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ