### PR TITLE
fix: notification text align (PIN-10422)

### DIFF
--- a/packages/email-notification-dispatcher/test/handleEserviceDescriptorActivatedToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceDescriptorActivatedToProducer.test.ts
@@ -67,10 +67,10 @@ describe("handleEserviceDescriptorActivatedToProducer", () => {
   const { logger } = getMockContext({});
 
   const expectedDescriptorMessageBody =
-    /<p>La versione \d+ dell'e-service "[^"]+" è di nuovo attiva\. I fruitori potranno nuovamente scambiare dati con questa versione\.<\/p>[\s\n]*<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno \d{2}\/\d{2}\/\d{4}\.<\/p>/;
+    /<p>\s*La versione <strong>\d+<\/strong> dell'e-service <strong>\s*[^<]+\s*<\/strong> è di nuovo attiva\. I fruitori potranno nuovamente scambiare dati con questa versione\.\s*La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno <strong>\d{2}\/\d{2}\/\d{4}<\/strong>\.\s*<\/p>/;
 
   const expectedEserviceMessageBody =
-    /<p>La versione \d+ dell'e-service "[^"]+" è di nuovo attiva\. I fruitori potranno nuovamente scambiare dati con questa versione\.<\/p>[\s\n]*<p>L'e-service è in fase di archiviazione e sarà archiviato definitivamente il giorno \d{2}\/\d{2}\/\d{4}\.<\/p>/;
+    /<p>\s*La versione <strong>\d+<\/strong> dell'e-service <strong>\s*[^<]+\s*<\/strong> è di nuovo attiva\. I fruitori potranno nuovamente scambiare dati con questa versione\.\s*L'e-service è in fase di archiviazione e sarà archiviato definitivamente il giorno <strong>\d{2}\/\d{2}\/\d{4}<\/strong>\.\s*<\/p>/;
 
   beforeEach(async () => {
     await addOneEService(eservice);

--- a/packages/email-notification-dispatcher/test/handleEserviceDescriptorActivatedToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceDescriptorActivatedToProducer.test.ts
@@ -67,10 +67,10 @@ describe("handleEserviceDescriptorActivatedToProducer", () => {
   const { logger } = getMockContext({});
 
   const expectedDescriptorMessageBody =
-    /<p>La versione \d+ dell'e-service "[^"]+" è di nuovo attiva. I fruitori potranno nuovamente scambiare dati con questa versione.<\/p>[\s\n]+<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno \d{2}\/\d{2}\/\d{4}\./;
+    /<p>La versione \d+ dell'e-service "[^"]+" è di nuovo attiva\. I fruitori potranno nuovamente scambiare dati con questa versione\.<\/p>[\s\n]*<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno \d{2}\/\d{2}\/\d{4}\.<\/p>/;
 
   const expectedEserviceMessageBody =
-    /<p>La versione \d+ dell'e-service "[^"]+" è di nuovo attiva. I fruitori potranno nuovamente scambiare dati con questa versione.<\/p>[\s\n]+<p>L'e-service è in fase di archiviazione e sarà archiviato definitivamente il giorno \d{2}\/\d{2}\/\d{4}\./;
+    /<p>La versione \d+ dell'e-service "[^"]+" è di nuovo attiva\. I fruitori potranno nuovamente scambiare dati con questa versione\.<\/p>[\s\n]*<p>L'e-service è in fase di archiviazione e sarà archiviato definitivamente il giorno \d{2}\/\d{2}\/\d{4}\.<\/p>/;
 
   beforeEach(async () => {
     await addOneEService(eservice);

--- a/packages/email-notification-dispatcher/test/handleEserviceDescriptorSuspendedToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceDescriptorSuspendedToProducer.test.ts
@@ -67,10 +67,10 @@ describe("handleEserviceDescriptorSuspendedToProducer", () => {
   const { logger } = getMockContext({});
 
   const expectedDescriptorMessageBody =
-    /<p>La versione \d+ dell'e-service "[^"]+" è al momento sospesa\. I fruitori non potranno più scambiare dati con questa versione\.<\/p>[\s\n]*<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno \d{2}\/\d{2}\/\d{4}\./;
+    /<p>\s*La versione <strong>\d+<\/strong> dell'e-service <strong>\s*[^<]+\s*<\/strong> è al momento sospesa\. I fruitori non potranno più scambiare dati con questa versione\.<\/p>[\s\n]*<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno <strong>\d{2}\/\d{2}\/\d{4}<\/strong>\.<\/p>/;
 
   const expectedEserviceMessageBody =
-    /<p>La versione \d+ dell'e-service "[^"]+" è al momento sospesa\. I fruitori non potranno più scambiare dati con questa versione\.<\/p>[\s\n]*<p>L'e-service è in fase di archiviazione e sarà archiviato definitivamente il giorno \d{2}\/\d{2}\/\d{4}\./;
+    /<p>\s*La versione <strong>\d+<\/strong> dell'e-service <strong>\s*[^<]+\s*<\/strong> è al momento sospesa\. I fruitori non potranno più scambiare dati con questa versione\.<\/p>[\s\n]*<p>L'e-service è in fase di archiviazione e sarà archiviato definitivamente il giorno <strong>\d{2}\/\d{2}\/\d{4}<\/strong>\.<\/p>/;
 
   beforeEach(async () => {
     await addOneEService(eservice);

--- a/packages/email-notification-dispatcher/test/handleEserviceDescriptorSuspendedToProducer.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceDescriptorSuspendedToProducer.test.ts
@@ -67,10 +67,10 @@ describe("handleEserviceDescriptorSuspendedToProducer", () => {
   const { logger } = getMockContext({});
 
   const expectedDescriptorMessageBody =
-    /<p>La versione \d+ dell'e-service "[^"]+" è al momento sospesa. I fruitori non potranno più scambiare dati con questa versione.<\/p>[\s\n]+<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno \d{2}\/\d{2}\/\d{4}./;
+    /<p>La versione \d+ dell'e-service "[^"]+" è al momento sospesa\. I fruitori non potranno più scambiare dati con questa versione\.<\/p>[\s\n]*<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno \d{2}\/\d{2}\/\d{4}\./;
 
   const expectedEserviceMessageBody =
-    /<p>La versione \d+ dell'e-service "[^"]+" è al momento sospesa. I fruitori non potranno più scambiare dati con questa versione.<\/p>[\s\n]+<p>L'e-service è in fase di archiviazione e sarà archiviato definitivamente il giorno \d{2}\/\d{2}\/\d{4}./;
+    /<p>La versione \d+ dell'e-service "[^"]+" è al momento sospesa\. I fruitori non potranno più scambiare dati con questa versione\.<\/p>[\s\n]*<p>L'e-service è in fase di archiviazione e sarà archiviato definitivamente il giorno \d{2}\/\d{2}\/\d{4}\./;
 
   beforeEach(async () => {
     await addOneEService(eservice);

--- a/packages/in-app-notification-dispatcher/src/handlers/eservices/handleEserviceStateChangedToConsumer.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eservices/handleEserviceStateChangedToConsumer.ts
@@ -223,7 +223,7 @@ function getBodyAndDescriptorId(
               eservice.name,
               descriptor?.version,
               archivingSchedule.archivableOn,
-              archivingSchedule.scope === archivingScope.descriptor
+              archivingSchedule.scope === archivingScope.eservice
             ),
             descriptorId,
           };

--- a/packages/in-app-notification-dispatcher/test/handleEserviceStateChangedToConsumer.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleEserviceStateChangedToConsumer.test.ts
@@ -419,7 +419,7 @@ describe("handleEserviceStateChangedToConsumer", async () => {
           eserviceWithArchivingSchedule.descriptors[0].version,
           eserviceWithArchivingSchedule.descriptors[0]!.archivingSchedule!
             .archivableOn!,
-          true
+          false
         ),
     },
     {
@@ -436,7 +436,7 @@ describe("handleEserviceStateChangedToConsumer", async () => {
           archivingEservice.name,
           archivingEservice.descriptors[0].version,
           archivingEservice.descriptors[0]!.archivingSchedule!.archivableOn!,
-          false
+          true
         ),
     },
     {

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-consumer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-consumer-mail.html
@@ -59,7 +59,7 @@
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
         La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ eserviceName
-        }}</strong> con cui stai scambiando dati è stata archiviata definitivamente il
+        }}</strong> con cui stai scambiando dati è stata archiviata definitivamente il 
         giorno <strong>{{ archivableOn }}</strong> e non può più essere utilizzata.
         Per continuare a scambiare dati con l'e-service, passa alla nuova versione.
         La richiesta di fruizione collegata a questa versione può essere archiviata.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-consumer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-consumer-mail.html
@@ -58,8 +58,8 @@
       ">
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione {{ eserviceVersion }} dell'e-service "{{ eserviceName
-        }}" con cui stai scambiando dati è stata archiviata definitivamente il 
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ eserviceName
+        }}</strong> con cui stai scambiando dati è stata archiviata definitivamente il 
         giorno <strong>{{ archivableOn }}</strong> e non può più essere utilizzata.
         Per continuare a scambiare dati con l'e-service, passa alla nuova versione.
         La richiesta di fruizione collegata a questa versione può essere archiviata.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-consumer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-consumer-mail.html
@@ -59,7 +59,7 @@
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
         La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ eserviceName
-        }}</strong> con cui stai scambiando dati è stata archiviata definitivamente il 
+        }}</strong> con cui stai scambiando dati è stata archiviata definitivamente il
         giorno <strong>{{ archivableOn }}</strong> e non può più essere utilizzata.
         Per continuare a scambiare dati con l'e-service, passa alla nuova versione.
         La richiesta di fruizione collegata a questa versione può essere archiviata.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-producer-mail.html
@@ -76,9 +76,9 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
         eserviceName }}</strong> è stata archiviata il giorno <strong>{{ archivedOn }}</strong>.
-        Da ora non è più attiva e i fruitori non potranno più
+        Da ora non è più attiva e i fruitori non potranno più 
         scambiare dati con questa versione.
       </p>
     </div>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-producer-mail.html
@@ -76,8 +76,8 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione "{{ eserviceVersion }}" dell'e-service "{{ eserviceName 
-        }}" è stata archiviata il giorno <strong>{{ archivedOn }}</strong>.
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+        eserviceName }}</strong> è stata archiviata il giorno <strong>{{ archivedOn }}</strong>.
         Da ora non è più attiva e i fruitori non potranno più 
         scambiare dati con questa versione.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-descriptor-to-producer-mail.html
@@ -76,9 +76,9 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
         eserviceName }}</strong> è stata archiviata il giorno <strong>{{ archivedOn }}</strong>.
-        Da ora non è più attiva e i fruitori non potranno più 
+        Da ora non è più attiva e i fruitori non potranno più
         scambiare dati con questa versione.
       </p>
     </div>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-eservice-to-consumer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-eservice-to-consumer-mail.html
@@ -58,7 +58,7 @@
       ">
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'e-service "{{ eserviceName }}" con cui stai scambiando dati è
+        L'e-service <strong>{{ eserviceName }}</strong> con cui stai scambiando dati è
         stato archiviato definitivamente il giorno <strong>{{ archivableOn
         }}</strong> e non può più essere utilizzato.
         È stato rimosso dal catalogo e la richiesta di fruizione collegata a

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-eservice-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-eservice-to-producer-mail.html
@@ -76,7 +76,7 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'e-service <strong>{{eserviceName}}</strong> è stato archiviato
+        L'e-service <strong>{{eserviceName}}</strong> è stato archiviato 
         definitivamente e non è più attivo.
         È stato rimosso dal catalogo e i fruitori non potranno più inviare
         richieste di fruizione o scambiare dati con questo e-service.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-eservice-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-eservice-to-producer-mail.html
@@ -76,7 +76,7 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'e-service "{{eserviceName}}" è stato archiviato 
+        L'e-service <strong>{{eserviceName}}</strong> è stato archiviato 
         definitivamente e non è più attivo.
         È stato rimosso dal catalogo e i fruitori non potranno più inviare
         richieste di fruizione o scambiare dati con questo e-service.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-eservice-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-completed-eservice-to-producer-mail.html
@@ -76,7 +76,7 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'e-service <strong>{{eserviceName}}</strong> è stato archiviato 
+        L'e-service <strong>{{eserviceName}}</strong> è stato archiviato
         definitivamente e non è più attivo.
         È stato rimosso dal catalogo e i fruitori non potranno più inviare
         richieste di fruizione o scambiare dati con questo e-service.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-activated-to-consumer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-activated-to-consumer-mail.html
@@ -76,8 +76,8 @@
       "
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
-      <p>La versione {{ eserviceVersion }} dell'e-service "{{ eserviceName }}" è di nuovo attiva.</p>
-      {{#if archivableOn}}<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno {{ archivableOn }}.{{#if newerVersionAvailable }} È disponibile una nuova versione per continuare a scambiare dati con l'e-service.{{/if}}</p>{{/if}}
+      <p>La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ eserviceName }}</strong> è di nuovo attiva.</p>
+      {{#if archivableOn}}<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno <strong>{{ archivableOn }}</strong>.{{#if newerVersionAvailable }} È disponibile una nuova versione per continuare a scambiare dati con l'e-service.{{/if}}</p>{{/if}}
     </div>
   </td>
 </tr>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-activated-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-activated-to-producer-mail.html
@@ -77,7 +77,7 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
         eserviceName }}</strong> è di nuovo attiva. I fruitori potranno nuovamente scambiare dati con questa versione.
         {{#if isEserviceArchiving}}L'e-service è in fase di archiviazione e sarà archiviato{{
         else}}La versione è in fase di archiviazione e sarà archiviata{{/if}} definitivamente il giorno <strong>{{ archivableOn }}</strong>.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-activated-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-activated-to-producer-mail.html
@@ -76,8 +76,12 @@
       "
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
-       <p>La versione {{ eserviceVersion }} dell'e-service "{{ eserviceName }}" è di nuovo attiva. I fruitori potranno nuovamente scambiare dati con questa versione.</p>
-       <p>{{#if isEserviceArchiving}}L'e-service è in fase di archiviazione e sarà archiviato{{else}}La versione è in fase di archiviazione e sarà archiviata{{/if}} definitivamente il giorno {{ archivableOn }}.</p>
+      <p>
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+        eserviceName }}</strong> è di nuovo attiva. I fruitori potranno nuovamente scambiare dati con questa versione.
+        {{#if isEserviceArchiving}}L'e-service è in fase di archiviazione e sarà archiviato{{
+        else}}La versione è in fase di archiviazione e sarà archiviata{{/if}} definitivamente il giorno <strong>{{ archivableOn }}</strong>.
+      </p>
     </div>
   </td>
 </tr>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-activated-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-activated-to-producer-mail.html
@@ -77,7 +77,7 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
         eserviceName }}</strong> è di nuovo attiva. I fruitori potranno nuovamente scambiare dati con questa versione.
         {{#if isEserviceArchiving}}L'e-service è in fase di archiviazione e sarà archiviato{{
         else}}La versione è in fase di archiviazione e sarà archiviata{{/if}} definitivamente il giorno <strong>{{ archivableOn }}</strong>.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-archived-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-archived-to-producer-mail.html
@@ -75,8 +75,8 @@
       "
     >
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
-          eserviceName }}</strong> è stata archiviata il giorno <strong>{{ archivingDate
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+          eserviceName }}</strong> è stata archiviata il giorno <strong>{{ archivingDate 
         }}</strong> perché senza fruitori. Da ora non è più attiva.
       </p>
     </div>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-archived-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-archived-to-producer-mail.html
@@ -74,7 +74,11 @@
         color: #17324d;
       "
     >
-      <p>La versione {{ eserviceVersion }} dell'e-service "{{ eserviceName }}" è stata archiviata il giorno  {{ archivingDate }} perché senza fruitori. Da ora non è più attiva.</p>
+      <p>
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+          eserviceName }}</strong> è stata archiviata il giorno <strong>{{ archivingDate 
+        }}</strong> perché senza fruitori. Da ora non è più attiva.
+      </p>
     </div>
   </td>
 </tr>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-archived-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-archived-to-producer-mail.html
@@ -75,8 +75,8 @@
       "
     >
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
-          eserviceName }}</strong> è stata archiviata il giorno <strong>{{ archivingDate 
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
+          eserviceName }}</strong> è stata archiviata il giorno <strong>{{ archivingDate
         }}</strong> perché senza fruitori. Da ora non è più attiva.
       </p>
     </div>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-suspended-to-consumer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-suspended-to-consumer-mail.html
@@ -76,8 +76,8 @@
       "
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
-      <p>La versione {{ eserviceVersion }} dell'e-service "{{ eserviceName }}" è al momento sospesa.</p>
-      {{#if archivableOn}}<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno {{ archivableOn }}.{{#if newerVersionAvailable }} È disponibile una nuova versione per continuare a scambiare dati con l'e-service.{{/if}}</p>{{/if}}
+      <p>La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ eserviceName }}</strong> è al momento sospesa.</p>
+      {{#if archivableOn}}<p>La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno <strong>{{ archivableOn }}</strong>.{{#if newerVersionAvailable }} È disponibile una nuova versione per continuare a scambiare dati con l'e-service.{{/if}}</p>{{/if}}
     </div>
   </td>
 </tr>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-suspended-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-suspended-to-producer-mail.html
@@ -77,7 +77,7 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
           eserviceName }}</strong> è al momento sospesa. I fruitori non potranno più scambiare dati con questa versione.</p>
       <p>{{#if isEserviceArchiving}}L'e-service è in fase di archiviazione e sarà archiviato{{else}}La versione è in fase di archiviazione e sarà archiviata{{/if}} definitivamente il giorno <strong>{{ archivableOn }}</strong>.</p>
     </div>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-suspended-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-suspended-to-producer-mail.html
@@ -77,7 +77,7 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
           eserviceName }}</strong> è al momento sospesa. I fruitori non potranno più scambiare dati con questa versione.</p>
       <p>{{#if isEserviceArchiving}}L'e-service è in fase di archiviazione e sarà archiviato{{else}}La versione è in fase di archiviazione e sarà archiviata{{/if}} definitivamente il giorno <strong>{{ archivableOn }}</strong>.</p>
     </div>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-suspended-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-descriptor-suspended-to-producer-mail.html
@@ -76,8 +76,10 @@
       "
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
-       <p>La versione {{ eserviceVersion }} dell'e-service "{{ eserviceName }}" è al momento sospesa. I fruitori non potranno più scambiare dati con questa versione.</p>
-       <p>{{#if isEserviceArchiving}}L'e-service è in fase di archiviazione e sarà archiviato{{else}}La versione è in fase di archiviazione e sarà archiviata{{/if}} definitivamente il giorno {{ archivableOn }}.</p>
+      <p>
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+          eserviceName }}</strong> è al momento sospesa. I fruitori non potranno più scambiare dati con questa versione.</p>
+      <p>{{#if isEserviceArchiving}}L'e-service è in fase di archiviazione e sarà archiviato{{else}}La versione è in fase di archiviazione e sarà archiviata{{/if}} definitivamente il giorno <strong>{{ archivableOn }}</strong>.</p>
     </div>
   </td>
 </tr>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-descriptor-to-consumer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-descriptor-to-consumer-mail.html
@@ -76,7 +76,7 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione {{ eserviceVersion }} dell'e-service "{{ eserviceName }}"
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ eserviceName }}</strong>
         con cui stai scambiando dati è in fase di archiviazione ma è ancora attiva.
         L'archiviazione avverrà il giorno <strong>{{ archivableOn }}</strong>.
         Dopo questa data, la versione sarà archiviata definitivamente e

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-descriptor-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-descriptor-to-producer-mail.html
@@ -76,11 +76,11 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
         eserviceName }}</strong> è in fase di archiviazione ma è ancora attiva.
         L'archiviazione avverrà il giorno <strong>{{ archivableOn }}</strong>.
         Dopo questa data, la versione sarà archiviata definitivamente
-        e non risulterà più attiva. Puoi annullare l'archiviazione
+        e non risulterà più attiva. Puoi annullare l'archiviazione 
         solo entro questo periodo di preavviso.
       </p>
     </div>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-descriptor-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-descriptor-to-producer-mail.html
@@ -76,11 +76,11 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
         eserviceName }}</strong> è in fase di archiviazione ma è ancora attiva.
         L'archiviazione avverrà il giorno <strong>{{ archivableOn }}</strong>.
         Dopo questa data, la versione sarà archiviata definitivamente
-        e non risulterà più attiva. Puoi annullare l'archiviazione 
+        e non risulterà più attiva. Puoi annullare l'archiviazione
         solo entro questo periodo di preavviso.
       </p>
     </div>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-descriptor-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-descriptor-to-producer-mail.html
@@ -76,8 +76,8 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione "{{ eserviceVersion }}" dell'e-service "{{ eserviceName 
-        }}" è in fase di archiviazione ma è ancora attiva.
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+        eserviceName }}</strong> è in fase di archiviazione ma è ancora attiva.
         L'archiviazione avverrà il giorno <strong>{{ archivableOn }}</strong>.
         Dopo questa data, la versione sarà archiviata definitivamente
         e non risulterà più attiva. Puoi annullare l'archiviazione 

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-eservice-to-producer-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-archiving-started-eservice-to-producer-mail.html
@@ -76,7 +76,7 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'e-service "{{eserviceName}}" è in fase di archiviazione
+        L'e-service <strong>{{eserviceName}}</strong> è in fase di archiviazione
         ma è ancora attivo. L'archiviazione avverrà il giorno <strong>{{ 
         archivableOn }}</strong>. Dopo questa data, l'e-service sarà 
         archiviato definitivamente e non risulterà più attivo.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-descriptor-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-descriptor-mail.html
@@ -58,8 +58,8 @@
       ">
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
-        eserviceName }}</strong> sarà archiviata il giorno <strong>{{ 
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
+        eserviceName }}</strong> sarà archiviata il giorno <strong>{{
         archivableOn }}</strong>. Dopo questa data non potrai più
         scambiare dati con l'e-service.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-descriptor-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-descriptor-mail.html
@@ -58,8 +58,8 @@
       ">
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{
-        eserviceName }}</strong> sarà archiviata il giorno <strong>{{
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+        eserviceName }}</strong> sarà archiviata il giorno <strong>{{ 
         archivableOn }}</strong>. Dopo questa data non potrai più
         scambiare dati con l'e-service.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-descriptor-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-descriptor-mail.html
@@ -58,8 +58,8 @@
       ">
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service "{{ 
-        eserviceName }}" sarà archiviata il giorno <strong>{{ 
+        La versione <strong>{{ eserviceVersion }}</strong> dell'e-service <strong>{{ 
+        eserviceName }}</strong> sarà archiviata il giorno <strong>{{ 
         archivableOn }}</strong>. Dopo questa data non potrai più
         scambiare dati con l'e-service.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-eservice-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-eservice-mail.html
@@ -58,7 +58,7 @@
       ">
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'e-service <strong>{{ eserviceName }}</strong> sarà archiviato il giorno <strong>{{
+        L'e-service <strong>{{ eserviceName }}</strong> sarà archiviato il giorno <strong>{{ 
         archivableOn }}</strong>.
         Dopo questa data non potrai più scambiare dati con l'e-service.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-eservice-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-eservice-mail.html
@@ -58,7 +58,7 @@
       ">
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'e-service <strong>{{ eserviceName }}</strong> sarà archiviato il giorno <strong>{{ 
+        L'e-service <strong>{{ eserviceName }}</strong> sarà archiviato il giorno <strong>{{
         archivableOn }}</strong>.
         Dopo questa data non potrai più scambiare dati con l'e-service.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-eservice-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-consumer-scheduled-reminder-eservice-mail.html
@@ -58,7 +58,7 @@
       ">
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'e-service "{{ eserviceName }}" sarà archiviato il giorno <strong>{{ 
+        L'e-service <strong>{{ eserviceName }}</strong> sarà archiviato il giorno <strong>{{ 
         archivableOn }}</strong>.
         Dopo questa data non potrai più scambiare dati con l'e-service.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-descriptor-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-descriptor-mail.html
@@ -59,8 +59,8 @@
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
         L'archiviazione della versione <strong>{{ eserviceVersion }}</strong>
-        dell'e-service <strong>{{ eserviceName }}</strong> avverrà il giorno <strong>{{
-        archivableOn }}</strong>. Dopo questa data, la versione sarà
+        dell'e-service <strong>{{ eserviceName }}</strong> avverrà il giorno <strong>{{ 
+        archivableOn }}</strong>. Dopo questa data, la versione sarà 
         archiviata definitivamente e non risulterà più attiva.
         Puoi annullare l'archiviazione solo entro questo periodo di preavviso.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-descriptor-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-descriptor-mail.html
@@ -59,7 +59,7 @@
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
         L'archiviazione della versione <strong>{{ eserviceVersion }}</strong>
-        dell'e-service {{ eserviceName }} avverrà il giorno <strong>{{ 
+        dell'e-service <strong>{{ eserviceName }}</strong> avverrà il giorno <strong>{{ 
         archivableOn }}</strong>. Dopo questa data, la versione sarà 
         archiviata definitivamente e non risulterà più attiva.
         Puoi annullare l'archiviazione solo entro questo periodo di preavviso.

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-descriptor-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-descriptor-mail.html
@@ -59,8 +59,8 @@
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
         L'archiviazione della versione <strong>{{ eserviceVersion }}</strong>
-        dell'e-service "{{ eserviceName }}" avverrà il giorno <strong>{{ 
-        archivableOn }}</strong>.Dopo questa data, la versione sarà 
+        dell'e-service {{ eserviceName }} avverrà il giorno <strong>{{ 
+        archivableOn }}</strong>. Dopo questa data, la versione sarà 
         archiviata definitivamente e non risulterà più attiva.
         Puoi annullare l'archiviazione solo entro questo periodo di preavviso.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-descriptor-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-descriptor-mail.html
@@ -59,8 +59,8 @@
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
         L'archiviazione della versione <strong>{{ eserviceVersion }}</strong>
-        dell'e-service <strong>{{ eserviceName }}</strong> avverrà il giorno <strong>{{ 
-        archivableOn }}</strong>. Dopo questa data, la versione sarà 
+        dell'e-service <strong>{{ eserviceName }}</strong> avverrà il giorno <strong>{{
+        archivableOn }}</strong>. Dopo questa data, la versione sarà
         archiviata definitivamente e non risulterà più attiva.
         Puoi annullare l'archiviazione solo entro questo periodo di preavviso.
       </p>

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-eservice-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-state-changed-to-producer-scheduled-reminder-eservice-mail.html
@@ -58,7 +58,7 @@
       ">
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'archiviazione dell'e-service "{{ eserviceName }}" avverrà il giorno
+        L'archiviazione dell'e-service <strong>{{ eserviceName }}</strong> avverrà il giorno
         <strong>{{ archivableOn }}</strong>. Dopo questa data, 
         l'e-service sarà archiviato definitivamente e non risulterà più attivo.
         Puoi annullare l'archiviazione solo entro questo periodo di preavviso.

--- a/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
+++ b/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
@@ -515,11 +515,11 @@ export const inAppTemplates = {
     descriptorVersion: string,
     archivableOn: Date | undefined
   ): string =>
-    `La versione ${descriptorVersion} dell'e-service ${eserviceName} sarà archiviata il giorno ${archivableOn ? ` ${dateAtRomeZone(archivableOn)}` : ""}.`,
+    `La versione ${descriptorVersion} dell'e-service ${eserviceName} sarà archiviata il giorno ${archivableOn ? `${dateAtRomeZone(archivableOn)}` : ""}.`,
   eserviceDescriptorArchivingScheduledReminderToConsumer: (
     eserviceName: string,
     descriptorVersion: string,
     archivableOn: Date | undefined
   ): string =>
-    `La versione ${descriptorVersion} dell'e-service ${eserviceName} sarà archiviata il giorno ${archivableOn ? ` ${dateAtRomeZone(archivableOn)}. Dopo questa data non potrai più scambiare dati con l’e-service` : ""}.`,
+    `La versione ${descriptorVersion} dell'e-service ${eserviceName} sarà archiviata il giorno ${archivableOn ? `${dateAtRomeZone(archivableOn)}. Dopo questa data non potrai più scambiare dati con l’e-service` : ""}.`,
 };

--- a/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
+++ b/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
@@ -127,11 +127,11 @@ export const inAppTemplates = {
       eserviceName
     } è al momento sospesa. L'archiviazione avverrà il giorno ${dateAtRomeZone(
       archivableOn
-    )}.${
+    )}${
       newVersionAvailable
-        ? " È disponibile una nuova versione per continuare a scambiare dati con l'e-service."
+        ? ". È disponibile una nuova versione per continuare a scambiare dati con l'e-service"
         : ""
-    }`,
+    }.`,
   eserviceArchivingDescriptorSuspendedToProducer: (
     eserviceName: string,
     version: string,
@@ -443,11 +443,11 @@ export const inAppTemplates = {
     eserviceVersion: string,
     archivableOn: Date | undefined
   ): string =>
-    `La versione ${eserviceVersion} dell'e-service ${eserviceName} è in fase di archiviazione ma è ancora attiva.${
+    `La versione ${eserviceVersion} dell'e-service ${eserviceName} è in fase di archiviazione ma è ancora attiva${
       archivableOn
-        ? ` L'archiviazione avverrà il giorno ${dateAtRomeZone(archivableOn)}. È disponibile una nuova versione.`
+        ? `. L'archiviazione avverrà il giorno ${dateAtRomeZone(archivableOn)}. È disponibile una nuova versione`
         : ""
-    }`,
+    }.`,
   eserviceArchivingStartedEserviceToConsumer: (
     eserviceName: string,
     archivableOn: Date | undefined
@@ -464,7 +464,7 @@ export const inAppTemplates = {
   ): string =>
     `La versione ${descriptorVersion} dell'e-service "${eserviceName}" ${
       archivableOn
-        ? `è stata archiviata il giorno ${dateAtRomeZone(archivableOn)}. Per continuare a scambiare dati con l’e-service, passa alla nuova versione.`
+        ? `è stata archiviata il giorno ${dateAtRomeZone(archivableOn)}. Per continuare a scambiare dati con l’e-service, passa alla nuova versione`
         : ""
     }.`,
   eserviceArchivingCompletedEserviceToConsumer: (
@@ -496,18 +496,18 @@ export const inAppTemplates = {
     eserviceName: string,
     archivableOn: Date | undefined
   ): string =>
-    `Il tuo e-service "${eserviceName}" ${
+    `Il tuo e-service ${eserviceName} ${
       archivableOn
-        ? `sarà archiviato il giorno ${dateAtRomeZone(archivableOn)}.`
+        ? `sarà archiviato il giorno ${dateAtRomeZone(archivableOn)}`
         : ""
     }.`,
   eserviceArchivingScheduledReminderToConsumer: (
     eserviceName: string,
     archivableOn: Date | undefined
   ): string =>
-    `L'e-service "${eserviceName}" ${
+    `L'e-service ${eserviceName} ${
       archivableOn
-        ? `sarà archiviato il giorno ${dateAtRomeZone(archivableOn)}. Dopo questa data non potrai più scambiare dati con l’e-service.`
+        ? `sarà archiviato il giorno ${dateAtRomeZone(archivableOn)}. Dopo questa data non potrai più scambiare dati con l’e-service`
         : ""
     }.`,
   eserviceDescriptorArchivingScheduledReminderToProducer: (
@@ -515,11 +515,11 @@ export const inAppTemplates = {
     descriptorVersion: string,
     archivableOn: Date | undefined
   ): string =>
-    `La versione ${descriptorVersion} dell'e-service "${eserviceName}" sarà archiviata il giorno ${archivableOn ? ` (${dateAtRomeZone(archivableOn)})` : ""}.`,
+    `La versione ${descriptorVersion} dell'e-service ${eserviceName} sarà archiviata il giorno ${archivableOn ? ` ${dateAtRomeZone(archivableOn)}` : ""}.`,
   eserviceDescriptorArchivingScheduledReminderToConsumer: (
     eserviceName: string,
     descriptorVersion: string,
     archivableOn: Date | undefined
   ): string =>
-    `La versione ${descriptorVersion} dell'e-service "${eserviceName}" sarà archiviata il giorno ${archivableOn ? ` (${dateAtRomeZone(archivableOn)}). Dopo questa data non potrai più scambiare dati con l’e-service.` : ""}.`,
+    `La versione ${descriptorVersion} dell'e-service ${eserviceName} sarà archiviata il giorno ${archivableOn ? ` ${dateAtRomeZone(archivableOn)}. Dopo questa data non potrai più scambiare dati con l’e-service` : ""}.`,
 };

--- a/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
+++ b/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
@@ -428,16 +428,16 @@ export const inAppTemplates = {
     descriptorVersion: string,
     archivableOn: Date | undefined
   ): string =>
-    `La versione ${descriptorVersion} dell'e-service "${eserviceName}" è stata archiviata il giorno ${archivableOn ? dateAtRomeZone(archivableOn) : ""}. Da ora non è più attiva e i fruitori non potranno più scambiare dati.`,
+    `La versione ${descriptorVersion} dell'e-service ${eserviceName} è stata archiviata il giorno ${archivableOn ? dateAtRomeZone(archivableOn) : ""}. Da ora non è più attiva e i fruitori non potranno più scambiare dati.`,
   eserviceArchivingCompletedEserviceToProducer: (
     eserviceName: string
   ): string =>
-    `l'e-service "${eserviceName}" è stato archiviato e non è più attivo. È stato rimosso dal catalogo e i fruitori non potranno più inviare richieste di fruizione o scambiare dati.`,
+    `l'e-service ${eserviceName} è stato archiviato e non è più attivo. È stato rimosso dal catalogo e i fruitori non potranno più inviare richieste di fruizione o scambiare dati.`,
   eserviceArchivingDescriptorArchivedToProducer: (
     eserviceName: string,
     descriptorVersion: string
   ): string =>
-    `La versione ${descriptorVersion} dell'e-service "${eserviceName}" è stata archiviata il giorno ${dateAtRomeZone(new Date())} perché senza fruitori. Da ora non è più attiva.`,
+    `La versione ${descriptorVersion} dell'e-service ${eserviceName} è stata archiviata il giorno ${dateAtRomeZone(new Date())} perché senza fruitori. Da ora non è più attiva.`,
   eserviceArchivingStartedDescriptorToConsumer: (
     eserviceName: string,
     eserviceVersion: string,
@@ -462,18 +462,18 @@ export const inAppTemplates = {
     descriptorVersion: string,
     archivableOn: Date | undefined
   ): string =>
-    `La versione ${descriptorVersion} dell'e-service "${eserviceName}" ${
+    `La versione ${descriptorVersion} dell'e-service ${eserviceName}${
       archivableOn
-        ? `è stata archiviata il giorno ${dateAtRomeZone(archivableOn)}. Per continuare a scambiare dati con l’e-service, passa alla nuova versione`
+        ? ` è stata archiviata il giorno ${dateAtRomeZone(archivableOn)}. Per continuare a scambiare dati con l’e-service, passa alla nuova versione`
         : ""
     }.`,
   eserviceArchivingCompletedEserviceToConsumer: (
     eserviceName: string,
     archivableOn: Date | undefined
   ): string =>
-    `L'e-service "${eserviceName}" ${
+    `L'e-service ${eserviceName}${
       archivableOn
-        ? `è stato archiviato definitivamente il giorno ${dateAtRomeZone(archivableOn)} e non può più essere utilizzato.`
+        ? ` è stato archiviato definitivamente il giorno ${dateAtRomeZone(archivableOn)} e non può più essere utilizzato`
         : ""
     }.`,
   eserviceArchivingCanceledDescriptorToConsumer: (

--- a/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
+++ b/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
@@ -125,7 +125,7 @@ export const inAppTemplates = {
   ): string =>
     `La versione ${version ?? ""} dell'e-service ${
       eserviceName
-    } è al momento sospesa. La versione è in fase di archiviazione e sarà archiviata definitivamente il giorno ${dateAtRomeZone(
+    } è al momento sospesa. L'archiviazione avverrà il giorno ${dateAtRomeZone(
       archivableOn
     )}.${
       newVersionAvailable
@@ -153,13 +153,11 @@ export const inAppTemplates = {
     eserviceName: string,
     version: string | undefined,
     archivableOn: Date,
-    newVersionAvailable: boolean
+    isEserviceArchiving: boolean
   ): string =>
     `La versione ${version ?? ""} dell'e-service ${
       eserviceName
-    } è di nuovo attiva. L'archiviazione avverrà il giorno ${dateAtRomeZone(
-      archivableOn
-    )}.${newVersionAvailable ? " È disponibile una nuova versione." : ""}`,
+    } è di nuovo attiva. ${isEserviceArchiving ? "L'e-service sarà archiviato" : "Sarà archiviata"} il giorno ${dateAtRomeZone(archivableOn)}.`,
   eserviceArchivingDescriptorActivatedToProducer: (
     eserviceName: string,
     version: string,
@@ -411,18 +409,18 @@ export const inAppTemplates = {
     descriptorVersion: string,
     archivableOn: Date | undefined
   ): string =>
-    `La versione ${descriptorVersion} dell'e-service ${eserviceName} è in fase di archiviazione ma è ancora attiva.${
+    `La versione ${descriptorVersion} dell'e-service ${eserviceName} è in fase di archiviazione ma è ancora attiva${
       archivableOn
-        ? ` L'archiviazione avverrà il giorno ${dateAtRomeZone(archivableOn)}.`
+        ? `. L'archiviazione avverrà il giorno ${dateAtRomeZone(archivableOn)}`
         : ""
     }.`,
   eserviceArchivingStartedEserviceToProducer: (
     eserviceName: string,
     archivableOn: Date | undefined
   ): string =>
-    `Il tuo e-service ${eserviceName} è in fase di archiviazione, ma risulta ancora attivo ${
+    `Il tuo e-service ${eserviceName} è in fase di archiviazione, ma risulta ancora attivo${
       archivableOn
-        ? `. L'archiviazione avverrà il giorno ${dateAtRomeZone(archivableOn)}`
+        ? `. L'e-service sarà archiviato il giorno ${dateAtRomeZone(archivableOn)}`
         : ""
     }.`,
   eserviceArchivingCompletedDescriptorToProducer: (
@@ -482,9 +480,9 @@ export const inAppTemplates = {
     eserviceName: string,
     descriptorVersion: string
   ): string =>
-    `La versione ${descriptorVersion} dell'e-service "${eserviceName}" non è più in fase di archiviazione. Se vuoi, è disponibile una nuova versione.`,
+    `La versione ${descriptorVersion} dell'e-service ${eserviceName} non è più in fase di archiviazione. Se vuoi, è disponibile una nuova versione.`,
   eserviceArchivingCanceledEserviceToConsumer: (eserviceName: string): string =>
-    `L'e-service "${eserviceName}" non è più in fase di archiviazione.`,
+    `L'e-service ${eserviceName} non è più in fase di archiviazione.`,
   asyncEserviceWithoutKeychainToProducer: (eserviceName: string): string =>
     `All'e-service asincrono "${eserviceName}" non è collegato nessun portachiavi. Per scambiare i dati in modalità asincrona con i fruitori, è necessario collegare almeno un portachiavi con una chiave.`,
   producerKeychainNoKeysForAsyncEserviceToProducerUsers: (


### PR DESCRIPTION
## Issue
- [PIN-10422](https://pagopa.atlassian.net/browse/PIN-10422)
- comments on [PIN-10347](https://pagopa.atlassian.net/browse/PIN-10347)

## Context
Following feedback, this PR fixes the text and wording discrepancies in the notification messages, aligning them with the design document.

## Scope
- notification-commons

## Traceability Checklist
- [X] PR title compliant (type(scope): description (KEY))
- [X] Service labels applied

[PIN-10422]: https://pagopa.atlassian.net/browse/PIN-10422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PIN-10347]: https://pagopa.atlassian.net/browse/PIN-10347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ