### PR TITLE
fix: Fix e-service template catalog description (PIN-9193)

### DIFF
--- a/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
@@ -71,7 +71,7 @@ export function toBffCatalogEServiceTemplate(
   return {
     id: eserviceTemplate.id,
     name: eserviceTemplate.name,
-    description: eserviceTemplate.intendedTarget,
+    description: eserviceTemplate.description,
     creator: toBffCatalogTenant(creator),
     publishedVersion: toBffCompactEServiceTemplateVersion(publishedVersion),
   };

--- a/packages/backend-for-frontend/test/eserviceTemplateApiConverter.test.ts
+++ b/packages/backend-for-frontend/test/eserviceTemplateApiConverter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { eserviceTemplateApi } from "pagopa-interop-api-clients";
+import {
+  getMockedApiEserviceTemplateVersion,
+  getMockedApiEServiceTemplate,
+  getMockedApiTenant,
+} from "pagopa-interop-commons-test";
+import { toBffCatalogEServiceTemplate } from "../src/api/eserviceTemplateApiConverter.js";
+
+describe("eserviceTemplateApiConverter", () => {
+  describe("toBffCatalogEServiceTemplate", () => {
+    it("should use the template description as catalog description", () => {
+      const eserviceTemplate = getMockedApiEServiceTemplate({
+        versions: [
+          getMockedApiEserviceTemplateVersion({
+            state:
+              eserviceTemplateApi.EServiceTemplateVersionState.Values.PUBLISHED,
+          }),
+        ],
+      });
+      const templateWithDistinctDescriptions = {
+        ...eserviceTemplate,
+        intendedTarget: "template intended target",
+        description: "template description",
+      };
+      const creator = getMockedApiTenant();
+
+      const result = toBffCatalogEServiceTemplate(
+        templateWithDistinctDescriptions,
+        creator
+      );
+
+      expect(result.description).toBe(
+        templateWithDistinctDescriptions.description
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes the BFF catalog e-service template converter so the catalog description uses the template description instead of the intended target. Adds a unit test with distinct description and intendedTarget values to prevent regressions.

https://pagopa.atlassian.net/browse/PIN-9193