### PR TITLE
fix: fix certified discrete attribute handling (PIN-10358)

### DIFF
--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -80,6 +80,7 @@ const errorCodes = {
   eserviceNotInArchiving: "0063",
   eServiceAlreadyArchived: "0064",
   attributeDiscreteConfigNotAllowed: "0065",
+  certifiedDiscreteAttributeConfigCannotBeChanged: "0066",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -677,6 +678,18 @@ export function attributeDiscreteConfigNotAllowed(
     detail: `Discrete config is not allowed for non-certified attribute ${attributeId}`,
     code: "attributeDiscreteConfigNotAllowed",
     title: "Discrete config not allowed for non-certified attribute",
+  });
+}
+
+export function certifiedDiscreteAttributeConfigCannotBeChanged(
+  eserviceId: EServiceId,
+  descriptorId: DescriptorId,
+  attributeId: AttributeId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Certified discrete attribute ${attributeId} config cannot be changed for descriptor ${descriptorId} of EService ${eserviceId}`,
+    code: "certifiedDiscreteAttributeConfigCannotBeChanged",
+    title: "Certified discrete attribute config cannot be changed",
   });
 }
 

--- a/packages/catalog-process/src/services/attributeGroupUtils.ts
+++ b/packages/catalog-process/src/services/attributeGroupUtils.ts
@@ -1,0 +1,67 @@
+import { type EServiceAttributeCertifiedDiscreteConfig } from "pagopa-interop-models";
+
+export type CertifiedAttributeComparison = {
+  id: string;
+  discreteConfig?: EServiceAttributeCertifiedDiscreteConfig;
+};
+
+export const certifiedAttributeRequirementsEqual = (
+  first: CertifiedAttributeComparison,
+  second: CertifiedAttributeComparison
+): boolean =>
+  first.id === second.id &&
+  first.discreteConfig?.threshold === second.discreteConfig?.threshold &&
+  first.discreteConfig?.comparator === second.discreteConfig?.comparator &&
+  Boolean(first.discreteConfig) === Boolean(second.discreteConfig);
+
+export const certifiedAttributeIdsEqual = (
+  first: CertifiedAttributeComparison,
+  second: CertifiedAttributeComparison
+): boolean => first.id === second.id;
+
+export const certifiedGroupContainsAllByRequirement = (
+  candidateGroup: CertifiedAttributeComparison[],
+  requiredGroup: CertifiedAttributeComparison[]
+): boolean =>
+  requiredGroup.every((requiredAttribute) =>
+    candidateGroup.some((candidateAttribute) =>
+      certifiedAttributeRequirementsEqual(candidateAttribute, requiredAttribute)
+    )
+  );
+
+export const certifiedGroupContainsAllById = (
+  candidateGroup: CertifiedAttributeComparison[],
+  requiredGroup: CertifiedAttributeComparison[]
+): boolean =>
+  requiredGroup.every((requiredAttribute) =>
+    candidateGroup.some((candidateAttribute) =>
+      certifiedAttributeIdsEqual(candidateAttribute, requiredAttribute)
+    )
+  );
+
+export const findMatchingCertifiedGroup = <
+  TGroup extends CertifiedAttributeComparison,
+>(
+  groups: TGroup[][],
+  groupToMatch: CertifiedAttributeComparison[],
+  usedGroupIndexes: Set<number>,
+  groupMatches: (
+    candidateGroup: TGroup[],
+    groupToMatch: CertifiedAttributeComparison[]
+  ) => boolean
+): TGroup[] | undefined => {
+  for (const [groupIndex, group] of groups.entries()) {
+    if (usedGroupIndexes.has(groupIndex)) {
+      continue;
+    }
+
+    if (!groupMatches(group, groupToMatch)) {
+      continue;
+    }
+
+    usedGroupIndexes.add(groupIndex);
+    return group;
+  }
+
+  return undefined;
+};

--- a/packages/catalog-process/src/services/attributeGroupUtils.ts
+++ b/packages/catalog-process/src/services/attributeGroupUtils.ts
@@ -14,7 +14,7 @@ export const certifiedAttributeRequirementsEqual = (
   first.discreteConfig?.comparator === second.discreteConfig?.comparator &&
   Boolean(first.discreteConfig) === Boolean(second.discreteConfig);
 
-export const certifiedAttributeIdsEqual = (
+const certifiedAttributeIdsEqual = (
   first: CertifiedAttributeComparison,
   second: CertifiedAttributeComparison
 ): boolean => first.id === second.id;

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -82,6 +82,7 @@ import {
 import {
   attributeNotFound,
   audienceCannotBeEmpty,
+  certifiedDiscreteAttributeConfigCannotBeChanged,
   descriptorAttributeGroupSupersetMissingInAttributesSeed,
   documentPrettyNameDuplicate,
   eServiceAlreadyUpgraded,
@@ -2410,6 +2411,14 @@ export function catalogServiceBuilder(
       assertDescriptorUpdatableAfterPublish(descriptor);
       assertConsistentDailyCalls(seed);
 
+      if (seed.attributes !== undefined) {
+        assertCertifiedDiscreteConfigsUnchanged(
+          eserviceId,
+          descriptor,
+          seed.attributes
+        );
+      }
+
       const updatedAttributes = seed.attributes
         ? await parseAndCheckAttributes(seed.attributes, readModelService)
         : descriptor.attributes;
@@ -3322,6 +3331,8 @@ export function catalogServiceBuilder(
 
       const descriptor = retrieveDescriptor(descriptorId, eservice);
       assertDescriptorUpdatableAfterPublish(descriptor);
+
+      assertCertifiedDiscreteConfigsUnchanged(eserviceId, descriptor, seed);
 
       const newAttributes = updateEServiceDescriptorAttributeInAdd(
         eserviceId,
@@ -5016,6 +5027,62 @@ function updateEServiceDescriptorAttributeInAdd(
     ...verifiedAttributes,
     ...declaredAttributes,
   ].map(unsafeBrandId<AttributeId>);
+}
+
+function assertCertifiedDiscreteConfigsUnchanged(
+  eserviceId: EServiceId,
+  descriptor: Descriptor,
+  seed: catalogApi.AttributesSeed
+): void {
+  const usedSeedGroupIndexesByRequirement = new Set<number>();
+  const usedSeedGroupIndexesById = new Set<number>();
+
+  for (const descriptorGroup of descriptor.attributes.certified) {
+    const sameRequirementSeedGroup = findMatchingCertifiedGroup(
+      seed.certified,
+      descriptorGroup,
+      usedSeedGroupIndexesByRequirement,
+      (seedGroup, descriptorGroup) =>
+        certifiedGroupContainsAllByRequirement(seedGroup, descriptorGroup)
+    );
+
+    if (sameRequirementSeedGroup !== undefined) {
+      continue;
+    }
+
+    const sameIdsSeedGroup = findMatchingCertifiedGroup(
+      seed.certified,
+      descriptorGroup,
+      usedSeedGroupIndexesById,
+      (seedGroup, descriptorGroup) =>
+        certifiedGroupContainsAllById(seedGroup, descriptorGroup)
+    );
+
+    if (sameIdsSeedGroup === undefined) {
+      continue;
+    }
+
+    const changedCertifiedDiscreteAttribute = descriptorGroup.find(
+      (descriptorAttribute) =>
+        getEServiceAttributeDiscreteConfig(descriptorAttribute) !== undefined &&
+        sameIdsSeedGroup.some(
+          (seedAttribute) =>
+            seedAttribute.id === descriptorAttribute.id &&
+            !certifiedAttributeRequirementsEqual(
+              seedAttribute,
+              descriptorAttribute
+            )
+        )
+    );
+
+    if (changedCertifiedDiscreteAttribute !== undefined) {
+      throw certifiedDiscreteAttributeConfigCannotBeChanged(
+        eserviceId,
+        descriptor.id,
+        changedCertifiedDiscreteAttribute.id
+      );
+    }
+  }
 }
 
 function hasCertifiedAttributeConfigurationChanged(

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -232,6 +232,13 @@ import {
   DEFAULT_DAILY_CALLS_PER_CONSUMER,
   DEFAULT_DAILY_CALLS_TOTAL,
 } from "../model/domain/constants.js";
+import {
+  certifiedAttributeRequirementsEqual,
+  certifiedGroupContainsAllById,
+  certifiedGroupContainsAllByRequirement,
+  findMatchingCertifiedGroup,
+  type CertifiedAttributeComparison,
+} from "./attributeGroupUtils.js";
 
 const retrieveEService = async (
   eserviceId: EServiceId,
@@ -4862,44 +4869,12 @@ function retainCurrentCertifiedDailyCalls(
   incomingAttributes: EserviceAttributes,
   currentAttributes: EserviceAttributes
 ): EserviceAttributes {
-  function isMatchingCertifiedGroup(
-    incomingGroup: EServiceCertifiedAttribute[],
-    currentGroup: EServiceCertifiedAttribute[]
-  ): boolean {
-    return currentGroup.every((currentAttribute) =>
-      incomingGroup.some(
-        (incomingAttribute) => incomingAttribute.id === currentAttribute.id
-      )
-    );
-  }
-
-  function findMatchingCertifiedGroup(
-    incomingGroup: EServiceCertifiedAttribute[],
-    currentGroups: EServiceCertifiedAttribute[][],
-    usedCurrentGroupIndexes: Set<number>
-  ): EServiceCertifiedAttribute[] | undefined {
-    for (const [groupIndex, currentGroup] of currentGroups.entries()) {
-      if (usedCurrentGroupIndexes.has(groupIndex)) {
-        continue;
-      }
-
-      if (!isMatchingCertifiedGroup(incomingGroup, currentGroup)) {
-        continue;
-      }
-
-      usedCurrentGroupIndexes.add(groupIndex);
-      return currentGroup;
-    }
-
-    return undefined;
-  }
-
   function findCurrentCertifiedAttribute(
     incomingAttribute: EServiceCertifiedAttribute,
     currentGroup: EServiceCertifiedAttribute[] | undefined
   ): EServiceCertifiedAttribute | undefined {
-    return currentGroup?.find(
-      (currentAttribute) => currentAttribute.id === incomingAttribute.id
+    return currentGroup?.find((currentAttribute) =>
+      certifiedAttributeRequirementsEqual(currentAttribute, incomingAttribute)
     );
   }
 
@@ -4943,9 +4918,11 @@ function retainCurrentCertifiedDailyCalls(
   const updatedCertifiedAttributes = incomingAttributes.certified.map(
     (incomingGroup) => {
       const currentGroup = findMatchingCertifiedGroup(
-        incomingGroup,
         currentAttributes.certified,
-        usedCurrentGroupIndexes
+        incomingGroup,
+        usedCurrentGroupIndexes,
+        (currentGroup, incomingGroup) =>
+          certifiedGroupContainsAllByRequirement(incomingGroup, currentGroup)
       );
 
       return retainCurrentDailyCallsInCertifiedGroup(
@@ -4976,7 +4953,16 @@ function updateEServiceDescriptorAttributeInAdd(
    */
   function validateAndRetrieveNewAttributes(
     attributesDescriptor: EServiceAttribute[][],
-    attributesSeed: catalogApi.Attribute[][]
+    attributesSeed: catalogApi.Attribute[][],
+    groupContainsAll: (
+      candidateGroup: CertifiedAttributeComparison[],
+      requiredGroup: CertifiedAttributeComparison[]
+    ) => boolean = certifiedGroupContainsAllById,
+    attributeAlreadyExists: (
+      descriptorAttribute: CertifiedAttributeComparison,
+      seedAttribute: CertifiedAttributeComparison
+    ) => boolean = (descriptorAttribute, seedAttribute) =>
+      descriptorAttribute.id === seedAttribute.id
   ): string[] {
     // If the seed has a different number of attribute groups than the descriptor, it's invalid
     if (attributesDescriptor.length !== attributesSeed.length) {
@@ -4986,11 +4972,7 @@ function updateEServiceDescriptorAttributeInAdd(
     return attributesDescriptor.flatMap((attributeGroup) => {
       // Get the seed group that is a superset of the descriptor group
       const supersetSeed = attributesSeed.find((seedGroup) =>
-        attributeGroup.every((descriptorAttribute) =>
-          seedGroup.some(
-            (seedAttribute) => descriptorAttribute.id === seedAttribute.id
-          )
-        )
+        groupContainsAll(seedGroup, attributeGroup)
       );
 
       if (!supersetSeed) {
@@ -5004,7 +4986,9 @@ function updateEServiceDescriptorAttributeInAdd(
       return supersetSeed
         .filter(
           (seedAttribute) =>
-            !attributeGroup.some((att) => att.id === seedAttribute.id)
+            !attributeGroup.some((descriptorAttribute) =>
+              attributeAlreadyExists(descriptorAttribute, seedAttribute)
+            )
         )
         .flatMap((seedAttribute) => seedAttribute.id);
     });
@@ -5012,7 +4996,9 @@ function updateEServiceDescriptorAttributeInAdd(
 
   const certifiedAttributes = validateAndRetrieveNewAttributes(
     descriptor.attributes.certified,
-    seed.certified
+    seed.certified,
+    certifiedGroupContainsAllByRequirement,
+    certifiedAttributeRequirementsEqual
   );
 
   const verifiedAttributes = validateAndRetrieveNewAttributes(
@@ -5037,13 +5023,14 @@ function hasCertifiedAttributeConfigurationChanged(
   descriptor: Descriptor,
   seed: catalogApi.AttributesSeed
 ): boolean {
+  const usedSeedGroupIndexes = new Set<number>();
   return descriptor.attributes.certified.some((descriptorAttributesGroup) => {
-    const seedAttrGroup = seed.certified.find((seedGroup) =>
-      descriptorAttributesGroup.every((descriptorAttribute) =>
-        seedGroup.some(
-          (seedAttribute) => seedAttribute.id === descriptorAttribute.id
-        )
-      )
+    const seedAttrGroup = findMatchingCertifiedGroup(
+      seed.certified,
+      descriptorAttributesGroup,
+      usedSeedGroupIndexes,
+      (seedGroup, descriptorGroup) =>
+        certifiedGroupContainsAllByRequirement(seedGroup, descriptorGroup)
     );
 
     if (seedAttrGroup === undefined) {

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -26,7 +26,6 @@ import {
   EServiceId,
   eserviceMode,
   EServiceTemplateId,
-  getEServiceAttributeDiscreteConfig,
   operationForbidden,
   RiskAnalysisId,
   technology,
@@ -661,16 +660,11 @@ function assertAttributeGroupsUnchanged(
         (attr) => attr.id === descriptorAttr.id
       );
 
-      const descriptorDiscreteConfig =
-        getEServiceAttributeDiscreteConfig(descriptorAttr);
-
       if (
         !seedAttr ||
         seedAttr.explicitAttributeVerification !==
           descriptorAttr.explicitAttributeVerification ||
-        !certifiedAttributeRequirementsEqual(seedAttr, descriptorAttr) ||
-        Boolean(seedAttr.discreteConfig) !==
-          (descriptorDiscreteConfig !== undefined)
+        !certifiedAttributeRequirementsEqual(seedAttr, descriptorAttr)
       ) {
         throw templateInstanceNotAllowed(eserviceId, templateId);
       }

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -79,6 +79,11 @@ import {
   getLatestDescriptor,
 } from "../utilities/versionGenerator.js";
 import { catalogApi } from "pagopa-interop-api-clients";
+import {
+  certifiedAttributeRequirementsEqual,
+  certifiedGroupContainsAllByRequirement,
+  findMatchingCertifiedGroup,
+} from "./attributeGroupUtils.js";
 
 export function descriptorStatesNotAllowingDocumentOperations(
   descriptor: Descriptor
@@ -636,13 +641,15 @@ function assertAttributeGroupsUnchanged(
     throw templateInstanceNotAllowed(eserviceId, templateId);
   }
 
+  const usedSeedGroupIndexes = new Set<number>();
   for (const descriptorGroup of descriptorGroups) {
-    const matchingSeedGroup = seedGroups.find(
-      (seedGroup) =>
+    const matchingSeedGroup = findMatchingCertifiedGroup(
+      seedGroups,
+      descriptorGroup,
+      usedSeedGroupIndexes,
+      (seedGroup, descriptorGroup) =>
         seedGroup.length === descriptorGroup.length &&
-        descriptorGroup.every((descriptorAttr) =>
-          seedGroup.some((seedAttr) => seedAttr.id === descriptorAttr.id)
-        )
+        certifiedGroupContainsAllByRequirement(seedGroup, descriptorGroup)
     );
 
     if (!matchingSeedGroup) {
@@ -661,10 +668,7 @@ function assertAttributeGroupsUnchanged(
         !seedAttr ||
         seedAttr.explicitAttributeVerification !==
           descriptorAttr.explicitAttributeVerification ||
-        seedAttr.discreteConfig?.threshold !==
-          descriptorDiscreteConfig?.threshold ||
-        seedAttr.discreteConfig?.comparator !==
-          descriptorDiscreteConfig?.comparator ||
+        !certifiedAttributeRequirementsEqual(seedAttr, descriptorAttr) ||
         Boolean(seedAttr.discreteConfig) !==
           (descriptorDiscreteConfig !== undefined)
       ) {

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -743,7 +743,6 @@ export const updateTemplateInstanceDescriptorErrorMapper = (
       "inconsistentDailyCalls",
       "attributeDailyCallsNotAllowed",
       "attributeDiscreteConfigNotAllowed",
-      "certifiedDiscreteAttributeConfigCannotBeChanged",
       "templateInstanceNotAllowed",
       () => HTTP_STATUS_BAD_REQUEST
     )

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -279,6 +279,7 @@ export const updateDescriptorErrorMapper = (
       "attributeDailyCallsNotAllowed",
       "templateInstanceNotAllowed",
       "attributeDiscreteConfigNotAllowed",
+      "certifiedDiscreteAttributeConfigCannotBeChanged",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -511,6 +512,7 @@ export const updateDescriptorAttributesErrorMapper = (
       "notValidDescriptor",
       "attributeDailyCallsNotAllowed",
       "attributeDiscreteConfigNotAllowed",
+      "certifiedDiscreteAttributeConfigCannotBeChanged",
       "templateInstanceNotAllowed",
       "inconsistentDailyCalls",
       () => HTTP_STATUS_BAD_REQUEST
@@ -741,6 +743,7 @@ export const updateTemplateInstanceDescriptorErrorMapper = (
       "inconsistentDailyCalls",
       "attributeDailyCallsNotAllowed",
       "attributeDiscreteConfigNotAllowed",
+      "certifiedDiscreteAttributeConfigCannotBeChanged",
       "templateInstanceNotAllowed",
       () => HTTP_STATUS_BAD_REQUEST
     )

--- a/packages/catalog-process/test/integration/parseAndCheckAttributes.test.ts
+++ b/packages/catalog-process/test/integration/parseAndCheckAttributes.test.ts
@@ -124,6 +124,39 @@ describe("parseAndCheckAttributes", () => {
     expect(result).toEqual(seed);
   });
 
+  it("should parse and check the same certified discrete attribute in different groups", async () => {
+    const seed: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: certifiedDiscrete1.id,
+            explicitAttributeVerification: false,
+            discreteConfig: {
+              threshold: 1000,
+              comparator: attributeCertifiedDiscreteComparator.GT,
+            },
+          },
+        ],
+        [
+          {
+            id: certifiedDiscrete1.id,
+            explicitAttributeVerification: false,
+            discreteConfig: {
+              threshold: 10000,
+              comparator: attributeCertifiedDiscreteComparator.LT,
+            },
+          },
+        ],
+      ],
+      declared: [],
+      verified: [],
+    };
+
+    const result = await parseAndCheckAttributes(seed, readModelService);
+
+    expect(result).toEqual(seed);
+  });
+
   it("should throw attributeNotFound when a certified discrete attribute has no discrete config", async () => {
     const seed: catalogApi.AttributesSeed = {
       certified: [
@@ -264,6 +297,36 @@ describe("parseAndCheckAttributes", () => {
   });
 
   it("Should throw attributeDuplicatedInGroup in case of attribute duplicated in group", async () => {
+    await expect(
+      parseAndCheckAttributes(
+        {
+          certified: [
+            [
+              {
+                id: certifiedDiscrete1.id,
+                explicitAttributeVerification: false,
+                discreteConfig: {
+                  threshold: 1000,
+                  comparator: attributeCertifiedDiscreteComparator.GT,
+                },
+              },
+              {
+                id: certifiedDiscrete1.id,
+                explicitAttributeVerification: false,
+                discreteConfig: {
+                  threshold: 10000,
+                  comparator: attributeCertifiedDiscreteComparator.LT,
+                },
+              },
+            ],
+          ],
+          declared: [],
+          verified: [],
+        },
+        readModelService
+      )
+    ).rejects.toThrowError(attributeDuplicatedInGroup(certifiedDiscrete1.id));
+
     await expect(
       parseAndCheckAttributes(
         {

--- a/packages/catalog-process/test/integration/updateDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptor.test.ts
@@ -10,6 +10,7 @@ import {
   getMockEService,
 } from "pagopa-interop-commons-test";
 import {
+  attributeCertifiedDiscreteComparator,
   attributeKind,
   Descriptor,
   descriptorState,
@@ -24,10 +25,11 @@ import {
   unsafeBrandId,
 } from "pagopa-interop-models";
 import { catalogApi } from "pagopa-interop-api-clients";
-import { expect, describe, it } from "vitest";
+import { expect, describe, it, afterEach } from "vitest";
 import {
   attributeDailyCallsNotAllowed,
   attributeDiscreteConfigNotAllowed,
+  certifiedDiscreteAttributeConfigCannotBeChanged,
   eServiceNotFound,
   eServiceDescriptorNotFound,
   notValidDescriptorState,
@@ -41,11 +43,16 @@ import {
   catalogService,
   readLastEserviceEvent,
 } from "../integrationUtils.js";
+import { config } from "../../src/config/config.js";
 
 describe("update descriptor", () => {
   const mockEService = getMockEService();
   const mockDescriptor = getMockDescriptor();
   const mockDocument = getMockDocument();
+
+  afterEach(() => {
+    config.featureFlagAttributeCertifiedDiscrete = false;
+  });
   it.each([
     descriptorState.published,
     descriptorState.suspended,
@@ -470,6 +477,155 @@ describe("update descriptor", () => {
       eservice: toEServiceV2(expectedEService),
       descriptorId: descriptor.id,
     });
+  });
+
+  it("should update certified discrete attribute dailyCallsPerConsumer on a published descriptor", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const certifiedDiscreteAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+    await addOneAttribute(certifiedDiscreteAttribute);
+
+    const discreteConfig = {
+      threshold: 1000,
+      comparator: attributeCertifiedDiscreteComparator.GTE,
+    };
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 500,
+              discreteConfig,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    const returnedEService = await catalogService.updateDescriptor(
+      eservice.id,
+      descriptor.id,
+      seed,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    expect(
+      returnedEService.data.descriptors[0].attributes.certified[0][0]
+    ).toEqual({
+      id: certifiedDiscreteAttribute.id,
+      explicitAttributeVerification: false,
+      dailyCallsPerConsumer: 500,
+      discreteConfig,
+    });
+  });
+
+  it("should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing discreteConfig on a published descriptor", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const certifiedDiscreteAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+    await addOneAttribute(certifiedDiscreteAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: {
+                threshold: 1000,
+                comparator: attributeCertifiedDiscreteComparator.GTE,
+              },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: descriptor.dailyCallsPerConsumer,
+      dailyCallsTotal: descriptor.dailyCallsTotal,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: {
+                threshold: 10000,
+                comparator: attributeCertifiedDiscreteComparator.LT,
+              },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    await expect(
+      catalogService.updateDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      certifiedDiscreteAttributeConfigCannotBeChanged(
+        eservice.id,
+        descriptor.id,
+        certifiedDiscreteAttribute.id
+      )
+    );
   });
 
   it("should clear existing certified attribute dailyCallsPerConsumer when seed.attributes omits them", async () => {

--- a/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
@@ -14,6 +14,7 @@ import {
   EService,
   toEServiceV2,
   generateId,
+  attributeCertifiedDiscreteComparator,
   attributeKind,
   EServiceDescriptorAttributesUpdatedV2,
   operationForbidden,
@@ -24,7 +25,7 @@ import {
   unsafeBrandId,
 } from "pagopa-interop-models";
 import { catalogApi } from "pagopa-interop-api-clients";
-import { expect, describe, it, beforeEach } from "vitest";
+import { expect, describe, it, beforeEach, afterEach } from "vitest";
 import {
   attributeNotFound,
   eServiceDescriptorNotFound,
@@ -37,7 +38,9 @@ import {
   attributeDailyCallsNotAllowed,
   attributeDiscreteConfigNotAllowed,
   templateInstanceNotAllowed,
+  certifiedDiscreteAttributeConfigCannotBeChanged,
 } from "../../src/model/domain/errors.js";
+import { config } from "../../src/config/config.js";
 import {
   addOneAttribute,
   addOneDelegation,
@@ -120,6 +123,10 @@ describe("update descriptor", () => {
     await addOneAttribute(mockDeclaredAttribute1);
     await addOneAttribute(mockDeclaredAttribute2);
     await addOneAttribute(mockDeclaredAttribute3);
+  });
+
+  afterEach(() => {
+    config.featureFlagAttributeCertifiedDiscrete = false;
   });
 
   it.each([descriptorState.published, descriptorState.suspended])(
@@ -1366,6 +1373,161 @@ describe("update descriptor", () => {
       attributeIds: [],
       eservice: toEServiceV2(returnedEService.data),
     });
+  });
+
+  it("should update dailyCallsPerConsumer on a certified discrete attribute of a published descriptor", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const mockCertifiedDiscreteAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+    await addOneAttribute(mockCertifiedDiscreteAttribute);
+
+    const discreteConfig = {
+      threshold: 1000,
+      comparator: attributeCertifiedDiscreteComparator.GTE,
+    };
+
+    const mockDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      state: descriptorState.published,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockCertifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+      descriptors: [mockDescriptor],
+    };
+
+    await addOneEService(mockEService);
+
+    const seed: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedDiscreteAttribute.id,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 500,
+            discreteConfig,
+          },
+        ],
+      ],
+      verified: [],
+      declared: [],
+    };
+
+    const returnedEService = await catalogService.updateDescriptorAttributes(
+      mockEService.id,
+      mockDescriptor.id,
+      seed,
+      getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+    );
+
+    const writtenEvent = await readLastEserviceEvent(mockEService.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: mockEService.id,
+      version: "1",
+      type: "EServiceDescriptorAttributesUpdated",
+      event_version: 2,
+    });
+
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorAttributesUpdatedV2,
+      payload: writtenEvent.data,
+    });
+
+    const updatedDescriptor = returnedEService.data.descriptors[0];
+    expect(updatedDescriptor.attributes.certified[0][0]).toEqual({
+      id: mockCertifiedDiscreteAttribute.id,
+      explicitAttributeVerification: false,
+      dailyCallsPerConsumer: 500,
+      discreteConfig,
+    });
+    expect(writtenPayload).toEqual({
+      descriptorId: mockDescriptor.id,
+      attributeIds: [],
+      eservice: toEServiceV2(returnedEService.data),
+    });
+  });
+
+  it("should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing discreteConfig on a published descriptor", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const mockCertifiedDiscreteAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+    await addOneAttribute(mockCertifiedDiscreteAttribute);
+
+    const mockDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      state: descriptorState.published,
+      attributes: {
+        certified: [
+          [
+            {
+              id: mockCertifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: {
+                threshold: 1000,
+                comparator: attributeCertifiedDiscreteComparator.GTE,
+              },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+      descriptors: [mockDescriptor],
+    };
+
+    await addOneEService(mockEService);
+
+    const seed: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: mockCertifiedDiscreteAttribute.id,
+            explicitAttributeVerification: false,
+            discreteConfig: {
+              threshold: 10000,
+              comparator: attributeCertifiedDiscreteComparator.LT,
+            },
+          },
+        ],
+      ],
+      verified: [],
+      declared: [],
+    };
+
+    await expect(
+      catalogService.updateDescriptorAttributes(
+        mockEService.id,
+        mockDescriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      )
+    ).rejects.toThrowError(
+      certifiedDiscreteAttributeConfigCannotBeChanged(
+        mockEService.id,
+        mockDescriptor.id,
+        mockCertifiedDiscreteAttribute.id
+      )
+    );
   });
 
   it("should throw inconsistentDailyCalls if a certified attribute dailyCallsPerConsumer exceeds descriptor dailyCallsTotal", async () => {

--- a/packages/catalog-process/test/integration/updateDraftDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDraftDescriptor.test.ts
@@ -12,6 +12,7 @@ import {
   getMockAttribute,
 } from "pagopa-interop-commons-test";
 import {
+  attributeCertifiedDiscreteComparator,
   Descriptor,
   descriptorState,
   EService,
@@ -24,7 +25,7 @@ import {
   delegationKind,
   technology,
 } from "pagopa-interop-models";
-import { expect, describe, it, beforeEach } from "vitest";
+import { expect, describe, it, beforeEach, afterEach } from "vitest";
 import {
   eServiceNotFound,
   eServiceDescriptorNotFound,
@@ -60,6 +61,10 @@ describe("updateDraftDescriptor", () => {
     await addOneAttribute(certifiedAttribute);
     await addOneAttribute(verifiedAttribute);
     await addOneAttribute(declaredAttribute);
+  });
+
+  afterEach(() => {
+    config.featureFlagAttributeCertifiedDiscrete = false;
   });
 
   it("should write on event-store for the update of a draft descriptor", async () => {
@@ -148,6 +153,77 @@ describe("updateDraftDescriptor", () => {
     expect(updateDescriptorResponse).toEqual({
       data: expectedEService,
       metadata: { version: 1 },
+    });
+  });
+
+  it("should update certified discrete attribute config on a draft descriptor", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const certifiedDiscreteAttribute: Attribute =
+      getMockAttribute("CertifiedDiscrete");
+    await addOneAttribute(certifiedDiscreteAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: {
+                threshold: 1000,
+                comparator: attributeCertifiedDiscreteComparator.GTE,
+              },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const descriptorSeed: catalogApi.UpdateEServiceDescriptorSeed = {
+      ...buildUpdateDescriptorSeed(descriptor),
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: {
+                threshold: 10000,
+                comparator: attributeCertifiedDiscreteComparator.LT,
+              },
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+    const updateDescriptorResponse = await catalogService.updateDraftDescriptor(
+      eservice.id,
+      descriptor.id,
+      descriptorSeed,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    expect(
+      updateDescriptorResponse.data.descriptors[0].attributes.certified[0][0]
+    ).toEqual({
+      id: certifiedDiscreteAttribute.id,
+      explicitAttributeVerification: false,
+      discreteConfig: {
+        threshold: 10000,
+        comparator: attributeCertifiedDiscreteComparator.LT,
+      },
     });
   });
 

--- a/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateTemplateInstanceDescriptor.test.ts
@@ -23,7 +23,7 @@ import {
   attributeCertifiedDiscreteComparator,
 } from "pagopa-interop-models";
 import { catalogApi } from "pagopa-interop-api-clients";
-import { expect, describe, it } from "vitest";
+import { expect, describe, it, afterEach } from "vitest";
 import {
   eServiceNotFound,
   eServiceDescriptorNotFound,
@@ -49,6 +49,10 @@ describe("update descriptor", () => {
   const mockTemplate = getMockEServiceTemplate();
   const mockDescriptor = getMockDescriptor();
   const mockDocument = getMockDocument();
+
+  afterEach(() => {
+    config.featureFlagAttributeCertifiedDiscrete = false;
+  });
   it.each([
     descriptorState.published,
     descriptorState.suspended,
@@ -491,6 +495,115 @@ describe("update descriptor", () => {
         }),
       ])
     );
+  });
+
+  it("should update dailyCallsPerConsumer on certified discrete attributes with the same id in different groups of a published template instance descriptor", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const certifiedDiscreteAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+
+    await addOneAttribute(certifiedDiscreteAttribute);
+
+    const lowerBoundConfig = {
+      threshold: 1000,
+      comparator: attributeCertifiedDiscreteComparator.GT,
+    };
+    const upperBoundConfig = {
+      threshold: 10000,
+      comparator: attributeCertifiedDiscreteComparator.LT,
+    };
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: lowerBoundConfig,
+            },
+          ],
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: upperBoundConfig,
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      templateId: mockTemplate.id,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+    await addOneEServiceTemplate(mockTemplate);
+
+    const descriptorQuotasSeed: catalogApi.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+      {
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedDiscreteAttribute.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: 500,
+                discreteConfig: lowerBoundConfig,
+              },
+            ],
+            [
+              {
+                id: certifiedDiscreteAttribute.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: 300,
+                discreteConfig: upperBoundConfig,
+              },
+            ],
+          ],
+          declared: [],
+          verified: [],
+        },
+      };
+
+    const returnedEService =
+      await catalogService.updateTemplateInstanceDescriptor(
+        eservice.id,
+        descriptor.id,
+        descriptorQuotasSeed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      );
+
+    expect(returnedEService.descriptors[0].attributes.certified).toEqual([
+      [
+        {
+          id: certifiedDiscreteAttribute.id,
+          explicitAttributeVerification: false,
+          dailyCallsPerConsumer: 500,
+          discreteConfig: lowerBoundConfig,
+        },
+      ],
+      [
+        {
+          id: certifiedDiscreteAttribute.id,
+          explicitAttributeVerification: false,
+          dailyCallsPerConsumer: 300,
+          discreteConfig: upperBoundConfig,
+        },
+      ],
+    ]);
   });
 
   it("should clear existing certified attribute dailyCallsPerConsumer when seed.attributes omits them", async () => {

--- a/packages/catalog-process/test/integration/updateTemplateInstanceDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateTemplateInstanceDescriptorAttributes.test.ts
@@ -13,12 +13,13 @@ import {
   EService,
   toEServiceV2,
   generateId,
+  attributeCertifiedDiscreteComparator,
   attributeKind,
   EServiceDescriptorAttributesUpdatedByTemplateUpdateV2,
   AttributeId,
 } from "pagopa-interop-models";
 import { catalogApi } from "pagopa-interop-api-clients";
-import { expect, describe, it, beforeEach } from "vitest";
+import { expect, describe, it, beforeEach, afterEach } from "vitest";
 import {
   attributeNotFound,
   eServiceDescriptorNotFound,
@@ -26,6 +27,7 @@ import {
   inconsistentAttributesSeedGroupsCount,
   descriptorAttributeGroupSupersetMissingInAttributesSeed,
 } from "../../src/model/domain/errors.js";
+import { config } from "../../src/config/config.js";
 import {
   addOneAttribute,
   addOneEService,
@@ -105,6 +107,10 @@ describe("updateTemplateInstanceDescriptorAttributes", () => {
     await addOneAttribute(mockDeclaredAttribute1);
     await addOneAttribute(mockDeclaredAttribute2);
     await addOneAttribute(mockDeclaredAttribute3);
+  });
+
+  afterEach(() => {
+    config.featureFlagAttributeCertifiedDiscrete = false;
   });
 
   it.each([descriptorState.published, descriptorState.suspended])(
@@ -694,6 +700,128 @@ describe("updateTemplateInstanceDescriptorAttributes", () => {
       };
 
       expect(writtenPayload.eservice).toEqual(toEServiceV2(expectedEService));
+    }
+  );
+
+  it.each([descriptorState.published, descriptorState.suspended])(
+    "should preserve distinct dailyCallsPerConsumer values when the same certified discrete attribute id appears in multiple groups",
+    async (descriptorState) => {
+      config.featureFlagAttributeCertifiedDiscrete = true;
+      const certifiedDiscreteAttribute = getMockAttribute(
+        attributeKind.certifiedDiscrete
+      );
+      await addOneAttribute(certifiedDiscreteAttribute);
+
+      const lowerBoundConfig = {
+        threshold: 1000,
+        comparator: attributeCertifiedDiscreteComparator.GT,
+      };
+      const upperBoundConfig = {
+        threshold: 10000,
+        comparator: attributeCertifiedDiscreteComparator.LT,
+      };
+      const lowerBoundDailyCalls = 100;
+      const upperBoundDailyCalls = 200;
+
+      const mockDescriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedDiscreteAttribute.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: lowerBoundDailyCalls,
+                discreteConfig: lowerBoundConfig,
+              },
+            ],
+            [
+              {
+                id: certifiedDiscreteAttribute.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: upperBoundDailyCalls,
+                discreteConfig: upperBoundConfig,
+              },
+            ],
+          ],
+          verified: [],
+          declared: [],
+        },
+      };
+
+      const mockEService: EService = {
+        ...getMockEService(),
+        descriptors: [mockDescriptor],
+      };
+
+      await addOneEService(mockEService);
+
+      const seedWithNewAttribute: catalogApi.AttributesSeed = {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: lowerBoundConfig,
+            },
+            {
+              id: mockCertifiedAttribute1.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: upperBoundConfig,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      };
+
+      await catalogService.internalUpdateTemplateInstanceDescriptorAttributes(
+        mockEService.id,
+        mockDescriptor.id,
+        seedWithNewAttribute,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      );
+
+      const writtenEvent = await readLastEserviceEvent(mockEService.id);
+      expect(writtenEvent).toMatchObject({
+        stream_id: mockEService.id,
+        version: "1",
+        type: "EServiceDescriptorAttributesUpdatedByTemplateUpdate",
+        event_version: 2,
+      });
+
+      const writtenPayload = decodeProtobufPayload({
+        messageType: EServiceDescriptorAttributesUpdatedByTemplateUpdateV2,
+        payload: writtenEvent.data,
+      });
+
+      const updatedDescriptor = writtenPayload.eservice?.descriptors[0];
+      const lowerBoundGroup =
+        updatedDescriptor?.attributes?.certified[0]?.values;
+      const upperBoundGroup =
+        updatedDescriptor?.attributes?.certified[1]?.values;
+
+      const lowerBoundAttribute = lowerBoundGroup?.find(
+        (attr) => attr.id === certifiedDiscreteAttribute.id
+      );
+      expect(lowerBoundAttribute?.dailyCallsPerConsumer).toBe(
+        lowerBoundDailyCalls
+      );
+
+      const upperBoundAttribute = upperBoundGroup?.find(
+        (attr) => attr.id === certifiedDiscreteAttribute.id
+      );
+      expect(upperBoundAttribute?.dailyCallsPerConsumer).toBe(
+        upperBoundDailyCalls
+      );
     }
   );
 });


### PR DESCRIPTION
## Jira Issue
[PIN-10358](https://pagopa.atlassian.net/browse/PIN-10358)

Related subtasks:
- [PIN-10359](https://pagopa.atlassian.net/browse/PIN-10359)
- [PIN-10360](https://pagopa.atlassian.net/browse/PIN-10360)

## Context
- Certified discrete attributes with the same id must be handled as distinct requirements when threshold or comparator differs.
- Published descriptors must not allow access condition changes, while dailyCallsPerConsumer remains editable.

## Services Affected
- catalog-process

## Key Changes
- Match certified discrete attributes by id, threshold, and comparator.
- Preserve per-attribute dailyCallsPerConsumer for matching discrete requirements in template instances.
- Reject published certified discrete threshold/comparator changes and keep draft updates allowed.
- Add integration coverage for valid and invalid descriptor and template instance flows.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [x] Fix Version set in Jira
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno collection or endpoint definition updated

[PIN-10358]: https://pagopa.atlassian.net/browse/PIN-10358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-10359]: https://pagopa.atlassian.net/browse/PIN-10359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-10360]: https://pagopa.atlassian.net/browse/PIN-10360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ