### PR TITLE
PIN-9366-esporre-in-m-2-m-listanziazione-da-template

### DIFF
--- a/collections/m2m gateway-v3/eServiceTemplates/Create EService instance from template.bru
+++ b/collections/m2m gateway-v3/eServiceTemplates/Create EService instance from template.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Create EService instance from template
+  type: http
+}
+
+post {
+  url: {{host-m2m-gw-v3}}/eserviceTemplates/:templateId/eservices
+  body: json
+  auth: none
+}
+
+params:path {
+  templateId: {{eserviceTemplateId}}
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M-ADMIN}}
+  DPoP: {{DPOP-PROOF}}
+}
+
+body:json {
+  {
+    "isSignalHubEnabled": false,
+    "isConsumerDelegable": false,
+    "isClientAccessDelegable": false,
+    "instanceLabel": "instance-01"
+  }
+}
+
+vars:post-response {
+  eserviceId: res.body.id
+}

--- a/collections/m2m gateway-v3/eServiceTemplates/Create template instance descriptor.bru
+++ b/collections/m2m gateway-v3/eServiceTemplates/Create template instance descriptor.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Create template instance descriptor
+  type: http
+}
+
+post {
+  url: {{host-m2m-gw-v3}}/eserviceTemplates/eservices/:eserviceId/descriptors
+  body: json
+  auth: none
+}
+
+params:path {
+  eserviceId: {{eserviceId}}
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M-ADMIN}}
+  DPoP: {{DPOP-PROOF}}
+}
+
+body:json {
+  {
+    "audience": [
+      "string"
+    ],
+    "dailyCallsPerConsumer": 100,
+    "dailyCallsTotal": 1000,
+    "agreementApprovalPolicy": "AUTOMATIC"
+  }
+}
+
+vars:post-response {
+  descriptorId: res.body.id
+}

--- a/collections/m2m gateway-v3/eServiceTemplates/Update EService template instance label.bru
+++ b/collections/m2m gateway-v3/eServiceTemplates/Update EService template instance label.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Update EService template instance label
+  type: http
+}
+
+post {
+  url: {{host-m2m-gw-v3}}/eserviceTemplates/eservices/:eserviceId/instanceLabel
+  body: json
+  auth: none
+}
+
+params:path {
+  eserviceId: {{eserviceId}}
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M-ADMIN}}
+  DPoP: {{DPOP-PROOF}}
+}
+
+body:json {
+  {
+    "instanceLabel": "instance-02"
+  }
+}

--- a/collections/m2m gateway-v3/eServiceTemplates/Update EService template instance.bru
+++ b/collections/m2m gateway-v3/eServiceTemplates/Update EService template instance.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Update EService template instance
+  type: http
+}
+
+post {
+  url: {{host-m2m-gw-v3}}/eserviceTemplates/eservices/:eserviceId
+  body: json
+  auth: none
+}
+
+params:path {
+  eserviceId: {{eserviceId}}
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M-ADMIN}}
+  DPoP: {{DPOP-PROOF}}
+}
+
+body:json {
+  {
+    "isSignalHubEnabled": true,
+    "isConsumerDelegable": true,
+    "isClientAccessDelegable": false,
+    "instanceLabel": "instance-01"
+  }
+}

--- a/collections/m2m gateway-v3/eServiceTemplates/Update draft descriptor template instance.bru
+++ b/collections/m2m gateway-v3/eServiceTemplates/Update draft descriptor template instance.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Update draft descriptor template instance
+  type: http
+}
+
+post {
+  url: {{host-m2m-gw-v3}}/eserviceTemplates/eservices/:eserviceId/descriptors/:descriptorId
+  body: json
+  auth: none
+}
+
+params:path {
+  eserviceId: {{eserviceId}}
+  descriptorId: {{descriptorId}}
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M-ADMIN}}
+  DPoP: {{DPOP-PROOF}}
+}
+
+body:json {
+  {
+    "audience": [
+      "string"
+    ],
+    "dailyCallsPerConsumer": 100,
+    "dailyCallsTotal": 1000,
+    "agreementApprovalPolicy": "AUTOMATIC"
+  }
+}

--- a/collections/m2m gateway-v3/eServiceTemplates/Update template instance descriptor quotas.bru
+++ b/collections/m2m gateway-v3/eServiceTemplates/Update template instance descriptor quotas.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Update template instance descriptor quotas
+  type: http
+}
+
+post {
+  url: {{host-m2m-gw-v3}}/eserviceTemplates/eservices/:eserviceId/descriptors/:descriptorId/quotas
+  body: json
+  auth: none
+}
+
+params:path {
+  eserviceId: {{eserviceId}}
+  descriptorId: {{descriptorId}}
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M-ADMIN}}
+  DPoP: {{DPOP-PROOF}}
+}
+
+body:json {
+  {
+    "dailyCallsPerConsumer": 1000,
+    "dailyCallsTotal": 10000
+  }
+}

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -10608,6 +10608,312 @@ paths:
           $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+  /eserviceTemplates/{templateId}/eservices:
+    parameters:
+      - name: templateId
+        in: path
+        description: The E-Service Template ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/TemplateId"
+    post:
+      tags:
+        - eserviceTemplates
+      summary: Create an E-Service instance from a template
+      description: Creates a new E-Service instance from the specified template
+      operationId: createEServiceInstanceFromTemplate
+      requestBody:
+        description: Template instantiation parameters
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InstanceEServiceSeed"
+        required: true
+      responses:
+        "200":
+          description: E-Service instance created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EService"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /eserviceTemplates/eservices/{eserviceId}:
+    parameters:
+      - name: eserviceId
+        in: path
+        description: The E-Service ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceId"
+    post:
+      tags:
+        - eserviceTemplates
+      summary: Update an E-Service template instance
+      description: Updates the general information of the specified E-Service template instance
+      operationId: updateEServiceTemplateInstance
+      requestBody:
+        description: An E-Service template instance update seed
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEServiceTemplateInstanceSeed"
+        required: true
+      responses:
+        "200":
+          description: E-Service template instance updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EService"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /eserviceTemplates/eservices/{eserviceId}/instanceLabel:
+    parameters:
+      - name: eserviceId
+        in: path
+        description: The E-Service ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceId"
+    post:
+      tags:
+        - eserviceTemplates
+      summary: Update the instance label of a template instance
+      description: Updates the instance label of the specified E-Service template instance after publication
+      operationId: updateEServiceTemplateInstanceLabel
+      requestBody:
+        description: A payload containing the new instance label
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EServiceInstanceLabelUpdateSeed"
+        required: true
+      responses:
+        "200":
+          description: Instance label updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EService"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /eserviceTemplates/eservices/{eserviceId}/descriptors:
+    parameters:
+      - name: eserviceId
+        in: path
+        description: The E-Service ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceId"
+    post:
+      tags:
+        - eserviceTemplates
+      summary: Create a descriptor for a template instance
+      description: Creates a new descriptor for the specified E-Service template instance
+      operationId: createTemplateInstanceDescriptor
+      requestBody:
+        description: A template instance descriptor seed
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EServiceInstanceDescriptorSeed"
+        required: true
+      responses:
+        "200":
+          description: Descriptor created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceDescriptor"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /eserviceTemplates/eservices/{eserviceId}/descriptors/{descriptorId}:
+    parameters:
+      - name: eserviceId
+        in: path
+        description: The E-Service ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceId"
+      - name: descriptorId
+        in: path
+        description: The Descriptor ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/DescriptorId"
+    post:
+      tags:
+        - eserviceTemplates
+      summary: Update a draft descriptor of a template instance
+      description: Updates the draft descriptor of the specified E-Service template instance
+      operationId: updateDraftDescriptorTemplateInstance
+      requestBody:
+        description: A template instance draft descriptor update seed
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEServiceDescriptorTemplateInstanceSeed"
+        required: true
+      responses:
+        "200":
+          description: Descriptor updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceDescriptor"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /eserviceTemplates/eservices/{eserviceId}/descriptors/{descriptorId}/quotas:
+    parameters:
+      - name: eserviceId
+        in: path
+        description: The E-Service ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/EServiceId"
+      - name: descriptorId
+        in: path
+        description: The Descriptor ID
+        required: true
+        schema:
+          $ref: "#/components/schemas/DescriptorId"
+    post:
+      tags:
+        - eserviceTemplates
+      summary: Update the quotas of a template instance descriptor
+      description: Updates the quotas of the specified descriptor of an E-Service template instance
+      operationId: updateTemplateInstanceDescriptorQuotas
+      requestBody:
+        description: A template instance descriptor quotas update seed
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEServiceTemplateInstanceDescriptorQuotasSeed"
+        required: true
+      responses:
+        "200":
+          description: Descriptor quotas updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EServiceDescriptor"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 components:
   parameters:
     OffsetParam:
@@ -12212,6 +12518,8 @@ components:
           type: string
         asyncExchange:
           type: boolean
+        instanceLabel:
+          type: string
       required:
         - id
         - producerId
@@ -12220,6 +12528,118 @@ components:
         - technology
         - descriptors
         - mode
+    InstanceEServiceSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        isSignalHubEnabled:
+          type: boolean
+        isConsumerDelegable:
+          type: boolean
+        isClientAccessDelegable:
+          type: boolean
+        instanceLabel:
+          type: string
+          minLength: 1
+          maxLength: 12
+    UpdateEServiceTemplateInstanceSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        isSignalHubEnabled:
+          type: boolean
+        isConsumerDelegable:
+          type: boolean
+        isClientAccessDelegable:
+          type: boolean
+        instanceLabel:
+          type: string
+          minLength: 1
+          maxLength: 12
+    EServiceInstanceLabelUpdateSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        instanceLabel:
+          type: string
+          minLength: 1
+          maxLength: 12
+    EServiceInstanceDescriptorSeed:
+      type: object
+      additionalProperties: false
+      required:
+        - audience
+        - dailyCallsPerConsumer
+        - dailyCallsTotal
+      properties:
+        audience:
+          type: array
+          items:
+            type: string
+            minLength: 0
+            maxLength: 250
+        dailyCallsPerConsumer:
+          description: Maximum number of daily calls that this descriptor can afford per consumer
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        dailyCallsTotal:
+          description: Total daily calls available for this E-Service
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        agreementApprovalPolicy:
+          $ref: "#/components/schemas/AgreementApprovalPolicy"
+    UpdateEServiceDescriptorTemplateInstanceSeed:
+      type: object
+      additionalProperties: false
+      required:
+        - audience
+        - dailyCallsPerConsumer
+        - dailyCallsTotal
+        - agreementApprovalPolicy
+      properties:
+        audience:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 250
+        dailyCallsPerConsumer:
+          description: Maximum number of daily calls that this descriptor can afford per consumer
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        dailyCallsTotal:
+          description: Total daily calls available for this E-Service
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        agreementApprovalPolicy:
+          $ref: "#/components/schemas/AgreementApprovalPolicy"
+    UpdateEServiceTemplateInstanceDescriptorQuotasSeed:
+      type: object
+      additionalProperties: false
+      required:
+        - dailyCallsPerConsumer
+        - dailyCallsTotal
+      properties:
+        dailyCallsPerConsumer:
+          description: Maximum number of daily calls that this descriptor can afford per consumer
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+        dailyCallsTotal:
+          description: Total daily calls available for this E-Service
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
     EServiceDraftUpdateSeed:
       type: object
       additionalProperties: false

--- a/packages/m2m-gateway-v3/src/api/eserviceApiConverter.ts
+++ b/packages/m2m-gateway-v3/src/api/eserviceApiConverter.ts
@@ -41,6 +41,7 @@ export function toM2MGatewayApiEService(
     personalData: eservice.personalData,
     archivingReason: eservice.archivingReason,
     asyncExchange: eservice.asyncExchange,
+    instanceLabel: eservice.instanceLabel,
   };
 }
 

--- a/packages/m2m-gateway-v3/src/app.ts
+++ b/packages/m2m-gateway-v3/src/app.ts
@@ -130,7 +130,12 @@ export async function createApp(
     agreementRouter(zodiosCtx, agreementService, kmsClient),
     tenantRouter(zodiosCtx, tenantService),
     delegationRouter(zodiosCtx, delegationService),
-    eserviceTemplateRouter(zodiosCtx, eserviceTemplateService, kmsClient),
+    eserviceTemplateRouter(
+      zodiosCtx,
+      eserviceTemplateService,
+      eserviceService,
+      kmsClient
+    ),
     clientRouter(zodiosCtx, clientService),
     producerKeychainRouter(zodiosCtx, producerKeychainService),
     keyRouter(zodiosCtx, keyService),

--- a/packages/m2m-gateway-v3/src/routers/eserviceTemplateRouter.ts
+++ b/packages/m2m-gateway-v3/src/routers/eserviceTemplateRouter.ts
@@ -12,6 +12,7 @@ import {
 import { emptyErrorMapper, unsafeBrandId } from "pagopa-interop-models";
 import { makeApiProblem } from "../model/errors.js";
 import { EserviceTemplateService } from "../services/eserviceTemplateService.js";
+import { EserviceService } from "../services/eserviceService.js";
 import { fromM2MGatewayAppContext } from "../utils/context.js";
 import {
   deleteDraftEServiceTemplateVersionErrorMapper,
@@ -28,6 +29,7 @@ import { sendDownloadedDocumentAsFormData } from "../utils/fileDownload.js";
 const eserviceTemplateRouter = (
   ctx: ZodiosContext,
   eserviceTemplateService: EserviceTemplateService,
+  eserviceService: EserviceService,
   kmsClient: KMSClient
 ): ZodiosRouter<ZodiosEndpointDefinitions, ExpressContext> => {
   const { M2M_ROLE, M2M_ADMIN_ROLE } = authRole;
@@ -1044,6 +1046,169 @@ const eserviceTemplateRouter = (
             assignEServiceTemplateVersionAttributesErrorMapper,
             ctx,
             `Error assigning verified attributes to version with id ${req.params.versionId} for eservice template with id ${req.params.templateId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post("/eserviceTemplates/:templateId/eservices", async (req, res) => {
+      const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+      try {
+        validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+        const eservice =
+          await eserviceService.createEServiceInstanceFromTemplate(
+            unsafeBrandId(req.params.templateId),
+            req.body,
+            ctx
+          );
+
+        return res.status(200).send(m2mGatewayApiV3.EService.parse(eservice));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx,
+          `Error creating E-Service instance from template ${req.params.templateId}`
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
+    .post("/eserviceTemplates/eservices/:eserviceId", async (req, res) => {
+      const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+      try {
+        validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+        const eservice = await eserviceService.updateEServiceTemplateInstance(
+          unsafeBrandId(req.params.eserviceId),
+          req.body,
+          ctx
+        );
+
+        return res.status(200).send(m2mGatewayApiV3.EService.parse(eservice));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx,
+          `Error updating E-Service template instance ${req.params.eserviceId}`
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
+    .post(
+      "/eserviceTemplates/eservices/:eserviceId/instanceLabel",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          const eservice =
+            await eserviceService.updateEServiceTemplateInstanceLabel(
+              unsafeBrandId(req.params.eserviceId),
+              req.body,
+              ctx
+            );
+
+          return res.status(200).send(m2mGatewayApiV3.EService.parse(eservice));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error updating instance label for E-Service template instance ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/eserviceTemplates/eservices/:eserviceId/descriptors",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          const descriptor =
+            await eserviceService.createTemplateInstanceDescriptor(
+              unsafeBrandId(req.params.eserviceId),
+              req.body,
+              ctx
+            );
+
+          return res
+            .status(200)
+            .send(m2mGatewayApiV3.EServiceDescriptor.parse(descriptor));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error creating descriptor for E-Service template instance ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/eserviceTemplates/eservices/:eserviceId/descriptors/:descriptorId",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          const descriptor =
+            await eserviceService.updateDraftDescriptorTemplateInstance(
+              unsafeBrandId(req.params.eserviceId),
+              unsafeBrandId(req.params.descriptorId),
+              req.body,
+              ctx
+            );
+
+          return res
+            .status(200)
+            .send(m2mGatewayApiV3.EServiceDescriptor.parse(descriptor));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error updating draft descriptor ${req.params.descriptorId} for E-Service template instance ${req.params.eserviceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/eserviceTemplates/eservices/:eserviceId/descriptors/:descriptorId/quotas",
+      async (req, res) => {
+        const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+        try {
+          validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+          const descriptor =
+            await eserviceService.updateTemplateInstanceDescriptorQuotas(
+              unsafeBrandId(req.params.eserviceId),
+              unsafeBrandId(req.params.descriptorId),
+              req.body,
+              ctx
+            );
+
+          return res
+            .status(200)
+            .send(m2mGatewayApiV3.EServiceDescriptor.parse(descriptor));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error updating quotas for descriptor ${req.params.descriptorId} of E-Service template instance ${req.params.eserviceId}`
           );
           return res.status(errorRes.status).send(errorRes);
         }

--- a/packages/m2m-gateway-v3/src/services/eserviceService.ts
+++ b/packages/m2m-gateway-v3/src/services/eserviceService.ts
@@ -9,6 +9,7 @@ import {
   DescriptorId,
   EServiceDocumentId,
   EServiceId,
+  EServiceTemplateId,
   ListResult,
   RiskAnalysisId,
   unsafeBrandId,
@@ -1687,6 +1688,138 @@ export function eserviceServiceBuilder(
         );
 
       await pollEService(response, headers);
+    },
+
+    async createEServiceInstanceFromTemplate(
+      templateId: EServiceTemplateId,
+      seed: m2mGatewayApiV3.InstanceEServiceSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.EService> {
+      logger.info(`Creating E-Service instance from template ${templateId}`);
+
+      const response =
+        await clients.catalogProcessClient.createEServiceInstanceFromTemplate(
+          seed,
+          {
+            params: { templateId },
+            headers,
+          }
+        );
+      const polledResource = await pollEService(response, headers);
+      return toM2MGatewayApiEService(polledResource.data);
+    },
+
+    async updateEServiceTemplateInstance(
+      eserviceId: EServiceId,
+      seed: m2mGatewayApiV3.UpdateEServiceTemplateInstanceSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.EService> {
+      logger.info(`Updating E-Service template instance ${eserviceId}`);
+
+      const response =
+        await clients.catalogProcessClient.updateEServiceTemplateInstanceById(
+          seed,
+          {
+            params: { eServiceId: eserviceId },
+            headers,
+          }
+        );
+      const polledResource = await pollEService(response, headers);
+      return toM2MGatewayApiEService(polledResource.data);
+    },
+
+    async updateEServiceTemplateInstanceLabel(
+      eserviceId: EServiceId,
+      seed: m2mGatewayApiV3.EServiceInstanceLabelUpdateSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.EService> {
+      logger.info(
+        `Updating instance label for E-Service template instance ${eserviceId}`
+      );
+
+      const response =
+        await clients.catalogProcessClient.updateEServiceInstanceLabelAfterPublication(
+          seed,
+          {
+            params: { eServiceId: eserviceId },
+            headers,
+          }
+        );
+      const polledResource = await pollEService(response, headers);
+      return toM2MGatewayApiEService(polledResource.data);
+    },
+
+    async createTemplateInstanceDescriptor(
+      eserviceId: EServiceId,
+      seed: m2mGatewayApiV3.EServiceInstanceDescriptorSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.EServiceDescriptor> {
+      logger.info(
+        `Creating descriptor for E-Service template instance ${eserviceId}`
+      );
+
+      const { data: descriptor, metadata } =
+        await clients.catalogProcessClient.createTemplateInstanceDescriptor(
+          seed,
+          {
+            params: { eServiceId: eserviceId },
+            headers,
+          }
+        );
+
+      await pollEServiceById(eserviceId, metadata, headers);
+
+      return toM2MGatewayApiEServiceDescriptor(descriptor);
+    },
+
+    async updateDraftDescriptorTemplateInstance(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      seed: m2mGatewayApiV3.UpdateEServiceDescriptorTemplateInstanceSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.EServiceDescriptor> {
+      logger.info(
+        `Updating draft descriptor ${descriptorId} for E-Service template instance ${eserviceId}`
+      );
+
+      const response =
+        await clients.catalogProcessClient.updateDraftDescriptorTemplateInstance(
+          seed,
+          {
+            params: { eServiceId: eserviceId, descriptorId },
+            headers,
+          }
+        );
+      const polledResource = await pollEService(response, headers);
+
+      return toM2MGatewayApiEServiceDescriptor(
+        retrieveEServiceDescriptorById(polledResource, descriptorId)
+      );
+    },
+
+    async updateTemplateInstanceDescriptorQuotas(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      seed: m2mGatewayApiV3.UpdateEServiceTemplateInstanceDescriptorQuotasSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.EServiceDescriptor> {
+      logger.info(
+        `Updating quotas for descriptor ${descriptorId} of E-Service template instance ${eserviceId}`
+      );
+
+      const response =
+        await clients.catalogProcessClient.updateTemplateInstanceDescriptor(
+          seed,
+          {
+            params: { eServiceId: eserviceId, descriptorId },
+            headers,
+          }
+        );
+      const polledResource = await pollEService(response, headers);
+
+      return toM2MGatewayApiEServiceDescriptor(
+        retrieveEServiceDescriptorById(polledResource, descriptorId)
+      );
     },
   };
 }

--- a/packages/m2m-gateway-v3/test/api/eServiceTemplates/createEServiceInstanceFromTemplate.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eServiceTemplates/createEServiceInstanceFromTemplate.test.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  generateToken,
+  getMockedApiEservice,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { toM2MGatewayApiEService } from "../../../src/api/eserviceApiConverter.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("POST /eserviceTemplates/{templateId}/eservices router test", () => {
+  const seed: m2mGatewayApiV3.InstanceEServiceSeed = {
+    isSignalHubEnabled: true,
+    isConsumerDelegable: false,
+    isClientAccessDelegable: false,
+    instanceLabel: "label",
+  };
+
+  const mockResponse: m2mGatewayApiV3.EService = toM2MGatewayApiEService(
+    getMockedApiEservice()
+  );
+
+  mockEserviceService.createEServiceInstanceFromTemplate = vi
+    .fn()
+    .mockResolvedValue(mockResponse);
+
+  const makeRequest = async (
+    token: string,
+    templateId: string = generateId(),
+    body: m2mGatewayApiV3.InstanceEServiceSeed = seed
+  ) =>
+    request(api)
+      .post(`${appBasePath}/eserviceTemplates/${templateId}/eservices`)
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { ...seed, instanceLabel: "" },
+    { ...seed, instanceLabel: "a".repeat(13) },
+    { ...seed, extraField: "invalid" },
+  ])("Should return 400 if passed an invalid seed (#%#)", async (body) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      body as m2mGatewayApiV3.InstanceEServiceSeed
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockEserviceService.createEServiceInstanceFromTemplate = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/eServiceTemplates/createTemplateInstanceDescriptor.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eServiceTemplates/createTemplateInstanceDescriptor.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  generateToken,
+  getMockedApiEserviceDescriptor,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { toM2MGatewayApiEServiceDescriptor } from "../../../src/api/eserviceApiConverter.js";
+import { config } from "../../../src/config/config.js";
+import {
+  eserviceDescriptorNotFound,
+  missingMetadata,
+} from "../../../src/model/errors.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("POST /eserviceTemplates/eservices/{eserviceId}/descriptors router test", () => {
+  const seed: m2mGatewayApiV3.EServiceInstanceDescriptorSeed = {
+    audience: ["http/test.test"],
+    dailyCallsPerConsumer: 10,
+    dailyCallsTotal: 100,
+    agreementApprovalPolicy: "AUTOMATIC",
+  };
+
+  const mockResponse: m2mGatewayApiV3.EServiceDescriptor =
+    toM2MGatewayApiEServiceDescriptor(getMockedApiEserviceDescriptor());
+
+  mockEserviceService.createTemplateInstanceDescriptor = vi
+    .fn()
+    .mockResolvedValue(mockResponse);
+
+  const makeRequest = async (
+    token: string,
+    eserviceId: string = generateId(),
+    body: m2mGatewayApiV3.EServiceInstanceDescriptorSeed = seed
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/eserviceTemplates/eservices/${eserviceId}/descriptors`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { ...seed, audience: undefined },
+    { ...seed, dailyCallsPerConsumer: undefined },
+    { ...seed, dailyCallsTotal: undefined },
+    { ...seed, agreementApprovalPolicy: "INVALID_POLICY" },
+    { ...seed, extraField: "invalid" },
+  ])("Should return 400 if passed an invalid seed (#%#)", async (body) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      body as m2mGatewayApiV3.EServiceInstanceDescriptorSeed
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    eserviceDescriptorNotFound(generateId(), generateId()),
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockEserviceService.createTemplateInstanceDescriptor = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/eServiceTemplates/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eServiceTemplates/updateDraftDescriptorTemplateInstance.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  generateToken,
+  getMockedApiEserviceDescriptor,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { toM2MGatewayApiEServiceDescriptor } from "../../../src/api/eserviceApiConverter.js";
+import { config } from "../../../src/config/config.js";
+import {
+  eserviceDescriptorNotFound,
+  missingMetadata,
+} from "../../../src/model/errors.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("POST /eserviceTemplates/eservices/{eserviceId}/descriptors/{descriptorId} router test", () => {
+  const seed: m2mGatewayApiV3.UpdateEServiceDescriptorTemplateInstanceSeed = {
+    audience: ["http/test.test"],
+    dailyCallsPerConsumer: 10,
+    dailyCallsTotal: 100,
+    agreementApprovalPolicy: "AUTOMATIC",
+  };
+
+  const mockResponse: m2mGatewayApiV3.EServiceDescriptor =
+    toM2MGatewayApiEServiceDescriptor(getMockedApiEserviceDescriptor());
+
+  mockEserviceService.updateDraftDescriptorTemplateInstance = vi
+    .fn()
+    .mockResolvedValue(mockResponse);
+
+  const makeRequest = async (
+    token: string,
+    eserviceId: string = generateId(),
+    descriptorId: string = generateId(),
+    body: m2mGatewayApiV3.UpdateEServiceDescriptorTemplateInstanceSeed = seed
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/eserviceTemplates/eservices/${eserviceId}/descriptors/${descriptorId}`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { ...seed, audience: undefined },
+    { ...seed, dailyCallsPerConsumer: undefined },
+    { ...seed, dailyCallsTotal: undefined },
+    { ...seed, agreementApprovalPolicy: undefined },
+    { ...seed, agreementApprovalPolicy: "INVALID_POLICY" },
+    { ...seed, extraField: "invalid" },
+  ])("Should return 400 if passed an invalid seed (#%#)", async (body) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      generateId(),
+      body as m2mGatewayApiV3.UpdateEServiceDescriptorTemplateInstanceSeed
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    eserviceDescriptorNotFound(generateId(), generateId()),
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockEserviceService.updateDraftDescriptorTemplateInstance = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/eServiceTemplates/updateEServiceTemplateInstance.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eServiceTemplates/updateEServiceTemplateInstance.test.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  generateToken,
+  getMockedApiEservice,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { toM2MGatewayApiEService } from "../../../src/api/eserviceApiConverter.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("POST /eserviceTemplates/eservices/{eserviceId} router test", () => {
+  const seed: m2mGatewayApiV3.UpdateEServiceTemplateInstanceSeed = {
+    isSignalHubEnabled: true,
+    isConsumerDelegable: true,
+    isClientAccessDelegable: false,
+    instanceLabel: "updated",
+  };
+
+  const mockResponse: m2mGatewayApiV3.EService = toM2MGatewayApiEService(
+    getMockedApiEservice()
+  );
+
+  mockEserviceService.updateEServiceTemplateInstance = vi
+    .fn()
+    .mockResolvedValue(mockResponse);
+
+  const makeRequest = async (
+    token: string,
+    eserviceId: string = generateId(),
+    body: m2mGatewayApiV3.UpdateEServiceTemplateInstanceSeed = seed
+  ) =>
+    request(api)
+      .post(`${appBasePath}/eserviceTemplates/eservices/${eserviceId}`)
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { ...seed, instanceLabel: "" },
+    { ...seed, instanceLabel: "a".repeat(13) },
+    { ...seed, extraField: "invalid" },
+  ])("Should return 400 if passed an invalid seed (#%#)", async (body) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      body as m2mGatewayApiV3.UpdateEServiceTemplateInstanceSeed
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockEserviceService.updateEServiceTemplateInstance = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/eServiceTemplates/updateEServiceTemplateInstanceLabel.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eServiceTemplates/updateEServiceTemplateInstanceLabel.test.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  generateToken,
+  getMockedApiEservice,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { toM2MGatewayApiEService } from "../../../src/api/eserviceApiConverter.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("POST /eserviceTemplates/eservices/{eserviceId}/instanceLabel router test", () => {
+  const seed: m2mGatewayApiV3.EServiceInstanceLabelUpdateSeed = {
+    instanceLabel: "new-label",
+  };
+
+  const mockResponse: m2mGatewayApiV3.EService = toM2MGatewayApiEService(
+    getMockedApiEservice()
+  );
+
+  mockEserviceService.updateEServiceTemplateInstanceLabel = vi
+    .fn()
+    .mockResolvedValue(mockResponse);
+
+  const makeRequest = async (
+    token: string,
+    eserviceId: string = generateId(),
+    body: m2mGatewayApiV3.EServiceInstanceLabelUpdateSeed = seed
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/eserviceTemplates/eservices/${eserviceId}/instanceLabel`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { instanceLabel: "" },
+    { instanceLabel: "a".repeat(13) },
+    { instanceLabel: "ok", extraField: "invalid" },
+  ])("Should return 400 if passed an invalid seed (#%#)", async (body) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      body as m2mGatewayApiV3.EServiceInstanceLabelUpdateSeed
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockEserviceService.updateEServiceTemplateInstanceLabel = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/eServiceTemplates/updateTemplateInstanceDescriptorQuotas.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eServiceTemplates/updateTemplateInstanceDescriptorQuotas.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import { generateId, pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  generateToken,
+  getMockedApiEserviceDescriptor,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { api, mockEserviceService } from "../../vitest.api.setup.js";
+import { toM2MGatewayApiEServiceDescriptor } from "../../../src/api/eserviceApiConverter.js";
+import { config } from "../../../src/config/config.js";
+import {
+  eserviceDescriptorNotFound,
+  missingMetadata,
+} from "../../../src/model/errors.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+
+describe("POST /eserviceTemplates/eservices/{eserviceId}/descriptors/{descriptorId}/quotas router test", () => {
+  const seed: m2mGatewayApiV3.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+    {
+      dailyCallsPerConsumer: 1000,
+      dailyCallsTotal: 10000,
+    };
+
+  const mockResponse: m2mGatewayApiV3.EServiceDescriptor =
+    toM2MGatewayApiEServiceDescriptor(getMockedApiEserviceDescriptor());
+
+  mockEserviceService.updateTemplateInstanceDescriptorQuotas = vi
+    .fn()
+    .mockResolvedValue(mockResponse);
+
+  const makeRequest = async (
+    token: string,
+    eserviceId: string = generateId(),
+    descriptorId: string = generateId(),
+    body: m2mGatewayApiV3.UpdateEServiceTemplateInstanceDescriptorQuotasSeed = seed
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/eserviceTemplates/eservices/${eserviceId}/descriptors/${descriptorId}/quotas`
+      )
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { ...seed, dailyCallsPerConsumer: undefined },
+    { ...seed, dailyCallsTotal: undefined },
+    { ...seed, dailyCallsPerConsumer: 0 },
+    { ...seed, extraField: "invalid" },
+  ])("Should return 400 if passed an invalid seed (#%#)", async (body) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      generateId(),
+      generateId(),
+      body as m2mGatewayApiV3.UpdateEServiceTemplateInstanceDescriptorQuotasSeed
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    eserviceDescriptorNotFound(generateId(), generateId()),
+    missingMetadata(),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockEserviceService.updateTemplateInstanceDescriptorQuotas = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/createEServiceInstanceFromTemplate.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/createEServiceInstanceFromTemplate.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  EServiceTemplateId,
+  generateId,
+  pollingMaxRetriesExceeded,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceService,
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import {
+  getMockM2MAdminAppContext,
+  testToM2mGatewayApiEService,
+} from "../../mockUtils.js";
+
+describe("createEServiceInstanceFromTemplate", () => {
+  const templateId = generateId<EServiceTemplateId>();
+  const mockedApiEservice = getMockedApiEservice();
+
+  const mockSeed: m2mGatewayApiV3.InstanceEServiceSeed = {
+    isSignalHubEnabled: true,
+    isConsumerDelegable: false,
+    isClientAccessDelegable: false,
+    instanceLabel: "label",
+  };
+
+  const mockEserviceProcessResponse = getMockWithMetadata(mockedApiEservice);
+
+  const mockCreateInstance = vi
+    .fn()
+    .mockResolvedValue(mockEserviceProcessResponse);
+  const mockGetEservice = vi.fn(
+    mockPollingResponse(mockEserviceProcessResponse, 2)
+  );
+
+  mockInteropBeClients.catalogProcessClient = {
+    createEServiceInstanceFromTemplate: mockCreateInstance,
+    getEServiceById: mockGetEservice,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockCreateInstance.mockClear();
+    mockGetEservice.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const m2mEserviceResponse: m2mGatewayApiV3.EService =
+      testToM2mGatewayApiEService(mockEserviceProcessResponse.data);
+
+    const result = await eserviceService.createEServiceInstanceFromTemplate(
+      templateId,
+      mockSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(m2mEserviceResponse);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient
+          .createEServiceInstanceFromTemplate,
+      params: { templateId },
+      body: mockSeed,
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockEserviceProcessResponse.data.id },
+    });
+    expect(
+      mockInteropBeClients.catalogProcessClient.getEServiceById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the creation POST call has no metadata", async () => {
+    mockCreateInstance.mockResolvedValueOnce({
+      ...mockEserviceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.createEServiceInstanceFromTemplate(
+        templateId,
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the polling GET call has no metadata", async () => {
+    mockGetEservice.mockResolvedValueOnce({
+      ...mockEserviceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.createEServiceInstanceFromTemplate(
+        templateId,
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEservice.mockImplementation(
+      mockPollingResponse(
+        mockEserviceProcessResponse,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      eserviceService.createEServiceInstanceFromTemplate(
+        templateId,
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEservice).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/createTemplateInstanceDescriptor.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/createTemplateInstanceDescriptor.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockedApiEserviceDescriptor,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceService,
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("createTemplateInstanceDescriptor", () => {
+  const mockDescriptor = getMockedApiEserviceDescriptor();
+  const mockEService = getMockedApiEservice({ descriptors: [mockDescriptor] });
+
+  const mockSeed: m2mGatewayApiV3.EServiceInstanceDescriptorSeed = {
+    audience: ["http/test.test"],
+    dailyCallsPerConsumer: 10,
+    dailyCallsTotal: 100,
+    agreementApprovalPolicy: "AUTOMATIC",
+  };
+
+  const mockCreateDescriptor = vi.fn().mockResolvedValue({
+    data: mockDescriptor,
+    metadata: { version: 0 },
+  });
+  const mockGetEService = vi.fn(
+    mockPollingResponse(getMockWithMetadata(mockEService), 2)
+  );
+
+  mockInteropBeClients.catalogProcessClient = {
+    createTemplateInstanceDescriptor: mockCreateDescriptor,
+    getEServiceById: mockGetEService,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockCreateDescriptor.mockClear();
+    mockGetEService.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const expectedM2MDescriptor: m2mGatewayApiV3.EServiceDescriptor = {
+      id: mockDescriptor.id,
+      version: mockDescriptor.version,
+      description: mockDescriptor.description,
+      audience: mockDescriptor.audience,
+      voucherLifespan: mockDescriptor.voucherLifespan,
+      dailyCallsPerConsumer: mockDescriptor.dailyCallsPerConsumer,
+      dailyCallsTotal: mockDescriptor.dailyCallsTotal,
+      state: mockDescriptor.state,
+      agreementApprovalPolicy: mockDescriptor.agreementApprovalPolicy,
+      serverUrls: mockDescriptor.serverUrls,
+      publishedAt: mockDescriptor.publishedAt,
+      suspendedAt: mockDescriptor.suspendedAt,
+      deprecatedAt: mockDescriptor.deprecatedAt,
+      archivedAt: mockDescriptor.archivedAt,
+      templateVersionId: mockDescriptor.templateVersionRef?.id,
+      archivingSchedule: mockDescriptor.archivingSchedule,
+      asyncExchangeProperties: mockDescriptor.asyncExchangeProperties,
+    };
+
+    const result = await eserviceService.createTemplateInstanceDescriptor(
+      unsafeBrandId(mockEService.id),
+      mockSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(expectedM2MDescriptor);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient
+          .createTemplateInstanceDescriptor,
+      params: { eServiceId: mockEService.id },
+      body: mockSeed,
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockEService.id },
+    });
+    expect(
+      mockInteropBeClients.catalogProcessClient.getEServiceById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw missingMetadata in case the descriptor returned by the creation POST call has no metadata", async () => {
+    mockCreateDescriptor.mockResolvedValueOnce({
+      data: mockDescriptor,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.createTemplateInstanceDescriptor(
+        unsafeBrandId(mockEService.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the polling GET call has no metadata", async () => {
+    mockGetEService.mockResolvedValueOnce({
+      data: mockEService,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.createTemplateInstanceDescriptor(
+        unsafeBrandId(mockEService.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEService.mockImplementation(
+      mockPollingResponse(
+        getMockWithMetadata(mockEService),
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      eserviceService.createTemplateInstanceDescriptor(
+        unsafeBrandId(mockEService.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEService).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/updateDraftDescriptorTemplateInstance.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/updateDraftDescriptorTemplateInstance.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockedApiEserviceDescriptor,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceService,
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import {
+  eserviceDescriptorNotFound,
+  missingMetadata,
+} from "../../../src/model/errors.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("updateDraftDescriptorTemplateInstance", () => {
+  const mockDescriptor = getMockedApiEserviceDescriptor();
+  const mockEService = getMockedApiEservice({ descriptors: [mockDescriptor] });
+  const mockEServiceProcessResponse = getMockWithMetadata(mockEService);
+
+  const mockSeed: m2mGatewayApiV3.UpdateEServiceDescriptorTemplateInstanceSeed =
+    {
+      audience: ["http/test.test"],
+      dailyCallsPerConsumer: 10,
+      dailyCallsTotal: 100,
+      agreementApprovalPolicy: "AUTOMATIC",
+    };
+
+  const mockUpdateDraftDescriptor = vi
+    .fn()
+    .mockResolvedValue(mockEServiceProcessResponse);
+  const mockGetEService = vi.fn(
+    mockPollingResponse(mockEServiceProcessResponse, 2)
+  );
+
+  mockInteropBeClients.catalogProcessClient = {
+    updateDraftDescriptorTemplateInstance: mockUpdateDraftDescriptor,
+    getEServiceById: mockGetEService,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockUpdateDraftDescriptor.mockClear();
+    mockGetEService.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const expectedM2MDescriptor: m2mGatewayApiV3.EServiceDescriptor = {
+      id: mockDescriptor.id,
+      version: mockDescriptor.version,
+      description: mockDescriptor.description,
+      audience: mockDescriptor.audience,
+      voucherLifespan: mockDescriptor.voucherLifespan,
+      dailyCallsPerConsumer: mockDescriptor.dailyCallsPerConsumer,
+      dailyCallsTotal: mockDescriptor.dailyCallsTotal,
+      state: mockDescriptor.state,
+      agreementApprovalPolicy: mockDescriptor.agreementApprovalPolicy,
+      serverUrls: mockDescriptor.serverUrls,
+      publishedAt: mockDescriptor.publishedAt,
+      suspendedAt: mockDescriptor.suspendedAt,
+      deprecatedAt: mockDescriptor.deprecatedAt,
+      archivedAt: mockDescriptor.archivedAt,
+      templateVersionId: mockDescriptor.templateVersionRef?.id,
+      archivingSchedule: mockDescriptor.archivingSchedule,
+      asyncExchangeProperties: mockDescriptor.asyncExchangeProperties,
+    };
+
+    const result = await eserviceService.updateDraftDescriptorTemplateInstance(
+      unsafeBrandId(mockEService.id),
+      unsafeBrandId(mockDescriptor.id),
+      mockSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(expectedM2MDescriptor);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient
+          .updateDraftDescriptorTemplateInstance,
+      params: {
+        eServiceId: mockEService.id,
+        descriptorId: mockDescriptor.id,
+      },
+      body: mockSeed,
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockEService.id },
+    });
+    expect(
+      mockInteropBeClients.catalogProcessClient.getEServiceById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw eserviceDescriptorNotFound when the descriptor is missing in the returned eservice", async () => {
+    const eserviceWithoutDescriptor = getMockWithMetadata({
+      ...mockEService,
+      descriptors: [],
+    });
+    mockUpdateDraftDescriptor.mockResolvedValueOnce(eserviceWithoutDescriptor);
+    mockGetEService.mockImplementation(
+      mockPollingResponse(eserviceWithoutDescriptor, 1)
+    );
+
+    await expect(
+      eserviceService.updateDraftDescriptorTemplateInstance(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      eserviceDescriptorNotFound(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id)
+      )
+    );
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the update POST call has no metadata", async () => {
+    mockUpdateDraftDescriptor.mockResolvedValueOnce({
+      ...mockEServiceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.updateDraftDescriptorTemplateInstance(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the polling GET call has no metadata", async () => {
+    mockGetEService.mockResolvedValueOnce({
+      ...mockEServiceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.updateDraftDescriptorTemplateInstance(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEService.mockImplementation(
+      mockPollingResponse(
+        mockEServiceProcessResponse,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      eserviceService.updateDraftDescriptorTemplateInstance(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEService).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/updateEServiceTemplateInstance.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/updateEServiceTemplateInstance.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceService,
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import {
+  getMockM2MAdminAppContext,
+  testToM2mGatewayApiEService,
+} from "../../mockUtils.js";
+
+describe("updateEServiceTemplateInstance", () => {
+  const mockedApiEservice = getMockedApiEservice();
+
+  const mockSeed: m2mGatewayApiV3.UpdateEServiceTemplateInstanceSeed = {
+    isSignalHubEnabled: true,
+    isConsumerDelegable: true,
+    isClientAccessDelegable: false,
+    instanceLabel: "updated",
+  };
+
+  const mockEserviceProcessResponse = getMockWithMetadata(mockedApiEservice);
+
+  const mockUpdateInstance = vi
+    .fn()
+    .mockResolvedValue(mockEserviceProcessResponse);
+  const mockGetEservice = vi.fn(
+    mockPollingResponse(mockEserviceProcessResponse, 2)
+  );
+
+  mockInteropBeClients.catalogProcessClient = {
+    updateEServiceTemplateInstanceById: mockUpdateInstance,
+    getEServiceById: mockGetEservice,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockUpdateInstance.mockClear();
+    mockGetEservice.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const m2mEserviceResponse: m2mGatewayApiV3.EService =
+      testToM2mGatewayApiEService(mockEserviceProcessResponse.data);
+
+    const result = await eserviceService.updateEServiceTemplateInstance(
+      unsafeBrandId(mockedApiEservice.id),
+      mockSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(m2mEserviceResponse);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient
+          .updateEServiceTemplateInstanceById,
+      params: { eServiceId: mockedApiEservice.id },
+      body: mockSeed,
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockEserviceProcessResponse.data.id },
+    });
+    expect(
+      mockInteropBeClients.catalogProcessClient.getEServiceById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the update POST call has no metadata", async () => {
+    mockUpdateInstance.mockResolvedValueOnce({
+      ...mockEserviceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.updateEServiceTemplateInstance(
+        unsafeBrandId(mockedApiEservice.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the polling GET call has no metadata", async () => {
+    mockGetEservice.mockResolvedValueOnce({
+      ...mockEserviceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.updateEServiceTemplateInstance(
+        unsafeBrandId(mockedApiEservice.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEservice.mockImplementation(
+      mockPollingResponse(
+        mockEserviceProcessResponse,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      eserviceService.updateEServiceTemplateInstance(
+        unsafeBrandId(mockedApiEservice.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEservice).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/updateEServiceTemplateInstanceLabel.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/updateEServiceTemplateInstanceLabel.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceService,
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import { missingMetadata } from "../../../src/model/errors.js";
+import {
+  getMockM2MAdminAppContext,
+  testToM2mGatewayApiEService,
+} from "../../mockUtils.js";
+
+describe("updateEServiceTemplateInstanceLabel", () => {
+  const mockedApiEservice = getMockedApiEservice();
+
+  const mockSeed: m2mGatewayApiV3.EServiceInstanceLabelUpdateSeed = {
+    instanceLabel: "new-label",
+  };
+
+  const mockEserviceProcessResponse = getMockWithMetadata(mockedApiEservice);
+
+  const mockUpdateLabel = vi
+    .fn()
+    .mockResolvedValue(mockEserviceProcessResponse);
+  const mockGetEservice = vi.fn(
+    mockPollingResponse(mockEserviceProcessResponse, 2)
+  );
+
+  mockInteropBeClients.catalogProcessClient = {
+    updateEServiceInstanceLabelAfterPublication: mockUpdateLabel,
+    getEServiceById: mockGetEservice,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockUpdateLabel.mockClear();
+    mockGetEservice.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const m2mEserviceResponse: m2mGatewayApiV3.EService =
+      testToM2mGatewayApiEService(mockEserviceProcessResponse.data);
+
+    const result = await eserviceService.updateEServiceTemplateInstanceLabel(
+      unsafeBrandId(mockedApiEservice.id),
+      mockSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(m2mEserviceResponse);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient
+          .updateEServiceInstanceLabelAfterPublication,
+      params: { eServiceId: mockedApiEservice.id },
+      body: mockSeed,
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockEserviceProcessResponse.data.id },
+    });
+    expect(
+      mockInteropBeClients.catalogProcessClient.getEServiceById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the update POST call has no metadata", async () => {
+    mockUpdateLabel.mockResolvedValueOnce({
+      ...mockEserviceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.updateEServiceTemplateInstanceLabel(
+        unsafeBrandId(mockedApiEservice.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the polling GET call has no metadata", async () => {
+    mockGetEservice.mockResolvedValueOnce({
+      ...mockEserviceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.updateEServiceTemplateInstanceLabel(
+        unsafeBrandId(mockedApiEservice.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEservice.mockImplementation(
+      mockPollingResponse(
+        mockEserviceProcessResponse,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      eserviceService.updateEServiceTemplateInstanceLabel(
+        unsafeBrandId(mockedApiEservice.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEservice).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/eservices/updateTemplateInstanceDescriptorQuotas.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/eservices/updateTemplateInstanceDescriptorQuotas.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { m2mGatewayApiV3 } from "pagopa-interop-api-clients";
+import {
+  pollingMaxRetriesExceeded,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import {
+  getMockedApiEservice,
+  getMockedApiEserviceDescriptor,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceService,
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import {
+  eserviceDescriptorNotFound,
+  missingMetadata,
+} from "../../../src/model/errors.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("updateTemplateInstanceDescriptorQuotas", () => {
+  const mockDescriptor = getMockedApiEserviceDescriptor();
+  const mockEService = getMockedApiEservice({ descriptors: [mockDescriptor] });
+  const mockEServiceProcessResponse = getMockWithMetadata(mockEService);
+
+  const mockSeed: m2mGatewayApiV3.UpdateEServiceTemplateInstanceDescriptorQuotasSeed =
+    {
+      dailyCallsPerConsumer: 1000,
+      dailyCallsTotal: 10000,
+    };
+
+  const mockUpdateDescriptorQuotas = vi
+    .fn()
+    .mockResolvedValue(mockEServiceProcessResponse);
+  const mockGetEService = vi.fn(
+    mockPollingResponse(mockEServiceProcessResponse, 2)
+  );
+
+  mockInteropBeClients.catalogProcessClient = {
+    updateTemplateInstanceDescriptor: mockUpdateDescriptorQuotas,
+    getEServiceById: mockGetEService,
+  } as unknown as PagoPAInteropBeClients["catalogProcessClient"];
+
+  beforeEach(() => {
+    mockUpdateDescriptorQuotas.mockClear();
+    mockGetEService.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const expectedM2MDescriptor: m2mGatewayApiV3.EServiceDescriptor = {
+      id: mockDescriptor.id,
+      version: mockDescriptor.version,
+      description: mockDescriptor.description,
+      audience: mockDescriptor.audience,
+      voucherLifespan: mockDescriptor.voucherLifespan,
+      dailyCallsPerConsumer: mockDescriptor.dailyCallsPerConsumer,
+      dailyCallsTotal: mockDescriptor.dailyCallsTotal,
+      state: mockDescriptor.state,
+      agreementApprovalPolicy: mockDescriptor.agreementApprovalPolicy,
+      serverUrls: mockDescriptor.serverUrls,
+      publishedAt: mockDescriptor.publishedAt,
+      suspendedAt: mockDescriptor.suspendedAt,
+      deprecatedAt: mockDescriptor.deprecatedAt,
+      archivedAt: mockDescriptor.archivedAt,
+      templateVersionId: mockDescriptor.templateVersionRef?.id,
+      archivingSchedule: mockDescriptor.archivingSchedule,
+      asyncExchangeProperties: mockDescriptor.asyncExchangeProperties,
+    };
+
+    const result = await eserviceService.updateTemplateInstanceDescriptorQuotas(
+      unsafeBrandId(mockEService.id),
+      unsafeBrandId(mockDescriptor.id),
+      mockSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(expectedM2MDescriptor);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.catalogProcessClient
+          .updateTemplateInstanceDescriptor,
+      params: {
+        eServiceId: mockEService.id,
+        descriptorId: mockDescriptor.id,
+      },
+      body: mockSeed,
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.catalogProcessClient.getEServiceById,
+      params: { eServiceId: mockEService.id },
+    });
+    expect(
+      mockInteropBeClients.catalogProcessClient.getEServiceById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should throw eserviceDescriptorNotFound when the descriptor is missing in the returned eservice", async () => {
+    const eserviceWithoutDescriptor = getMockWithMetadata({
+      ...mockEService,
+      descriptors: [],
+    });
+    mockUpdateDescriptorQuotas.mockResolvedValueOnce(eserviceWithoutDescriptor);
+    mockGetEService.mockImplementation(
+      mockPollingResponse(eserviceWithoutDescriptor, 1)
+    );
+
+    await expect(
+      eserviceService.updateTemplateInstanceDescriptorQuotas(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      eserviceDescriptorNotFound(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id)
+      )
+    );
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the update POST call has no metadata", async () => {
+    mockUpdateDescriptorQuotas.mockResolvedValueOnce({
+      ...mockEServiceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.updateTemplateInstanceDescriptorQuotas(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the eservice returned by the polling GET call has no metadata", async () => {
+    mockGetEService.mockResolvedValueOnce({
+      ...mockEServiceProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      eserviceService.updateTemplateInstanceDescriptorQuotas(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetEService.mockImplementation(
+      mockPollingResponse(
+        mockEServiceProcessResponse,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      eserviceService.updateTemplateInstanceDescriptorQuotas(
+        unsafeBrandId(mockEService.id),
+        unsafeBrandId(mockDescriptor.id),
+        mockSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrowError(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetEService).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});

--- a/packages/m2m-gateway-v3/test/mockUtils.ts
+++ b/packages/m2m-gateway-v3/test/mockUtils.ts
@@ -184,6 +184,7 @@ export const testToM2mGatewayApiEService = (
   personalData: eservice.personalData,
   archivingReason: eservice.archivingReason,
   asyncExchange: eservice.asyncExchange,
+  instanceLabel: eservice.instanceLabel,
 });
 
 export const testToM2mGatewayApiEServiceEvent = (


### PR DESCRIPTION
## Jira Issue
[PIN-9366](https://pagopa.atlassian.net/browse/PIN-9366)

## Context
The e-service "instantiation from template" features were not exposed over the
machine-to-machine API. This PR adds them to the **M2M gateway V3** (the V3
api-gateway, `m2mGatewayApiV3` / server `/v3`), alongside the already-exposed
template management endpoints.

Each new operation delegates to `catalog-process` and polls the read model until
the resource version is aligned, consistently with the other V3 endpoints. All
endpoints require the `M2M_ADMIN` role.

## Services Affected
- `m2m-gateway-v3`
- `api-clients` (OpenAPI `m2mGatewayApiV3.yml`)

## Key Changes
- Added 6 `POST` endpoints (tag `eserviceTemplates`) to `m2mGatewayApiV3.yml`:

  | Endpoint | operationId |
  |---|---|
  | `POST /eserviceTemplates/{templateId}/eservices` | `createEServiceInstanceFromTemplate` |
  | `POST /eserviceTemplates/eservices/{eserviceId}` | `updateEServiceTemplateInstance` |
  | `POST /eserviceTemplates/eservices/{eserviceId}/instanceLabel` | `updateEServiceTemplateInstanceLabel` |
  | `POST /eserviceTemplates/eservices/{eserviceId}/descriptors` | `createTemplateInstanceDescriptor` |
  | `POST /eserviceTemplates/eservices/{eserviceId}/descriptors/{descriptorId}` | `updateDraftDescriptorTemplateInstance` |
  | `POST /eserviceTemplates/eservices/{eserviceId}/descriptors/{descriptorId}/quotas` | `updateTemplateInstanceDescriptorQuotas` |

- Added the related request seeds (`InstanceEServiceSeed`, `UpdateEServiceTemplateInstanceSeed`, `EServiceInstanceLabelUpdateSeed`, `EServiceInstanceDescriptorSeed`, `UpdateEServiceDescriptorTemplateInstanceSeed`, `UpdateEServiceTemplateInstanceDescriptorQuotasSeed`) and the optional `instanceLabel` field to the `EService` schema.
- Implemented the 6 operations in `eserviceService` (they create/update e-services and descriptors, so they reuse the existing polling helpers, converters and `retrieveEServiceDescriptorById`); mapped `instanceLabel` in `toM2MGatewayApiEService`.
- Wired the routes in `eserviceTemplateRouter`, injecting `eserviceService` into the router (and updated `app.ts` accordingly).
- Added API and integration tests for all 6 operations (happy path, `missingMetadata`, `pollingMaxRetriesExceeded`, `eserviceDescriptorNotFound`, authorization and request-validation cases).


[PIN-9366]: https://pagopa.atlassian.net/browse/PIN-9366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ