### PR TITLE
fix: inline email font styles (PIN-7938)

### DIFF
--- a/packages/email-digest-dispatcher/src/resources/templates/digest-mail.html
+++ b/packages/email-digest-dispatcher/src/resources/templates/digest-mail.html
@@ -60,14 +60,81 @@
         }
       </style>
     <![endif]-->
-    <!--[if !mso]><!-->
-    <link
-      rel="stylesheet"
-      href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-      integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-      crossorigin="anonymous"
-    />
-    <!--<![endif]-->
+  <!--[if !mso]><!-->
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
+  <!--<![endif]-->
     <style type="text/css">
       @media only screen and (min-width: 480px) {
         .mj-column-per-100 {

--- a/packages/notification-commons/src/templates/email/resources/templates/headers/common-header.hbs
+++ b/packages/notification-commons/src/templates/email/resources/templates/headers/common-header.hbs
@@ -36,12 +36,79 @@
         </style>
         <![endif]-->
   <!--[if !mso]><!-->
-  <link
-    rel="stylesheet"
-    href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-    integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-    crossorigin="anonymous"
-  />
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) { .mj-column-per-100 { width: 100%

--- a/packages/notification-commons/test/emailTemplateFontStyles.test.ts
+++ b/packages/notification-commons/test/emailTemplateFontStyles.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(currentDir, "../../..");
+
+const templatePaths = [
+  join(
+    repoRoot,
+    "packages/notification-commons/src/templates/email/resources/templates/headers/common-header.hbs"
+  ),
+  join(
+    repoRoot,
+    "packages/email-digest-dispatcher/src/resources/templates/digest-mail.html"
+  ),
+  ...readdirSync(
+    join(repoRoot, "packages/notification-email-sender/src/resources/templates")
+  )
+    .filter((fileName) => fileName.endsWith(".html"))
+    .map((fileName) =>
+      join(
+        repoRoot,
+        "packages/notification-email-sender/src/resources/templates",
+        fileName
+      )
+    ),
+];
+
+describe("email template font styles", () => {
+  it.each(
+    templatePaths.map((path) => [path.replace(`${repoRoot}/`, ""), path])
+  )(
+    "inlines font styles without relying on the SelfCare stylesheet integrity: %s",
+    (_templateName, templatePath) => {
+      const template = readFileSync(templatePath, "utf8");
+
+      expect(template).not.toContain(
+        "https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
+      );
+      expect(template).not.toContain("sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ");
+      expect(template).not.toContain('crossorigin="anonymous"');
+      expect(template).toContain("@font-face");
+      expect(template).toMatch(/font-family:\s*["']Titillium Web["']/);
+    }
+  );
+});

--- a/packages/notification-email-sender/src/resources/templates/agreement-activated-mail.html
+++ b/packages/notification-email-sender/src/resources/templates/agreement-activated-mail.html
@@ -57,12 +57,79 @@
         </style>
         <![endif]-->
   <!--[if !mso]><!-->
-  <link
-    rel="stylesheet"
-    href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-    integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-    crossorigin="anonymous"
-  />
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {

--- a/packages/notification-email-sender/src/resources/templates/agreement-rejected-mail.html
+++ b/packages/notification-email-sender/src/resources/templates/agreement-rejected-mail.html
@@ -57,12 +57,79 @@
         </style>
         <![endif]-->
   <!--[if !mso]><!-->
-  <link
-    rel="stylesheet"
-    href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-    integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-    crossorigin="anonymous"
-  />
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {

--- a/packages/notification-email-sender/src/resources/templates/agreement-submitted-mail.html
+++ b/packages/notification-email-sender/src/resources/templates/agreement-submitted-mail.html
@@ -57,12 +57,79 @@
         </style>
         <![endif]-->
   <!--[if !mso]><!-->
-  <link
-    rel="stylesheet"
-    href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-    integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-    crossorigin="anonymous"
-  />
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {

--- a/packages/notification-email-sender/src/resources/templates/eservice-descriptor-published-mail.html
+++ b/packages/notification-email-sender/src/resources/templates/eservice-descriptor-published-mail.html
@@ -57,12 +57,79 @@
         </style>
         <![endif]-->
   <!--[if !mso]><!-->
-  <link
-    rel="stylesheet"
-    href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-    integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-    crossorigin="anonymous"
-  />
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {

--- a/packages/notification-email-sender/src/resources/templates/first-purpose-version-rejected-mail.html
+++ b/packages/notification-email-sender/src/resources/templates/first-purpose-version-rejected-mail.html
@@ -62,14 +62,81 @@
         }
       </style>
     <![endif]-->
-    <!--[if !mso]><!-->
-    <link
-      rel="stylesheet"
-      href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-      integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-      crossorigin="anonymous"
-    />
-    <!--<![endif]-->
+  <!--[if !mso]><!-->
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
+  <!--<![endif]-->
     <style type="text/css">
       @media only screen and (min-width: 480px) {
         .mj-column-per-100 {

--- a/packages/notification-email-sender/src/resources/templates/new-purpose-version-waiting-for-approval-mail.html
+++ b/packages/notification-email-sender/src/resources/templates/new-purpose-version-waiting-for-approval-mail.html
@@ -57,12 +57,79 @@
         </style>
         <![endif]-->
   <!--[if !mso]><!-->
-  <link
-    rel="stylesheet"
-    href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-    integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-    crossorigin="anonymous"
-  />
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {

--- a/packages/notification-email-sender/src/resources/templates/other-purpose-version-rejected-mail.html
+++ b/packages/notification-email-sender/src/resources/templates/other-purpose-version-rejected-mail.html
@@ -62,14 +62,81 @@
         }
       </style>
     <![endif]-->
-    <!--[if !mso]><!-->
-    <link
-      rel="stylesheet"
-      href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-      integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-      crossorigin="anonymous"
-    />
-    <!--<![endif]-->
+  <!--[if !mso]><!-->
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
+  <!--<![endif]-->
     <style type="text/css">
       @media only screen and (min-width: 480px) {
         .mj-column-per-100 {

--- a/packages/notification-email-sender/src/resources/templates/purpose-version-activated-mail.html
+++ b/packages/notification-email-sender/src/resources/templates/purpose-version-activated-mail.html
@@ -57,12 +57,79 @@
         </style>
         <![endif]-->
   <!--[if !mso]><!-->
-  <link
-    rel="stylesheet"
-    href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-    integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-    crossorigin="anonymous"
-  />
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {

--- a/packages/notification-email-sender/src/resources/templates/purpose-waiting-for-approval-mail.html
+++ b/packages/notification-email-sender/src/resources/templates/purpose-waiting-for-approval-mail.html
@@ -57,12 +57,79 @@
         </style>
         <![endif]-->
   <!--[if !mso]><!-->
-  <link
-    rel="stylesheet"
-    href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-    integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-    crossorigin="anonymous"
-  />
+  <style type="text/css">
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Web";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff")
+          format("woff"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf")
+          format("truetype");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 400;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 600;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff")
+          format("woff");
+    }
+
+    @font-face {
+      font-family: "Titillium Sans Pro";
+      font-display: swap;
+      font-weight: 700;
+      src:
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2")
+          format("woff2"),
+        url("https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff")
+          format("woff");
+    }
+  </style>
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {


### PR DESCRIPTION
## Issue
- [PIN-7938](https://pagopa.atlassian.net/browse/PIN-7938)

## Context / Why
- Email templates used the SelfCare hosted font stylesheet with a fixed SRI hash.
- Previously sent emails could fail to load the stylesheet if the remote CSS changed and the integrity hash no longer matched.

## Scope
- Inline the common font `@font-face` declarations in notification email templates.
- Remove the external SelfCare stylesheet link, SRI hash, and crossorigin attribute from the affected templates.
- Add a guard test covering the shared header, digest template, and legacy notification email templates.

## Key Changes
- Updated notification commons, notification email sender, and email digest dispatcher templates.
- Added `emailTemplateFontStyles.test.ts` to prevent reintroducing the remote stylesheet dependency.

## Testing / Validation
- [x] Lint
- [x] Type check
- [x] Unit tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-7938]: https://pagopa.atlassian.net/browse/PIN-7938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ