### PR TITLE
build: add agreement-lifecycle to purpose-process Dockerfile (PIN-10339)

### DIFF
--- a/packages/purpose-process/Dockerfile
+++ b/packages/purpose-process/Dockerfile
@@ -12,6 +12,7 @@ COPY pnpm-workspace.yaml /app/
 COPY .npmrc /app/
 
 COPY ./packages/purpose-process/package.json /app/packages/purpose-process/package.json
+COPY ./packages/agreement-lifecycle/package.json /app/packages/agreement-lifecycle/package.json
 COPY ./packages/commons/package.json /app/packages/commons/package.json
 COPY ./packages/models/package.json /app/packages/models/package.json
 COPY ./packages/api-clients/package.json /app/packages/api-clients/package.json
@@ -26,6 +27,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 COPY tsconfig.json /app/
 COPY turbo.json /app/
 COPY ./packages/purpose-process /app/packages/purpose-process
+COPY ./packages/agreement-lifecycle /app/packages/agreement-lifecycle
 COPY ./packages/commons /app/packages/commons
 COPY ./packages/models /app/packages/models
 COPY ./packages/api-clients /app/packages/api-clients
@@ -43,6 +45,7 @@ RUN NODE_OPTIONS="--max-old-space-size=${NODE_HEAP_SIZE}" pnpm build && \
   cp -a --parents -t /out \
   node_modules packages/purpose-process/node_modules \
   package*.json packages/purpose-process/package*.json \
+  packages/agreement-lifecycle/ \
   packages/commons/ \
   packages/models/ \
   packages/api-clients \

--- a/packages/purpose-process/test/api/validators.test.ts
+++ b/packages/purpose-process/test/api/validators.test.ts
@@ -648,6 +648,23 @@ describe("getUpdatedQuotas - certified discrete attributes", () => {
     expect(result.maxDailyCallsPerConsumer).toBe(200);
   });
 
+  it("applies the differentiated quota even when it is lower than the descriptor default", async () => {
+    const eservice = buildEService([
+      [
+        discreteDescriptorAttribute(
+          1000,
+          attributeCertifiedDiscreteComparator.GTE,
+          50
+        ),
+      ],
+    ]);
+    const tenant = tenantWith([discreteTenantAttribute(1500)]);
+
+    const result = await runWith(eservice, tenant);
+
+    expect(result.maxDailyCallsPerConsumer).toBe(50);
+  });
+
   it("falls back to the descriptor default when the discrete value does NOT satisfy the threshold", async () => {
     const eservice = buildEService([
       [

--- a/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
+++ b/packages/purpose-process/test/integration/getRemainingDailyCalls.test.ts
@@ -267,6 +267,26 @@ describe("getRemainingDailyCalls", () => {
       });
     });
 
+    it("applies the differentiated discrete quota even when it is lower than the descriptor default", async () => {
+      config.featureFlagAttributeCertifiedDiscrete = true;
+
+      const { purposeId, consumerId } = await setupDiscreteScenario({
+        threshold: 1000,
+        discreteValue: 1500,
+        differentiatedDailyCalls: 50,
+      });
+
+      const result = await purposeService.getRemainingDailyCalls({
+        purposeId,
+        ctx: getMockContext({ authData: getMockAuthData(consumerId) }),
+      });
+
+      expect(result).toEqual({
+        remainingDailyCallsPerConsumer: 10,
+        remainingDailyCallsTotal: 960,
+      });
+    });
+
     it("falls back to the descriptor default when the discrete value does not satisfy the threshold", async () => {
       config.featureFlagAttributeCertifiedDiscrete = true;
 


### PR DESCRIPTION
## Jira Issue
[PIN-10339](https://pagopa.atlassian.net/browse/PIN-10339)

## Context
PR #3475 (PIN-10337) introduced the workspace dependency `pagopa-interop-agreement-lifecycle` in purpose-process, but the service Dockerfile copies workspace packages with an explicit list that did not include the new package. Since that merge the purpose-process Docker image build fails: `pnpm build` inside the container cannot resolve the import, no new image is published to ECR and the pods keep running the pre-fix code, so the differentiated quota for certified discrete attributes is not applied in any environment.

## Services Affected
- purpose-process

## Key Changes
- Add `agreement-lifecycle` to the purpose-process Dockerfile: COPY of its `package.json` for the install step, COPY of its sources for the build step, and inclusion in the final stage `cp` list for the runtime. Same pattern already used by agreement-process, backend-for-frontend and documents-generator.
- Add regression tests for the case where the differentiated discrete quota is lower than the descriptor default, which was not covered by the PR #3475 tests: one in the `getUpdatedQuotas` API tests and one in the `getRemainingDailyCalls` integration tests.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)

[PIN-10339]: https://pagopa.atlassian.net/browse/PIN-10339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ