### PR TITLE
fix: read e-service import zip root folder from archive content (PIN-10161)

### DIFF
--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -1604,10 +1604,18 @@ export function catalogServiceBuilder(
 
       const zip = new AdmZip(Buffer.from(zipFile));
 
-      const rootFolderName = fileResource.filename.replace(".zip", "");
+      const entries = zip.getEntries();
+      const topLevelSegments = new Set(
+        entries.map((e) => e.entryName.split("/")[0])
+      );
+      const rootFolderPrefix =
+        topLevelSegments.size === 1 &&
+        entries.every((e) => e.entryName.includes("/"))
+          ? `${[...topLevelSegments][0]}/`
+          : "";
 
-      const entriesMap = zip.getEntries().reduce((map, entry) => {
-        map.set(entry.entryName.replace(rootFolderName + "/", ""), entry);
+      const entriesMap = entries.reduce((map, entry) => {
+        map.set(entry.entryName.replace(rootFolderPrefix, ""), entry);
         return map;
       }, new Map<string, AdmZip.IZipEntry>());
       entriesMap.delete("");

--- a/packages/backend-for-frontend/test/importEService.test.ts
+++ b/packages/backend-for-frontend/test/importEService.test.ts
@@ -188,11 +188,24 @@ describe("importEService", () => {
 
     it("should import eService when the zip has a root folder whose name differs from the file name", async () => {
       const rootFolderName = "myRoot";
+      const docPath = "documents/doc1.pdf";
+
+      const configurationWithDoc = {
+        ...configuration,
+        descriptor: {
+          ...configuration.descriptor,
+          docs: [{ path: docPath, prettyName: "doc1 prettyName" }],
+        },
+      };
 
       const zipWithRootFolder = new AdmZip();
       zipWithRootFolder.addFile(
         `${rootFolderName}/${jsonFilename}`,
-        Buffer.from(JSON.stringify(configuration))
+        Buffer.from(JSON.stringify(configurationWithDoc))
+      );
+      zipWithRootFolder.addFile(
+        `${rootFolderName}/${docPath}`,
+        Buffer.from("doc content")
       );
 
       const renamedFileResource: bffApi.FileResource = {

--- a/packages/backend-for-frontend/test/importEService.test.ts
+++ b/packages/backend-for-frontend/test/importEService.test.ts
@@ -185,6 +185,48 @@ describe("importEService", () => {
       });
       fs.unlinkSync(zipPath);
     });
+
+    it("should import eService when the zip has a root folder whose name differs from the file name", async () => {
+      const rootFolderName = "myRoot";
+
+      const zipWithRootFolder = new AdmZip();
+      zipWithRootFolder.addFile(
+        `${rootFolderName}/${jsonFilename}`,
+        Buffer.from(JSON.stringify(configuration))
+      );
+
+      const renamedFileResource: bffApi.FileResource = {
+        filename: "myRoot (1).zip",
+        url: "/import/folder",
+      };
+
+      const zipPath = path.join(__dirname, "test_root.zip");
+      zipWithRootFolder.writeZip(zipPath);
+
+      const zipContent = fs.readFileSync(zipPath);
+
+      await fileManager.storeBytes(
+        {
+          bucket: config.importEserviceContainer,
+          path: `${config.importEservicePath}`,
+          resourceId: `${tenantId}`,
+          name: `${renamedFileResource.filename}`,
+          content: zipContent,
+        },
+        genericLogger
+      );
+
+      const result = await catalogService.importEService(
+        renamedFileResource,
+        bffMockContext
+      );
+
+      expect(result).toEqual({
+        id: baseEService.id,
+        descriptorId: baseEService.descriptors[0].id,
+      });
+      fs.unlinkSync(zipPath);
+    });
   });
   describe("error case", () => {
     it("should throw invalidZipStructure error when file name is not configuration.json", async () => {


### PR DESCRIPTION
## Summary

Importing an e-service via `.zip` failed with `400 Invalid zip structure: Error reading configuration.json` (`008-0021`) whenever the external `.zip` file name differed from the archive's internal root folder — e.g. when the browser appends a ` (1)`/`(1)` suffix on download to avoid overwriting an existing file.

The root folder was **derived from the file name** (`fileResource.filename.replace(".zip", "")`) instead of being read from the archive content. This relied on the implicit invariant set at export time (`exportEServiceDescriptor`), where a single variable produces both the inner folder and the file name. The invariant breaks as soon as the file is renamed: the prefix no longer matches the zip entries, so `configuration.json` (and docs/interface) is not found.

## Fix

Detect the root folder **dynamically from the zip entries** instead of from the file name. Handles both:
1. zip with a single root folder (real export format — every entry starts with `<root>/`)
2. zip with files at root, no folder (format used by the existing tests) → empty prefix

`fileResource.filename` is now used only to resolve the S3 path.

## Tests

Added a success case to `importEService.test.ts` with a root folder whose name differs from the file name (`myRoot/...` inside `myRoot (1).zip`) — this would fail with `invalidZipStructure` on the old code. Existing tests (files at root) stay green.

## How to test

Export a descriptor, rename the downloaded zip adding ` (1)` before the extension (or download it twice), then import it → it now succeeds.

## Related

- Companion FE PR: pagopa/pdnd-interop-frontend#2056 — that is only a mitigation of the `(n)` suffix; this is the definitive fix on the BFF side.
- Jira: PIN-10161