### PR TITLE
fix: Using tenant remoteId to revoke certified discrete attribute (PIN-10338)

### DIFF
--- a/packages/istat-certified-attributes-importer/src/service/processor.ts
+++ b/packages/istat-certified-attributes-importer/src/service/processor.ts
@@ -208,7 +208,20 @@ async function revokeMissingMunicipalities(
     await Promise.all(
       chunk.map(async (tenant) => {
         const tenantData = tenant.data;
-        logger.info(`Revoking ${tenantData.id}`);
+
+        const istatRemoteId = tenantData.remoteIds?.find(
+          (r) => r.origin === ISTAT_ATTRIBUTE_SEED.origin
+        );
+
+        if (!istatRemoteId) {
+          logger.warn(`istatRemoteId not found for tenant: ${tenantData.id}`);
+          stats.errors++;
+          return;
+        }
+
+        logger.info(
+          `Revoking attribute for tenant ${tenantData.id} (RemoteId: ${istatRemoteId?.origin} / ${istatRemoteId?.value})`
+        );
         try {
           const token = await refreshableToken.get();
           const context: InteropContext = {
@@ -218,8 +231,8 @@ async function revokeMissingMunicipalities(
 
           const metadata =
             await tenantProcess.internalRevokeCertifiedDiscreteAttribute(
-              tenantData.externalId.origin,
-              tenantData.externalId.value,
+              istatRemoteId.origin,
+              istatRemoteId.value,
               ISTAT_ATTRIBUTE_SEED.origin,
               ISTAT_ATTRIBUTE_SEED.code,
               context,

--- a/packages/istat-certified-attributes-importer/test/processor.test.ts
+++ b/packages/istat-certified-attributes-importer/test/processor.test.ts
@@ -478,8 +478,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       {
         data: {
           id: "tenant-malformed",
-          externalId: { origin: "ISTAT", value: "12342" },
-          remoteIds: [],
+          remoteIds: [{ origin: "ISTAT", value: "12342" }],
         },
         metadata: { version: 1 },
       },

--- a/packages/istat-certified-attributes-importer/test/processor.test.ts
+++ b/packages/istat-certified-attributes-importer/test/processor.test.ts
@@ -642,6 +642,51 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything()
     );
   });
+  it("should skip revocation and count an error when a tenant has no ISTAT remoteId", async () => {
+    const warnSpy = vi.spyOn(genericLogger, "warn");
+    readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
+      data: { id: generateId() },
+      metadata: { version: 1 },
+    });
+    tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
+      internalAssignCertifiedDiscreteAttributeMock
+    );
+
+    readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValueOnce([
+      {
+        data: {
+          id: "tenant-without-istat-remoteid",
+          externalId: { origin: "ISTAT", value: "999999" },
+          remoteIds: [],
+        },
+        metadata: { version: 1 },
+      },
+    ]);
+
+    tenantProcessMock.internalRevokeCertifiedDiscreteAttribute.mockImplementation(
+      internalRevokeCertifiedDiscreteAttributeMock
+    );
+
+    await importAttributes(
+      istatClientMock as any,
+      readModelQueriesMock as any,
+      tenantProcessMock as any,
+      attributeProcessMock as any,
+      refreshableTokenMock,
+      { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
+      csvChunkSize,
+      genericLogger,
+      generateId()
+    );
+
+    expect(
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
+    ).not.toHaveBeenCalled();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "istatRemoteId not found for tenant: tenant-without-istat-remoteid"
+    );
+  });
   it("should continue revoking other tenants if one revocation fails", async () => {
     readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
       data: { id: generateId() },


### PR DESCRIPTION
## Context
The attribute revocation process was failing because it incorrectly used the tenant's primary `externalId`  instead of the specific ISTAT `remoteId`. This caused a mismatch, as the `tenant-process` API expects the `remoteId` identifier to correctly locate and revoke the attribute.

## Services Affected
- `istat-certified-discrete-attributes-importer`

## Key Changes
- **Target the correct ID:** The processor now extracts the ISTAT `remoteId` from the tenant's `remoteIds` array.
- **API Alignment:** Passed the correct `remoteId.origin` and `remoteId.value` to `internalRevokeCertifiedDiscreteAttribute`
- **Tests Updated:** Adjusted the test suite to validate the correct API payload 

## Traceability Checklist
- [X] Branch name contain the Jira key
- [X] PR title is compliant with the standard (type(scope): descrizione (KEY))
- [X] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated