### PR TITLE
PIN-10284 Fix new roles in GET endpoints

### DIFF
--- a/packages/api-clients/template-bff.hbs
+++ b/packages/api-clients/template-bff.hbs
@@ -51,6 +51,8 @@ export type {{@key}} = z.infer<typeof {{@key}}>;
 						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeVersionState).optional().default([])), z.array(PurposeVersionState).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(DelegationState).optional().default([])"))}}
 						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(DelegationState).optional().default([])), z.array(DelegationState).optional().default([])])
+				{{else if (and (eq type "Query") (eq schema "z.array(RiskAnalysisSigningState).optional().default([])"))}}
+						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(RiskAnalysisSigningState).optional().default([])), z.array(RiskAnalysisSigningState).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(TenantFeatureType).optional().default([])"))}}
 						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(TenantFeatureType).optional().default([])), z.array(TenantFeatureType).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(PurposeTemplateState).optional().default([])"))}}

--- a/packages/api-clients/template.hbs
+++ b/packages/api-clients/template.hbs
@@ -57,6 +57,8 @@ export type {{@key}} = z.infer<typeof {{@key}}>;
 						schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(EServiceTemplateVersionState).optional().default([])), z.array(EServiceTemplateVersionState).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.array(PurposeTemplateState).optional().default([])"))}}
 					schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(PurposeTemplateState).optional().default([])), z.array(PurposeTemplateState).optional().default([])])
+				{{else if (and (eq type "Query") (eq schema "z.array(RiskAnalysisSigningState).optional().default([])"))}}
+					schema: z.union([z.string().optional().transform(v => v ? v.split(",") : undefined ).pipe(z.array(RiskAnalysisSigningState).optional().default([])), z.array(RiskAnalysisSigningState).optional().default([])])
 				{{else if (and (eq type "Query") (eq schema "z.string().uuid().nullish()"))}}
 					schema: z.union([z.string().uuid(), z.null(), z.undefined()])
 				{{else if (and (eq type "Query") (eq schema "z.array(NotificationType).optional().default([])"))}}

--- a/packages/attribute-registry-process/src/routers/AttributeRouter.ts
+++ b/packages/attribute-registry-process/src/routers/AttributeRouter.ts
@@ -202,6 +202,8 @@ const attributeRouter = (
             SECURITY_ROLE,
             M2M_ADMIN_ROLE,
             M2M_ROLE,
+            REVIEWER_ROLE,
+            VIEWER_ROLE,
           ]);
 
           const { data, metadata } =

--- a/packages/attribute-registry-process/test/api/getAttributeById.test.ts
+++ b/packages/attribute-registry-process/test/api/getAttributeById.test.ts
@@ -35,6 +35,8 @@ describe("API /attributes/{attributeId} authorization test", () => {
     authRole.M2M_ROLE,
     authRole.M2M_ADMIN_ROLE,
     authRole.SUPPORT_ROLE,
+    authRole.REVIEWER_ROLE,
+    authRole.VIEWER_ROLE,
   ];
   it.each(authorizedRoles)(
     "Should return 200 for user with role %s",

--- a/packages/backend-for-frontend/src/services/purposeService.ts
+++ b/packages/backend-for-frontend/src/services/purposeService.ts
@@ -200,14 +200,16 @@ export function purposeServiceBuilder(
         )
       : undefined;
 
-    const clients = authData.userRoles.includes(authRole.VIEWER_ROLE)
-      ? []
-      : await getAllClients(
-          authorizationClient,
-          authData.organizationId,
-          purpose.id,
-          headers
-        );
+    const clients =
+      authData.userRoles.includes(authRole.VIEWER_ROLE) ||
+      authData.userRoles.includes(authRole.REVIEWER_ROLE)
+        ? []
+        : await getAllClients(
+            authorizationClient,
+            authData.organizationId,
+            purpose.id,
+            headers
+          );
 
     const hasNotifications = notifications.includes(purpose.id);
 

--- a/packages/backend-for-frontend/src/services/purposeService.ts
+++ b/packages/backend-for-frontend/src/services/purposeService.ts
@@ -4,6 +4,7 @@ import {
   removeDuplicates,
   UIAuthData,
   getRulesetExpiration,
+  authRole,
 } from "pagopa-interop-commons";
 import {
   CorrelationId,
@@ -199,12 +200,14 @@ export function purposeServiceBuilder(
         )
       : undefined;
 
-    const clients = await getAllClients(
-      authorizationClient,
-      authData.organizationId,
-      purpose.id,
-      headers
-    );
+    const clients = authData.userRoles.includes(authRole.VIEWER_ROLE)
+      ? []
+      : await getAllClients(
+          authorizationClient,
+          authData.organizationId,
+          purpose.id,
+          headers
+        );
 
     const hasNotifications = notifications.includes(purpose.id);
 

--- a/packages/delegation-process/src/routers/DelegationRouter.ts
+++ b/packages/delegation-process/src/routers/DelegationRouter.ts
@@ -49,6 +49,8 @@ const {
   SUPPORT_ROLE,
   M2M_ADMIN_ROLE,
   INTERNAL_ROLE,
+  REVIEWER_ROLE,
+  VIEWER_ROLE,
 } = authRole;
 
 const delegationRouter = (
@@ -80,6 +82,8 @@ const delegationRouter = (
           M2M_ROLE,
           M2M_ADMIN_ROLE,
           SUPPORT_ROLE,
+          REVIEWER_ROLE,
+          VIEWER_ROLE,
         ]);
 
         const delegations = await delegationService.getDelegations(
@@ -487,6 +491,7 @@ const delegationRouter = (
           SECURITY_ROLE,
           M2M_ROLE,
           SUPPORT_ROLE,
+          VIEWER_ROLE,
         ]);
 
         const delegators = await delegationService.getConsumerDelegators(
@@ -524,6 +529,7 @@ const delegationRouter = (
           SECURITY_ROLE,
           M2M_ROLE,
           SUPPORT_ROLE,
+          VIEWER_ROLE,
         ]);
 
         const delegators =

--- a/packages/delegation-process/test/api/getConsumerDelegators.test.ts
+++ b/packages/delegation-process/test/api/getConsumerDelegators.test.ts
@@ -53,6 +53,7 @@ describe("API GET /consumer/delegators test", () => {
     authRole.SECURITY_ROLE,
     authRole.M2M_ROLE,
     authRole.SUPPORT_ROLE,
+    authRole.VIEWER_ROLE,
   ];
 
   it.each(authorizedRoles)(

--- a/packages/delegation-process/test/api/getConsumerDelegatorsWithAgreements.test.ts
+++ b/packages/delegation-process/test/api/getConsumerDelegatorsWithAgreements.test.ts
@@ -52,6 +52,7 @@ describe("API GET /consumer/delegatorsWithAgreements test", () => {
     authRole.SECURITY_ROLE,
     authRole.M2M_ROLE,
     authRole.SUPPORT_ROLE,
+    authRole.VIEWER_ROLE,
   ];
 
   it.each(authorizedRoles)(

--- a/packages/delegation-process/test/api/getDelegations.test.ts
+++ b/packages/delegation-process/test/api/getDelegations.test.ts
@@ -63,6 +63,8 @@ describe("API GET /delegations test", () => {
     authRole.M2M_ROLE,
     authRole.M2M_ADMIN_ROLE,
     authRole.SUPPORT_ROLE,
+    authRole.REVIEWER_ROLE,
+    authRole.VIEWER_ROLE,
   ];
 
   it.each(authorizedRoles)(

--- a/packages/in-app-notification-manager/src/routers/notificationRouter.ts
+++ b/packages/in-app-notification-manager/src/routers/notificationRouter.ts
@@ -52,6 +52,7 @@ export const notificationRouter = (
           API_ROLE,
           SECURITY_ROLE,
           SUPPORT_ROLE,
+          VIEWER_ROLE,
         ]);
 
         const filterUnreadNotifications: string[] =

--- a/packages/in-app-notification-manager/src/routers/notificationRouter.ts
+++ b/packages/in-app-notification-manager/src/routers/notificationRouter.ts
@@ -52,6 +52,7 @@ export const notificationRouter = (
           API_ROLE,
           SECURITY_ROLE,
           SUPPORT_ROLE,
+          REVIEWER_ROLE,
           VIEWER_ROLE,
         ]);
 

--- a/packages/in-app-notification-manager/test/api/filterUnreadNotifications.test.ts
+++ b/packages/in-app-notification-manager/test/api/filterUnreadNotifications.test.ts
@@ -33,6 +33,7 @@ describe("API GET /filterUnreadNotifications", () => {
     authRole.API_ROLE,
     authRole.SECURITY_ROLE,
     authRole.SUPPORT_ROLE,
+    authRole.REVIEWER_ROLE,
     authRole.VIEWER_ROLE,
   ];
 

--- a/packages/in-app-notification-manager/test/api/filterUnreadNotifications.test.ts
+++ b/packages/in-app-notification-manager/test/api/filterUnreadNotifications.test.ts
@@ -33,6 +33,7 @@ describe("API GET /filterUnreadNotifications", () => {
     authRole.API_ROLE,
     authRole.SECURITY_ROLE,
     authRole.SUPPORT_ROLE,
+    authRole.VIEWER_ROLE,
   ];
 
   it.each(authorizedRoles)(

--- a/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
+++ b/packages/purpose-template-process/src/routers/PurposeTemplateRouter.ts
@@ -87,6 +87,7 @@ const purposeTemplateRouter = (
     SECURITY_ROLE,
     SUPPORT_ROLE,
     INTERNAL_ROLE,
+    VIEWER_ROLE,
   } = authRole;
 
   purposeTemplateRouter
@@ -100,6 +101,7 @@ const purposeTemplateRouter = (
           M2M_ROLE,
           SECURITY_ROLE,
           SUPPORT_ROLE,
+          VIEWER_ROLE,
         ]);
 
         const {
@@ -177,6 +179,7 @@ const purposeTemplateRouter = (
           API_ROLE,
           SECURITY_ROLE,
           SUPPORT_ROLE,
+          VIEWER_ROLE,
         ]);
 
         const { creatorName, offset, limit } = req.query;

--- a/packages/purpose-template-process/test/api/getPurposeTemplates.test.ts
+++ b/packages/purpose-template-process/test/api/getPurposeTemplates.test.ts
@@ -77,6 +77,7 @@ describe("API GET /purposeTemplates", () => {
     authRole.M2M_ROLE,
     authRole.M2M_ADMIN_ROLE,
     authRole.SUPPORT_ROLE,
+    authRole.VIEWER_ROLE,
   ];
 
   it.each(authorizedRoles)(

--- a/packages/purpose-template-process/test/api/getPurposeTemplatesCreators.test.ts
+++ b/packages/purpose-template-process/test/api/getPurposeTemplatesCreators.test.ts
@@ -58,6 +58,7 @@ describe("API GET /creators test", () => {
     authRole.API_ROLE,
     authRole.SECURITY_ROLE,
     authRole.SUPPORT_ROLE,
+    authRole.VIEWER_ROLE,
   ];
   it.each(authorizedRoles)(
     "Should return 200 for user with role %s",


### PR DESCRIPTION
This PR adds VIEWER and REVIEWER in more GET endpoints.
A custom fix has been make in getPurposes: that endpoint need to retrieves all the clients related, but it shouldn't be made in case of VIEWER. So, since the call is made internally, I have let it return an empty array instead of getting the clients.