### PR TITLE
fix: block certified discrete config changes on published e-service (PIN-10358)

### DIFF
--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -80,6 +80,7 @@ const errorCodes = {
   eserviceNotInArchiving: "0063",
   eServiceAlreadyArchived: "0064",
   attributeDiscreteConfigNotAllowed: "0065",
+  certifiedDiscreteAttributeConfigCannotBeChanged: "0066",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -677,6 +678,18 @@ export function attributeDiscreteConfigNotAllowed(
     detail: `Discrete config is not allowed for non-certified attribute ${attributeId}`,
     code: "attributeDiscreteConfigNotAllowed",
     title: "Discrete config not allowed for non-certified attribute",
+  });
+}
+
+export function certifiedDiscreteAttributeConfigCannotBeChanged(
+  eserviceId: EServiceId,
+  descriptorId: DescriptorId,
+  attributeId: AttributeId
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `Discrete config of certified attribute ${attributeId} cannot be changed for descriptor ${descriptorId} of EService ${eserviceId} because the descriptor is not in draft state`,
+    code: "certifiedDiscreteAttributeConfigCannotBeChanged",
+    title: "Certified discrete attribute config cannot be changed",
   });
 }
 

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -682,12 +682,10 @@ export function attributeDiscreteConfigNotAllowed(
 }
 
 export function certifiedDiscreteAttributeConfigCannotBeChanged(
-  eserviceId: EServiceId,
-  descriptorId: DescriptorId,
   attributeId: AttributeId
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `Discrete config of certified attribute ${attributeId} cannot be changed for descriptor ${descriptorId} of EService ${eserviceId} because the descriptor is not in draft state`,
+    detail: `The discrete configuration for the certified attribute ${attributeId} cannot be changed`,
     code: "certifiedDiscreteAttributeConfigCannotBeChanged",
     title: "Certified discrete attribute config cannot be changed",
   });

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -2410,11 +2410,7 @@ export function catalogServiceBuilder(
 
       assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
       assertDiscreteConfigForCertifiedAttributesOnly(updatedAttributes);
-      assertCertifiedDiscreteConfigUnchanged(
-        eserviceId,
-        descriptor,
-        updatedAttributes
-      );
+      assertCertifiedDiscreteConfigUnchanged(descriptor, updatedAttributes);
 
       const updatedDescriptor: Descriptor = {
         ...descriptor,
@@ -3341,11 +3337,7 @@ export function catalogServiceBuilder(
 
       assertDailyCallsForCertifiedAttributesOnly(parsedAttributes);
       assertDiscreteConfigForCertifiedAttributesOnly(parsedAttributes);
-      assertCertifiedDiscreteConfigUnchanged(
-        eserviceId,
-        descriptor,
-        parsedAttributes
-      );
+      assertCertifiedDiscreteConfigUnchanged(descriptor, parsedAttributes);
       assertAttributeDailyCallsConsistentWithTotal(
         parsedAttributes,
         descriptor.dailyCallsTotal

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -213,6 +213,7 @@ import {
   assertAsyncExchangeReadyForPublication,
   assertDailyCallsForCertifiedAttributesOnly,
   assertDiscreteConfigForCertifiedAttributesOnly,
+  assertCertifiedDiscreteConfigUnchanged,
   assertAttributeDailyCallsConsistentWithTotal,
   assertEserviceIsNotInArchivingOrArchivedState,
   assertDescriptorArchivable,
@@ -2409,6 +2410,11 @@ export function catalogServiceBuilder(
 
       assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
       assertDiscreteConfigForCertifiedAttributesOnly(updatedAttributes);
+      assertCertifiedDiscreteConfigUnchanged(
+        eserviceId,
+        descriptor,
+        updatedAttributes
+      );
 
       const updatedDescriptor: Descriptor = {
         ...descriptor,
@@ -3335,6 +3341,11 @@ export function catalogServiceBuilder(
 
       assertDailyCallsForCertifiedAttributesOnly(parsedAttributes);
       assertDiscreteConfigForCertifiedAttributesOnly(parsedAttributes);
+      assertCertifiedDiscreteConfigUnchanged(
+        eserviceId,
+        descriptor,
+        parsedAttributes
+      );
       assertAttributeDailyCallsConsistentWithTotal(
         parsedAttributes,
         descriptor.dailyCallsTotal

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -599,7 +599,6 @@ export function assertDiscreteConfigForCertifiedAttributesOnly(
 }
 
 export function assertCertifiedDiscreteConfigUnchanged(
-  eserviceId: EServiceId,
   descriptor: Descriptor,
   newAttributes: EserviceAttributes
 ): void {
@@ -631,11 +630,7 @@ export function assertCertifiedDiscreteConfigUnchanged(
       [...publishedConfigs].every((config) => newConfigs.has(config));
 
     if (!configsUnchanged) {
-      throw certifiedDiscreteAttributeConfigCannotBeChanged(
-        eserviceId,
-        descriptor.id,
-        attributeId
-      );
+      throw certifiedDiscreteAttributeConfigCannotBeChanged(attributeId);
     }
   }
 }

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -16,6 +16,7 @@ import {
 import {
   archivingScope,
   AsyncExchangeProperties,
+  AttributeId,
   delegationKind,
   delegationState,
   Descriptor,
@@ -23,6 +24,7 @@ import {
   descriptorState,
   DescriptorState,
   EService,
+  EServiceAttributeCertifiedDiscreteConfig,
   EServiceId,
   eserviceMode,
   EServiceTemplateId,
@@ -65,6 +67,7 @@ import {
   riskAnalysisTenantKindMismatch,
   attributeDailyCallsNotAllowed,
   attributeDiscreteConfigNotAllowed,
+  certifiedDiscreteAttributeConfigCannotBeChanged,
   eserviceInArchivingOrArchivedState,
   descriptorArchivingNotCancelableByScope,
   notValidEServiceState,
@@ -593,6 +596,54 @@ export function assertDiscreteConfigForCertifiedAttributesOnly(
 
   if (invalidAttribute) {
     throw attributeDiscreteConfigNotAllowed(invalidAttribute.id);
+  }
+}
+
+export function assertCertifiedDiscreteConfigUnchanged(
+  eserviceId: EServiceId,
+  descriptor: Descriptor,
+  newAttributes: EserviceAttributes
+): void {
+  if (descriptor.state === descriptorState.draft) {
+    return;
+  }
+
+  const publishedDiscreteConfigsById = new Map<
+    AttributeId,
+    EServiceAttributeCertifiedDiscreteConfig[]
+  >();
+  for (const attribute of descriptor.attributes.certified.flat()) {
+    const config = getEServiceAttributeDiscreteConfig(attribute);
+    if (config === undefined) {
+      continue;
+    }
+    const configs = publishedDiscreteConfigsById.get(attribute.id) ?? [];
+    configs.push(config);
+    publishedDiscreteConfigsById.set(attribute.id, configs);
+  }
+
+  for (const attribute of newAttributes.certified.flat()) {
+    const publishedConfigs = publishedDiscreteConfigsById.get(attribute.id);
+
+    if (publishedConfigs === undefined) {
+      continue;
+    }
+
+    const config = getEServiceAttributeDiscreteConfig(attribute);
+
+    const isPublishedConfig = publishedConfigs.some(
+      (publishedConfig) =>
+        publishedConfig.threshold === config?.threshold &&
+        publishedConfig.comparator === config?.comparator
+    );
+
+    if (!isPublishedConfig) {
+      throw certifiedDiscreteAttributeConfigCannotBeChanged(
+        eserviceId,
+        descriptor.id,
+        attribute.id
+      );
+    }
   }
 }
 

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -24,7 +24,6 @@ import {
   descriptorState,
   DescriptorState,
   EService,
-  EServiceAttributeCertifiedDiscreteConfig,
   EServiceId,
   eserviceMode,
   EServiceTemplateId,
@@ -608,43 +607,53 @@ export function assertCertifiedDiscreteConfigUnchanged(
     return;
   }
 
-  const publishedDiscreteConfigsById = new Map<
-    AttributeId,
-    EServiceAttributeCertifiedDiscreteConfig[]
-  >();
-  for (const attribute of descriptor.attributes.certified.flat()) {
+  const publishedConfigsById = collectDiscreteConfigKeysById(
+    descriptor.attributes.certified.flat()
+  );
+
+  if (publishedConfigsById.size === 0) {
+    return;
+  }
+
+  const newConfigsById = collectDiscreteConfigKeysById(
+    newAttributes.certified.flat()
+  );
+
+  for (const [attributeId, publishedConfigs] of publishedConfigsById) {
+    const newConfigs = newConfigsById.get(attributeId);
+
+    if (newConfigs === undefined) {
+      continue;
+    }
+
+    const configsUnchanged =
+      newConfigs.size === publishedConfigs.size &&
+      [...publishedConfigs].every((config) => newConfigs.has(config));
+
+    if (!configsUnchanged) {
+      throw certifiedDiscreteAttributeConfigCannotBeChanged(
+        eserviceId,
+        descriptor.id,
+        attributeId
+      );
+    }
+  }
+}
+
+function collectDiscreteConfigKeysById(
+  attributes: EServiceCertifiedAttribute[]
+): Map<AttributeId, Set<string>> {
+  const configsById = new Map<AttributeId, Set<string>>();
+  for (const attribute of attributes) {
     const config = getEServiceAttributeDiscreteConfig(attribute);
     if (config === undefined) {
       continue;
     }
-    const configs = publishedDiscreteConfigsById.get(attribute.id) ?? [];
-    configs.push(config);
-    publishedDiscreteConfigsById.set(attribute.id, configs);
+    const configs = configsById.get(attribute.id) ?? new Set<string>();
+    configs.add(`${config.comparator}:${config.threshold}`);
+    configsById.set(attribute.id, configs);
   }
-
-  for (const attribute of newAttributes.certified.flat()) {
-    const publishedConfigs = publishedDiscreteConfigsById.get(attribute.id);
-
-    if (publishedConfigs === undefined) {
-      continue;
-    }
-
-    const config = getEServiceAttributeDiscreteConfig(attribute);
-
-    const isPublishedConfig = publishedConfigs.some(
-      (publishedConfig) =>
-        publishedConfig.threshold === config?.threshold &&
-        publishedConfig.comparator === config?.comparator
-    );
-
-    if (!isPublishedConfig) {
-      throw certifiedDiscreteAttributeConfigCannotBeChanged(
-        eserviceId,
-        descriptor.id,
-        attribute.id
-      );
-    }
-  }
+  return configsById;
 }
 
 export function assertTemplateInstanceAttributeStructureUnchanged(

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -279,6 +279,7 @@ export const updateDescriptorErrorMapper = (
       "attributeDailyCallsNotAllowed",
       "templateInstanceNotAllowed",
       "attributeDiscreteConfigNotAllowed",
+      "certifiedDiscreteAttributeConfigCannotBeChanged",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -511,6 +512,7 @@ export const updateDescriptorAttributesErrorMapper = (
       "notValidDescriptor",
       "attributeDailyCallsNotAllowed",
       "attributeDiscreteConfigNotAllowed",
+      "certifiedDiscreteAttributeConfigCannotBeChanged",
       "templateInstanceNotAllowed",
       "inconsistentDailyCalls",
       () => HTTP_STATUS_BAD_REQUEST

--- a/packages/catalog-process/test/integration/updateDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptor.test.ts
@@ -28,6 +28,7 @@ import { expect, describe, it } from "vitest";
 import {
   attributeDailyCallsNotAllowed,
   attributeDiscreteConfigNotAllowed,
+  certifiedDiscreteAttributeConfigCannotBeChanged,
   eServiceNotFound,
   eServiceDescriptorNotFound,
   notValidDescriptorState,
@@ -41,6 +42,7 @@ import {
   catalogService,
   readLastEserviceEvent,
 } from "../integrationUtils.js";
+import { config } from "../../src/config/config.js";
 
 describe("update descriptor", () => {
   const mockEService = getMockEService();
@@ -828,5 +830,425 @@ describe("update descriptor", () => {
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
     ).rejects.toThrowError(inconsistentDailyCalls());
+  });
+
+  it("should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing the discreteConfig of an existing certified attribute on a published descriptor", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const certifiedAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+    await addOneAttribute(certifiedAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 200, comparator: "LT" },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    await expect(
+      catalogService.updateDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      certifiedDiscreteAttributeConfigCannotBeChanged(
+        eservice.id,
+        descriptor.id,
+        certifiedAttribute.id
+      )
+    );
+  });
+
+  it("should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing the discreteConfig while restructuring the certified attribute groups", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const discreteAttribute = getMockAttribute(attributeKind.certifiedDiscrete);
+    const plainAttribute = getMockAttribute(attributeKind.certified);
+    await addOneAttribute(discreteAttribute);
+    await addOneAttribute(plainAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+            {
+              id: plainAttribute.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 200, comparator: "LT" },
+            },
+          ],
+          [
+            {
+              id: plainAttribute.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    await expect(
+      catalogService.updateDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      certifiedDiscreteAttributeConfigCannotBeChanged(
+        eservice.id,
+        descriptor.id,
+        discreteAttribute.id
+      )
+    );
+  });
+
+  it("should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing the discreteConfig of one occurrence of an attribute present in multiple certified groups", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const discreteAttribute = getMockAttribute(attributeKind.certifiedDiscrete);
+    await addOneAttribute(discreteAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 200, comparator: "LT" },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    await expect(
+      catalogService.updateDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      certifiedDiscreteAttributeConfigCannotBeChanged(
+        eservice.id,
+        descriptor.id,
+        discreteAttribute.id
+      )
+    );
+  });
+
+  it("should throw certifiedDiscreteAttributeConfigCannotBeChanged when adding a new occurrence of an already published discrete attribute with a different discreteConfig", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const discreteAttribute = getMockAttribute(attributeKind.certifiedDiscrete);
+    const plainAttribute = getMockAttribute(attributeKind.certified);
+    await addOneAttribute(discreteAttribute);
+    await addOneAttribute(plainAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+          [
+            {
+              id: plainAttribute.id,
+              explicitAttributeVerification: false,
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+          [
+            {
+              id: plainAttribute.id,
+              explicitAttributeVerification: false,
+            },
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 200, comparator: "LT" },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    await expect(
+      catalogService.updateDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      certifiedDiscreteAttributeConfigCannotBeChanged(
+        eservice.id,
+        descriptor.id,
+        discreteAttribute.id
+      )
+    );
+  });
+
+  it("should update only dailyCallsPerConsumer of a certified discrete attribute without changing its discreteConfig on a published descriptor", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const certifiedAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+    await addOneAttribute(certifiedAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.published,
+      interface: mockDocument,
+      publishedAt: new Date(),
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 100,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+      voucherLifespan: 1000,
+      dailyCallsPerConsumer: 1,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedAttribute.id,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 200,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    const expectedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          voucherLifespan: 1000,
+          dailyCallsPerConsumer: 1,
+          dailyCallsTotal: 1000,
+          attributes: {
+            certified: [
+              [
+                {
+                  id: certifiedAttribute.id,
+                  explicitAttributeVerification: false,
+                  dailyCallsPerConsumer: 200,
+                  discreteConfig: { threshold: 100, comparator: "GT" },
+                },
+              ],
+            ],
+            verified: [],
+            declared: [],
+          },
+        },
+      ],
+    };
+
+    await catalogService.updateDescriptor(
+      eservice.id,
+      descriptor.id,
+      seed,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    const lastEvent = await readLastEserviceEvent(eservice.id);
+    expect(lastEvent).toMatchObject({
+      stream_id: eservice.id,
+      version: "1",
+      type: "EServiceDescriptorQuotasUpdated",
+      event_version: 2,
+    });
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorQuotasUpdatedV2,
+      payload: lastEvent.data,
+    });
+    expect(writtenPayload).toEqual({
+      eservice: toEServiceV2(expectedEService),
+      descriptorId: descriptor.id,
+    });
   });
 });

--- a/packages/catalog-process/test/integration/updateDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptor.test.ts
@@ -902,11 +902,7 @@ describe("update descriptor", () => {
           getMockContext({ authData: getMockAuthData(eservice.producerId) })
         )
       ).rejects.toThrowError(
-        certifiedDiscreteAttributeConfigCannotBeChanged(
-          eservice.id,
-          descriptor.id,
-          certifiedAttribute.id
-        )
+        certifiedDiscreteAttributeConfigCannotBeChanged(certifiedAttribute.id)
       );
     }
   );
@@ -982,11 +978,7 @@ describe("update descriptor", () => {
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
     ).rejects.toThrowError(
-      certifiedDiscreteAttributeConfigCannotBeChanged(
-        eservice.id,
-        descriptor.id,
-        discreteAttribute.id
-      )
+      certifiedDiscreteAttributeConfigCannotBeChanged(discreteAttribute.id)
     );
   });
 
@@ -1063,11 +1055,7 @@ describe("update descriptor", () => {
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
     ).rejects.toThrowError(
-      certifiedDiscreteAttributeConfigCannotBeChanged(
-        eservice.id,
-        descriptor.id,
-        discreteAttribute.id
-      )
+      certifiedDiscreteAttributeConfigCannotBeChanged(discreteAttribute.id)
     );
   });
 
@@ -1149,11 +1137,7 @@ describe("update descriptor", () => {
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
     ).rejects.toThrowError(
-      certifiedDiscreteAttributeConfigCannotBeChanged(
-        eservice.id,
-        descriptor.id,
-        discreteAttribute.id
-      )
+      certifiedDiscreteAttributeConfigCannotBeChanged(discreteAttribute.id)
     );
   });
 
@@ -1230,11 +1214,7 @@ describe("update descriptor", () => {
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       )
     ).rejects.toThrowError(
-      certifiedDiscreteAttributeConfigCannotBeChanged(
-        eservice.id,
-        descriptor.id,
-        discreteAttribute.id
-      )
+      certifiedDiscreteAttributeConfigCannotBeChanged(discreteAttribute.id)
     );
   });
 

--- a/packages/catalog-process/test/integration/updateDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptor.test.ts
@@ -48,6 +48,13 @@ describe("update descriptor", () => {
   const mockEService = getMockEService();
   const mockDescriptor = getMockDescriptor();
   const mockDocument = getMockDocument();
+  const updatableAfterPublishStates = [
+    descriptorState.deprecated,
+    descriptorState.published,
+    descriptorState.suspended,
+    descriptorState.archiving,
+    descriptorState.archivingSuspended,
+  ];
   it.each([
     descriptorState.published,
     descriptorState.suspended,
@@ -832,74 +839,77 @@ describe("update descriptor", () => {
     ).rejects.toThrowError(inconsistentDailyCalls());
   });
 
-  it("should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing the discreteConfig of an existing certified attribute on a published descriptor", async () => {
-    config.featureFlagAttributeCertifiedDiscrete = true;
-    const certifiedAttribute = getMockAttribute(
-      attributeKind.certifiedDiscrete
-    );
-    await addOneAttribute(certifiedAttribute);
+  it.each(updatableAfterPublishStates)(
+    "should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing the discreteConfig of an existing certified attribute on a descriptor with state %s",
+    async (state) => {
+      config.featureFlagAttributeCertifiedDiscrete = true;
+      const certifiedAttribute = getMockAttribute(
+        attributeKind.certifiedDiscrete
+      );
+      await addOneAttribute(certifiedAttribute);
 
-    const descriptor: Descriptor = {
-      ...mockDescriptor,
-      state: descriptorState.published,
-      interface: mockDocument,
-      publishedAt: new Date(),
-      dailyCallsPerConsumer: 1,
-      dailyCallsTotal: 1000,
-      attributes: {
-        certified: [
-          [
-            {
-              id: certifiedAttribute.id,
-              explicitAttributeVerification: false,
-              discreteConfig: { threshold: 100, comparator: "GT" },
-            },
+      const descriptor: Descriptor = {
+        ...mockDescriptor,
+        state,
+        interface: mockDocument,
+        publishedAt: new Date(),
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedAttribute.id,
+                explicitAttributeVerification: false,
+                discreteConfig: { threshold: 100, comparator: "GT" },
+              },
+            ],
           ],
-        ],
-        verified: [],
-        declared: [],
-      },
-    };
-    const eservice: EService = {
-      ...mockEService,
-      descriptors: [descriptor],
-    };
-    await addOneEService(eservice);
+          verified: [],
+          declared: [],
+        },
+      };
+      const eservice: EService = {
+        ...mockEService,
+        descriptors: [descriptor],
+      };
+      await addOneEService(eservice);
 
-    const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
-      voucherLifespan: 1000,
-      dailyCallsPerConsumer: 1,
-      dailyCallsTotal: 1000,
-      attributes: {
-        certified: [
-          [
-            {
-              id: certifiedAttribute.id,
-              explicitAttributeVerification: false,
-              discreteConfig: { threshold: 200, comparator: "LT" },
-            },
+      const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+        voucherLifespan: 1000,
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedAttribute.id,
+                explicitAttributeVerification: false,
+                discreteConfig: { threshold: 200, comparator: "LT" },
+              },
+            ],
           ],
-        ],
-        verified: [],
-        declared: [],
-      },
-    };
+          verified: [],
+          declared: [],
+        },
+      };
 
-    await expect(
-      catalogService.updateDescriptor(
-        eservice.id,
-        descriptor.id,
-        seed,
-        getMockContext({ authData: getMockAuthData(eservice.producerId) })
-      )
-    ).rejects.toThrowError(
-      certifiedDiscreteAttributeConfigCannotBeChanged(
-        eservice.id,
-        descriptor.id,
-        certifiedAttribute.id
-      )
-    );
-  });
+      await expect(
+        catalogService.updateDescriptor(
+          eservice.id,
+          descriptor.id,
+          seed,
+          getMockContext({ authData: getMockAuthData(eservice.producerId) })
+        )
+      ).rejects.toThrowError(
+        certifiedDiscreteAttributeConfigCannotBeChanged(
+          eservice.id,
+          descriptor.id,
+          certifiedAttribute.id
+        )
+      );
+    }
+  );
 
   it("should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing the discreteConfig while restructuring the certified attribute groups", async () => {
     config.featureFlagAttributeCertifiedDiscrete = true;
@@ -1147,12 +1157,10 @@ describe("update descriptor", () => {
     );
   });
 
-  it("should update only dailyCallsPerConsumer of a certified discrete attribute without changing its discreteConfig on a published descriptor", async () => {
+  it("should throw certifiedDiscreteAttributeConfigCannotBeChanged when removing one of the published discreteConfig values of an attribute present in multiple certified groups", async () => {
     config.featureFlagAttributeCertifiedDiscrete = true;
-    const certifiedAttribute = getMockAttribute(
-      attributeKind.certifiedDiscrete
-    );
-    await addOneAttribute(certifiedAttribute);
+    const discreteAttribute = getMockAttribute(attributeKind.certifiedDiscrete);
+    await addOneAttribute(discreteAttribute);
 
     const descriptor: Descriptor = {
       ...mockDescriptor,
@@ -1165,10 +1173,16 @@ describe("update descriptor", () => {
         certified: [
           [
             {
-              id: certifiedAttribute.id,
+              id: discreteAttribute.id,
               explicitAttributeVerification: false,
-              dailyCallsPerConsumer: 100,
               discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 200, comparator: "LT" },
             },
           ],
         ],
@@ -1190,9 +1204,15 @@ describe("update descriptor", () => {
         certified: [
           [
             {
-              id: certifiedAttribute.id,
+              id: discreteAttribute.id,
               explicitAttributeVerification: false,
-              dailyCallsPerConsumer: 200,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
               discreteConfig: { threshold: 100, comparator: "GT" },
             },
           ],
@@ -1202,53 +1222,127 @@ describe("update descriptor", () => {
       },
     };
 
-    const expectedEService: EService = {
-      ...eservice,
-      descriptors: [
-        {
-          ...descriptor,
-          voucherLifespan: 1000,
-          dailyCallsPerConsumer: 1,
-          dailyCallsTotal: 1000,
-          attributes: {
-            certified: [
-              [
-                {
-                  id: certifiedAttribute.id,
-                  explicitAttributeVerification: false,
-                  dailyCallsPerConsumer: 200,
-                  discreteConfig: { threshold: 100, comparator: "GT" },
-                },
-              ],
-            ],
-            verified: [],
-            declared: [],
-          },
-        },
-      ],
-    };
-
-    await catalogService.updateDescriptor(
-      eservice.id,
-      descriptor.id,
-      seed,
-      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    await expect(
+      catalogService.updateDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      )
+    ).rejects.toThrowError(
+      certifiedDiscreteAttributeConfigCannotBeChanged(
+        eservice.id,
+        descriptor.id,
+        discreteAttribute.id
+      )
     );
-
-    const lastEvent = await readLastEserviceEvent(eservice.id);
-    expect(lastEvent).toMatchObject({
-      stream_id: eservice.id,
-      version: "1",
-      type: "EServiceDescriptorQuotasUpdated",
-      event_version: 2,
-    });
-    const writtenPayload = decodeProtobufPayload({
-      messageType: EServiceDescriptorQuotasUpdatedV2,
-      payload: lastEvent.data,
-    });
-    expect(writtenPayload).toEqual({
-      eservice: toEServiceV2(expectedEService),
-      descriptorId: descriptor.id,
-    });
   });
+
+  it.each(updatableAfterPublishStates)(
+    "should update only dailyCallsPerConsumer of a certified discrete attribute without changing its discreteConfig on a descriptor with state %s",
+    async (state) => {
+      config.featureFlagAttributeCertifiedDiscrete = true;
+      const certifiedAttribute = getMockAttribute(
+        attributeKind.certifiedDiscrete
+      );
+      await addOneAttribute(certifiedAttribute);
+
+      const descriptor: Descriptor = {
+        ...mockDescriptor,
+        state,
+        interface: mockDocument,
+        publishedAt: new Date(),
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedAttribute.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: 100,
+                discreteConfig: { threshold: 100, comparator: "GT" },
+              },
+            ],
+          ],
+          verified: [],
+          declared: [],
+        },
+      };
+      const eservice: EService = {
+        ...mockEService,
+        descriptors: [descriptor],
+      };
+      await addOneEService(eservice);
+
+      const seed: catalogApi.UpdateEServiceDescriptorQuotasSeed = {
+        voucherLifespan: 1000,
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedAttribute.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: 200,
+                discreteConfig: { threshold: 100, comparator: "GT" },
+              },
+            ],
+          ],
+          verified: [],
+          declared: [],
+        },
+      };
+
+      const expectedEService: EService = {
+        ...eservice,
+        descriptors: [
+          {
+            ...descriptor,
+            voucherLifespan: 1000,
+            dailyCallsPerConsumer: 1,
+            dailyCallsTotal: 1000,
+            attributes: {
+              certified: [
+                [
+                  {
+                    id: certifiedAttribute.id,
+                    explicitAttributeVerification: false,
+                    dailyCallsPerConsumer: 200,
+                    discreteConfig: { threshold: 100, comparator: "GT" },
+                  },
+                ],
+              ],
+              verified: [],
+              declared: [],
+            },
+          },
+        ],
+      };
+
+      await catalogService.updateDescriptor(
+        eservice.id,
+        descriptor.id,
+        seed,
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      );
+
+      const lastEvent = await readLastEserviceEvent(eservice.id);
+      expect(lastEvent).toMatchObject({
+        stream_id: eservice.id,
+        version: "1",
+        type: "EServiceDescriptorQuotasUpdated",
+        event_version: 2,
+      });
+      const writtenPayload = decodeProtobufPayload({
+        messageType: EServiceDescriptorQuotasUpdatedV2,
+        payload: lastEvent.data,
+      });
+      expect(writtenPayload).toEqual({
+        eservice: toEServiceV2(expectedEService),
+        descriptorId: descriptor.id,
+      });
+    }
+  );
 });

--- a/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
@@ -1730,7 +1730,13 @@ describe("update descriptor", () => {
     );
   });
 
-  it.each([descriptorState.published, descriptorState.suspended])(
+  it.each([
+    descriptorState.deprecated,
+    descriptorState.published,
+    descriptorState.suspended,
+    descriptorState.archiving,
+    descriptorState.archivingSuspended,
+  ])(
     "should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing the discreteConfig of an existing certified attribute on a descriptor with state %s",
     async (state) => {
       config.featureFlagAttributeCertifiedDiscrete = true;
@@ -1795,107 +1801,116 @@ describe("update descriptor", () => {
     }
   );
 
-  it("should allow updating only dailyCallsPerConsumer of a certified discrete attribute without changing its discreteConfig", async () => {
-    config.featureFlagAttributeCertifiedDiscrete = true;
-    const certifiedDiscreteAttribute = getMockAttribute(
-      attributeKind.certifiedDiscrete
-    );
-    await addOneAttribute(certifiedDiscreteAttribute);
+  it.each([
+    descriptorState.deprecated,
+    descriptorState.published,
+    descriptorState.suspended,
+    descriptorState.archiving,
+    descriptorState.archivingSuspended,
+  ])(
+    "should allow updating only dailyCallsPerConsumer of a certified discrete attribute without changing its discreteConfig on a descriptor with state %s",
+    async (state) => {
+      config.featureFlagAttributeCertifiedDiscrete = true;
+      const certifiedDiscreteAttribute = getMockAttribute(
+        attributeKind.certifiedDiscrete
+      );
+      await addOneAttribute(certifiedDiscreteAttribute);
 
-    const mockDescriptor: Descriptor = {
-      ...getMockDescriptor(),
-      state: descriptorState.published,
-      dailyCallsTotal: 1000,
-      attributes: {
+      const mockDescriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state,
+        dailyCallsTotal: 1000,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedDiscreteAttribute.id,
+                explicitAttributeVerification: false,
+                dailyCallsPerConsumer: 100,
+                discreteConfig: { threshold: 100, comparator: "GT" },
+              },
+            ],
+          ],
+          verified: [],
+          declared: [],
+        },
+      };
+
+      const mockEService: EService = {
+        ...getMockEService(),
+        descriptors: [mockDescriptor],
+      };
+
+      await addOneEService(mockEService);
+
+      const seedWithUpdatedDailyCalls: catalogApi.AttributesSeed = {
         certified: [
           [
             {
               id: certifiedDiscreteAttribute.id,
               explicitAttributeVerification: false,
-              dailyCallsPerConsumer: 100,
+              dailyCallsPerConsumer: 200,
               discreteConfig: { threshold: 100, comparator: "GT" },
             },
           ],
         ],
         verified: [],
         declared: [],
-      },
-    };
+      };
 
-    const mockEService: EService = {
-      ...getMockEService(),
-      descriptors: [mockDescriptor],
-    };
-
-    await addOneEService(mockEService);
-
-    const seedWithUpdatedDailyCalls: catalogApi.AttributesSeed = {
-      certified: [
-        [
+      const updatedEService: EService = {
+        ...mockEService,
+        descriptors: [
           {
-            id: certifiedDiscreteAttribute.id,
-            explicitAttributeVerification: false,
-            dailyCallsPerConsumer: 200,
-            discreteConfig: { threshold: 100, comparator: "GT" },
+            ...mockDescriptor,
+            attributes: {
+              certified: [
+                [
+                  {
+                    id: certifiedDiscreteAttribute.id,
+                    explicitAttributeVerification: false,
+                    dailyCallsPerConsumer: 200,
+                    discreteConfig: { threshold: 100, comparator: "GT" },
+                  },
+                ],
+              ],
+              verified: [],
+              declared: [],
+            },
           },
         ],
-      ],
-      verified: [],
-      declared: [],
-    };
+      };
 
-    const updatedEService: EService = {
-      ...mockEService,
-      descriptors: [
-        {
-          ...mockDescriptor,
-          attributes: {
-            certified: [
-              [
-                {
-                  id: certifiedDiscreteAttribute.id,
-                  explicitAttributeVerification: false,
-                  dailyCallsPerConsumer: 200,
-                  discreteConfig: { threshold: 100, comparator: "GT" },
-                },
-              ],
-            ],
-            verified: [],
-            declared: [],
-          },
-        },
-      ],
-    };
+      const returnedEService = await catalogService.updateDescriptorAttributes(
+        mockEService.id,
+        mockDescriptor.id,
+        seedWithUpdatedDailyCalls,
+        getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+      );
 
-    const returnedEService = await catalogService.updateDescriptorAttributes(
-      mockEService.id,
-      mockDescriptor.id,
-      seedWithUpdatedDailyCalls,
-      getMockContext({ authData: getMockAuthData(mockEService.producerId) })
-    );
+      const writtenEvent = await readLastEserviceEvent(mockEService.id);
+      expect(writtenEvent).toMatchObject({
+        stream_id: mockEService.id,
+        version: "1",
+        type: "EServiceDescriptorAttributesUpdated",
+        event_version: 2,
+      });
 
-    const writtenEvent = await readLastEserviceEvent(mockEService.id);
-    expect(writtenEvent).toMatchObject({
-      stream_id: mockEService.id,
-      version: "1",
-      type: "EServiceDescriptorAttributesUpdated",
-      event_version: 2,
-    });
+      const writtenPayload = decodeProtobufPayload({
+        messageType: EServiceDescriptorAttributesUpdatedV2,
+        payload: writtenEvent.data,
+      });
 
-    const writtenPayload = decodeProtobufPayload({
-      messageType: EServiceDescriptorAttributesUpdatedV2,
-      payload: writtenEvent.data,
-    });
-
-    expect(writtenPayload).toEqual({
-      descriptorId: mockDescriptor.id,
-      attributeIds: [],
-      eservice: toEServiceV2(updatedEService),
-    });
-    expect(writtenPayload).toEqual({
-      descriptorId: mockDescriptor.id,
-      attributeIds: [],
-      eservice: toEServiceV2(returnedEService.data),
-    });
-  });
+      expect(writtenPayload).toEqual({
+        descriptorId: mockDescriptor.id,
+        attributeIds: [],
+        eservice: toEServiceV2(updatedEService),
+      });
+      expect(writtenPayload).toEqual({
+        descriptorId: mockDescriptor.id,
+        attributeIds: [],
+        eservice: toEServiceV2(returnedEService.data),
+      });
+    }
+  );
 });

--- a/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
@@ -36,6 +36,7 @@ import {
   unchangedAttributes,
   attributeDailyCallsNotAllowed,
   attributeDiscreteConfigNotAllowed,
+  certifiedDiscreteAttributeConfigCannotBeChanged,
   templateInstanceNotAllowed,
 } from "../../src/model/domain/errors.js";
 import {
@@ -47,6 +48,7 @@ import {
   readModelDB,
 } from "../integrationUtils.js";
 import { upsertEService } from "pagopa-interop-readmodel/testUtils";
+import { config } from "../../src/config/config.js";
 
 describe("update descriptor", () => {
   const mockCertifiedAttribute1 = getMockAttribute(attributeKind.certified);
@@ -1726,5 +1728,174 @@ describe("update descriptor", () => {
     ).rejects.toThrowError(
       attributeDiscreteConfigNotAllowed(mockVerifiedAttribute1.id)
     );
+  });
+
+  it.each([descriptorState.published, descriptorState.suspended])(
+    "should throw certifiedDiscreteAttributeConfigCannotBeChanged when changing the discreteConfig of an existing certified attribute on a descriptor with state %s",
+    async (state) => {
+      config.featureFlagAttributeCertifiedDiscrete = true;
+      const certifiedDiscreteAttribute = getMockAttribute(
+        attributeKind.certifiedDiscrete
+      );
+      await addOneAttribute(certifiedDiscreteAttribute);
+
+      const mockDescriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state,
+        attributes: {
+          certified: [
+            [
+              {
+                id: certifiedDiscreteAttribute.id,
+                explicitAttributeVerification: false,
+                discreteConfig: { threshold: 100, comparator: "GT" },
+              },
+            ],
+          ],
+          verified: [],
+          declared: [],
+        },
+      };
+
+      const mockEService: EService = {
+        ...getMockEService(),
+        descriptors: [mockDescriptor],
+      };
+
+      await addOneEService(mockEService);
+
+      const seedWithChangedDiscreteConfig: catalogApi.AttributesSeed = {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 200, comparator: "GT" },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      };
+
+      await expect(
+        catalogService.updateDescriptorAttributes(
+          mockEService.id,
+          mockDescriptor.id,
+          seedWithChangedDiscreteConfig,
+          getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+        )
+      ).rejects.toThrowError(
+        certifiedDiscreteAttributeConfigCannotBeChanged(
+          mockEService.id,
+          mockDescriptor.id,
+          certifiedDiscreteAttribute.id
+        )
+      );
+    }
+  );
+
+  it("should allow updating only dailyCallsPerConsumer of a certified discrete attribute without changing its discreteConfig", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const certifiedDiscreteAttribute = getMockAttribute(
+      attributeKind.certifiedDiscrete
+    );
+    await addOneAttribute(certifiedDiscreteAttribute);
+
+    const mockDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      state: descriptorState.published,
+      dailyCallsTotal: 1000,
+      attributes: {
+        certified: [
+          [
+            {
+              id: certifiedDiscreteAttribute.id,
+              explicitAttributeVerification: false,
+              dailyCallsPerConsumer: 100,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+        ],
+        verified: [],
+        declared: [],
+      },
+    };
+
+    const mockEService: EService = {
+      ...getMockEService(),
+      descriptors: [mockDescriptor],
+    };
+
+    await addOneEService(mockEService);
+
+    const seedWithUpdatedDailyCalls: catalogApi.AttributesSeed = {
+      certified: [
+        [
+          {
+            id: certifiedDiscreteAttribute.id,
+            explicitAttributeVerification: false,
+            dailyCallsPerConsumer: 200,
+            discreteConfig: { threshold: 100, comparator: "GT" },
+          },
+        ],
+      ],
+      verified: [],
+      declared: [],
+    };
+
+    const updatedEService: EService = {
+      ...mockEService,
+      descriptors: [
+        {
+          ...mockDescriptor,
+          attributes: {
+            certified: [
+              [
+                {
+                  id: certifiedDiscreteAttribute.id,
+                  explicitAttributeVerification: false,
+                  dailyCallsPerConsumer: 200,
+                  discreteConfig: { threshold: 100, comparator: "GT" },
+                },
+              ],
+            ],
+            verified: [],
+            declared: [],
+          },
+        },
+      ],
+    };
+
+    const returnedEService = await catalogService.updateDescriptorAttributes(
+      mockEService.id,
+      mockDescriptor.id,
+      seedWithUpdatedDailyCalls,
+      getMockContext({ authData: getMockAuthData(mockEService.producerId) })
+    );
+
+    const writtenEvent = await readLastEserviceEvent(mockEService.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: mockEService.id,
+      version: "1",
+      type: "EServiceDescriptorAttributesUpdated",
+      event_version: 2,
+    });
+
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorAttributesUpdatedV2,
+      payload: writtenEvent.data,
+    });
+
+    expect(writtenPayload).toEqual({
+      descriptorId: mockDescriptor.id,
+      attributeIds: [],
+      eservice: toEServiceV2(updatedEService),
+    });
+    expect(writtenPayload).toEqual({
+      descriptorId: mockDescriptor.id,
+      attributeIds: [],
+      eservice: toEServiceV2(returnedEService.data),
+    });
   });
 });

--- a/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
+++ b/packages/catalog-process/test/integration/updateDescriptorAttributes.test.ts
@@ -1793,8 +1793,6 @@ describe("update descriptor", () => {
         )
       ).rejects.toThrowError(
         certifiedDiscreteAttributeConfigCannotBeChanged(
-          mockEService.id,
-          mockDescriptor.id,
           certifiedDiscreteAttribute.id
         )
       );

--- a/packages/catalog-process/test/integration/updateDraftDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/updateDraftDescriptor.test.ts
@@ -16,6 +16,7 @@ import {
   descriptorState,
   EService,
   Attribute,
+  attributeKind,
   generateId,
   EServiceDraftDescriptorUpdatedV2,
   toEServiceV2,
@@ -130,6 +131,101 @@ describe("updateDraftDescriptor", () => {
       descriptorSeed,
       getMockContext({ authData: getMockAuthData(eservice.producerId) })
     );
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent).toMatchObject({
+      stream_id: eservice.id,
+      version: "1",
+      type: "EServiceDraftDescriptorUpdated",
+      event_version: 2,
+    });
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDraftDescriptorUpdatedV2,
+      payload: writtenEvent.data,
+    });
+    expect(writtenPayload).toEqual({
+      eservice: toEServiceV2(expectedEService),
+      descriptorId: descriptor.id,
+    });
+    expect(updateDescriptorResponse).toEqual({
+      data: expectedEService,
+      metadata: { version: 1 },
+    });
+  });
+
+  it("should allow changing the discreteConfig of a certified discrete attribute on a draft descriptor", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
+    const discreteAttribute = getMockAttribute(attributeKind.certifiedDiscrete);
+    await addOneAttribute(discreteAttribute);
+
+    const descriptor: Descriptor = {
+      ...mockDescriptor,
+      state: descriptorState.draft,
+      attributes: {
+        certified: [
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 100, comparator: "GT" },
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+    const eservice: EService = {
+      ...mockEService,
+      descriptors: [descriptor],
+    };
+    await addOneEService(eservice);
+
+    const descriptorSeed: catalogApi.UpdateEServiceDescriptorSeed = {
+      ...buildUpdateDescriptorSeed(descriptor),
+      attributes: {
+        certified: [
+          [
+            {
+              id: discreteAttribute.id,
+              explicitAttributeVerification: false,
+              discreteConfig: { threshold: 200, comparator: "LT" },
+            },
+          ],
+        ],
+        declared: [],
+        verified: [],
+      },
+    };
+
+    const expectedEService: EService = {
+      ...eservice,
+      descriptors: [
+        {
+          ...descriptor,
+          attributes: {
+            certified: [
+              [
+                {
+                  id: discreteAttribute.id,
+                  explicitAttributeVerification: false,
+                  discreteConfig: { threshold: 200, comparator: "LT" },
+                },
+              ],
+            ],
+            declared: [],
+            verified: [],
+          },
+        },
+      ],
+    };
+
+    const updateDescriptorResponse = await catalogService.updateDraftDescriptor(
+      eservice.id,
+      descriptor.id,
+      descriptorSeed,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
     const writtenEvent = await readLastEserviceEvent(eservice.id);
     expect(writtenEvent).toMatchObject({
       stream_id: eservice.id,


### PR DESCRIPTION
## Jira Issue
[PIN-10358](https://pagopa.atlassian.net/browse/PIN-10358)

## Context
- On a published descriptor the discreteConfig, threshold and comparator, of an existing certified discrete attribute can be changed. Once the descriptor is published it must be immutable. Only the per consumer daily calls override stays editable, and in draft the config is still freely editable.

## Services Affected
- catalog-process

## Key Changes
- Block changing the discreteConfig of an already published certified discrete attribute in `updateDescriptor` and `updateDescriptorAttributes`.
- Add error `certifiedDiscreteAttributeConfigCannotBeChanged`, mapped to 400.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)

[PIN-10358]: https://pagopa.atlassian.net/browse/PIN-10358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ