### PR TITLE
fix: consider certified discrete attributes in remaining daily calls (PIN-10337)

### DIFF
--- a/packages/purpose-process/package.json
+++ b/packages/purpose-process/package.json
@@ -37,6 +37,7 @@
     "dotenv-flow": "catalog:",
     "drizzle-orm": "catalog:",
     "express": "catalog:",
+    "pagopa-interop-agreement-lifecycle": "workspace:*",
     "pagopa-interop-api-clients": "workspace:*",
     "pagopa-interop-application-audit": "workspace:*",
     "pagopa-interop-commons": "workspace:*",

--- a/packages/purpose-process/src/config/config.ts
+++ b/packages/purpose-process/src/config/config.ts
@@ -8,6 +8,7 @@ import {
   TenantKindHistoryDBConfig,
   FeatureFlagTenantKindInRiskAnalysisConfig,
   FeatureFlagNewOperatorsConfig,
+  FeatureFlagAttributeCertifiedDiscreteConfig,
 } from "pagopa-interop-commons";
 import { z } from "zod";
 
@@ -27,7 +28,8 @@ const PurposeProcessConfig = CommonHTTPServiceConfig.and(ReadModelSQLDbConfig)
       }))
   )
   .and(ApplicationAuditProducerConfig)
-  .and(FeatureFlagNewOperatorsConfig);
+  .and(FeatureFlagNewOperatorsConfig)
+  .and(FeatureFlagAttributeCertifiedDiscreteConfig);
 type PurposeProcessConfig = z.infer<typeof PurposeProcessConfig>;
 
 export const config: PurposeProcessConfig = PurposeProcessConfig.parse(

--- a/packages/purpose-process/src/services/validators.ts
+++ b/packages/purpose-process/src/services/validators.ts
@@ -1,5 +1,7 @@
 import { purposeApi } from "pagopa-interop-api-clients";
+import { matchesCertifiedDescriptorAttribute } from "pagopa-interop-agreement-lifecycle";
 import {
+  isFeatureFlagEnabled,
   M2MAdminAuthData,
   Ownership,
   ownership,
@@ -28,7 +30,6 @@ import {
   TenantId,
   tenantKind,
   TenantKind,
-  tenantAttributeType,
   RiskAnalysisFormId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
@@ -56,6 +57,7 @@ import {
   tenantNotAllowed,
   tenantNotFound,
 } from "../model/domain/errors.js";
+import { config } from "../config/config.js";
 import { UpdatedQuotas } from "../model/domain/models.js";
 import {
   retrieveActiveAgreement,
@@ -327,21 +329,21 @@ export async function getUpdatedQuotas(
     throw tenantNotFound(consumerId);
   }
 
-  const consumerCertifiedAttributesIds = new Set(
-    tenant.attributes
-      .filter(
-        (a) =>
-          a.type === tenantAttributeType.CERTIFIED && !a.revocationTimestamp
-      )
-      .map((a) => a.id)
+  const certifiedDiscreteEnabled = isFeatureFlagEnabled(
+    config,
+    "featureFlagAttributeCertifiedDiscrete"
   );
 
   const maxDailyCallsPerConsumer =
     currentDescriptor.attributes.certified.flat().reduce((max, current) => {
-      if (!consumerCertifiedAttributesIds.has(current.id)) {
+      if (!current.dailyCallsPerConsumer) {
         return max;
       }
-      if (!current.dailyCallsPerConsumer) {
+      if (
+        !matchesCertifiedDescriptorAttribute(current, tenant.attributes, {
+          certifiedDiscreteEnabled,
+        })
+      ) {
         return max;
       }
       return Math.max(max, current.dailyCallsPerConsumer);

--- a/packages/purpose-process/test/api/validators.test.ts
+++ b/packages/purpose-process/test/api/validators.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from "vitest";
 import {
   EService,
   Purpose,
@@ -7,6 +7,11 @@ import {
   tenantKind,
   eserviceMode,
   tenantAttributeType,
+  attributeCertifiedDiscreteComparator,
+  AttributeCertifiedDiscreteComparator,
+  CertifiedDiscreteTenantAttribute,
+  EServiceAttributeCertified,
+  EServiceAttributeCertifiedDiscrete,
   EServiceId,
   DescriptorId,
   TenantId,
@@ -25,6 +30,7 @@ import {
 } from "../../src/model/domain/errors.js";
 import { ReadModelServiceSQL } from "../../src/services/readModelServiceSQL.js";
 import { retrieveActiveAgreement } from "../../src/services/purposeService.js";
+import { config } from "../../src/config/config.js";
 
 vi.mock("../../src/services/purposeService.js", () => ({
   retrieveActiveAgreement: vi.fn(),
@@ -489,5 +495,410 @@ describe("getUpdatedQuotas", () => {
     await expect(
       getUpdatedQuotas(eservice, consumerId, mockReadModelService)
     ).rejects.toThrow(tenantNotFound(consumerId));
+  });
+});
+
+describe("getUpdatedQuotas - certified discrete attributes", () => {
+  const eserviceId = "eservice-id" as EServiceId;
+  const consumerId = "consumer-id" as TenantId;
+  const descriptorId = "descriptor-id" as DescriptorId;
+  const producerId = "producer-id" as TenantId;
+  const agreementId = "agreement-id";
+  const discreteAttributeId = "discrete-attribute-id" as AttributeId;
+  const plainAttributeId = "plain-attribute-id" as AttributeId;
+
+  const DESCRIPTOR_DEFAULT_PER_CONSUMER = 100;
+  const DESCRIPTOR_TOTAL = 1000;
+
+  const buildEService = (
+    certified: Array<
+      Array<EServiceAttributeCertified | EServiceAttributeCertifiedDiscrete>
+    >
+  ): EService => ({
+    id: eserviceId,
+    producerId,
+    name: "eservice name",
+    description: "eservice description",
+    technology: "Rest",
+    mode: eserviceMode.deliver,
+    attributes: { certified: [], declared: [], verified: [] },
+    descriptors: [
+      {
+        id: descriptorId,
+        version: "1",
+        docs: [],
+        state: "Published",
+        audience: [],
+        voucherLifespan: 0,
+        dailyCallsPerConsumer: DESCRIPTOR_DEFAULT_PER_CONSUMER,
+        dailyCallsTotal: DESCRIPTOR_TOTAL,
+        interface: undefined,
+        agreementApprovalPolicy: "Automatic",
+        serverUrls: [],
+        attributes: {
+          certified,
+          declared: [],
+          verified: [],
+        },
+        createdAt: new Date(),
+      },
+    ],
+    createdAt: new Date(),
+    riskAnalysis: [],
+  });
+
+  const discreteDescriptorAttribute = (
+    threshold: number,
+    comparator: AttributeCertifiedDiscreteComparator,
+    dailyCallsPerConsumer: number | undefined,
+    id: AttributeId = discreteAttributeId
+  ): EServiceAttributeCertifiedDiscrete => ({
+    id,
+    explicitAttributeVerification: false,
+    ...(dailyCallsPerConsumer !== undefined ? { dailyCallsPerConsumer } : {}),
+    discreteConfig: { threshold, comparator },
+  });
+
+  const discreteTenantAttribute = (
+    discreteValue: number,
+    revoked = false,
+    id: AttributeId = discreteAttributeId
+  ): CertifiedDiscreteTenantAttribute => ({
+    id,
+    type: tenantAttributeType.CERTIFIED_DISCRETE,
+    assignmentTimestamp: new Date(),
+    revocationTimestamp: revoked ? new Date() : undefined,
+    discreteValue,
+  });
+
+  const agreement: Agreement = {
+    id: unsafeBrandId(agreementId),
+    eserviceId,
+    descriptorId,
+    producerId,
+    consumerId,
+    state: "Active",
+    verifiedAttributes: [],
+    certifiedAttributes: [],
+    certifiedDiscreteAttributes: [],
+    declaredAttributes: [],
+    suspendedByConsumer: undefined,
+    suspendedByProducer: undefined,
+    suspendedByPlatform: undefined,
+    createdAt: new Date(),
+    updatedAt: undefined,
+    consumerDocuments: [],
+    stamps: {
+      submission: undefined,
+      activation: undefined,
+      rejection: undefined,
+      suspensionByProducer: undefined,
+      suspensionByConsumer: undefined,
+      upgrade: undefined,
+      archiving: undefined,
+    },
+    contract: undefined,
+  };
+
+  const tenantWith = (attributes: Tenant["attributes"]): Tenant => ({
+    id: consumerId,
+    kind: tenantKind.PA,
+    selfcareId: "selfcare-id",
+    externalId: { origin: "origin", value: "value" },
+    features: [],
+    attributes,
+    createdAt: new Date(),
+    name: "tenant name",
+    mails: [],
+  });
+
+  const runWith = async (
+    eservice: EService,
+    tenant: Tenant
+  ): Promise<Awaited<ReturnType<typeof getUpdatedQuotas>>> => {
+    (retrieveActiveAgreement as Mock).mockResolvedValue(agreement);
+    (mockReadModelService.getAllPurposes as Mock).mockResolvedValue([]);
+    (mockReadModelService.getTenantById as Mock).mockResolvedValue(tenant);
+    return getUpdatedQuotas(eservice, consumerId, mockReadModelService);
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    config.featureFlagAttributeCertifiedDiscrete = true;
+  });
+
+  afterEach(() => {
+    config.featureFlagAttributeCertifiedDiscrete = false;
+  });
+
+  it("applies the differentiated quota when the discrete value satisfies the threshold", async () => {
+    const eservice = buildEService([
+      [
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          200
+        ),
+      ],
+    ]);
+    const tenant = tenantWith([discreteTenantAttribute(1500)]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(200);
+  });
+
+  it("falls back to the descriptor default when the discrete value does NOT satisfy the threshold", async () => {
+    const eservice = buildEService([
+      [
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          200
+        ),
+      ],
+    ]);
+    const tenant = tenantWith([discreteTenantAttribute(500)]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(
+      DESCRIPTOR_DEFAULT_PER_CONSUMER
+    );
+  });
+
+  it("falls back to the descriptor default when the consumer does not hold the discrete attribute", async () => {
+    const eservice = buildEService([
+      [
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          200
+        ),
+      ],
+    ]);
+    const tenant = tenantWith([]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(
+      DESCRIPTOR_DEFAULT_PER_CONSUMER
+    );
+  });
+
+  it("ignores a revoked discrete attribute even if its value would satisfy the threshold", async () => {
+    const eservice = buildEService([
+      [
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          200
+        ),
+      ],
+    ]);
+    const tenant = tenantWith([discreteTenantAttribute(1500, true)]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(
+      DESCRIPTOR_DEFAULT_PER_CONSUMER
+    );
+  });
+
+  it("ignores a discrete attribute that has no differentiated quota even when satisfied", async () => {
+    const eservice = buildEService([
+      [
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          undefined
+        ),
+      ],
+    ]);
+    const tenant = tenantWith([discreteTenantAttribute(1500)]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(
+      DESCRIPTOR_DEFAULT_PER_CONSUMER
+    );
+  });
+
+  describe.each<{
+    comparator: AttributeCertifiedDiscreteComparator;
+    pass: number;
+    fail: number;
+  }>([
+    {
+      comparator: attributeCertifiedDiscreteComparator.GT,
+      pass: 1001,
+      fail: 1000,
+    },
+    {
+      comparator: attributeCertifiedDiscreteComparator.LT,
+      pass: 999,
+      fail: 1000,
+    },
+    {
+      comparator: attributeCertifiedDiscreteComparator.EQ,
+      pass: 1000,
+      fail: 999,
+    },
+    {
+      comparator: attributeCertifiedDiscreteComparator.GTE,
+      pass: 1000,
+      fail: 999,
+    },
+    {
+      comparator: attributeCertifiedDiscreteComparator.LTE,
+      pass: 1000,
+      fail: 1001,
+    },
+    {
+      comparator: attributeCertifiedDiscreteComparator.NE,
+      pass: 999,
+      fail: 1000,
+    },
+  ])("comparator $comparator", ({ comparator, pass, fail }) => {
+    it(`applies the differentiated quota when value satisfies ${comparator}`, async () => {
+      const eservice = buildEService([
+        [discreteDescriptorAttribute(1000, comparator, 200)],
+      ]);
+      const tenant = tenantWith([discreteTenantAttribute(pass)]);
+
+      const result = await runWith(eservice, tenant);
+
+      expect(result.maxDailyCallsPerConsumer).toBe(200);
+    });
+
+    it(`falls back to default when value does not satisfy ${comparator}`, async () => {
+      const eservice = buildEService([
+        [discreteDescriptorAttribute(1000, comparator, 200)],
+      ]);
+      const tenant = tenantWith([discreteTenantAttribute(fail)]);
+
+      const result = await runWith(eservice, tenant);
+
+      expect(result.maxDailyCallsPerConsumer).toBe(
+        DESCRIPTOR_DEFAULT_PER_CONSUMER
+      );
+    });
+  });
+
+  it("picks the highest differentiated quota across multiple satisfied discrete attributes", async () => {
+    const secondAttributeId = "discrete-attribute-id-2" as AttributeId;
+    const eservice = buildEService([
+      [
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          200,
+          discreteAttributeId
+        ),
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          500,
+          secondAttributeId
+        ),
+      ],
+    ]);
+    const tenant = tenantWith([
+      discreteTenantAttribute(1500, false, discreteAttributeId),
+      discreteTenantAttribute(1500, false, secondAttributeId),
+    ]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(500);
+  });
+
+  it("combines plain certified and discrete certified attributes, taking the max satisfied quota", async () => {
+    const eservice = buildEService([
+      [
+        {
+          id: plainAttributeId,
+          explicitAttributeVerification: false,
+          dailyCallsPerConsumer: 300,
+        },
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          200
+        ),
+      ],
+    ]);
+    const tenant = tenantWith([
+      {
+        id: plainAttributeId,
+        type: tenantAttributeType.CERTIFIED,
+        assignmentTimestamp: new Date(),
+        revocationTimestamp: undefined,
+      },
+      discreteTenantAttribute(1500),
+    ]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(300);
+  });
+
+  it("ignores discrete descriptor attributes when the feature flag is disabled", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = false;
+
+    const eservice = buildEService([
+      [
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          200
+        ),
+      ],
+    ]);
+    const tenant = tenantWith([discreteTenantAttribute(1500)]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(
+      DESCRIPTOR_DEFAULT_PER_CONSUMER
+    );
+  });
+
+  it("does not apply a plain certified quota to a discrete-only tenant attribute when the flag is disabled", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = false;
+
+    const eservice = buildEService([
+      [
+        {
+          id: discreteAttributeId,
+          explicitAttributeVerification: false,
+          dailyCallsPerConsumer: 200,
+        },
+      ],
+    ]);
+    const tenant = tenantWith([discreteTenantAttribute(1500)]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(
+      DESCRIPTOR_DEFAULT_PER_CONSUMER
+    );
+  });
+
+  it("applies a plain certified quota to a discrete tenant attribute when the flag is enabled", async () => {
+    const eservice = buildEService([
+      [
+        {
+          id: discreteAttributeId,
+          explicitAttributeVerification: false,
+          dailyCallsPerConsumer: 200,
+        },
+      ],
+    ]);
+    const tenant = tenantWith([discreteTenantAttribute(1500)]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(200);
   });
 });

--- a/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
+++ b/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
@@ -1,13 +1,15 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   Agreement,
+  AttributeId,
   EService,
   EServiceId,
   Purpose,
   PurposeId,
   TenantId,
   agreementState,
+  attributeCertifiedDiscreteComparator,
   descriptorState,
   generateId,
   purposeVersionState,
@@ -26,6 +28,7 @@ import {
   purposeNotFound,
   tenantIsNotTheConsumer,
 } from "../../src/model/domain/errors.js";
+import { config } from "../../src/config/config.js";
 import {
   addOneAgreement,
   addOneEService,
@@ -164,5 +167,144 @@ describe("getRemainingDailyCalls", () => {
     ).rejects.toThrowError(
       tenantIsNotTheConsumer(anotherConsumerId, undefined)
     );
+  });
+
+  describe("certified discrete attributes (PIN-10337)", () => {
+    afterEach(() => {
+      config.featureFlagAttributeCertifiedDiscrete = false;
+    });
+
+    const setupDiscreteScenario = async ({
+      threshold,
+      discreteValue,
+      differentiatedDailyCalls,
+    }: {
+      threshold: number;
+      discreteValue: number;
+      differentiatedDailyCalls: number;
+    }): Promise<{ purposeId: PurposeId; consumerId: TenantId }> => {
+      const consumerId: TenantId = generateId();
+      const producerId: TenantId = generateId();
+      const eserviceId: EServiceId = generateId();
+      const attributeId: AttributeId = generateId();
+
+      const descriptor = {
+        ...getMockDescriptor(descriptorState.published),
+        dailyCallsPerConsumer: 100,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: attributeId,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: differentiatedDailyCalls,
+                discreteConfig: {
+                  threshold,
+                  comparator: attributeCertifiedDiscreteComparator.GTE,
+                },
+              },
+            ],
+          ],
+          declared: [],
+          verified: [],
+        },
+      };
+      const eservice: EService = getMockEService(eserviceId, producerId, [
+        descriptor,
+      ]);
+      const agreement: Agreement = {
+        ...getMockAgreement(eservice.id, consumerId, agreementState.active),
+        descriptorId: descriptor.id,
+        producerId,
+      };
+      const consumerPurpose: Purpose = {
+        ...getMockPurpose([
+          {
+            ...getMockPurposeVersion(purposeVersionState.active),
+            dailyCalls: 40,
+          },
+        ]),
+        eserviceId: eservice.id,
+        consumerId,
+      };
+
+      await addOneTenant({
+        ...getMockTenant(consumerId, [
+          {
+            id: attributeId,
+            type: "PersistentCertifiedDiscreteAttribute",
+            assignmentTimestamp: new Date(),
+            revocationTimestamp: undefined,
+            discreteValue,
+          },
+        ]),
+      });
+      await addOneEService(eservice);
+      await addOneAgreement(agreement);
+      await addOnePurpose(consumerPurpose);
+
+      return { purposeId: consumerPurpose.id, consumerId };
+    };
+
+    it("applies the differentiated discrete quota when the flag is enabled and the threshold is satisfied", async () => {
+      config.featureFlagAttributeCertifiedDiscrete = true;
+
+      const { purposeId, consumerId } = await setupDiscreteScenario({
+        threshold: 1000,
+        discreteValue: 1500,
+        differentiatedDailyCalls: 500,
+      });
+
+      const result = await purposeService.getRemainingDailyCalls({
+        purposeId,
+        ctx: getMockContext({ authData: getMockAuthData(consumerId) }),
+      });
+
+      expect(result).toEqual({
+        remainingDailyCallsPerConsumer: 460,
+        remainingDailyCallsTotal: 960,
+      });
+    });
+
+    it("falls back to the descriptor default when the discrete value does not satisfy the threshold", async () => {
+      config.featureFlagAttributeCertifiedDiscrete = true;
+
+      const { purposeId, consumerId } = await setupDiscreteScenario({
+        threshold: 1000,
+        discreteValue: 500,
+        differentiatedDailyCalls: 500,
+      });
+
+      const result = await purposeService.getRemainingDailyCalls({
+        purposeId,
+        ctx: getMockContext({ authData: getMockAuthData(consumerId) }),
+      });
+
+      expect(result).toEqual({
+        remainingDailyCallsPerConsumer: 60,
+        remainingDailyCallsTotal: 960,
+      });
+    });
+
+    it("ignores the discrete attribute when the feature flag is disabled", async () => {
+      config.featureFlagAttributeCertifiedDiscrete = false;
+
+      const { purposeId, consumerId } = await setupDiscreteScenario({
+        threshold: 1000,
+        discreteValue: 1500,
+        differentiatedDailyCalls: 500,
+      });
+
+      const result = await purposeService.getRemainingDailyCalls({
+        purposeId,
+        ctx: getMockContext({ authData: getMockAuthData(consumerId) }),
+      });
+
+      expect(result).toEqual({
+        remainingDailyCallsPerConsumer: 60,
+        remainingDailyCallsTotal: 960,
+      });
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5427,6 +5427,9 @@ importers:
       express:
         specifier: 'catalog:'
         version: 4.20.0
+      pagopa-interop-agreement-lifecycle:
+        specifier: workspace:*
+        version: link:../agreement-lifecycle
       pagopa-interop-api-clients:
         specifier: workspace:*
         version: link:../api-clients


### PR DESCRIPTION
## Jira Issue
[PIN-10337](https://pagopa.atlassian.net/browse/PIN-10337)

## Context
When creating a purpose, certified discrete attributes of the consumer were ignored while computing the remaining daily calls. The differentiated `dailyCallsPerConsumer` threshold only looked at tenant attributes of type `CERTIFIED`. It skipped `CERTIFIED_DISCRETE` attributes and never evaluated the descriptor `discreteConfig` with its threshold and comparator. As a result the differentiated quota was never applied to consumers holding a discrete attribute.

## Services Affected
- purpose-process

## Key Changes
- `getUpdatedQuotas` now applies the differentiated descriptor quota only when the consumer actually satisfies the attribute. It reuses the shared matcher `matchesCertifiedDescriptorAttribute` from `pagopa-interop-agreement-lifecycle`, which for discrete attributes compares the tenant `discreteValue` against the descriptor threshold and comparator.
- The behavior is gated by the existing `featureFlagAttributeCertifiedDiscrete`. With the flag off the behavior is identical to before.
- `getUpdatedQuotas` is shared with `isOverQuota`, so discrete attributes now also affect quota validation on purpose and version creation, not only the `/remainingDailyCalls` endpoint.

## Deployment Note
The `FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE` environment variable now needs to be configured on the purpose-process pod as well. It defaults to `false`, so the behavior stays unchanged until the flag is enabled.


[PIN-10337]: https://pagopa.atlassian.net/browse/PIN-10337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ