### PR TITLE
chore: Updated ISTAT certified discrete attribute name

### DIFF
--- a/packages/istat-certified-attributes-importer/src/config/constants.ts
+++ b/packages/istat-certified-attributes-importer/src/config/constants.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-const ISTAT_POPULATION_ATTRIBUTE_NAME = "popolazione_residente";
+const ISTAT_POPULATION_ATTRIBUTE_NAME = "Popolazione residente";
 export const SUMMARY_AGE_CODE = 999;
 const ISTAT_CERTIFIER_ORIGIN = "ISTAT";
 


### PR DESCRIPTION
## Context
The certified discrete attribute related to ISTAT has a camel_case name that is not compliant with the rest of certified attributes. So The new name will be "**Popolazione Residente**"

## Services Affected
- `istat-certified-discrete-attributes-importer`

## Key Changes
- **Set the correct attribute name:** Update the value in the constants file with the new value.

## Traceability Checklist
- [X] Branch name contain the Jira key
- [X] PR title is compliant with the standard (type(scope): descrizione (KEY))
- [X] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated