### PR TITLE
feature: add istat code filter for L6 municipalities (PIN-10361)

### DIFF
--- a/packages/ipa-certified-attributes-importer/src/services/ipaCertifiedAttributesImporterService.ts
+++ b/packages/ipa-certified-attributes-importer/src/services/ipaCertifiedAttributesImporterService.ts
@@ -212,7 +212,11 @@ export function getTenantUpsertData(
       originId: i.originId,
       description: i.description,
       attributes,
-      istatCode: i.category === MUNICIPALITY_CODE ? i.istatCode : undefined,
+      istatCode:
+        i.category === MUNICIPALITY_CODE &&
+        i.classification === AGENCY_CLASSIFICATION
+          ? i.istatCode
+          : undefined,
     };
   });
 }

--- a/packages/ipa-certified-attributes-importer/src/services/ipaCertifiedAttributesImporterService.ts
+++ b/packages/ipa-certified-attributes-importer/src/services/ipaCertifiedAttributesImporterService.ts
@@ -31,7 +31,7 @@ import { ReadModelServiceSQL } from "./readModelServiceSQL.js";
 import { IPACertifiedAttributesImporterConfig } from "../config/config.js";
 
 const AGENCY_CLASSIFICATION = "Agency";
-
+const MUNICIPALITY_CODE = "L6";
 // Tipologia Gestori di Pubblici Servizi
 export const PUBLIC_SERVICES_MANAGERS_TYPOLOGY = "Gestori di Pubblici Servizi";
 
@@ -212,7 +212,7 @@ export function getTenantUpsertData(
       originId: i.originId,
       description: i.description,
       attributes,
-      istatCode: i.istatCode,
+      istatCode: i.category === MUNICIPALITY_CODE ? i.istatCode : undefined,
     };
   });
 }

--- a/packages/ipa-certified-attributes-importer/test/assignAttribute.test.ts
+++ b/packages/ipa-certified-attributes-importer/test/assignAttribute.test.ts
@@ -1,17 +1,11 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { randomUUID } from "crypto";
-import {
-  Attribute,
-  PUBLIC_ADMINISTRATIONS_IDENTIFIER,
-  Tenant,
-  unsafeBrandId,
-} from "pagopa-interop-models";
+import { Attribute, Tenant, unsafeBrandId } from "pagopa-interop-models";
 import { expect, describe, it, vi, beforeAll, afterAll } from "vitest";
 import { genericLogger } from "pagopa-interop-commons";
 import {
   TenantSeed,
   getAttributesToAssign,
-  getTenantUpsertData,
 } from "../src/services/ipaCertifiedAttributesImporterService.js";
 import { attributes } from "./expectation.js";
 import { parseIPACertifiedAttributesImporterConfig } from "../src/config/config.js";
@@ -384,67 +378,5 @@ describe("GetAttributesToAssign", async () => {
         remoteIds: undefined,
       },
     ]);
-  });
-  describe("getTenantUpsertData", () => {
-    it("should populate istatCode only if the institution category is L6", () => {
-      const registryData = {
-        institutions: [
-          {
-            id: "tax-code-1",
-            originId: "ipa-l6",
-            origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
-            category: "L6",
-            description: "Ente L6",
-            kind: "Pubbliche Amministrazioni",
-            classification: "Agency" as const,
-            istatCode: "123456",
-          },
-          {
-            id: "tax-code-2",
-            originId: "ipa-l18",
-            origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
-            category: "L18",
-            description: "Ente L18",
-            kind: "Pubbliche Amministrazioni",
-            classification: "Agency" as const,
-            istatCode: "654321",
-          },
-        ],
-        attributes: [],
-      };
-
-      const platformTenants: Tenant[] = [
-        {
-          id: unsafeBrandId("1"),
-          externalId: {
-            origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
-            value: "ipa-l6",
-          },
-        } as Tenant,
-        {
-          id: unsafeBrandId("2"),
-          externalId: {
-            origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
-            value: "ipa-l18",
-          },
-        } as Tenant,
-      ];
-
-      const economicAccountCompaniesAllowlist: string[] = [];
-
-      const tenantSeeds = getTenantUpsertData(
-        registryData,
-        platformTenants,
-        economicAccountCompaniesAllowlist
-      );
-
-      const l6Seed = tenantSeeds.find((seed) => seed.originId === "ipa-l6");
-      expect(l6Seed).toBeDefined();
-      expect(l6Seed?.istatCode).toBe("123456");
-
-      const l18Seed = tenantSeeds.find((seed) => seed.originId === "ipa-l18");
-      expect(l18Seed).toBeDefined();
-      expect(l18Seed?.istatCode).toBeUndefined();
-    });
   });
 });

--- a/packages/ipa-certified-attributes-importer/test/assignAttribute.test.ts
+++ b/packages/ipa-certified-attributes-importer/test/assignAttribute.test.ts
@@ -1,11 +1,17 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { randomUUID } from "crypto";
-import { Attribute, Tenant, unsafeBrandId } from "pagopa-interop-models";
+import {
+  Attribute,
+  PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+  Tenant,
+  unsafeBrandId,
+} from "pagopa-interop-models";
 import { expect, describe, it, vi, beforeAll, afterAll } from "vitest";
 import { genericLogger } from "pagopa-interop-commons";
 import {
   TenantSeed,
   getAttributesToAssign,
+  getTenantUpsertData,
 } from "../src/services/ipaCertifiedAttributesImporterService.js";
 import { attributes } from "./expectation.js";
 import { parseIPACertifiedAttributesImporterConfig } from "../src/config/config.js";
@@ -378,5 +384,67 @@ describe("GetAttributesToAssign", async () => {
         remoteIds: undefined,
       },
     ]);
+  });
+  describe("getTenantUpsertData", () => {
+    it("should populate istatCode only if the institution category is L6", () => {
+      const registryData = {
+        institutions: [
+          {
+            id: "tax-code-1",
+            originId: "ipa-l6",
+            origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+            category: "L6",
+            description: "Ente L6",
+            kind: "Pubbliche Amministrazioni",
+            classification: "Agency" as const,
+            istatCode: "123456",
+          },
+          {
+            id: "tax-code-2",
+            originId: "ipa-l18",
+            origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+            category: "L18",
+            description: "Ente L18",
+            kind: "Pubbliche Amministrazioni",
+            classification: "Agency" as const,
+            istatCode: "654321",
+          },
+        ],
+        attributes: [],
+      };
+
+      const platformTenants: Tenant[] = [
+        {
+          id: unsafeBrandId("1"),
+          externalId: {
+            origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+            value: "ipa-l6",
+          },
+        } as Tenant,
+        {
+          id: unsafeBrandId("2"),
+          externalId: {
+            origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+            value: "ipa-l18",
+          },
+        } as Tenant,
+      ];
+
+      const economicAccountCompaniesAllowlist: string[] = [];
+
+      const tenantSeeds = getTenantUpsertData(
+        registryData,
+        platformTenants,
+        economicAccountCompaniesAllowlist
+      );
+
+      const l6Seed = tenantSeeds.find((seed) => seed.originId === "ipa-l6");
+      expect(l6Seed).toBeDefined();
+      expect(l6Seed?.istatCode).toBe("123456");
+
+      const l18Seed = tenantSeeds.find((seed) => seed.originId === "ipa-l18");
+      expect(l18Seed).toBeDefined();
+      expect(l18Seed?.istatCode).toBeUndefined();
+    });
   });
 });

--- a/packages/ipa-certified-attributes-importer/test/tenantUpsertData.test.ts
+++ b/packages/ipa-certified-attributes-importer/test/tenantUpsertData.test.ts
@@ -2,10 +2,12 @@ import { expect, describe, it } from "vitest";
 import { getMockTenant } from "pagopa-interop-commons-test";
 import {
   ECONOMIC_ACCOUNT_COMPANIES_PUBLIC_SERVICE_IDENTIFIER,
+  PUBLIC_ADMINISTRATIONS_IDENTIFIER,
   PUBLIC_SERVICES_MANAGERS,
   Tenant,
   TenantId,
   generateId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import {
   ECONOMIC_ACCOUNT_COMPANIES_TYPOLOGY,
@@ -495,5 +497,75 @@ describe("TenantUpsertData", async () => {
           a.origin === mockInstitution.origin
       )
     ).toBeDefined();
+  });
+  it("should populate istatCode only if the institution category is L6", async () => {
+    const registryData = {
+      institutions: [
+        {
+          id: "tax-code-1",
+          originId: "ipa-l6",
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          category: "L6",
+          description: "Ente L6",
+          kind: "Pubbliche Amministrazioni",
+          classification: "Agency" as const,
+          istatCode: "123456",
+        },
+        {
+          id: "tax-code-2",
+          originId: "ipa-l18",
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          category: "L18",
+          description: "Ente L18",
+          kind: "Pubbliche Amministrazioni",
+          classification: "Agency" as const,
+          istatCode: "654321",
+        },
+      ],
+      attributes: [],
+    };
+
+    const platformTenants: Tenant[] = [
+      {
+        id: unsafeBrandId<TenantId>("1"),
+        externalId: {
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          value: "ipa-l6",
+        },
+        features: [],
+        attributes: [],
+        createdAt: new Date(),
+        mails: [],
+        name: "ipa-l6",
+      },
+      {
+        id: unsafeBrandId<TenantId>("1"),
+        externalId: {
+          origin: PUBLIC_ADMINISTRATIONS_IDENTIFIER,
+          value: "ipa-l18",
+        },
+        features: [],
+        attributes: [],
+        createdAt: new Date(),
+        mails: [],
+        name: "ipa-l18",
+      },
+    ];
+
+    const economicAccountCompaniesAllowlist: string[] = [];
+
+    const tenantSeeds = getTenantUpsertData(
+      registryData,
+      platformTenants,
+      economicAccountCompaniesAllowlist
+    );
+
+    const l6Seed = tenantSeeds.find((seed) => seed.originId === "ipa-l6");
+    expect(l6Seed).toBeDefined();
+    expect(l6Seed?.istatCode).toBe("123456");
+
+    const l18Seed = tenantSeeds.find((seed) => seed.originId === "ipa-l18");
+    expect(l18Seed).toBeDefined();
+    expect(l18Seed?.istatCode).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Context
The IPA Job must be updated to assign the `istat_code` only to entities that are effectively Municipalities (Comuni).

To achieve this, you can rely on the available open data by filtering the `Codice_Categoria` field, selecting only entities with the value `L6`.

All entities that do not have this value must not be assigned an `istat_code` and, consequently, will not have the discrete certified attribute associated by the ISTAT job (which, incidentally, does not need to be modified).
## Services Affected
- `ipa-certified-attributes-importer`

## Key Changes
- **Added filter for record with L6 code**
- **Tests Updated:** Adjusted the test suite to check the filter by L6 code 

## Traceability Checklist
- [X] Branch name contain the Jira key
- [X] PR title is compliant with the standard (type(scope): descrizione (KEY))
- [X] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated