### PR TITLE
feat: track validation errors for non-numeric total in ISTAT import (PIN-10450)

### DIFF
--- a/packages/istat-certified-attributes-importer/src/service/processor.ts
+++ b/packages/istat-certified-attributes-importer/src/service/processor.ts
@@ -83,7 +83,7 @@ export async function importAttributes(
       chunk.map(async ([municipalityCode, totalCount]) => {
         stats.processed++;
         try {
-          if (isNaN(totalCount)) {
+          if (Number.isNaN(totalCount)) {
             logger.warn(
               `Value 'Totale' for municipality ${municipalityCode} is not a Number: ${totalCount}`
             );

--- a/packages/istat-certified-attributes-importer/src/service/processor.ts
+++ b/packages/istat-certified-attributes-importer/src/service/processor.ts
@@ -61,7 +61,8 @@ export async function importAttributes(
 
   const populationByMunicipality = await downloadAndAggregateData(
     istatClient,
-    logger
+    logger,
+    stats
   );
   logger.info(
     `Found ${populationByMunicipality.size} municipalities on ISTAT file.`
@@ -149,7 +150,8 @@ export async function importAttributes(
 
 async function downloadAndAggregateData(
   istatClient: IstatClient,
-  logger: Logger
+  logger: Logger,
+  stats: JobStats
 ): Promise<Map<string, number>> {
   const fileContent = await istatClient.downloadNationalDataset(logger);
   const populationMap = new Map<string, number>();
@@ -169,8 +171,16 @@ async function downloadAndAggregateData(
     if (Number(row["Età"]) === SUMMARY_AGE_CODE) {
       const codiceComune = row["Codice comune"];
       const totale = Number(row["Totale"]);
-      if (codiceComune && !isNaN(totale)) {
-        populationMap.set(codiceComune, totale);
+
+      if (codiceComune) {
+        if (!isNaN(totale)) {
+          populationMap.set(codiceComune, totale);
+        } else {
+          logger.warn(
+            `Value 'Totale' for municipality ${codiceComune} is not a Number: ${row["Totale"]}`
+          );
+          stats.errors++;
+        }
       }
     }
   }

--- a/packages/istat-certified-attributes-importer/src/service/processor.ts
+++ b/packages/istat-certified-attributes-importer/src/service/processor.ts
@@ -61,8 +61,7 @@ export async function importAttributes(
 
   const populationByMunicipality = await downloadAndAggregateData(
     istatClient,
-    logger,
-    stats
+    logger
   );
   logger.info(
     `Found ${populationByMunicipality.size} municipalities on ISTAT file.`
@@ -84,6 +83,14 @@ export async function importAttributes(
       chunk.map(async ([municipalityCode, totalCount]) => {
         stats.processed++;
         try {
+          if (isNaN(totalCount)) {
+            logger.warn(
+              `Value 'Totale' for municipality ${municipalityCode} is not a Number: ${totalCount}`
+            );
+            stats.errors++;
+            return;
+          }
+
           try {
             if (!validIstatCodes.has(municipalityCode)) {
               logger.debug(
@@ -150,8 +157,7 @@ export async function importAttributes(
 
 async function downloadAndAggregateData(
   istatClient: IstatClient,
-  logger: Logger,
-  stats: JobStats
+  logger: Logger
 ): Promise<Map<string, number>> {
   const fileContent = await istatClient.downloadNationalDataset(logger);
   const populationMap = new Map<string, number>();
@@ -171,16 +177,8 @@ async function downloadAndAggregateData(
     if (Number(row["Età"]) === SUMMARY_AGE_CODE) {
       const codiceComune = row["Codice comune"];
       const totale = Number(row["Totale"]);
-
       if (codiceComune) {
-        if (!isNaN(totale)) {
-          populationMap.set(codiceComune, totale);
-        } else {
-          logger.warn(
-            `Value 'Totale' for municipality ${codiceComune} is not a Number: ${row["Totale"]}`
-          );
-          stats.errors++;
-        }
+        populationMap.set(codiceComune, totale);
       }
     }
   }

--- a/packages/istat-certified-attributes-importer/test/processor.test.ts
+++ b/packages/istat-certified-attributes-importer/test/processor.test.ts
@@ -499,7 +499,15 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       data: { id: generateId() },
       metadata: { version: 1 },
     });
-    readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValue([]);
+    readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValue([
+      {
+        data: {
+          id: generateId(),
+          remoteIds: [{ origin: ISTAT_ATTRIBUTE_SEED.origin, value: "001002" }],
+        },
+        metadata: { version: 1 },
+      },
+    ]);
     readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue([
       "001001",
       "001002",

--- a/packages/istat-certified-attributes-importer/test/processor.test.ts
+++ b/packages/istat-certified-attributes-importer/test/processor.test.ts
@@ -551,6 +551,9 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything(),
       expect.anything()
     );
+    expect(
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
+    ).not.toHaveBeenCalled();
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("Value 'Totale' for municipality 001002")

--- a/packages/istat-certified-attributes-importer/test/processor.test.ts
+++ b/packages/istat-certified-attributes-importer/test/processor.test.ts
@@ -157,11 +157,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 3, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "015146",
@@ -169,11 +169,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       1350000,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "090001",
@@ -181,11 +181,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       2800000,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "028001",
@@ -193,29 +193,29 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       227,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       "ISTAT",
       "999999",
       ISTAT_ATTRIBUTE_SEED.origin,
       ISTAT_ATTRIBUTE_SEED.code,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
     ).not.toHaveBeenCalledWith(
       expect.any(String),
       "015146",
       expect.any(String),
       expect.any(String),
       expect.any(Object),
-      expect.any(Object),
+      expect.any(Object)
     );
   });
   it("should exclusively process rows where Età is 999 and ignore specific ages", async () => {
@@ -228,7 +228,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
   "001002";"Roma";999;200;200;400`;
 
     istatClientMock.downloadNationalDataset.mockResolvedValueOnce(
-      specificAgesCsv,
+      specificAgesCsv
     );
     readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
       data: { id: generateId() },
@@ -237,7 +237,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValue([]);
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock,
+      internalAssignCertifiedDiscreteAttributeMock
     );
 
     await importAttributes(
@@ -249,15 +249,15 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledTimes(2);
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "001001",
@@ -265,11 +265,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       100,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "001002",
@@ -277,7 +277,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       400,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
   });
   it("should create attribute if missing and assign values", async () => {
@@ -289,10 +289,10 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       });
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock,
+      internalAssignCertifiedDiscreteAttributeMock
     );
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockImplementation(
-      getTenantsWithDiscreteAttributeMock,
+      getTenantsWithDiscreteAttributeMock
     );
 
     await importAttributes(
@@ -304,14 +304,14 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 2, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      attributeProcessMock.createInternalCertifiedDiscreteAttribute,
+      attributeProcessMock.createInternalCertifiedDiscreteAttribute
     ).toBeCalledTimes(1);
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalled();
   });
   it("should process municipalities in chunks successfully", async () => {
@@ -321,10 +321,10 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     });
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValue([]);
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock,
+      internalAssignCertifiedDiscreteAttributeMock
     );
     const fakeIds = Array.from({ length: 1200 }, (_, i) =>
-      String(i).padStart(6, "0"),
+      String(i).padStart(6, "0")
     );
     readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue(fakeIds);
     const largePopulationMap = new Map<string, number>();
@@ -336,7 +336,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     for (let i = 0; i < 1200; i++) {
       hugeCsv += `"${String(i).padStart(
         6,
-        "0",
+        "0"
       )}";"Comune ${i}";999;50;50;100\n`;
     }
 
@@ -351,11 +351,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledTimes(1200);
   });
   it("should attempt an update if an assignment conflict (409) occurs", async () => {
@@ -369,7 +369,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     axiosError.response = { status: 409 };
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockRejectedValueOnce(
-      axiosError,
+      axiosError
     );
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute
       .mockRejectedValueOnce({
@@ -383,7 +383,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     tenantProcessMock.internalUpdateCertifiedDiscreteAttribute.mockResolvedValue(
       {
         version: 1,
-      },
+      }
     );
 
     const csvContent = `"Popolazione residente per età e sesso"
@@ -401,15 +401,15 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalled();
 
     expect(
-      tenantProcessMock.internalUpdateCertifiedDiscreteAttribute,
+      tenantProcessMock.internalUpdateCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "001001",
@@ -417,7 +417,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       100,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
   });
   it("should skip assignment if the tenant is not found in the read model", async () => {
@@ -432,7 +432,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue(["001001"]);
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock,
+      internalAssignCertifiedDiscreteAttributeMock
     );
 
     const csvContent = `"Popolazione residente per età e sesso"
@@ -451,15 +451,15 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledTimes(1);
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "001001",
@@ -467,11 +467,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything(),
       100,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).not.toHaveBeenCalledWith(
       expect.anything(),
       "001002",
@@ -479,16 +479,16 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
     expect(debugSpy).toHaveBeenCalledWith(
-      "Tenant with remoteId: 001002 not found in DB. Skipping.",
+      "Tenant with remoteId: 001002 not found in DB. Skipping."
     );
 
     expect(infoSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Process complete. Processed: 2, Success: 1, Updated: 0, Skipped: 1, Revoked: 0, Error: 0",
-      ),
+        "Process complete. Processed: 2, Success: 1, Updated: 0, Skipped: 1, Revoked: 0, Error: 0"
+      )
     );
   });
   it("should skip municipality and increment errors if 'Totale' in CSV is not a valid number", async () => {
@@ -506,7 +506,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     ]);
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock,
+      internalAssignCertifiedDiscreteAttributeMock
     );
 
     const csvContent = `"Popolazione residente per età e sesso"
@@ -525,11 +525,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "001001",
@@ -537,11 +537,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything(),
       100,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).not.toHaveBeenCalledWith(
       expect.anything(),
       "001002",
@@ -549,11 +549,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Value 'Totale' for municipality 001002"),
+      expect.stringContaining("Value 'Totale' for municipality 001002")
     );
 
     expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining("Error: 1"));
@@ -564,7 +564,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       metadata: { version: 1 },
     });
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock,
+      internalAssignCertifiedDiscreteAttributeMock
     );
 
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValueOnce([
@@ -579,7 +579,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     ]);
 
     tenantProcessMock.internalRevokeCertifiedDiscreteAttribute.mockImplementation(
-      internalRevokeCertifiedDiscreteAttributeMock,
+      internalRevokeCertifiedDiscreteAttributeMock
     );
 
     await importAttributes(
@@ -591,18 +591,18 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       "ISTAT",
       "999999",
       ISTAT_ATTRIBUTE_SEED.origin,
       ISTAT_ATTRIBUTE_SEED.code,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
   });
   it("should throw a timeout error if attribute polling max retries are reached", async () => {
@@ -618,12 +618,12 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
         { defaultPollingMaxRetries: 2, defaultPollingRetryDelay: 1 },
         csvChunkSize,
         genericLogger,
-        generateId(),
-      ),
+        generateId()
+      )
     ).rejects.toThrowError();
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).not.toHaveBeenCalled();
   });
   it("should continue processing other municipalities if one assignment fails", async () => {
@@ -656,11 +656,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
     ).toHaveBeenCalledTimes(8);
   });
   it("should revoke a tenant if it possesses the attribute but lacks a valid ISTAT remoteId", async () => {
@@ -669,7 +669,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       metadata: { version: 1 },
     });
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock,
+      internalAssignCertifiedDiscreteAttributeMock
     );
 
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValueOnce([
@@ -683,7 +683,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     ]);
 
     tenantProcessMock.internalRevokeCertifiedDiscreteAttribute.mockImplementation(
-      internalRevokeCertifiedDiscreteAttributeMock,
+      internalRevokeCertifiedDiscreteAttributeMock
     );
 
     await importAttributes(
@@ -695,18 +695,18 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
     ).toHaveBeenCalledWith(
       "ISTAT",
       "12342",
       ISTAT_ATTRIBUTE_SEED.origin,
       ISTAT_ATTRIBUTE_SEED.code,
       expect.anything(),
-      expect.anything(),
+      expect.anything()
     );
   });
   it("should skip revocation and count an error when a tenant has no ISTAT remoteId", async () => {
@@ -716,7 +716,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       metadata: { version: 1 },
     });
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock,
+      internalAssignCertifiedDiscreteAttributeMock
     );
 
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValueOnce([
@@ -731,7 +731,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     ]);
 
     tenantProcessMock.internalRevokeCertifiedDiscreteAttribute.mockImplementation(
-      internalRevokeCertifiedDiscreteAttributeMock,
+      internalRevokeCertifiedDiscreteAttributeMock
     );
 
     await importAttributes(
@@ -743,15 +743,15 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
     ).not.toHaveBeenCalled();
 
     expect(warnSpy).toHaveBeenCalledWith(
-      "istatRemoteId not found for tenant: tenant-without-istat-remoteid",
+      "istatRemoteId not found for tenant: tenant-without-istat-remoteid"
     );
   });
   it("should continue revoking other tenants if one revocation fails", async () => {
@@ -760,7 +760,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       metadata: { version: 1 },
     });
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock,
+      internalAssignCertifiedDiscreteAttributeMock
     );
 
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValueOnce([
@@ -795,11 +795,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId(),
+      generateId()
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
     ).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/istat-certified-attributes-importer/test/processor.test.ts
+++ b/packages/istat-certified-attributes-importer/test/processor.test.ts
@@ -157,11 +157,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 3, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "015146",
@@ -169,11 +169,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       1350000,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "090001",
@@ -181,11 +181,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       2800000,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "028001",
@@ -193,29 +193,29 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       227,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       "ISTAT",
       "999999",
       ISTAT_ATTRIBUTE_SEED.origin,
       ISTAT_ATTRIBUTE_SEED.code,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
     ).not.toHaveBeenCalledWith(
       expect.any(String),
       "015146",
       expect.any(String),
       expect.any(String),
       expect.any(Object),
-      expect.any(Object)
+      expect.any(Object),
     );
   });
   it("should exclusively process rows where Età is 999 and ignore specific ages", async () => {
@@ -228,7 +228,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
   "001002";"Roma";999;200;200;400`;
 
     istatClientMock.downloadNationalDataset.mockResolvedValueOnce(
-      specificAgesCsv
+      specificAgesCsv,
     );
     readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
       data: { id: generateId() },
@@ -237,7 +237,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValue([]);
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock
+      internalAssignCertifiedDiscreteAttributeMock,
     );
 
     await importAttributes(
@@ -249,15 +249,15 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledTimes(2);
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "001001",
@@ -265,11 +265,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       100,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "001002",
@@ -277,7 +277,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       400,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
   });
   it("should create attribute if missing and assign values", async () => {
@@ -289,10 +289,10 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       });
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock
+      internalAssignCertifiedDiscreteAttributeMock,
     );
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockImplementation(
-      getTenantsWithDiscreteAttributeMock
+      getTenantsWithDiscreteAttributeMock,
     );
 
     await importAttributes(
@@ -304,14 +304,14 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 2, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      attributeProcessMock.createInternalCertifiedDiscreteAttribute
+      attributeProcessMock.createInternalCertifiedDiscreteAttribute,
     ).toBeCalledTimes(1);
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalled();
   });
   it("should process municipalities in chunks successfully", async () => {
@@ -321,10 +321,10 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     });
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValue([]);
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock
+      internalAssignCertifiedDiscreteAttributeMock,
     );
     const fakeIds = Array.from({ length: 1200 }, (_, i) =>
-      String(i).padStart(6, "0")
+      String(i).padStart(6, "0"),
     );
     readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue(fakeIds);
     const largePopulationMap = new Map<string, number>();
@@ -336,7 +336,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     for (let i = 0; i < 1200; i++) {
       hugeCsv += `"${String(i).padStart(
         6,
-        "0"
+        "0",
       )}";"Comune ${i}";999;50;50;100\n`;
     }
 
@@ -351,11 +351,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledTimes(1200);
   });
   it("should attempt an update if an assignment conflict (409) occurs", async () => {
@@ -369,7 +369,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     axiosError.response = { status: 409 };
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockRejectedValueOnce(
-      axiosError
+      axiosError,
     );
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute
       .mockRejectedValueOnce({
@@ -383,7 +383,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     tenantProcessMock.internalUpdateCertifiedDiscreteAttribute.mockResolvedValue(
       {
         version: 1,
-      }
+      },
     );
 
     const csvContent = `"Popolazione residente per età e sesso"
@@ -401,15 +401,15 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalled();
 
     expect(
-      tenantProcessMock.internalUpdateCertifiedDiscreteAttribute
+      tenantProcessMock.internalUpdateCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "001001",
@@ -417,7 +417,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       ISTAT_ATTRIBUTE_SEED.code,
       100,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
   });
   it("should skip assignment if the tenant is not found in the read model", async () => {
@@ -432,7 +432,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue(["001001"]);
 
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock
+      internalAssignCertifiedDiscreteAttributeMock,
     );
 
     const csvContent = `"Popolazione residente per età e sesso"
@@ -451,15 +451,15 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledTimes(1);
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       ISTAT_ATTRIBUTE_SEED.origin,
       "001001",
@@ -467,11 +467,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything(),
       100,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).not.toHaveBeenCalledWith(
       expect.anything(),
       "001002",
@@ -479,17 +479,84 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
     expect(debugSpy).toHaveBeenCalledWith(
-      "Tenant with remoteId: 001002 not found in DB. Skipping."
+      "Tenant with remoteId: 001002 not found in DB. Skipping.",
     );
 
     expect(infoSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Process complete. Processed: 2, Success: 1, Updated: 0, Skipped: 1, Revoked: 0, Error: 0"
-      )
+        "Process complete. Processed: 2, Success: 1, Updated: 0, Skipped: 1, Revoked: 0, Error: 0",
+      ),
     );
+  });
+  it("should skip municipality and increment errors if 'Totale' in CSV is not a valid number", async () => {
+    const infoSpy = vi.spyOn(genericLogger, "info");
+    const warnSpy = vi.spyOn(genericLogger, "warn");
+
+    readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
+      data: { id: generateId() },
+      metadata: { version: 1 },
+    });
+    readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValue([]);
+    readModelQueriesMock.getAllIstatRemoteIds.mockResolvedValue([
+      "001001",
+      "001002",
+    ]);
+
+    tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
+      internalAssignCertifiedDiscreteAttributeMock,
+    );
+
+    const csvContent = `"Popolazione residente per età e sesso"
+    "Codice comune";"Comune";"Età";"Totale maschi";"Totale femmine";"Totale"
+    "001001";"Trapani";999;50;50;100
+    "001002";"Roma";999;200;200;abcde`;
+
+    istatClientMock.downloadNationalDataset.mockResolvedValueOnce(csvContent);
+
+    await importAttributes(
+      istatClientMock as any,
+      readModelQueriesMock as any,
+      tenantProcessMock as any,
+      attributeProcessMock as any,
+      refreshableTokenMock,
+      { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
+      csvChunkSize,
+      genericLogger,
+      generateId(),
+    );
+
+    expect(
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+    ).toHaveBeenCalledWith(
+      ISTAT_ATTRIBUTE_SEED.origin,
+      "001001",
+      expect.anything(),
+      expect.anything(),
+      100,
+      expect.anything(),
+      expect.anything(),
+    );
+
+    expect(
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
+    ).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "001002",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Value 'Totale' for municipality 001002"),
+    );
+
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining("Error: 1"));
   });
   it("should revoke attribute for municipalities not in CSV", async () => {
     readModelQueriesMock.getAttributeByExternalId.mockResolvedValue({
@@ -497,7 +564,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       metadata: { version: 1 },
     });
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock
+      internalAssignCertifiedDiscreteAttributeMock,
     );
 
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValueOnce([
@@ -512,7 +579,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     ]);
 
     tenantProcessMock.internalRevokeCertifiedDiscreteAttribute.mockImplementation(
-      internalRevokeCertifiedDiscreteAttributeMock
+      internalRevokeCertifiedDiscreteAttributeMock,
     );
 
     await importAttributes(
@@ -524,18 +591,18 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       "ISTAT",
       "999999",
       ISTAT_ATTRIBUTE_SEED.origin,
       ISTAT_ATTRIBUTE_SEED.code,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
   });
   it("should throw a timeout error if attribute polling max retries are reached", async () => {
@@ -551,12 +618,12 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
         { defaultPollingMaxRetries: 2, defaultPollingRetryDelay: 1 },
         csvChunkSize,
         genericLogger,
-        generateId()
-      )
+        generateId(),
+      ),
     ).rejects.toThrowError();
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).not.toHaveBeenCalled();
   });
   it("should continue processing other municipalities if one assignment fails", async () => {
@@ -589,11 +656,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalAssignCertifiedDiscreteAttribute
+      tenantProcessMock.internalAssignCertifiedDiscreteAttribute,
     ).toHaveBeenCalledTimes(8);
   });
   it("should revoke a tenant if it possesses the attribute but lacks a valid ISTAT remoteId", async () => {
@@ -602,7 +669,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       metadata: { version: 1 },
     });
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock
+      internalAssignCertifiedDiscreteAttributeMock,
     );
 
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValueOnce([
@@ -616,7 +683,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     ]);
 
     tenantProcessMock.internalRevokeCertifiedDiscreteAttribute.mockImplementation(
-      internalRevokeCertifiedDiscreteAttributeMock
+      internalRevokeCertifiedDiscreteAttributeMock,
     );
 
     await importAttributes(
@@ -628,18 +695,18 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
     ).toHaveBeenCalledWith(
       "ISTAT",
       "12342",
       ISTAT_ATTRIBUTE_SEED.origin,
       ISTAT_ATTRIBUTE_SEED.code,
       expect.anything(),
-      expect.anything()
+      expect.anything(),
     );
   });
   it("should skip revocation and count an error when a tenant has no ISTAT remoteId", async () => {
@@ -649,7 +716,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       metadata: { version: 1 },
     });
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock
+      internalAssignCertifiedDiscreteAttributeMock,
     );
 
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValueOnce([
@@ -664,7 +731,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
     ]);
 
     tenantProcessMock.internalRevokeCertifiedDiscreteAttribute.mockImplementation(
-      internalRevokeCertifiedDiscreteAttributeMock
+      internalRevokeCertifiedDiscreteAttributeMock,
     );
 
     await importAttributes(
@@ -676,15 +743,15 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
     ).not.toHaveBeenCalled();
 
     expect(warnSpy).toHaveBeenCalledWith(
-      "istatRemoteId not found for tenant: tenant-without-istat-remoteid"
+      "istatRemoteId not found for tenant: tenant-without-istat-remoteid",
     );
   });
   it("should continue revoking other tenants if one revocation fails", async () => {
@@ -693,7 +760,7 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       metadata: { version: 1 },
     });
     tenantProcessMock.internalAssignCertifiedDiscreteAttribute.mockImplementation(
-      internalAssignCertifiedDiscreteAttributeMock
+      internalAssignCertifiedDiscreteAttributeMock,
     );
 
     readModelQueriesMock.getTenantsWithDiscreteAttribute.mockResolvedValueOnce([
@@ -728,11 +795,11 @@ describe("ISTAT Certified Discrete Attributes Importer", () => {
       { defaultPollingMaxRetries: 1, defaultPollingRetryDelay: 1 },
       csvChunkSize,
       genericLogger,
-      generateId()
+      generateId(),
     );
 
     expect(
-      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute
+      tenantProcessMock.internalRevokeCertifiedDiscreteAttribute,
     ).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Jira Issue
[PIN-10450](https://pagopa.atlassian.net/jira/software/c/projects/PIN/boards/6426?selectedIssue=PIN-10450)

## Context
- Currently, when parsing the national ISTAT dataset, rows containing non-numeric values in the `Totale` column (e.g., `'abcde'`) are silently skipped without incrementing the error counter or logging warnings. To ensure data quality and visibility on malformed rows, these validation failures must be intercepted and accounted for in the job execution stats.

## Services Affected
- `istat-certified-attributes-importer`

## Key Changes
- Pass the `stats` object by reference to `downloadAndAggregateData` to keep the counters coherent.
- Add an `else` block to catch `NaN` values on the parsed `Totale` field.
- Log a warning when a non-numeric total is found, specifying the affected municipality code.
- Increment the `stats.errors` counter for each malformed row.
- Add a dedicated unit test to verify that invalid rows are skipped and tracked under the error statistics.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [x] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)

[PIN-10450]: https://pagopa.atlassian.net/browse/PIN-10450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ