### PR TITLE
PIN-10334 Fix tenant kind to assign in past risk analyses

### DIFF
--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -394,7 +394,6 @@ export function purposeServiceBuilder(
         referenceDate
       );
 
-      // If historyKind wasn't found at referenceDate, try to recover the first available historyKind in ascending order
       const tenantKind =
         historyKind ?? (await readModelService.getFirstTenantKind(tenantId));
 

--- a/packages/purpose-process/src/services/purposeService.ts
+++ b/packages/purpose-process/src/services/purposeService.ts
@@ -393,7 +393,12 @@ export function purposeServiceBuilder(
         tenantId,
         referenceDate
       );
-      if (!historyKind) {
+
+      // If historyKind wasn't found at referenceDate, try to recover the first available historyKind in ascending order
+      const tenantKind =
+        historyKind ?? (await readModelService.getFirstTenantKind(tenantId));
+
+      if (!tenantKind) {
         throw tenantKindNotFound(tenantId);
       }
 
@@ -401,7 +406,7 @@ export function purposeServiceBuilder(
         ...purpose.data,
         riskAnalysisForm: {
           ...riskAnalysisForm,
-          tenantKind: historyKind,
+          tenantKind,
         },
       };
 

--- a/packages/purpose-process/src/services/readModelServiceSQL.ts
+++ b/packages/purpose-process/src/services/readModelServiceSQL.ts
@@ -57,6 +57,7 @@ import {
 } from "pagopa-interop-readmodel";
 import {
   and,
+  asc,
   desc,
   eq,
   inArray,
@@ -270,6 +271,17 @@ export function readModelServiceBuilderSQL({
           )
         )
         .orderBy(desc(tenantKindHistory.modifiedAt))
+        .limit(1);
+      return result?.kind ? TenantKind.parse(result.kind) : undefined;
+    },
+    async getFirstTenantKind(
+      tenantId: TenantId
+    ): Promise<TenantKind | undefined> {
+      const [result] = await tenantKindHistoryDB
+        .select()
+        .from(tenantKindHistory)
+        .where(eq(tenantKindHistory.tenantId, tenantId))
+        .orderBy(asc(tenantKindHistory.modifiedAt))
         .limit(1);
       return result?.kind ? TenantKind.parse(result.kind) : undefined;
     },

--- a/packages/purpose-process/test/integration/fixPurposeRiskAnalysisTenantKind.test.ts
+++ b/packages/purpose-process/test/integration/fixPurposeRiskAnalysisTenantKind.test.ts
@@ -177,6 +177,76 @@ describe("fixPurposeRiskAnalysisTenantKind", () => {
     });
   });
 
+  it("should use the first available tenant kind when reference date is before all history records", async () => {
+    const consumerKind: TenantKind = tenantKind.PA;
+    const consumer = getMockTenant();
+    const eservice: EService = {
+      ...getMockEService(),
+      mode: eserviceMode.deliver,
+      personalData: false,
+    };
+
+    const riskAnalysisId = generateId<RiskAnalysisId>();
+    const riskAnalysisForm = {
+      ...getMockValidRiskAnalysisForm(consumerKind),
+      riskAnalysisId,
+      tenantKind: undefined,
+    };
+
+    // Create a purpose with a creation date before the tenant kind history start
+    const purpose: Purpose = {
+      ...getMockPurpose(),
+      eserviceId: eservice.id,
+      consumerId: consumer.id,
+      riskAnalysisForm,
+      createdAt: new Date("2023-01-10T10:00:00.000Z"), // Before history starts
+    };
+
+    await addOneEService(eservice);
+    await addOnePurpose(purpose);
+
+    // Add tenant kind history record after the purpose creation date
+    await addOneTenantKindHistory({
+      tenantId: consumer.id,
+      metadataVersion: 0,
+      kind: consumerKind,
+      modifiedAt: new Date("2024-01-01T00:00:00.000Z"), // After purpose creation
+    });
+
+    // This should succeed by falling back to the first available tenant kind
+    await purposeService.fixPurposeRiskAnalysisTenantKind(
+      purpose.id,
+      getMockContextInternal({})
+    );
+
+    const writtenEvent = await readLastPurposeEvent(purpose.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: purpose.id,
+      version: "1",
+      type: "MaintenancePurposeRiskAnalysisSetTenantKind",
+      event_version: 2,
+    });
+
+    const writtenPayload = decodeProtobufPayload({
+      messageType: MaintenancePurposeRiskAnalysisSetTenantKindV2,
+      payload: writtenEvent.data,
+    });
+
+    const expectedPurpose: Purpose = {
+      ...purpose,
+      riskAnalysisForm: {
+        ...riskAnalysisForm,
+        tenantKind: consumerKind,
+      },
+    };
+
+    expect({
+      purpose: sortPurpose(writtenPayload.purpose),
+    }).toEqual({
+      purpose: sortPurpose(toPurposeV2(expectedPurpose)),
+    });
+  });
+
   it("Should throw tenantKindNotFound when history is empty", async () => {
     const consumerKind: TenantKind = tenantKind.PA;
     const riskAnalysisId = generateId<RiskAnalysisId>();


### PR DESCRIPTION
This PR introduces a fallback for the cases when we don't manage to find a tenantKind at a reference date, so we use the first one available.