### PR TITLE
Chore: Changed attribute discrete name and description on ISTAT importer (PIN-10472)

### DIFF
--- a/packages/istat-certified-attributes-importer/src/config/constants.ts
+++ b/packages/istat-certified-attributes-importer/src/config/constants.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-const ISTAT_POPULATION_ATTRIBUTE_NAME = "Popolazione residente";
+const ISTAT_POPULATION_ATTRIBUTE_NAME = "Popolazione residente comune";
 export const SUMMARY_AGE_CODE = 999;
 const ISTAT_CERTIFIER_ORIGIN = "ISTAT";
 
@@ -10,7 +10,7 @@ function generateCodeFromName(name: string): string {
 export const ISTAT_ATTRIBUTE_SEED = {
   name: ISTAT_POPULATION_ATTRIBUTE_NAME,
   description:
-    "Attributo certificato discreto indicante la popolazione comunale",
+    "Questo attributo certificato indica la popolazione che risiede in un comune",
   origin: ISTAT_CERTIFIER_ORIGIN,
   code: generateCodeFromName(ISTAT_POPULATION_ATTRIBUTE_NAME),
 } as const;

--- a/packages/istat-certified-attributes-importer/test/helpers.ts
+++ b/packages/istat-certified-attributes-importer/test/helpers.ts
@@ -103,11 +103,11 @@ export const persistentAttribute: Attribute = {
   id: unsafeBrandId<AttributeId>(ATTRIBUTE_ISTAT_POPULATION_ID),
   origin: ISTAT_ATTRIBUTE_SEED.origin,
   code: ISTAT_ATTRIBUTE_SEED.code,
-  name: "Popolazione Residente",
+  name: "Popolazione residente comune",
   kind: "Certified",
   creationTime: new Date(),
   description:
-    "Attributo certificato discreto indicante la popolazione comunale",
+    "Questo attributo certificato indica la popolazione che risiede in un comune",
 };
 
 export const getTenantsWithDiscreteAttributeMock = (): Promise<


### PR DESCRIPTION
## Jira Issue
[PIN-10472](https://pagopa.atlassian.net/browse/PIN-10472)

## Context
- Changed attribute name and description of `ISTAT_ATTRIBUTE_SEED`

## Services Affected
- `istat-certified-attributes-importer`

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [x] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)


[PIN-10472]: https://pagopa.atlassian.net/browse/PIN-10472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ