### PR TITLE
fix: flaky test patchUpdatePurpose

### DIFF
--- a/packages/purpose-process/test/integration/patchUpdatePurpose.test.ts
+++ b/packages/purpose-process/test/integration/patchUpdatePurpose.test.ts
@@ -730,7 +730,9 @@ describe("patchUpdatePurpose", () => {
         updatedAt: new Date(),
       };
 
-      expect(patchPurposeResult.data.purpose).toEqual(expectedPurpose);
+      expect(sortPurpose(patchPurposeResult.data.purpose)).toEqual(
+        sortPurpose(expectedPurpose)
+      );
     }
   );
 


### PR DESCRIPTION
## What

Fix flaky test `patchUpdatePurpose > should successfully update isFreeOfCharge and freeOfChargeReason`.

## Why

These cases only patch `isFreeOfCharge`/`freeOfChargeReason`, so `performUpdatePurpose` does not re-validate the risk analysis form — it returns `purpose.data.riskAnalysisForm` read straight from the read model.

The read model query (`getPurposeByFilter`) has no `ORDER BY`, so `singleAnswers` rows come back in arbitrary Postgres order and the aggregated array order varies run-to-run. The assertion compared the result directly against an in-memory expected purpose, so the non-deterministic order made it flaky.

## How

Wrap both sides of the assertion in `sortPurpose` (already imported), matching how every other assertion in this file handles the unordered `singleAnswers`. `singleAnswers` is semantically a set, so an order-insensitive comparison is correct.
