### PR TITLE
fix: trim string inputs in process services to reject blank values

### DIFF
--- a/packages/agreement-process/src/app.ts
+++ b/packages/agreement-process/src/app.ts
@@ -4,6 +4,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import {
@@ -38,6 +39,7 @@ export async function createApp(service: AgreementService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/attribute-registry-process/src/app.ts
+++ b/packages/attribute-registry-process/src/app.ts
@@ -4,6 +4,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import {
@@ -37,6 +38,7 @@ export async function createApp(service?: AttributeRegistryService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/authorization-process/src/app.ts
+++ b/packages/authorization-process/src/app.ts
@@ -3,6 +3,7 @@ import {
   contextMiddleware,
   errorsToApiProblemsMiddleware,
   healthRouter,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import {
@@ -30,6 +31,7 @@ export async function createApp(service: AuthorizationService) {
   app.use(await applicationAuditBeginMiddleware(serviceName, config));
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
+  app.use(trimMiddleware());
   app.use(authorizationRouter(zodiosCtx, service));
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/catalog-process/src/app.ts
+++ b/packages/catalog-process/src/app.ts
@@ -4,6 +4,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import {
@@ -32,6 +33,7 @@ export async function createApp(service: CatalogService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(eservicesRouter(zodiosCtx, service));
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/catalog-process/test/api/createEservice.test.ts
+++ b/packages/catalog-process/test/api/createEservice.test.ts
@@ -172,4 +172,44 @@ describe("API /eservices authorization test", () => {
 
     expect(res.status).toBe(400);
   });
+
+  // PIN-9436: the trimMiddleware trims string inputs before validation, so a
+  // name made only of whitespace becomes empty and fails the minLength check.
+  it.each(["     ", "\t\n  ", "                                "])(
+    "Should return 400 when name is only whitespace: %j",
+    async (name) => {
+      catalogService.createEService = vi
+        .fn()
+        .mockResolvedValue(serviceResponse);
+
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, {
+        ...eserviceSeed,
+        name,
+      } as catalogApi.EServiceSeed);
+
+      expect(res.status).toBe(400);
+    }
+  );
+
+  it("Should trim leading/trailing whitespace from string inputs before handling the request", async () => {
+    const createEServiceMock = vi.fn().mockResolvedValue(serviceResponse);
+    catalogService.createEService = createEServiceMock;
+
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, {
+      ...eserviceSeed,
+      name: `  ${eserviceSeed.name}  `,
+      description: `  ${eserviceSeed.description}  `,
+    });
+
+    expect(res.status).toBe(201);
+    expect(createEServiceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: eserviceSeed.name,
+        description: eserviceSeed.description,
+      }),
+      expect.anything()
+    );
+  });
 });

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -15,6 +15,7 @@ export * from "./repositories/db.js";
 export * from "./risk-analysis/index.js";
 export * from "./risk-analysis-template/index.js";
 export * from "./router/index.js";
+export * from "./sanitization/index.js";
 export * from "./templating/htmlTemplateService.js";
 export * from "./types/index.js";
 export * from "./utils/arrays.js";

--- a/packages/commons/src/sanitization/index.ts
+++ b/packages/commons/src/sanitization/index.ts
@@ -1,0 +1,61 @@
+import * as express from "express";
+import { P, match } from "ts-pattern";
+
+/**
+ * Recursively trims leading and trailing whitespace from every string found in
+ * the given value. Strings are trimmed; arrays and plain objects are traversed
+ * recursively; any other value is returned unchanged.
+ *
+ * Note: this only normalizes whitespace. It does NOT escape special characters
+ * (escaping must happen on output, not by mutating input data) and it does NOT
+ * convert empty strings to `undefined`. Rejecting empty-after-trim values is
+ * left to the Zodios/OpenAPI schema validation (e.g. `minLength`), which runs
+ * downstream of this middleware on the already-trimmed values.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function trimValue(value: any): any {
+  return match(value)
+    .with(P.string, (str) => str.trim())
+    .with(P.array(P._), (arr) => arr.map(trimValue))
+    .with(
+      P.not(P.nullish)
+        .and(P.not(P.array(P._)))
+        .and(P.when((v) => typeof v === "object")),
+      (obj) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const trimmed: Record<string, any> = {};
+        for (const key in obj) {
+          if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            // eslint-disable-next-line functional/immutable-data
+            trimmed[key] = trimValue(obj[key]);
+          }
+        }
+        return trimmed;
+      }
+    )
+    .otherwise(() => value);
+}
+
+/**
+ * Express middleware that trims leading and trailing whitespace from all string
+ * inputs found in the request body and query string (recursively, including
+ * nested objects and arrays).
+ *
+ * It must be registered before the router so that the trimmed values reach the
+ * schema validation: this makes whitespace-only inputs (e.g. an e-service name
+ * of only spaces) fail the existing `minLength` checks instead of being
+ * accepted. Path params are intentionally left untouched.
+ */
+export function trimMiddleware(): express.RequestHandler {
+  return (req, _res, next): void => {
+    if (req.body) {
+      // eslint-disable-next-line functional/immutable-data
+      req.body = trimValue(req.body);
+    }
+    if (req.query) {
+      // eslint-disable-next-line functional/immutable-data
+      req.query = trimValue(req.query);
+    }
+    next();
+  };
+}

--- a/packages/delegation-process/src/app.ts
+++ b/packages/delegation-process/src/app.ts
@@ -4,6 +4,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import {
@@ -34,6 +35,7 @@ export async function createApp(service: DelegationService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/eservice-template-process/src/app.ts
+++ b/packages/eservice-template-process/src/app.ts
@@ -4,6 +4,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import {
@@ -34,6 +35,7 @@ export async function createApp(service: EServiceTemplateService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/in-app-notification-manager/src/app.ts
+++ b/packages/in-app-notification-manager/src/app.ts
@@ -8,6 +8,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import { serviceName as modelsServiceName } from "pagopa-interop-models";
@@ -33,6 +34,7 @@ export async function createApp(service: InAppNotificationService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/m2m-event-manager/src/app.ts
+++ b/packages/m2m-event-manager/src/app.ts
@@ -8,6 +8,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import { serviceName as modelsServiceName } from "pagopa-interop-models";
@@ -33,6 +34,7 @@ export async function createApp(service: M2MEventService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/notification-config-process/src/app.ts
+++ b/packages/notification-config-process/src/app.ts
@@ -4,6 +4,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import {
@@ -34,6 +35,7 @@ export async function createApp(service: NotificationConfigService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/purpose-process/src/app.ts
+++ b/packages/purpose-process/src/app.ts
@@ -4,6 +4,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import {
@@ -34,6 +35,7 @@ export async function createApp(service: PurposeService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/purpose-template-process/src/app.ts
+++ b/packages/purpose-template-process/src/app.ts
@@ -8,6 +8,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import { serviceName as modelsServiceName } from "pagopa-interop-models";
@@ -32,6 +33,7 @@ export async function createApp(service: PurposeTemplateService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 

--- a/packages/tenant-process/src/app.ts
+++ b/packages/tenant-process/src/app.ts
@@ -4,6 +4,7 @@ import {
   errorsToApiProblemsMiddleware,
   healthRouter,
   loggerMiddleware,
+  trimMiddleware,
   zodiosCtx,
 } from "pagopa-interop-commons";
 import {
@@ -34,6 +35,7 @@ export async function createApp(service: TenantService) {
   app.use(await applicationAuditEndMiddleware(serviceName, config));
   app.use(authenticationMiddleware(config));
   app.use(loggerMiddleware(serviceName));
+  app.use(trimMiddleware());
   app.use(router);
   app.use(errorsToApiProblemsMiddleware);
 


### PR DESCRIPTION
[PIN-9436](https://pagopa.atlassian.net/browse/PIN-9436)

### Context
The frontend trims whitespace from text fields, but the backend did not. By calling BFF (or the M2M API) directly it was therefore possible to create resources with blank values — e.g. an e-service whose `name` is `"     "`: the surrounding spaces satisfy the `minLength` validation, so the empty value was accepted and persisted. The issue applies to every string input, not just the e-service name.

### Solution
Added a shared `trimMiddleware` in `commons` that recursively trims leading/trailing whitespace from all strings in the request **body** and **query** (nested objects and arrays included). It is registered **before the router** in each process service, so the trimmed values reach the Zodios/OpenAPI validation: whitespace-only inputs now collapse to an empty string and are rejected by the existing `minLength` checks (`400`), instead of being accepted.

Deliberately **not** included (vs. the approach proposed in #1981, which was closed):
- no HTML escaping of special characters — escaping belongs on output, not by mutating stored input;
- no `""` → `undefined` conversion — that stays a per-field semantic choice.

Placed at the process layer (the write authority where the validation schemas live) rather than at the gateways, so it covers every entry point — BFF, M2M and internal callers — in one place.

### Changes
- `packages/commons/src/sanitization/index.ts` — new `trimMiddleware`
- `packages/commons/src/index.ts` — export the new module
- `app.use(trimMiddleware())` registered before the router in 12 services: `catalog-process`, `agreement-process`, `attribute-regisprocess`, `tenant-process`, `purpose-process`, `purpose-template-process`, `delegation-process`, `eservice-template-process`,`notification-config-process`, `in-app-notification-manager`, `m2m-event-manager`
- `packages/catalog-process/test/api/createEservice.test.ts` — tests: whitespace-only name → `400`; surrounding whitespace trimmed before handling

### Notes
- Gateways (BFF, m2m-gateway, api-gateway) were intentionally left untouched: requests flow through the process services anyway.
- The localized `instanceLabel` fix from #3124 is left as-is; its whitespace handling becomes redundant, but its `""` → `undefined` antic concern.

### How to test
- `pnpm --filter pagopa-interop-catalog-process test:api` (see `createEservice.test.ts`)
- Manual: run `catalog-process` and execute the Bruno requests under `collections/catalog`.

[PIN-9436]: https://pagopa.atlassian.net/browse/PIN-9436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ