### PR TITLE
feat: tenantRemoteIds and TenantCertifiedDiscreteAttribute handling on domains-analytics-writer (PIN-9980)

### DIFF
--- a/packages/domains-analytics-writer/src/handlers/tenant/consumerServiceV1.ts
+++ b/packages/domains-analytics-writer/src/handlers/tenant/consumerServiceV1.ts
@@ -58,6 +58,9 @@ export async function handleTenantMessageV1(
               verifiedAttributeRevokersSQL:
                 splitResult.verifiedAttributeRevokersSQL,
               featuresSQL: splitResult.featuresSQL,
+              remoteIdsSQL: splitResult.remoteIdsSQL,
+              certifiedDiscreteAttributeSQL:
+                splitResult.certifiedDiscreteAttributesSQL,
             } satisfies z.input<typeof TenantItemsSchema>)
           );
         }

--- a/packages/domains-analytics-writer/src/handlers/tenant/consumerServiceV1.ts
+++ b/packages/domains-analytics-writer/src/handlers/tenant/consumerServiceV1.ts
@@ -59,7 +59,7 @@ export async function handleTenantMessageV1(
                 splitResult.verifiedAttributeRevokersSQL,
               featuresSQL: splitResult.featuresSQL,
               remoteIdsSQL: splitResult.remoteIdsSQL,
-              certifiedDiscreteAttributeSQL:
+              certifiedDiscreteAttributesSQL:
                 splitResult.certifiedDiscreteAttributesSQL,
             } satisfies z.input<typeof TenantItemsSchema>)
           );

--- a/packages/domains-analytics-writer/src/handlers/tenant/consumerServiceV2.ts
+++ b/packages/domains-analytics-writer/src/handlers/tenant/consumerServiceV2.ts
@@ -88,7 +88,7 @@ export async function handleTenantMessageV2(
                 splitResult.verifiedAttributeRevokersSQL,
               featuresSQL: splitResult.featuresSQL,
               remoteIdsSQL: splitResult.remoteIdsSQL,
-              certifiedDiscreteAttributeSQL:
+              certifiedDiscreteAttributesSQL:
                 splitResult.certifiedDiscreteAttributesSQL,
             } satisfies z.input<typeof TenantItemsSchema>)
           );

--- a/packages/domains-analytics-writer/src/handlers/tenant/consumerServiceV2.ts
+++ b/packages/domains-analytics-writer/src/handlers/tenant/consumerServiceV2.ts
@@ -87,6 +87,9 @@ export async function handleTenantMessageV2(
               verifiedAttributeRevokersSQL:
                 splitResult.verifiedAttributeRevokersSQL,
               featuresSQL: splitResult.featuresSQL,
+              remoteIdsSQL: splitResult.remoteIdsSQL,
+              certifiedDiscreteAttributeSQL:
+                splitResult.certifiedDiscreteAttributesSQL,
             } satisfies z.input<typeof TenantItemsSchema>)
           );
         }

--- a/packages/domains-analytics-writer/src/index.ts
+++ b/packages/domains-analytics-writer/src/index.ts
@@ -97,6 +97,8 @@ await retryConnection(
       TenantDbTable.tenant_verified_attribute_verifier,
       TenantDbTable.tenant_verified_attribute_revoker,
       TenantDbTable.tenant_feature,
+      TenantDbTable.tenant_remote_id,
+      TenantDbTable.tenant_certified_discrete_attribute,
       EserviceTemplateDbTable.eservice_template,
       EserviceTemplateDbTable.eservice_template_version,
       EserviceTemplateDbTable.eservice_template_version_attribute,

--- a/packages/domains-analytics-writer/src/model/db/tenant.ts
+++ b/packages/domains-analytics-writer/src/model/db/tenant.ts
@@ -7,6 +7,8 @@ import {
   tenantVerifiedAttributeVerifierInReadmodelTenant,
   tenantVerifiedAttributeRevokerInReadmodelTenant,
   tenantFeatureInReadmodelTenant,
+  tenantRemoteIdInReadmodelTenant,
+  tenantCertifiedDiscreteAttributeInReadmodelTenant,
 } from "pagopa-interop-readmodel-models";
 import { TenantSchema, TenantSelfcareIdSchema } from "../tenant/tenant.js";
 import { TenantCertifiedAttributeSchema } from "../tenant/tenantCertifiedAttribute.js";
@@ -16,6 +18,8 @@ import { TenantMailSchema } from "../tenant/tenantMail.js";
 import { TenantVerifiedAttributeSchema } from "../tenant/tenantVerifiedAttribute.js";
 import { TenantVerifiedAttributeRevokerSchema } from "../tenant/tenantVerifiedAttributeRevoker.js";
 import { TenantVerifiedAttributeVerifierSchema } from "../tenant/tenantVerifiedAttributeVerifier.js";
+import { TenantRemoteIdSchema } from "../tenant/tenantRemoteId.js";
+import { TenantCertifiedDiscreteAttributeSchema } from "../tenant/tenantCertifiedDiscreteAttribute.js";
 
 export const TenantDbPartialTableConfig = {
   tenant_self_care_id: TenantSelfcareIdSchema,
@@ -42,6 +46,8 @@ export const TenantDbTableConfig = {
   tenant_verified_attribute_verifier: TenantVerifiedAttributeVerifierSchema,
   tenant_verified_attribute_revoker: TenantVerifiedAttributeRevokerSchema,
   tenant_feature: TenantFeatureSchema,
+  tenant_remote_id: TenantRemoteIdSchema,
+  tenant_certified_discrete_attribute: TenantCertifiedDiscreteAttributeSchema,
 } as const;
 export type TenantDbTableConfig = typeof TenantDbTableConfig;
 
@@ -56,6 +62,9 @@ export const TenantDbTableReadModel = {
   tenant_verified_attribute_revoker:
     tenantVerifiedAttributeRevokerInReadmodelTenant,
   tenant_feature: tenantFeatureInReadmodelTenant,
+  tenant_remote_id: tenantRemoteIdInReadmodelTenant,
+  tenant_certified_discrete_attribute:
+    tenantCertifiedDiscreteAttributeInReadmodelTenant,
 } as const;
 export type TenantDbTableReadModel = typeof TenantDbTableReadModel;
 

--- a/packages/domains-analytics-writer/src/model/tenant/tenant.ts
+++ b/packages/domains-analytics-writer/src/model/tenant/tenant.ts
@@ -8,6 +8,8 @@ import { TenantFeatureSchema } from "./tenantFeature.js";
 import { TenantVerifiedAttributeSchema } from "./tenantVerifiedAttribute.js";
 import { TenantVerifiedAttributeRevokerSchema } from "./tenantVerifiedAttributeRevoker.js";
 import { TenantVerifiedAttributeVerifierSchema } from "./tenantVerifiedAttributeVerifier.js";
+import { TenantRemoteIdSchema } from "./tenantRemoteId.js";
+import { TenantCertifiedDiscreteAttributeSchema } from "./tenantCertifiedDiscreteAttribute.js";
 
 export const TenantSchema = createSelectSchema(tenantInReadmodelTenant).extend({
   deleted: z.boolean().default(false).optional(),
@@ -37,5 +39,9 @@ export const TenantItemsSchema = z.object({
   verifiedAttributeVerifiersSQL: z.array(TenantVerifiedAttributeVerifierSchema),
   verifiedAttributeRevokersSQL: z.array(TenantVerifiedAttributeRevokerSchema),
   featuresSQL: z.array(TenantFeatureSchema),
+  remoteIdsSQL: z.array(TenantRemoteIdSchema),
+  certifiedDiscreteAttributeSQL: z.array(
+    TenantCertifiedDiscreteAttributeSchema
+  ),
 });
 export type TenantItemsSchema = z.infer<typeof TenantItemsSchema>;

--- a/packages/domains-analytics-writer/src/model/tenant/tenant.ts
+++ b/packages/domains-analytics-writer/src/model/tenant/tenant.ts
@@ -40,7 +40,7 @@ export const TenantItemsSchema = z.object({
   verifiedAttributeRevokersSQL: z.array(TenantVerifiedAttributeRevokerSchema),
   featuresSQL: z.array(TenantFeatureSchema),
   remoteIdsSQL: z.array(TenantRemoteIdSchema),
-  certifiedDiscreteAttributeSQL: z.array(
+  certifiedDiscreteAttributesSQL: z.array(
     TenantCertifiedDiscreteAttributeSchema
   ),
 });

--- a/packages/domains-analytics-writer/src/model/tenant/tenantCertifiedDiscreteAttribute.ts
+++ b/packages/domains-analytics-writer/src/model/tenant/tenantCertifiedDiscreteAttribute.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { tenantCertifiedDiscreteAttributeInReadmodelTenant } from "pagopa-interop-readmodel-models";
+import { createSelectSchema } from "drizzle-zod";
+
+export const TenantCertifiedDiscreteAttributeSchema = createSelectSchema(
+  tenantCertifiedDiscreteAttributeInReadmodelTenant
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type TenantCertifiedDiscreteAttributeSchema = z.infer<
+  typeof TenantCertifiedDiscreteAttributeSchema
+>;

--- a/packages/domains-analytics-writer/src/model/tenant/tenantRemoteId.ts
+++ b/packages/domains-analytics-writer/src/model/tenant/tenantRemoteId.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { tenantRemoteIdInReadmodelTenant } from "pagopa-interop-readmodel-models";
+import { createSelectSchema } from "drizzle-zod";
+
+export const TenantRemoteIdSchema = createSelectSchema(
+  tenantRemoteIdInReadmodelTenant
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type TenantRemoteIdSchema = z.infer<typeof TenantRemoteIdSchema>;

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedDiscreteAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedDiscreteAttribute.repository.ts
@@ -11,7 +11,7 @@ import { config } from "../../config/config.js";
 import { TenantDbTable } from "../../model/db/index.js";
 import { TenantCertifiedDiscreteAttributeSchema } from "../../model/tenant/tenantCertifiedDiscreteAttribute.js";
 
-export function tenantCertiefiedDiscreteAttributeIdRepository(
+export function tenantCertifiedDiscreteAttributeIdRepository(
   conn: DBConnection
 ) {
   const schemaName = config.dbSchemaName;
@@ -31,7 +31,9 @@ export function tenantCertiefiedDiscreteAttributeIdRepository(
           TenantCertifiedDiscreteAttributeSchema
         );
         await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["tenantId"]));
+        await t.none(
+          generateStagingDeleteQuery(tableName, ["attributeId", "tenantId"])
+        );
       } catch (error: unknown) {
         throw genericInternalError(
           `Error inserting into staging table ${stagingTableName}: ${error}`

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedDiscreteAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedDiscreteAttribute.repository.ts
@@ -11,9 +11,7 @@ import { config } from "../../config/config.js";
 import { TenantDbTable } from "../../model/db/index.js";
 import { TenantCertifiedDiscreteAttributeSchema } from "../../model/tenant/tenantCertifiedDiscreteAttribute.js";
 
-export function tenantCertifiedDiscreteAttributeIdRepository(
-  conn: DBConnection
-) {
+export function tenantCertifiedDiscreteAttributeRepository(conn: DBConnection) {
   const schemaName = config.dbSchemaName;
   const tableName = TenantDbTable.tenant_certified_discrete_attribute;
   const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedDiscreteAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedDiscreteAttribute.repository.ts
@@ -47,7 +47,7 @@ export function tenantCertifiedDiscreteAttributeIdRepository(
           TenantCertifiedDiscreteAttributeSchema,
           schemaName,
           tableName,
-          ["tenantId"]
+          ["attributeId", "tenantId"]
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedDiscreteAttribute.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantCertifiedDiscreteAttribute.repository.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { IMain, ITask } from "pg-promise";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+import { config } from "../../config/config.js";
+import { TenantDbTable } from "../../model/db/index.js";
+import { TenantCertifiedDiscreteAttributeSchema } from "../../model/tenant/tenantCertifiedDiscreteAttribute.js";
+
+export function tenantCertiefiedDiscreteAttributeIdRepository(
+  conn: DBConnection
+) {
+  const schemaName = config.dbSchemaName;
+  const tableName = TenantDbTable.tenant_certified_discrete_attribute;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: TenantCertifiedDiscreteAttributeSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(
+          pgp,
+          tableName,
+          TenantCertifiedDiscreteAttributeSchema
+        );
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(generateStagingDeleteQuery(tableName, ["tenantId"]));
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          TenantCertifiedDiscreteAttributeSchema,
+          schemaName,
+          tableName,
+          ["tenantId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantRemoteId.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantRemoteId.repository.ts
@@ -41,7 +41,7 @@ export function tenantRemoteIdRepository(conn: DBConnection) {
           TenantRemoteIdSchema,
           schemaName,
           tableName,
-          ["tenantId"]
+          ["tenantId", "origin"]
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantRemoteId.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantRemoteId.repository.ts
@@ -25,7 +25,9 @@ export function tenantRemoteIdRepository(conn: DBConnection) {
       try {
         const cs = buildColumnSet(pgp, tableName, TenantRemoteIdSchema);
         await t.none(pgp.helpers.insert(records, cs));
-        await t.none(generateStagingDeleteQuery(tableName, ["tenantId"]));
+        await t.none(
+          generateStagingDeleteQuery(tableName, ["tenantId", "origin"])
+        );
       } catch (error: unknown) {
         throw genericInternalError(
           `Error inserting into staging table ${stagingTableName}: ${error}`

--- a/packages/domains-analytics-writer/src/repository/tenant/tenantRemoteId.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/tenant/tenantRemoteId.repository.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { genericInternalError } from "pagopa-interop-models";
+import { IMain, ITask } from "pg-promise";
+import { DBConnection } from "../../db/db.js";
+import {
+  buildColumnSet,
+  generateMergeQuery,
+  generateStagingDeleteQuery,
+} from "../../utils/sqlQueryHelper.js";
+import { config } from "../../config/config.js";
+import { TenantRemoteIdSchema } from "../../model/tenant/tenantRemoteId.js";
+import { TenantDbTable } from "../../model/db/index.js";
+
+export function tenantRemoteIdRepository(conn: DBConnection) {
+  const schemaName = config.dbSchemaName;
+  const tableName = TenantDbTable.tenant_remote_id;
+  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+
+  return {
+    async insert(
+      t: ITask<unknown>,
+      pgp: IMain,
+      records: TenantRemoteIdSchema[]
+    ): Promise<void> {
+      try {
+        const cs = buildColumnSet(pgp, tableName, TenantRemoteIdSchema);
+        await t.none(pgp.helpers.insert(records, cs));
+        await t.none(generateStagingDeleteQuery(tableName, ["tenantId"]));
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error inserting into staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+
+    async merge(t: ITask<unknown>): Promise<void> {
+      try {
+        const mergeQuery = generateMergeQuery(
+          TenantRemoteIdSchema,
+          schemaName,
+          tableName,
+          ["tenantId"]
+        );
+        await t.none(mergeQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async clean(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
+        );
+      }
+    },
+  };
+}

--- a/packages/domains-analytics-writer/src/service/tenantService.ts
+++ b/packages/domains-analytics-writer/src/service/tenantService.ts
@@ -24,7 +24,7 @@ import {
 } from "../model/tenant/tenant.js";
 import { TenantMailDeletingSchema } from "../model/tenant/tenantMail.js";
 import { tenantRemoteIdRepository } from "../repository/tenant/tenantRemoteId.repository.js";
-import { tenantCertiefiedDiscreteAttributeIdRepository } from "../repository/tenant/tenantCertifiedDiscreteAttribute.repository.js";
+import { tenantCertifiedDiscreteAttributeIdRepository } from "../repository/tenant/tenantCertifiedDiscreteAttribute.repository.js";
 
 export function tenantServiceBuilder(db: DBContext) {
   const tenantRepo = tenantRepository(db.conn);
@@ -45,7 +45,7 @@ export function tenantServiceBuilder(db: DBContext) {
   const tenantFeatureRepo = tenantFeatureRepository(db.conn);
   const tenantRemoteIdRepo = tenantRemoteIdRepository(db.conn);
   const tenantCertifiedDiscreteAttributeRepo =
-    tenantCertiefiedDiscreteAttributeIdRepository(db.conn);
+    tenantCertifiedDiscreteAttributeIdRepository(db.conn);
 
   return {
     async upsertBatchTenantItems(

--- a/packages/domains-analytics-writer/src/service/tenantService.ts
+++ b/packages/domains-analytics-writer/src/service/tenantService.ts
@@ -23,6 +23,8 @@ import {
   TenantDeletingSchema,
 } from "../model/tenant/tenant.js";
 import { TenantMailDeletingSchema } from "../model/tenant/tenantMail.js";
+import { tenantRemoteIdRepository } from "../repository/tenant/tenantRemoteId.repository.js";
+import { tenantCertiefiedDiscreteAttributeIdRepository } from "../repository/tenant/tenantCertifiedDiscreteAttribute.repository.js";
 
 export function tenantServiceBuilder(db: DBContext) {
   const tenantRepo = tenantRepository(db.conn);
@@ -41,6 +43,9 @@ export function tenantServiceBuilder(db: DBContext) {
   const tenantVerifiedAttributeRevokerRepo =
     tenantVerifiedAttributeRevokerRepository(db.conn);
   const tenantFeatureRepo = tenantFeatureRepository(db.conn);
+  const tenantRemoteIdRepo = tenantRemoteIdRepository(db.conn);
+  const tenantCertifiedDiscreteAttributeRepo =
+    tenantCertiefiedDiscreteAttributeIdRepository(db.conn);
 
   return {
     async upsertBatchTenantItems(
@@ -71,6 +76,10 @@ export function tenantServiceBuilder(db: DBContext) {
               (item) => item.verifiedAttributeRevokersSQL
             ),
             featuresSQL: batch.flatMap((item) => item.featuresSQL),
+            tenantRemoteIdSQL: batch.flatMap((item) => item.remoteIdsSQL),
+            tenantCertifiedDiscreteAttributeSQL: batch.flatMap(
+              (item) => item.certifiedDiscreteAttributeSQL
+            ),
           };
 
           if (batchItems.tenantSQL.length) {
@@ -121,6 +130,20 @@ export function tenantServiceBuilder(db: DBContext) {
               batchItems.featuresSQL
             );
           }
+          if (batchItems.tenantRemoteIdSQL.length) {
+            await tenantRemoteIdRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.tenantRemoteIdSQL
+            );
+          }
+          if (batchItems.tenantCertifiedDiscreteAttributeSQL.length) {
+            await tenantCertifiedDiscreteAttributeRepo.insert(
+              t,
+              dbContext.pgp,
+              batchItems.tenantCertifiedDiscreteAttributeSQL
+            );
+          }
 
           genericLogger.info(
             `Staging inserted for Tenant batch: ${batchItems.tenantSQL
@@ -137,6 +160,8 @@ export function tenantServiceBuilder(db: DBContext) {
         await tenantVerifiedAttributeVerifierRepo.merge(t);
         await tenantVerifiedAttributeRevokerRepo.merge(t);
         await tenantFeatureRepo.merge(t);
+        await tenantRemoteIdRepo.merge(t);
+        await tenantCertifiedDiscreteAttributeRepo.merge(t);
       });
 
       await dbContext.conn.tx(async (t) => {
@@ -151,6 +176,8 @@ export function tenantServiceBuilder(db: DBContext) {
             TenantDbTable.tenant_verified_attribute_verifier,
             TenantDbTable.tenant_verified_attribute_revoker,
             TenantDbTable.tenant_feature,
+            TenantDbTable.tenant_remote_id,
+            TenantDbTable.tenant_certified_discrete_attribute,
           ],
           TenantDbTable.tenant
         );
@@ -166,6 +193,8 @@ export function tenantServiceBuilder(db: DBContext) {
       await tenantVerifiedAttributeVerifierRepo.clean();
       await tenantVerifiedAttributeRevokerRepo.clean();
       await tenantFeatureRepo.clean();
+      await tenantRemoteIdRepo.clean();
+      await tenantCertifiedDiscreteAttributeRepo.clean();
 
       genericLogger.info(`Staging tables cleaned for Tenant batches`);
     },
@@ -227,6 +256,8 @@ export function tenantServiceBuilder(db: DBContext) {
             TenantDbTable.tenant_verified_attribute_verifier,
             TenantDbTable.tenant_verified_attribute_revoker,
             TenantDbTable.tenant_feature,
+            TenantDbTable.tenant_remote_id,
+            TenantDbTable.tenant_certified_discrete_attribute,
           ],
           DeletingDbTable.tenant_deleting_table
         );

--- a/packages/domains-analytics-writer/src/service/tenantService.ts
+++ b/packages/domains-analytics-writer/src/service/tenantService.ts
@@ -24,7 +24,7 @@ import {
 } from "../model/tenant/tenant.js";
 import { TenantMailDeletingSchema } from "../model/tenant/tenantMail.js";
 import { tenantRemoteIdRepository } from "../repository/tenant/tenantRemoteId.repository.js";
-import { tenantCertifiedDiscreteAttributeIdRepository } from "../repository/tenant/tenantCertifiedDiscreteAttribute.repository.js";
+import { tenantCertifiedDiscreteAttributeRepository } from "../repository/tenant/tenantCertifiedDiscreteAttribute.repository.js";
 
 export function tenantServiceBuilder(db: DBContext) {
   const tenantRepo = tenantRepository(db.conn);
@@ -45,7 +45,7 @@ export function tenantServiceBuilder(db: DBContext) {
   const tenantFeatureRepo = tenantFeatureRepository(db.conn);
   const tenantRemoteIdRepo = tenantRemoteIdRepository(db.conn);
   const tenantCertifiedDiscreteAttributeRepo =
-    tenantCertifiedDiscreteAttributeIdRepository(db.conn);
+    tenantCertifiedDiscreteAttributeRepository(db.conn);
 
   return {
     async upsertBatchTenantItems(
@@ -76,9 +76,9 @@ export function tenantServiceBuilder(db: DBContext) {
               (item) => item.verifiedAttributeRevokersSQL
             ),
             featuresSQL: batch.flatMap((item) => item.featuresSQL),
-            tenantRemoteIdSQL: batch.flatMap((item) => item.remoteIdsSQL),
-            tenantCertifiedDiscreteAttributeSQL: batch.flatMap(
-              (item) => item.certifiedDiscreteAttributeSQL
+            tenantRemoteIdsSQL: batch.flatMap((item) => item.remoteIdsSQL),
+            tenantCertifiedDiscreteAttributesSQL: batch.flatMap(
+              (item) => item.certifiedDiscreteAttributesSQL
             ),
           };
 
@@ -130,18 +130,18 @@ export function tenantServiceBuilder(db: DBContext) {
               batchItems.featuresSQL
             );
           }
-          if (batchItems.tenantRemoteIdSQL.length) {
+          if (batchItems.tenantRemoteIdsSQL.length) {
             await tenantRemoteIdRepo.insert(
               t,
               dbContext.pgp,
-              batchItems.tenantRemoteIdSQL
+              batchItems.tenantRemoteIdsSQL
             );
           }
-          if (batchItems.tenantCertifiedDiscreteAttributeSQL.length) {
+          if (batchItems.tenantCertifiedDiscreteAttributesSQL.length) {
             await tenantCertifiedDiscreteAttributeRepo.insert(
               t,
               dbContext.pgp,
-              batchItems.tenantCertifiedDiscreteAttributeSQL
+              batchItems.tenantCertifiedDiscreteAttributesSQL
             );
           }
 

--- a/packages/domains-analytics-writer/test/tenantService.test.ts
+++ b/packages/domains-analytics-writer/test/tenantService.test.ts
@@ -34,6 +34,7 @@ import {
   getMockVerifiedTenantAttribute,
   toTenantV1,
   getMockTenantRemoteId,
+  getMockCertifiedDiscreteTenantAttribute,
 } from "pagopa-interop-commons-test";
 import { handleTenantMessageV1 } from "../src/handlers/tenant/consumerServiceV1.js";
 import { handleTenantMessageV2 } from "../src/handlers/tenant/consumerServiceV2.js";
@@ -475,7 +476,151 @@ describe("Tenant messages consumers - handleTenantMessageV2", () => {
   beforeEach(async () => {
     await resetTargetTables(tenantTables);
   });
+  it("TenantOnboarded: inserts tenant with mails, attributes, features, and remote ids", async () => {
+    const mockTenantMail = getMockTenantMail();
+    const mockTenantFeatureCertifier: TenantFeatureCertifier = {
+      type: tenantFeatureType.persistentCertifier,
+      certifierId: generateId(),
+    };
 
+    const mockTenantVerifier = getMockTenant();
+    const mockTenantRevoker = getMockTenant();
+    const mockVerifiedBy: TenantVerifier = {
+      ...getMockVerifiedBy(),
+      id: mockTenantVerifier.id,
+    };
+    const mockRevokedBy: TenantRevoker = {
+      ...getMockRevokedBy(),
+      id: mockTenantRevoker.id,
+    };
+
+    const mockDeclaredTenantAttribute = getMockDeclaredTenantAttribute();
+    const mockCertifiedTenantAttribute = getMockCertifiedTenantAttribute();
+    const mockVerifiedTenantAttribute = getMockVerifiedTenantAttribute();
+    const mockCertifiedDiscreteTenantAttribute =
+      getMockCertifiedDiscreteTenantAttribute();
+    const mockTenantRemoteId = getMockTenantRemoteId();
+
+    mockVerifiedTenantAttribute.verifiedBy = [{ ...mockVerifiedBy }];
+    mockVerifiedTenantAttribute.revokedBy = [{ ...mockRevokedBy }];
+
+    const mockTenant = getMockTenant();
+    mockTenant.mails = [mockTenantMail];
+    mockTenant.attributes = [
+      mockDeclaredTenantAttribute,
+      mockVerifiedTenantAttribute,
+      mockCertifiedTenantAttribute,
+      mockCertifiedDiscreteTenantAttribute,
+    ];
+    mockTenant.features = [mockTenantFeatureCertifier];
+    mockTenant.remoteIds = [mockTenantRemoteId];
+
+    const msgTenantVerifier: TenantEventEnvelopeV2 = {
+      sequence_num: 1,
+      stream_id: mockTenantVerifier.id,
+      version: 1,
+      type: "TenantOnboarded",
+      event_version: 2,
+      data: { tenant: toTenantV2(mockTenantVerifier) },
+      log_date: new Date(),
+    };
+
+    const msgTenantRevoker: TenantEventEnvelopeV2 = {
+      sequence_num: 1,
+      stream_id: mockTenantRevoker.id,
+      version: 1,
+      type: "TenantOnboarded",
+      event_version: 2,
+      data: { tenant: toTenantV2(mockTenantRevoker) },
+      log_date: new Date(),
+    };
+
+    const msgTenantOnboarded: TenantEventEnvelopeV2 = {
+      sequence_num: 1,
+      stream_id: mockTenant.id,
+      version: 1,
+      type: "TenantOnboarded",
+      event_version: 2,
+      data: { tenant: toTenantV2(mockTenant) },
+      log_date: new Date(),
+    };
+
+    await handleTenantMessageV2(
+      [msgTenantVerifier, msgTenantRevoker, msgTenantOnboarded],
+      dbContext
+    );
+
+    const storedTenant = await getOneFromDb(dbContext, TenantDbTable.tenant, {
+      id: mockTenant.id,
+    });
+    expect(storedTenant?.id).toBe(mockTenant.id);
+    expect(storedTenant?.onboardedAt).toStrictEqual(mockTenant.createdAt);
+
+    const storedTenantMails = await getManyFromDb(
+      dbContext,
+      TenantDbTable.tenant_mail,
+      { id: mockTenantMail.id }
+    );
+    expect(storedTenantMails.length).toBe(1);
+    expect(storedTenantMails[0].id).toBe(mockTenantMail.id);
+
+    const storedDeclaredTenantAttributes = await getManyFromDb(
+      dbContext,
+      TenantDbTable.tenant_declared_attribute,
+      { attributeId: mockDeclaredTenantAttribute.id }
+    );
+    expect(storedDeclaredTenantAttributes.length).toBe(1);
+    expect(storedDeclaredTenantAttributes[0].attributeId).toBe(
+      mockDeclaredTenantAttribute.id
+    );
+
+    const storedVerifiedTenantAttributes = await getManyFromDb(
+      dbContext,
+      TenantDbTable.tenant_verified_attribute,
+      { attributeId: mockVerifiedTenantAttribute.id }
+    );
+    expect(storedVerifiedTenantAttributes.length).toBe(1);
+    expect(storedVerifiedTenantAttributes[0].attributeId).toBe(
+      mockVerifiedTenantAttribute.id
+    );
+
+    const storedCertifiedTenantAttributes = await getManyFromDb(
+      dbContext,
+      TenantDbTable.tenant_certified_attribute,
+      { attributeId: mockCertifiedTenantAttribute.id }
+    );
+    expect(storedCertifiedTenantAttributes.length).toBe(1);
+    expect(storedCertifiedTenantAttributes[0].attributeId).toBe(
+      mockCertifiedTenantAttribute.id
+    );
+    const storedCertifiedDiscreteTenantAttributes = await getManyFromDb(
+      dbContext,
+      TenantDbTable.tenant_certified_discrete_attribute,
+      { attributeId: mockCertifiedDiscreteTenantAttribute.id }
+    );
+    expect(storedCertifiedDiscreteTenantAttributes.length).toBe(1);
+    expect(storedCertifiedDiscreteTenantAttributes[0].attributeId).toBe(
+      mockCertifiedDiscreteTenantAttribute.id
+    );
+
+    const storedTenantFeatures = await getManyFromDb(
+      dbContext,
+      TenantDbTable.tenant_feature,
+      { tenantId: mockTenant.id, kind: mockTenantFeatureCertifier.type }
+    );
+    expect(storedTenantFeatures.length).toBe(1);
+    expect(storedTenantFeatures[0].certifierId).toBe(
+      mockTenantFeatureCertifier.certifierId
+    );
+
+    const storedTenantRemoteIds = await getManyFromDb(
+      dbContext,
+      TenantDbTable.tenant_remote_id,
+      { tenantId: mockTenant.id }
+    );
+    expect(storedTenantRemoteIds.length).toBe(1);
+    expect(storedTenantRemoteIds[0].tenantId).toBe(mockTenant.id);
+  });
   it("MaintenanceTenantUpdated: updates tenant fields", async () => {
     const originalTenant = getMockTenant();
     originalTenant.name = "Old Name";

--- a/packages/domains-analytics-writer/test/tenantService.test.ts
+++ b/packages/domains-analytics-writer/test/tenantService.test.ts
@@ -24,6 +24,7 @@ import {
   TenantEventEnvelopeV1,
   TenantMailAddedV1,
   TenantOnboardedV2,
+  TenantRemoteId,
 } from "pagopa-interop-models";
 import {
   getMockTenant,
@@ -32,6 +33,7 @@ import {
   getMockDeclaredTenantAttribute,
   getMockVerifiedTenantAttribute,
   toTenantV1,
+  getMockTenantRemoteId,
 } from "pagopa-interop-commons-test";
 import { handleTenantMessageV1 } from "../src/handlers/tenant/consumerServiceV1.js";
 import { handleTenantMessageV2 } from "../src/handlers/tenant/consumerServiceV2.js";
@@ -70,6 +72,7 @@ describe("Tenant messages consumers - handleTenantMessageV1", () => {
     const mockDeclaredTenantAttribute = getMockDeclaredTenantAttribute();
     const mockCertifiedTenantAttribute = getMockCertifiedTenantAttribute();
     const mockVerifiedTenantAttribute = getMockVerifiedTenantAttribute();
+    const mockTenantRemoteIds: TenantRemoteId = getMockTenantRemoteId();
     mockVerifiedTenantAttribute.verifiedBy = [{ ...mockVerifiedBy }];
     mockVerifiedTenantAttribute.revokedBy = [{ ...mockRevokedBy }];
 
@@ -81,7 +84,7 @@ describe("Tenant messages consumers - handleTenantMessageV1", () => {
       mockCertifiedTenantAttribute,
     ];
     mockTenant.features = [mockTenantFeatureCertifier];
-
+    mockTenant.remoteIds = [mockTenantRemoteIds];
     const payload: TenantCreatedV1 = {
       tenant: toTenantV1(mockTenant),
     };
@@ -194,12 +197,12 @@ describe("Tenant messages consumers - handleTenantMessageV1", () => {
       ...getMockRevokedBy(),
       id: mockTenantRevoker.id,
     };
-
     const mockDeclaredTenantAttribute = getMockDeclaredTenantAttribute();
     const mockCertifiedTenantAttribute = getMockCertifiedTenantAttribute();
     const mockVerifiedTenantAttribute = getMockVerifiedTenantAttribute();
     mockVerifiedTenantAttribute.verifiedBy = [{ ...mockVerifiedBy }];
     mockVerifiedTenantAttribute.revokedBy = [{ ...mockRevokedBy }];
+    const mockTenantRemoteIds: TenantRemoteId = getMockTenantRemoteId();
 
     const mockTenant = getMockTenant();
     mockTenant.mails = [mockTenantMail];
@@ -209,6 +212,7 @@ describe("Tenant messages consumers - handleTenantMessageV1", () => {
       mockCertifiedTenantAttribute,
     ];
     mockTenant.features = [mockTenantFeatureCertifier];
+    mockTenant.remoteIds = [mockTenantRemoteIds];
 
     const payload: TenantCreatedV1 = {
       tenant: toTenantV1(mockTenant),
@@ -282,6 +286,11 @@ describe("Tenant messages consumers - handleTenantMessageV1", () => {
         where: { tenantId },
       },
       { table: TenantDbTable.tenant_feature, where: { tenantId } },
+      { table: TenantDbTable.tenant_remote_id, where: { tenantId } },
+      {
+        table: TenantDbTable.tenant_certified_discrete_attribute,
+        where: { tenantId },
+      },
     ];
 
     for (const { table, where } of checks) {

--- a/packages/domains-analytics-writer/test/tenantService.test.ts
+++ b/packages/domains-analytics-writer/test/tenantService.test.ts
@@ -72,7 +72,7 @@ describe("Tenant messages consumers - handleTenantMessageV1", () => {
     const mockDeclaredTenantAttribute = getMockDeclaredTenantAttribute();
     const mockCertifiedTenantAttribute = getMockCertifiedTenantAttribute();
     const mockVerifiedTenantAttribute = getMockVerifiedTenantAttribute();
-    const mockTenantRemoteIds: TenantRemoteId = getMockTenantRemoteId();
+    const mockTenantRemoteId = getMockTenantRemoteId();
     mockVerifiedTenantAttribute.verifiedBy = [{ ...mockVerifiedBy }];
     mockVerifiedTenantAttribute.revokedBy = [{ ...mockRevokedBy }];
 
@@ -84,7 +84,7 @@ describe("Tenant messages consumers - handleTenantMessageV1", () => {
       mockCertifiedTenantAttribute,
     ];
     mockTenant.features = [mockTenantFeatureCertifier];
-    mockTenant.remoteIds = [mockTenantRemoteIds];
+    mockTenant.remoteIds = [mockTenantRemoteId];
     const payload: TenantCreatedV1 = {
       tenant: toTenantV1(mockTenant),
     };
@@ -164,6 +164,11 @@ describe("Tenant messages consumers - handleTenantMessageV1", () => {
       TenantDbTable.tenant_certified_attribute,
       { attributeId: mockCertifiedTenantAttribute.id }
     );
+    const storedTenantRemoteIds = await getManyFromDb(
+      dbContext,
+      TenantDbTable.tenant_remote_id,
+      { tenantId: mockTenant.id }
+    );
     expect(storedCertifiedTenantAttributes.length).toBe(1);
     expect(storedCertifiedTenantAttributes[0].attributeId).toBe(
       mockCertifiedTenantAttribute.id
@@ -179,6 +184,8 @@ describe("Tenant messages consumers - handleTenantMessageV1", () => {
     expect(storedTenantFeatures[0].certifierId).toBe(
       mockTenantFeatureCertifier.certifierId
     );
+    expect(storedTenantRemoteIds.length).toBe(1);
+    expect(storedTenantRemoteIds[0].tenantId).toBe(mockTenant.id);
   });
 
   it("TenantDeleted: cascades logical deletion to all related tables", async () => {

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -97,6 +97,8 @@ export const tenantTables: TenantDbTable[] = [
   TenantDbTable.tenant_verified_attribute,
   TenantDbTable.tenant_verified_attribute_revoker,
   TenantDbTable.tenant_verified_attribute_verifier,
+  TenantDbTable.tenant_remote_id,
+  TenantDbTable.tenant_certified_discrete_attribute,
 ];
 
 export const eserviceTemplateTables: EserviceTemplateDbTable[] = [


### PR DESCRIPTION
## Jira Issue
[PIN-9980](https://pagopa.atlassian.net/browse/PIN-9980)

## Context
Update package `domains-analytics-writer` to handle the new tables introducted with certified discrete attribute feature: `tenant_certified_discrete_attribute` - `tenant_remote_id`

## Services Affected
- `domains-analytics-writer`

## Key Changes
- **Added new schemas**: Added the new schemas on domains-analytics-writer repositories to handle the insert, merge and clean of the new tables.
- **Test Suite Update:** Updated Unit and Integration test to validate the new tablers

## Traceability Checklist
- [X] Branch name contain the Jira key
- [X] PR title is compliant with the standard (type(scope): descrizione (KEY))
- [X] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated

[PIN-9980]: https://pagopa.atlassian.net/browse/PIN-9980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ