### PR TITLE
fix (manual-archiving): Added message to producer for archiving canceled (PIN-10423)

### DIFF
--- a/packages/email-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingCanceledToProducer.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingCanceledToProducer.ts
@@ -18,7 +18,7 @@ import { config } from "../../config/config.js";
 
 const notificationType: NotificationType = "eserviceStateChangedToProducer";
 
-export async function handleEServiceArchivingCanceledToProducer(
+export async function handleEserviceArchivingCanceledToProducer(
   data: EServiceHandlerParams
 ): Promise<EmailNotificationMessagePayload[]> {
   const {
@@ -53,7 +53,7 @@ export async function handleEServiceArchivingCanceledToProducer(
 
   if (targets.length === 0) {
     logger.info(
-      `No producer users with email notifications enabled for handleEServiceArchivingCanceledToProducer - entityId: ${eservice.id}/${descriptor.id}`
+      `No producer users with email notifications enabled for handleEserviceArchivingCanceledToProducer - entityId: ${eservice.id}/${descriptor.id}`
     );
     return [];
   }

--- a/packages/email-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingCanceledToProducer.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingCanceledToProducer.ts
@@ -1,0 +1,81 @@
+import {
+  EmailNotificationMessagePayload,
+  fromEServiceV2,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+} from "pagopa-interop-models";
+import {
+  eventMailTemplateType,
+  getRecipientsForTenants,
+  mapRecipientToEmailPayload,
+  retrieveHTMLTemplate,
+  retrieveLatestDescriptor,
+  retrieveTenant,
+} from "pagopa-interop-notification-commons";
+import { EServiceHandlerParams } from "../../models/handlerParams.js";
+import { config } from "../../config/config.js";
+
+const notificationType: NotificationType = "eserviceStateChangedToProducer";
+
+export async function handleEServiceArchivingCanceledToProducer(
+  data: EServiceHandlerParams
+): Promise<EmailNotificationMessagePayload[]> {
+  const {
+    eserviceV2Msg,
+    readModelService,
+    logger,
+    templateService,
+    correlationId,
+  } = data;
+
+  if (!eserviceV2Msg) {
+    throw missingKafkaMessageDataError("eservice", "EServiceArchivingCanceled");
+  }
+
+  const eservice = fromEServiceV2(eserviceV2Msg);
+  const descriptor = retrieveLatestDescriptor(eservice);
+
+  const [htmlTemplate, producer] = await Promise.all([
+    retrieveHTMLTemplate(
+      eventMailTemplateType.eserviceArchivingCanceledEserviceToProducerMailTemplate
+    ),
+    retrieveTenant(eservice.producerId, readModelService),
+  ]);
+
+  const targets = await getRecipientsForTenants({
+    tenants: [producer],
+    notificationType,
+    readModelService,
+    logger,
+    includeTenantContactEmails: false,
+  });
+
+  if (targets.length === 0) {
+    logger.info(
+      `No producer users with email notifications enabled for handleEServiceArchivingCanceledToProducer - entityId: ${eservice.id}/${descriptor.id}`
+    );
+    return [];
+  }
+
+  const subject = `Un tuo e-service non è più in fase di archiviazione`;
+
+  return targets.map((t) => ({
+    correlationId: correlationId ?? generateId(),
+    email: {
+      subject,
+      body: templateService.compileHtml(htmlTemplate, {
+        title: subject,
+        notificationType,
+        entityId: `${eservice.id}/${descriptor.id}`,
+        ...(t.type === "Tenant" ? { recipientName: producer.name } : {}),
+        eserviceName: eservice.name,
+        ctaLabel: `Visualizza e-service`,
+        selfcareId: t.selfcareId,
+        bffUrl: config.bffUrl,
+      }),
+    },
+    tenantId: t.tenantId,
+    ...mapRecipientToEmailPayload(t),
+  }));
+}

--- a/packages/email-notification-dispatcher/src/handlers/eservices/handleEserviceDescriptorArchivingCanceledToProducer.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eservices/handleEserviceDescriptorArchivingCanceledToProducer.ts
@@ -1,0 +1,89 @@
+import {
+  DescriptorId,
+  EmailNotificationMessagePayload,
+  fromEServiceV2,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  eventMailTemplateType,
+  getRecipientsForTenants,
+  mapRecipientToEmailPayload,
+  retrieveDescriptor,
+  retrieveHTMLTemplate,
+  retrieveTenant,
+} from "pagopa-interop-notification-commons";
+import { EServiceDescriptorHandlerParams } from "../../models/handlerParams.js";
+import { config } from "../../config/config.js";
+
+const notificationType: NotificationType = "eserviceStateChangedToProducer";
+
+export async function handleEserviceDescriptorArchivingCanceledToProducer(
+  data: EServiceDescriptorHandlerParams
+): Promise<EmailNotificationMessagePayload[]> {
+  const {
+    eserviceV2Msg,
+    descriptorId: descriptorIdFromEvent,
+    readModelService,
+    logger,
+    templateService,
+    correlationId,
+  } = data;
+
+  if (!eserviceV2Msg) {
+    throw missingKafkaMessageDataError(
+      "eservice",
+      "EServiceDescriptorArchivingCanceled"
+    );
+  }
+
+  const eservice = fromEServiceV2(eserviceV2Msg);
+  const descriptorId = unsafeBrandId<DescriptorId>(descriptorIdFromEvent);
+  const descriptor = retrieveDescriptor(eservice, descriptorId);
+
+  const [htmlTemplate, producer] = await Promise.all([
+    retrieveHTMLTemplate(
+      eventMailTemplateType.eserviceArchivingCanceledDescriptorToProducerMailTemplate
+    ),
+    retrieveTenant(eservice.producerId, readModelService),
+  ]);
+
+  const targets = await getRecipientsForTenants({
+    tenants: [producer],
+    notificationType,
+    readModelService,
+    logger,
+    includeTenantContactEmails: false,
+  });
+
+  if (targets.length === 0) {
+    logger.info(
+      `No producer users with email notifications enabled for handleEserviceDescriptorArchivingCanceledToProducer - entityId: ${eservice.id}/${descriptor.id}`
+    );
+    return [];
+  }
+
+  const subject = `La versione di un tuo e-service non è più in fase di archiviazione`;
+
+  return targets.map((t) => ({
+    correlationId: correlationId ?? generateId(),
+    email: {
+      subject,
+      body: templateService.compileHtml(htmlTemplate, {
+        title: subject,
+        notificationType,
+        entityId: `${eservice.id}/${descriptor.id}`,
+        ...(t.type === "Tenant" ? { recipientName: producer.name } : {}),
+        eserviceName: eservice.name,
+        eserviceVersion: descriptor.version,
+        ctaLabel: `Visualizza e-service`,
+        selfcareId: t.selfcareId,
+        bffUrl: config.bffUrl,
+      }),
+    },
+    tenantId: t.tenantId,
+    ...mapRecipientToEmailPayload(t),
+  }));
+}

--- a/packages/email-notification-dispatcher/src/handlers/eservices/handleEserviceEvent.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eservices/handleEserviceEvent.ts
@@ -24,6 +24,8 @@ import { handleEserviceArchivingCompletedToConsumer } from "./handleEserviceArch
 import { handleEserviceDescriptorArchivedToProducer } from "./handleEserviceDescriptorArchivedToProducer.js";
 import { handleEserviceArchivingCanceledToConsumer } from "./handleEserviceArchivingCanceledToConsumer.js";
 import { handleEserviceDescriptorArchivingCanceledToConsumer } from "./handleEserviceDescriptorArchivingCanceledToConsumer.js";
+import { handleEserviceArchivingCanceledToProducer } from "./handleEserviceArchivingCanceledToProducer.js";
+import { handleEserviceDescriptorArchivingCanceledToProducer } from "./handleEserviceDescriptorArchivingCanceledToProducer.js";
 
 export async function handleEServiceEvent(
   params: HandlerParams<typeof EServiceEvent>
@@ -262,28 +264,49 @@ export async function handleEServiceEvent(
     )
     .with(
       { type: "EServiceArchivingCanceled" },
-      // per the notification mapping, archiving cancellation is notified only
-      // to consumers (the producer initiated the cancellation)
-      async ({ data: { eservice } }) =>
-        handleEserviceArchivingCanceledToConsumer({
-          eserviceV2Msg: eservice,
-          logger,
-          readModelService,
-          templateService,
-          correlationId,
-        })
+      async ({ data: { eservice } }) => {
+        const [prod, cons] = await Promise.all([
+          handleEserviceArchivingCanceledToProducer({
+            eserviceV2Msg: eservice,
+            logger,
+            readModelService,
+            templateService,
+            correlationId,
+          }),
+          handleEserviceArchivingCanceledToConsumer({
+            eserviceV2Msg: eservice,
+            logger,
+            readModelService,
+            templateService,
+            correlationId,
+          }),
+        ]);
+        return [...prod, ...cons];
+      }
     )
     .with(
       { type: "EServiceDescriptorArchivingCanceled" },
-      async ({ data: { eservice, descriptorId } }) =>
-        handleEserviceDescriptorArchivingCanceledToConsumer({
-          eserviceV2Msg: eservice,
-          descriptorId,
-          logger,
-          readModelService,
-          templateService,
-          correlationId,
-        })
+      async ({ data: { eservice, descriptorId } }) => {
+        const [prod, cons] = await Promise.all([
+          handleEserviceDescriptorArchivingCanceledToProducer({
+            eserviceV2Msg: eservice,
+            descriptorId,
+            logger,
+            readModelService,
+            templateService,
+            correlationId,
+          }),
+          handleEserviceDescriptorArchivingCanceledToConsumer({
+            eserviceV2Msg: eservice,
+            descriptorId,
+            logger,
+            readModelService,
+            templateService,
+            correlationId,
+          }),
+        ]);
+        return [...prod, ...cons];
+      }
     )
     .with(
       {

--- a/packages/email-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
@@ -36,7 +36,7 @@ describe("handleEserviceArchivingCanceledToProducer", () => {
     archivingSchedule: {
       archivableOn: new Date("2026-12-31T00:00:00.000Z"),
       startedAt: new Date("2026-05-14T00:00:00.000Z"),
-      scope: archivingScope.descriptor,
+      scope: archivingScope.eservice,
     },
   };
   const eservice: EService = {
@@ -82,7 +82,7 @@ describe("handleEserviceArchivingCanceledToProducer", () => {
     );
   });
 
-  it("emits one email per consumer user with the expected subject", async () => {
+  it("emits one email per producer user with the expected subject", async () => {
     const messages = await handleEserviceArchivingCanceledToProducer({
       eserviceV2Msg: toEServiceV2(eservice),
       logger,

--- a/packages/email-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
@@ -18,7 +18,7 @@ import {
   toEServiceV2,
 } from "pagopa-interop-models";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { handleEServiceArchivingCanceledToProducer } from "../src/handlers/eservices/handleEserviceArchivingCanceledToProducer.js";
+import { handleEserviceArchivingCanceledToProducer } from "../src/handlers/eservices/handleEserviceArchivingCanceledToProducer.js";
 import {
   addOneEService,
   addOneTenant,
@@ -70,7 +70,7 @@ describe("handleEserviceArchivingCanceledToProducer", () => {
 
   it("throws missingKafkaMessageDataError when eservice is undefined", async () => {
     await expect(() =>
-      handleEServiceArchivingCanceledToProducer({
+      handleEserviceArchivingCanceledToProducer({
         eserviceV2Msg: undefined,
         logger,
         templateService,
@@ -83,7 +83,7 @@ describe("handleEserviceArchivingCanceledToProducer", () => {
   });
 
   it("emits one email per consumer user with the expected subject", async () => {
-    const messages = await handleEServiceArchivingCanceledToProducer({
+    const messages = await handleEserviceArchivingCanceledToProducer({
       eserviceV2Msg: toEServiceV2(eservice),
       logger,
       templateService,

--- a/packages/email-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable functional/immutable-data */
+import {
+  getMockContext,
+  getMockDescriptor,
+  getMockEService,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import { authRole } from "pagopa-interop-commons";
+import {
+  archivingScope,
+  CorrelationId,
+  Descriptor,
+  descriptorState,
+  EService,
+  generateId,
+  missingKafkaMessageDataError,
+  TenantId,
+  toEServiceV2,
+} from "pagopa-interop-models";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleEServiceArchivingCanceledToProducer } from "../src/handlers/eservices/handleEserviceArchivingCanceledToProducer.js";
+import {
+  addOneEService,
+  addOneTenant,
+  getMockUser,
+  readModelService,
+  templateService,
+} from "./utils.js";
+
+describe("handleEserviceArchivingCanceledToProducer", () => {
+  const producerId = generateId<TenantId>();
+  const producerTenant = { ...getMockTenant(producerId), name: "Producer T" };
+
+  const archivingDescriptor: Descriptor = {
+    ...getMockDescriptor(descriptorState.archiving),
+    archivingSchedule: {
+      archivableOn: new Date("2026-12-31T00:00:00.000Z"),
+      startedAt: new Date("2026-05-14T00:00:00.000Z"),
+      scope: archivingScope.descriptor,
+    },
+  };
+  const eservice: EService = {
+    ...getMockEService(),
+    name: "Test E-service",
+    producerId,
+    descriptors: [archivingDescriptor],
+  };
+  const users = [
+    getMockUser(producerTenant.id),
+    getMockUser(producerTenant.id),
+  ];
+
+  const { logger } = getMockContext({});
+
+  beforeEach(async () => {
+    await addOneEService(eservice);
+    await addOneTenant(producerTenant);
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockImplementation((tenantIds: TenantId[]) =>
+        users
+          .filter((u) => tenantIds.includes(u.tenantId))
+          .map((u) => ({
+            userId: u.id,
+            tenantId: u.tenantId,
+            userRoles: [authRole.ADMIN_ROLE],
+          }))
+      );
+  });
+
+  it("throws missingKafkaMessageDataError when eservice is undefined", async () => {
+    await expect(() =>
+      handleEServiceArchivingCanceledToProducer({
+        eserviceV2Msg: undefined,
+        logger,
+        templateService,
+        readModelService,
+        correlationId: generateId<CorrelationId>(),
+      })
+    ).rejects.toThrow(
+      missingKafkaMessageDataError("eservice", "EServiceArchivingCanceled")
+    );
+  });
+
+  it("emits one email per consumer user with the expected subject", async () => {
+    const messages = await handleEServiceArchivingCanceledToProducer({
+      eserviceV2Msg: toEServiceV2(eservice),
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(messages[0].email.subject).toContain(
+      "Un tuo e-service non è più in fase di archiviazione"
+    );
+  });
+});

--- a/packages/email-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
@@ -7,7 +7,6 @@ import {
 } from "pagopa-interop-commons-test";
 import { authRole } from "pagopa-interop-commons";
 import {
-  archivingScope,
   CorrelationId,
   Descriptor,
   descriptorState,
@@ -31,19 +30,14 @@ describe("handleEserviceArchivingCanceledToProducer", () => {
   const producerId = generateId<TenantId>();
   const producerTenant = { ...getMockTenant(producerId), name: "Producer T" };
 
-  const archivingDescriptor: Descriptor = {
-    ...getMockDescriptor(descriptorState.archiving),
-    archivingSchedule: {
-      archivableOn: new Date("2026-12-31T00:00:00.000Z"),
-      startedAt: new Date("2026-05-14T00:00:00.000Z"),
-      scope: archivingScope.eservice,
-    },
+  const descriptor: Descriptor = {
+    ...getMockDescriptor(descriptorState.published),
   };
   const eservice: EService = {
     ...getMockEService(),
     name: "Test E-service",
     producerId,
-    descriptors: [archivingDescriptor],
+    descriptors: [descriptor],
   };
   const users = [
     getMockUser(producerTenant.id),

--- a/packages/email-notification-dispatcher/test/handleEserviceDescriptorArchivingCanceledToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceDescriptorArchivingCanceledToProducer.test.ts
@@ -7,7 +7,6 @@ import {
 } from "pagopa-interop-commons-test";
 import { authRole } from "pagopa-interop-commons";
 import {
-  archivingScope,
   CorrelationId,
   Descriptor,
   descriptorState,
@@ -31,19 +30,14 @@ describe("handleEserviceDescriptorArchivingCanceledToProducer", () => {
   const producerId = generateId<TenantId>();
   const producerTenant = { ...getMockTenant(producerId), name: "Producer T" };
 
-  const archivingDescriptor: Descriptor = {
-    ...getMockDescriptor(descriptorState.archiving),
-    archivingSchedule: {
-      archivableOn: new Date("2026-12-31T00:00:00.000Z"),
-      startedAt: new Date("2026-05-14T00:00:00.000Z"),
-      scope: archivingScope.descriptor,
-    },
+  const descriptor: Descriptor = {
+    ...getMockDescriptor(descriptorState.published),
   };
   const eservice: EService = {
     ...getMockEService(),
     name: "Test E-service",
     producerId,
-    descriptors: [archivingDescriptor],
+    descriptors: [descriptor],
   };
   const users = [
     getMockUser(producerTenant.id),
@@ -72,7 +66,7 @@ describe("handleEserviceDescriptorArchivingCanceledToProducer", () => {
     await expect(() =>
       handleEserviceDescriptorArchivingCanceledToProducer({
         eserviceV2Msg: undefined,
-        descriptorId: archivingDescriptor.id,
+        descriptorId: descriptor.id,
         logger,
         templateService,
         readModelService,
@@ -89,7 +83,7 @@ describe("handleEserviceDescriptorArchivingCanceledToProducer", () => {
   it("emits one email per producer user with the expected subject", async () => {
     const messages = await handleEserviceDescriptorArchivingCanceledToProducer({
       eserviceV2Msg: toEServiceV2(eservice),
-      descriptorId: archivingDescriptor.id,
+      descriptorId: descriptor.id,
       logger,
       templateService,
       readModelService,

--- a/packages/email-notification-dispatcher/test/handleEserviceDescriptorArchivingCanceledToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceDescriptorArchivingCanceledToProducer.test.ts
@@ -1,0 +1,103 @@
+/* eslint-disable functional/immutable-data */
+import {
+  getMockContext,
+  getMockDescriptor,
+  getMockEService,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import { authRole } from "pagopa-interop-commons";
+import {
+  archivingScope,
+  CorrelationId,
+  Descriptor,
+  descriptorState,
+  EService,
+  generateId,
+  missingKafkaMessageDataError,
+  TenantId,
+  toEServiceV2,
+} from "pagopa-interop-models";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleEserviceDescriptorArchivingCanceledToProducer } from "../src/handlers/eservices/handleEserviceDescriptorArchivingCanceledToProducer.js";
+import {
+  addOneEService,
+  addOneTenant,
+  getMockUser,
+  readModelService,
+  templateService,
+} from "./utils.js";
+
+describe("handleEserviceDescriptorArchivingCanceledToProducer", () => {
+  const producerId = generateId<TenantId>();
+  const producerTenant = { ...getMockTenant(producerId), name: "Producer T" };
+
+  const archivingDescriptor: Descriptor = {
+    ...getMockDescriptor(descriptorState.archiving),
+    archivingSchedule: {
+      archivableOn: new Date("2026-12-31T00:00:00.000Z"),
+      startedAt: new Date("2026-05-14T00:00:00.000Z"),
+      scope: archivingScope.descriptor,
+    },
+  };
+  const eservice: EService = {
+    ...getMockEService(),
+    name: "Test E-service",
+    producerId,
+    descriptors: [archivingDescriptor],
+  };
+  const users = [
+    getMockUser(producerTenant.id),
+    getMockUser(producerTenant.id),
+  ];
+
+  const { logger } = getMockContext({});
+
+  beforeEach(async () => {
+    await addOneEService(eservice);
+    await addOneTenant(producerTenant);
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockImplementation((tenantIds: TenantId[]) =>
+        users
+          .filter((u) => tenantIds.includes(u.tenantId))
+          .map((u) => ({
+            userId: u.id,
+            tenantId: u.tenantId,
+            userRoles: [authRole.ADMIN_ROLE],
+          }))
+      );
+  });
+
+  it("throws missingKafkaMessageDataError when eservice is undefined", async () => {
+    await expect(() =>
+      handleEserviceDescriptorArchivingCanceledToProducer({
+        eserviceV2Msg: undefined,
+        descriptorId: archivingDescriptor.id,
+        logger,
+        templateService,
+        readModelService,
+        correlationId: generateId<CorrelationId>(),
+      })
+    ).rejects.toThrow(
+      missingKafkaMessageDataError(
+        "eservice",
+        "EServiceDescriptorArchivingCanceled"
+      )
+    );
+  });
+
+  it("emits one email per producer user with the expected subject", async () => {
+    const messages = await handleEserviceDescriptorArchivingCanceledToProducer({
+      eserviceV2Msg: toEServiceV2(eservice),
+      descriptorId: archivingDescriptor.id,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(messages[0].email.subject).toContain(
+      "La versione di un tuo e-service non è più in fase di archiviazione"
+    );
+  });
+});

--- a/packages/in-app-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingCanceledToProducer.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingCanceledToProducer.ts
@@ -1,0 +1,100 @@
+import {
+  Descriptor,
+  DescriptorId,
+  EService,
+  EServiceEventV2,
+  EServiceIdDescriptorId,
+  fromEServiceV2,
+  missingKafkaMessageDataError,
+  NewNotification,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import { Logger } from "pagopa-interop-commons";
+import { match } from "ts-pattern";
+import {
+  getNotificationRecipients,
+  inAppTemplates,
+  retrieveDescriptor,
+  retrieveLatestDescriptor,
+} from "pagopa-interop-notification-commons";
+import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
+
+type CanceledArchivingEventType =
+  | "EServiceArchivingCanceled"
+  | "EServiceDescriptorArchivingCanceled";
+
+type CanceledArchivingEvent = Extract<
+  EServiceEventV2,
+  { type: CanceledArchivingEventType }
+>;
+
+export async function handleEserviceArchivingCanceledToProducer(
+  msg: CanceledArchivingEvent,
+  logger: Logger,
+  readModelService: ReadModelServiceSQL
+): Promise<NewNotification[]> {
+  if (!msg.data.eservice) {
+    throw missingKafkaMessageDataError("eservice", msg.type);
+  }
+  const eservice = fromEServiceV2(msg.data.eservice);
+
+  logger.info(
+    `Sending in-app notification to producer for ${msg.type} - eservice ${eservice.id}`
+  );
+
+  const recipients = await getNotificationRecipients(
+    [eservice.producerId],
+    "eserviceStateChangedToProducer",
+    readModelService,
+    logger
+  );
+  if (recipients.length === 0) {
+    return [];
+  }
+
+  const { body, descriptor } = bodyAndDescriptorForProducer(msg, eservice);
+  const entityId = EServiceIdDescriptorId.parse(
+    `${eservice.id}/${descriptor.id}`
+  );
+
+  return recipients.map(({ userId, tenantId }) => ({
+    userId,
+    tenantId,
+    body,
+    notificationType: "eserviceStateChangedToProducer",
+    entityId,
+  }));
+}
+
+function bodyAndDescriptorForProducer(
+  msg: CanceledArchivingEvent,
+  eservice: EService
+): { body: string; descriptor: Descriptor } {
+  return match(msg)
+    .with(
+      { type: "EServiceDescriptorArchivingCanceled" },
+      ({ data: { descriptorId } }) => {
+        const descriptor = retrieveDescriptor(
+          eservice,
+          unsafeBrandId<DescriptorId>(descriptorId)
+        );
+        return {
+          body: inAppTemplates.eserviceArchivingCanceledDescriptorToProducer(
+            eservice.name,
+            descriptor.version
+          ),
+          descriptor,
+        };
+      }
+    )
+    .with({ type: "EServiceArchivingCanceled" }, () => {
+      const descriptor = retrieveLatestDescriptor(eservice);
+      return {
+        body: inAppTemplates.eserviceArchivingCanceledEserviceToProducer(
+          eservice.name
+        ),
+        descriptor,
+      };
+    })
+    .exhaustive();
+}

--- a/packages/in-app-notification-dispatcher/src/handlers/eservices/handleEserviceEvent.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eservices/handleEserviceEvent.ts
@@ -9,6 +9,7 @@ import { handleEserviceNewVersionSubmittedToDelegator } from "./handleEserviceNe
 import { handleEserviceArchivingToProducer } from "./handleEserviceArchivingToProducer.js";
 import { handleEserviceArchivingToConsumer } from "./handleEserviceArchivingToConsumer.js";
 import { handleEserviceArchivingCanceledToConsumer } from "./handleEserviceArchivingCanceledToConsumer.js";
+import { handleEserviceArchivingCanceledToProducer } from "./handleEserviceArchivingCanceledToProducer.js";
 
 export async function handleEServiceEvent(
   decodedMessage: EServiceEventEnvelope,
@@ -111,8 +112,21 @@ export async function handleEServiceEvent(
           "EServiceArchivingCanceled"
         ),
       },
-      (msg) =>
-        handleEserviceArchivingCanceledToConsumer(msg, logger, readModelService)
+      async (msg) => {
+        const [prod, cons] = await Promise.all([
+          handleEserviceArchivingCanceledToProducer(
+            msg,
+            logger,
+            readModelService
+          ),
+          handleEserviceArchivingCanceledToConsumer(
+            msg,
+            logger,
+            readModelService
+          ),
+        ]);
+        return [...prod, ...cons];
+      }
     )
     .with(
       {

--- a/packages/in-app-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, Mock } from "vitest";
+import {
+  getMockContext,
+  getMockDescriptor,
+  getMockEService,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import {
+  archivingScope,
+  Descriptor,
+  descriptorState,
+  EService,
+  EServiceArchivingCanceledV2,
+  EServiceDescriptorArchivingCanceledV2,
+  EServiceEventV2,
+  EServiceIdDescriptorId,
+  generateId,
+  missingKafkaMessageDataError,
+  toEServiceV2,
+  UserId,
+} from "pagopa-interop-models";
+import {
+  getNotificationRecipients,
+  inAppTemplates,
+} from "pagopa-interop-notification-commons";
+import { handleEserviceArchivingCanceledToProducer } from "../src/handlers/eservices/handleEserviceArchivingCanceledToProducer.js";
+import { addOneEService, addOneTenant, readModelService } from "./utils.js";
+
+describe("handleEserviceArchivingCanceledToProducer", () => {
+  const producerTenant = getMockTenant();
+  const userId = generateId<UserId>();
+  const { logger } = getMockContext({});
+
+  const archivingDescriptor: Descriptor = {
+    ...getMockDescriptor(descriptorState.archiving),
+    archivingSchedule: {
+      archivableOn: new Date("2026-12-31T00:00:00.000Z"),
+      startedAt: new Date("2026-05-14T00:00:00.000Z"),
+      scope: archivingScope.descriptor,
+    },
+  };
+
+  const eservice: EService = {
+    ...getMockEService(),
+    producerId: producerTenant.id,
+    descriptors: [archivingDescriptor],
+  };
+
+  const mockGetNotificationRecipients = getNotificationRecipients as Mock;
+
+  beforeEach(async () => {
+    mockGetNotificationRecipients.mockReset();
+    mockGetNotificationRecipients.mockResolvedValue([
+      { userId, tenantId: producerTenant.id },
+    ]);
+    await addOneEService(eservice);
+    await addOneTenant(producerTenant);
+  });
+
+  it("throws missingKafkaMessageDataError when eservice is undefined", async () => {
+    const msg: EServiceEventV2 = {
+      event_version: 2,
+      type: "EServiceArchivingCanceled",
+      data: {
+        eservice: undefined,
+      } satisfies EServiceArchivingCanceledV2,
+    };
+    await expect(() =>
+      handleEserviceArchivingCanceledToProducer(msg, logger, readModelService)
+    ).rejects.toThrow(
+      missingKafkaMessageDataError("eservice", "EServiceArchivingCanceled")
+    );
+  });
+
+  it("emits a notification for EServiceDescriptorArchivingCanceled (descriptor scope)", async () => {
+    const msg: EServiceEventV2 = {
+      event_version: 2,
+      type: "EServiceDescriptorArchivingCanceled",
+      data: {
+        eservice: toEServiceV2(eservice),
+        descriptorId: archivingDescriptor.id,
+      } satisfies EServiceDescriptorArchivingCanceledV2,
+    };
+    const notifications = await handleEserviceArchivingCanceledToProducer(
+      msg,
+      logger,
+      readModelService
+    );
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toEqual({
+      userId,
+      tenantId: producerTenant.id,
+      notificationType: "eserviceStateChangedToConsumer",
+      entityId: EServiceIdDescriptorId.parse(
+        `${eservice.id}/${archivingDescriptor.id}`
+      ),
+      body: inAppTemplates.eserviceArchivingCanceledDescriptorToProducer(
+        eservice.name,
+        archivingDescriptor.version
+      ),
+    });
+  });
+
+  it("emits a notification for EServiceArchivingCanceled (eservice scope)", async () => {
+    const msg: EServiceEventV2 = {
+      event_version: 2,
+      type: "EServiceArchivingCanceled",
+      data: {
+        eservice: toEServiceV2(eservice),
+      } satisfies EServiceArchivingCanceledV2,
+    };
+    const notifications = await handleEserviceArchivingCanceledToProducer(
+      msg,
+      logger,
+      readModelService
+    );
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].body).toBe(
+      inAppTemplates.eserviceArchivingCanceledEserviceToProducer(eservice.name)
+    );
+  });
+
+  it("returns empty when there are no recipients for the producer", async () => {
+    mockGetNotificationRecipients.mockResolvedValueOnce([]);
+    const msg: EServiceEventV2 = {
+      event_version: 2,
+      type: "EServiceDescriptorArchivingCanceled",
+      data: {
+        eservice: toEServiceV2(eservice),
+        descriptorId: archivingDescriptor.id,
+      } satisfies EServiceDescriptorArchivingCanceledV2,
+    };
+    const notifications = await handleEserviceArchivingCanceledToProducer(
+      msg,
+      logger,
+      readModelService
+    );
+    expect(notifications).toEqual([]);
+  });
+});

--- a/packages/in-app-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleEserviceArchivingCanceledToProducer.test.ts
@@ -90,7 +90,7 @@ describe("handleEserviceArchivingCanceledToProducer", () => {
     expect(notifications[0]).toEqual({
       userId,
       tenantId: producerTenant.id,
-      notificationType: "eserviceStateChangedToConsumer",
+      notificationType: "eserviceStateChangedToProducer",
       entityId: EServiceIdDescriptorId.parse(
         `${eservice.id}/${archivingDescriptor.id}`
       ),

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-canceled-descriptor-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-canceled-descriptor-to-producer-mail.html
@@ -1,0 +1,67 @@
+{{> common-header }}
+<tr>
+  <td align="left" class="title" style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 24px;
+      padding-right: 0px;
+      padding-bottom: 8px;
+      padding-left: 0px;
+      word-break: break-word;
+    ">
+    <div style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        line-height: 1;
+        text-align: left;
+        color: #17324d;
+      ">
+      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td align="left" class="text" style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 8px;
+      padding-right: 0px;
+      padding-bottom: 0px;
+      padding-left: 0px;
+      word-break: break-word;
+    ">
+    <div style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      ">
+      <p style="margin-bottom: 0px">
+        Gentile
+        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+      </p>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td align="left" class="text" style="font-size: 0px; padding: 0px; word-break: break-word">
+    <div style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      ">
+      <!-- Body 1 Desktop (from MUI Italia)-->
+      <p>
+        La versione {{ eserviceVersion }} dell'e-service "{{ eserviceName 
+        }}" non è più in fase di archiviazione.
+      </p>
+    </div>
+  </td>
+</tr>
+{{> common-footer }}

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-canceled-eservice-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-canceled-eservice-to-producer-mail.html
@@ -1,0 +1,66 @@
+{{> common-header }}
+<tr>
+  <td align="left" class="title" style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 24px;
+      padding-right: 0px;
+      padding-bottom: 8px;
+      padding-left: 0px;
+      word-break: break-word;
+    ">
+    <div style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        line-height: 1;
+        text-align: left;
+        color: #17324d;
+      ">
+      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td align="left" class="text" style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 8px;
+      padding-right: 0px;
+      padding-bottom: 0px;
+      padding-left: 0px;
+      word-break: break-word;
+    ">
+    <div style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      ">
+      <p style="margin-bottom: 0px">
+        Gentile
+        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+      </p>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td align="left" class="text" style="font-size: 0px; padding: 0px; word-break: break-word">
+    <div style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      ">
+      <!-- Body 1 Desktop (from MUI Italia)-->
+      <p>
+        L'e-service "{{ eserviceName }}" non è più in fase di archiviazione.
+      </p>
+    </div>
+  </td>
+</tr>
+{{> common-footer }}

--- a/packages/notification-commons/src/templates/email/templates.ts
+++ b/packages/notification-commons/src/templates/email/templates.ts
@@ -134,6 +134,10 @@ export const eventMailTemplateType = {
     "eservice-archiving-canceled-descriptor-to-consumer-mail",
   eserviceArchivingCanceledEserviceToConsumerMailTemplate:
     "eservice-archiving-canceled-eservice-to-consumer-mail",
+  eserviceArchivingCanceledDescriptorToProducerMailTemplate:
+    "eservice-archiving-canceled-descriptor-to-producer-mail",
+  eserviceArchivingCanceledEserviceToProducerMailTemplate:
+    "eservice-archiving-canceled-eservice-to-producer-mail",
   eserviceStateChangedToProducerScheduledReminderDescriptorMailTemplate:
     "eservice-state-changed-to-producer-scheduled-reminder-descriptor-mail",
   eserviceStateChangedToConsumerScheduledReminderDescriptorMailTemplate:

--- a/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
+++ b/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
@@ -483,7 +483,14 @@ export const inAppTemplates = {
     descriptorVersion: string
   ): string =>
     `La versione ${descriptorVersion} dell'e-service "${eserviceName}" non è più in fase di archiviazione. Se vuoi, è disponibile una nuova versione.`,
+  eserviceArchivingCanceledDescriptorToProducer: (
+    eserviceName: string,
+    descriptorVersion: string
+  ): string =>
+    `La versione ${descriptorVersion} dell'e-service "${eserviceName}" non è più in fase di archiviazione.`,
   eserviceArchivingCanceledEserviceToConsumer: (eserviceName: string): string =>
+    `L'e-service "${eserviceName}" non è più in fase di archiviazione.`,
+  eserviceArchivingCanceledEserviceToProducer: (eserviceName: string): string =>
     `L'e-service "${eserviceName}" non è più in fase di archiviazione.`,
   asyncEserviceWithoutKeychainToProducer: (eserviceName: string): string =>
     `All'e-service asincrono "${eserviceName}" non è collegato nessun portachiavi. Per scambiare i dati in modalità asincrona con i fruitori, è necessario collegare almeno un portachiavi con una chiave.`,


### PR DESCRIPTION
## Issue
- [PIN-10423](https://pagopa.atlassian.net/browse/PIN-10423)
- [SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2803302507/DRAFT+SRS+Archiviazione+manuale+e-service)

## Context

This PR introduces the message for cancel archive (both e-service and descriptor scope) for the producer, as stated at [row 11](https://docs.google.com/spreadsheets/d/1mJRnXVJM12oL3O3feDhtFHZ9eaFES2I6Pt5KUjWBPEo/edit?gid=1388377249#gid=1388377249&range=A11) and [row 24](https://docs.google.com/spreadsheets/d/1mJRnXVJM12oL3O3feDhtFHZ9eaFES2I6Pt5KUjWBPEo/edit?gid=1388377249#gid=1388377249&range=A24) of the notification sheet.

## Scope
- notifications

## Traceability Checklist
- [X] PR title compliant (type(scope): description (KEY))
- [X] Service labels applied


[PIN-10423]: https://pagopa.atlassian.net/browse/PIN-10423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ