### PR TITLE
PIN-10026 Improve testing on REST API interface interpolation

### DIFF
--- a/packages/commons-test/test/interpolateTemplateRestApiSpec.test.ts
+++ b/packages/commons-test/test/interpolateTemplateRestApiSpec.test.ts
@@ -101,6 +101,52 @@ describe("interpolateTemplateRestApiSpec", async () => {
     expect(yamlString).toContain("$ref");
   });
 
+  it("should not mutate the spec beyond the interpolated custom fields", async () => {
+    // The interpolation is only allowed to touch the custom fields
+    // (info.contact, info.termsOfService and servers). Everything else
+    // (paths, components, $ref, etc.) must stay byte-for-byte equivalent:
+    // the validation step must not dereference $ref nor reorder the spec.
+    const stripCustomFields = (spec: ReturnType<typeof JSON.parse>): void => {
+      delete spec.servers;
+      delete spec.info.contact;
+      delete spec.info.termsOfService;
+    };
+
+    const jsonResult: File = await interpolateTemplateRestApiSpec(
+      eservice,
+      file,
+      interfaceFileInfo,
+      eserviceInstanceInterfaceData
+    );
+    const jsonOutput = JSON.parse(await jsonResult.text());
+    const jsonInput = JSON.parse(file);
+    stripCustomFields(jsonOutput);
+    stripCustomFields(jsonInput);
+    expect(jsonOutput).toStrictEqual(jsonInput);
+
+    const yamlFileString: string = await readFileContent(
+      "test.openapi.3.0.2.yaml"
+    );
+    const yamlInterfaceFileInfo = {
+      id: generateId(),
+      name: "yaml",
+      contentType: "application/x-yaml",
+      prettyName: "Test Interface YAML",
+    };
+    const yamlResult: File = await interpolateTemplateRestApiSpec(
+      eservice,
+      yamlFileString,
+      yamlInterfaceFileInfo,
+      eserviceInstanceInterfaceData
+    );
+    const { parse } = await import("yaml");
+    const yamlOutput = parse(await yamlResult.text());
+    const yamlInput = parse(yamlFileString);
+    stripCustomFields(yamlOutput);
+    stripCustomFields(yamlInput);
+    expect(yamlOutput).toStrictEqual(yamlInput);
+  });
+
   it("should throw invalidInterfaceFileDetected error for unsupported file type", async () => {
     const interfaceFileInfo = {
       id: generateId(),


### PR DESCRIPTION
## Context

Improvement on top of PIN-10018 (REST, merged in #3328). When an eservice is instantiated from a template, its REST API interface is customized by interpolating custom fields (`info.contact`, `info.termsOfService`, `servers`). The OpenAPI validation (`SwaggerParser.validate`) used to resolve `$ref` in place — cloning components for JSON and rewriting them as YAML anchors (`&a1`/`*a1`) for YAML. #3328 fixed that by validating a `structuredClone` of the spec.

## What this PR does

Addresses the review suggestion from #3328 (https://github.com/pagopa/interop-be-monorepo/pull/3328#discussion_r3232038693): add an explicit, strict test that the interpolation does **not** alter the spec beyond the custom fields.

Adds `should not mutate the spec beyond the interpolated custom fields` to `interpolateTemplateRestApiSpec.test.ts`, for both JSON and YAML:
- runs the interpolation;
- strips only the customizable fields (`info.contact`, `info.termsOfService`, `servers`) from both the original and the interpolated spec;
- asserts the remainder is strictly equal (`toStrictEqual`), proving `paths`, `components`, `$ref`, etc. are left untouched (no dereferencing, no reordering, no YAML anchors).

## Scope

Scoped to REST so it can target `develop`. The SOAP/WSDL counterpart (PIN-10024) is handled separately in #3343.