### PR TITLE
feat: notify template creator on new template version published (PIN-10082)

### DIFF
--- a/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateVersionPublishedToCreator.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateVersionPublishedToCreator.ts
@@ -1,0 +1,97 @@
+import {
+  EmailNotificationMessagePayload,
+  EServiceTemplateIdEServiceTemplateVersionId,
+  fromEServiceTemplateV2,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+} from "pagopa-interop-models";
+import {
+  eventMailTemplateType,
+  retrieveHTMLTemplate,
+  retrieveTenant,
+  getRecipientsForTenants,
+  mapRecipientToEmailPayload,
+} from "pagopa-interop-notification-commons";
+import { EserviceTemplateHandlerParams } from "../../models/handlerParams.js";
+
+import { config } from "../../config/config.js";
+
+const notificationType: NotificationType = "templateStatusChangedToProducer";
+
+export async function handleEServiceTemplateVersionPublishedToCreator(
+  params: EserviceTemplateHandlerParams
+): Promise<EmailNotificationMessagePayload[]> {
+  const {
+    eserviceTemplateV2Msg,
+    eserviceTemplateVersionId,
+    readModelService,
+    logger,
+    templateService,
+    correlationId,
+  } = params;
+
+  if (!eserviceTemplateV2Msg) {
+    throw missingKafkaMessageDataError(
+      "eserviceTemplate",
+      "EServiceTemplateVersionPublished"
+    );
+  }
+
+  const eserviceTemplate = fromEServiceTemplateV2(eserviceTemplateV2Msg);
+
+  const eserviceTemplateVersion = eserviceTemplate.versions.find(
+    (version) => version.id === eserviceTemplateVersionId
+  );
+
+  if (!eserviceTemplateVersion) {
+    logger.error(
+      `No version found in eservice template ${eserviceTemplate.id} with id ${eserviceTemplateVersionId}`
+    );
+    return [];
+  }
+
+  const [htmlTemplate, creator] = await Promise.all([
+    retrieveHTMLTemplate(
+      eventMailTemplateType.eserviceTemplateVersionPublishedToCreatorMailTemplate
+    ),
+    retrieveTenant(eserviceTemplate.creatorId, readModelService),
+  ]);
+
+  const targets = await getRecipientsForTenants({
+    tenants: [creator],
+    notificationType,
+    readModelService,
+    logger,
+    includeTenantContactEmails: false,
+  });
+
+  if (targets.length === 0) {
+    logger.info(
+      `No users with email notifications enabled for handleEServiceTemplateVersionPublishedToCreator - entityId: ${eserviceTemplate.id}, eventType: ${notificationType}`
+    );
+    return [];
+  }
+
+  return targets.map((t) => ({
+    correlationId: correlationId ?? generateId(),
+    email: {
+      subject: `Hai pubblicato una nuova versione del tuo template e-service`,
+      body: templateService.compileHtml(htmlTemplate, {
+        title: "Hai pubblicato una nuova versione del tuo template e-service",
+        notificationType,
+        entityId: EServiceTemplateIdEServiceTemplateVersionId.parse(
+          `${eserviceTemplate.id}/${eserviceTemplateVersionId}`
+        ),
+        ...(t.type === "Tenant" ? { recipientName: creator.name } : {}),
+        version: eserviceTemplateVersion.version,
+        templateName: eserviceTemplate.name,
+        ctaLabel: `Visualizza template`,
+        selfcareId: t.selfcareId,
+        bffUrl: config.bffUrl,
+      }),
+    },
+    tenantId: t.tenantId,
+    ...mapRecipientToEmailPayload(t),
+  }));
+}

--- a/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplatesEvent.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplatesEvent.ts
@@ -8,6 +8,7 @@ import { match, P } from "ts-pattern";
 import { HandlerParams } from "../../models/handlerParams.js";
 import { handleEServiceTemplateVersionSuspendedToCreator } from "./handleEserviceTemplateVersionSuspendedToCreator.js";
 import { handleEServiceTemplateVersionPublished } from "./handleEserviceTemplateVersionPublished.js";
+import { handleEServiceTemplateVersionPublishedToCreator } from "./handleEserviceTemplateVersionPublishedToCreator.js";
 import { handleEServiceTemplateNameUpdated } from "./handleEserviceTemplateNameUpdated.js";
 import { handleEServiceTemplateVersionSuspendedToInstantiator } from "./handleEserviceTemplateVersionSuspendedToInstantiator.js";
 
@@ -49,8 +50,9 @@ export async function handleEServiceTemplateEvent(
     )
     .with(
       { type: "EServiceTemplateVersionPublished" },
-      async ({ data: { eserviceTemplate, eserviceTemplateVersionId } }) =>
-        handleEServiceTemplateVersionPublished({
+      async ({ data: { eserviceTemplate, eserviceTemplateVersionId } }) => [
+        // Instantiators == tenants that have instantiated an e-service from the template
+        ...(await handleEServiceTemplateVersionPublished({
           eserviceTemplateV2Msg: eserviceTemplate,
           eserviceTemplateVersionId: unsafeBrandId<EServiceTemplateVersionId>(
             eserviceTemplateVersionId
@@ -59,7 +61,19 @@ export async function handleEServiceTemplateEvent(
           readModelService,
           templateService,
           correlationId,
-        })
+        })),
+        // Creator == producer of the template
+        ...(await handleEServiceTemplateVersionPublishedToCreator({
+          eserviceTemplateV2Msg: eserviceTemplate,
+          eserviceTemplateVersionId: unsafeBrandId<EServiceTemplateVersionId>(
+            eserviceTemplateVersionId
+          ),
+          logger,
+          readModelService,
+          templateService,
+          correlationId,
+        })),
+      ]
     )
     .with(
       { type: "EServiceTemplateNameUpdated" },

--- a/packages/email-notification-dispatcher/test/handleEserviceTemplateVersionPublishedToCreator.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceTemplateVersionPublishedToCreator.test.ts
@@ -1,0 +1,246 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable sonarjs/no-identical-functions */
+import {
+  getMockContext,
+  getMockDescriptorPublished,
+  getMockEService,
+  getMockEServiceTemplate,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import { authRole } from "pagopa-interop-commons";
+import {
+  CorrelationId,
+  EService,
+  EServiceId,
+  EServiceTemplate,
+  EServiceTemplateId,
+  EServiceTemplateVersionId,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+  TenantId,
+  TenantNotificationConfigId,
+  toEServiceTemplateV2,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { match } from "ts-pattern";
+import { tenantNotFound } from "pagopa-interop-notification-commons";
+import { handleEServiceTemplateVersionPublishedToCreator } from "../src/handlers/eserviceTemplates/handleEserviceTemplateVersionPublishedToCreator.js";
+import {
+  addOneEService,
+  addOneEServiceTemplate,
+  addOneTenant,
+  getMockUser,
+  readModelService,
+  templateService,
+} from "./utils.js";
+
+describe("handleEServiceTemplateVersionPublishedToCreator", async () => {
+  const creatorId = generateId<TenantId>();
+  const eserviceId = generateId<EServiceId>();
+  const instantiatorId = generateId<TenantId>();
+  const eserviceTemplateId = generateId<EServiceTemplateId>();
+
+  const eserviceTemplate: EServiceTemplate = {
+    ...getMockEServiceTemplate(eserviceTemplateId),
+    creatorId,
+  };
+  const eservice: EService = {
+    ...getMockEService(eserviceId),
+    templateId: eserviceTemplateId,
+    producerId: instantiatorId,
+    descriptors: [getMockDescriptorPublished()],
+  };
+  const eserviceTemplateVersionId = eserviceTemplate.versions[0].id;
+
+  const creatorTenant = getMockTenant(creatorId);
+  const instantiatorTenant = getMockTenant(instantiatorId);
+  // The recipient of this notification is the creator, so the users belong to the creator tenant
+  const users = [getMockUser(creatorId), getMockUser(creatorId)];
+
+  const { logger } = getMockContext({});
+
+  beforeEach(async () => {
+    await addOneEServiceTemplate(eserviceTemplate);
+    await addOneEService(eservice);
+    await addOneTenant(instantiatorTenant);
+    await addOneTenant(creatorTenant);
+    readModelService.getTenantNotificationConfigByTenantId = vi
+      .fn()
+      .mockResolvedValue({
+        id: generateId<TenantNotificationConfigId>(),
+        tenantId: creatorTenant.id,
+        enabled: true,
+        createAt: new Date(),
+      });
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockImplementation((tenantIds: TenantId[], _: NotificationType) =>
+        users
+          .filter((user) =>
+            tenantIds.includes(unsafeBrandId<TenantId>(user.tenantId))
+          )
+          .map((user) => ({
+            userId: user.id,
+            tenantId: user.tenantId,
+            // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+            userRoles: [authRole.ADMIN_ROLE],
+          }))
+      );
+  });
+
+  it("should throw missingKafkaMessageDataError when eserviceTemplate is undefined", async () => {
+    await expect(() =>
+      handleEServiceTemplateVersionPublishedToCreator({
+        eserviceTemplateV2Msg: undefined,
+        eserviceTemplateVersionId,
+        logger,
+        templateService,
+        readModelService,
+        correlationId: generateId<CorrelationId>(),
+      })
+    ).rejects.toThrow(
+      missingKafkaMessageDataError(
+        "eserviceTemplate",
+        "EServiceTemplateVersionPublished"
+      )
+    );
+  });
+
+  it("should throw tenantNotFound when creator is not found", async () => {
+    const unknownCreatorId = generateId<TenantId>();
+    const eserviceTemplateUnknownCreator = {
+      ...getMockEServiceTemplate(),
+      creatorId: unknownCreatorId,
+    };
+    await addOneEServiceTemplate(eserviceTemplateUnknownCreator);
+
+    await expect(() =>
+      handleEServiceTemplateVersionPublishedToCreator({
+        eserviceTemplateV2Msg: toEServiceTemplateV2(
+          eserviceTemplateUnknownCreator
+        ),
+        eserviceTemplateVersionId:
+          eserviceTemplateUnknownCreator.versions[0].id,
+        logger,
+        templateService,
+        readModelService,
+        correlationId: generateId<CorrelationId>(),
+      })
+    ).rejects.toThrow(tenantNotFound(unknownCreatorId));
+  });
+
+  it("should generate no messages when eservice template version can't be found", async () => {
+    const unknownEServiceTemplateVersionId =
+      generateId<EServiceTemplateVersionId>();
+    const eserviceTemplateUnknownVersions: EServiceTemplate = {
+      ...getMockEServiceTemplate(eserviceTemplateId),
+      creatorId,
+    };
+    await addOneEServiceTemplate(eserviceTemplateUnknownVersions);
+
+    const messages = await handleEServiceTemplateVersionPublishedToCreator({
+      eserviceTemplateV2Msg: toEServiceTemplateV2(
+        eserviceTemplateUnknownVersions
+      ),
+      eserviceTemplateVersionId: unknownEServiceTemplateVersionId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toEqual(0);
+  });
+
+  it("should generate one message per user of the creator", async () => {
+    const messages = await handleEServiceTemplateVersionPublishedToCreator({
+      eserviceTemplateV2Msg: toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplateVersionId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toEqual(2);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[0].id
+      )
+    ).toBe(true);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[1].id
+      )
+    ).toBe(true);
+  });
+
+  it("should not generate a message if the user disabled this email notification", async () => {
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockResolvedValue([
+        {
+          userId: users[0].id,
+          tenantId: users[0].tenantId,
+          // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+          userRoles: [authRole.ADMIN_ROLE],
+        },
+      ]);
+
+    const messages = await handleEServiceTemplateVersionPublishedToCreator({
+      eserviceTemplateV2Msg: toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplateVersionId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toEqual(1);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[0].id
+      )
+    ).toBe(true);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[1].id
+      )
+    ).toBe(false);
+  });
+
+  it("should generate a complete and correct message", async () => {
+    const messages = await handleEServiceTemplateVersionPublishedToCreator({
+      eserviceTemplateV2Msg: toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplateVersionId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toBe(2);
+    messages.forEach((message) => {
+      expect(message.email.body).toContain("<!-- Footer -->");
+      expect(message.email.body).toContain("<!-- Title & Main Message -->");
+      expect(message.email.body).toContain(
+        `Hai pubblicato una nuova versione del tuo template e-service`
+      );
+      match(message.type)
+        .with("User", () => {
+          expect(message.email.body).toContain("{{ recipientName }}");
+        })
+        .with("Tenant", () => {
+          expect(message.email.body).toContain(creatorTenant.name);
+        })
+        .exhaustive();
+      expect(message.email.body).toContain(eserviceTemplate.name);
+      expect(message.email.body).toContain(
+        eserviceTemplate.versions[0].version
+      );
+      expect(message.email.body).toContain(`Visualizza template`);
+    });
+  });
+});

--- a/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplatesEvent.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplatesEvent.ts
@@ -7,6 +7,7 @@ import { P, match } from "ts-pattern";
 import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
 import { handleTemplateStatusChangedToProducer } from "./handleTemplateStatusChangedToProducer.js";
 import { handleNewEserviceTemplateVersionToInstantiator } from "./handleNewEserviceTemplateVersionToInstantiator.js";
+import { handleNewEserviceTemplateVersionToProducer } from "./handleNewEserviceTemplateVersionToProducer.js";
 import { handleEserviceTemplateNameChangedToInstantiator } from "./handleEserviceTemplateNameChangedToInstantiator.js";
 import { handleEserviceTemplateStatusChangedToInstantiator } from "./handleEserviceTemplateStatusChangedToInstantiator.js";
 
@@ -41,13 +42,22 @@ export async function handleEServiceTemplateEvent(
       {
         type: "EServiceTemplateVersionPublished",
       },
-      ({ data: { eserviceTemplate, eserviceTemplateVersionId } }) =>
-        handleNewEserviceTemplateVersionToInstantiator(
+      async ({ data: { eserviceTemplate, eserviceTemplateVersionId } }) => [
+        // Instantiators == tenants that have instantiated an e-service from the template
+        ...(await handleNewEserviceTemplateVersionToInstantiator(
           eserviceTemplate,
           eserviceTemplateVersionId,
           logger,
           readModelService
-        )
+        )),
+        // Producer == creator of the template
+        ...(await handleNewEserviceTemplateVersionToProducer(
+          eserviceTemplate,
+          eserviceTemplateVersionId,
+          logger,
+          readModelService
+        )),
+      ]
     )
     .with(
       {

--- a/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleNewEserviceTemplateVersionToProducer.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleNewEserviceTemplateVersionToProducer.ts
@@ -1,0 +1,70 @@
+import {
+  EServiceTemplateIdEServiceTemplateVersionId,
+  EServiceTemplateV2,
+  fromEServiceTemplateV2,
+  missingKafkaMessageDataError,
+  NewNotification,
+} from "pagopa-interop-models";
+import { Logger } from "pagopa-interop-commons";
+import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
+import {
+  inAppTemplates,
+  getNotificationRecipients,
+} from "pagopa-interop-notification-commons";
+
+export async function handleNewEserviceTemplateVersionToProducer(
+  eserviceTemplateV2Msg: EServiceTemplateV2 | undefined,
+  eserviceTemplateVersionId: string,
+  logger: Logger,
+  readModelService: ReadModelServiceSQL
+): Promise<NewNotification[]> {
+  if (!eserviceTemplateV2Msg) {
+    throw missingKafkaMessageDataError(
+      "eserviceTemplate",
+      "EServiceTemplateVersionPublished"
+    );
+  }
+
+  logger.info(
+    `Sending in-app notification for handleNewEserviceTemplateVersionToProducer - entityId: ${eserviceTemplateV2Msg.id}, eventType: EServiceTemplateVersionPublished`
+  );
+
+  const eserviceTemplate = fromEServiceTemplateV2(eserviceTemplateV2Msg);
+
+  const usersWithNotifications = await getNotificationRecipients(
+    [eserviceTemplate.creatorId],
+    "templateStatusChangedToProducer",
+    readModelService,
+    logger
+  );
+
+  if (usersWithNotifications.length === 0) {
+    logger.info(
+      `No users with notifications enabled for handleNewEserviceTemplateVersionToProducer - entityId: ${eserviceTemplate.id}, eventType: EServiceTemplateVersionPublished`
+    );
+    return [];
+  }
+
+  const eserviceTemplateVersion = eserviceTemplate.versions.find(
+    (version) => version.id === eserviceTemplateVersionId
+  );
+
+  const body = inAppTemplates.newEserviceTemplateVersionToProducer(
+    eserviceTemplateVersion?.version
+      ? eserviceTemplateVersion.version.toString()
+      : "",
+    eserviceTemplate.name
+  );
+
+  const entityId = EServiceTemplateIdEServiceTemplateVersionId.parse(
+    `${eserviceTemplate.id}/${eserviceTemplateVersionId}`
+  );
+
+  return usersWithNotifications.map(({ userId, tenantId }) => ({
+    userId,
+    tenantId,
+    body,
+    notificationType: "templateStatusChangedToProducer",
+    entityId,
+  }));
+}

--- a/packages/in-app-notification-dispatcher/test/handleNewEserviceTemplateVersionToProducer.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleNewEserviceTemplateVersionToProducer.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable functional/immutable-data */
+import { describe, it, expect, beforeEach, Mock } from "vitest";
+import {
+  getMockContext,
+  getMockEServiceTemplate,
+  getMockEServiceTemplateVersion,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceTemplateVersionState,
+  generateId,
+  missingKafkaMessageDataError,
+  TenantId,
+  toEServiceTemplateV2,
+} from "pagopa-interop-models";
+import {
+  getNotificationRecipients,
+  inAppTemplates,
+} from "pagopa-interop-notification-commons";
+import { handleNewEserviceTemplateVersionToProducer } from "../src/handlers/eserviceTemplates/handleNewEserviceTemplateVersionToProducer.js";
+
+import {
+  addOneEServiceTemplate,
+  addOneTenant,
+  readModelService,
+} from "./utils.js";
+
+describe("handleNewEserviceTemplateVersionToProducer", async () => {
+  const eserviceTemplate = getMockEServiceTemplate(undefined, undefined, [
+    getMockEServiceTemplateVersion(
+      undefined,
+      eserviceTemplateVersionState.published
+    ),
+  ]);
+  const { logger } = getMockContext({});
+
+  const mockGetNotificationRecipients = getNotificationRecipients as Mock;
+  await addOneEServiceTemplate(eserviceTemplate);
+
+  beforeEach(async () => {
+    mockGetNotificationRecipients.mockReset();
+  });
+
+  it("should throw missingKafkaMessageDataError when eserviceTemplate is undefined", async () => {
+    await expect(() =>
+      handleNewEserviceTemplateVersionToProducer(
+        undefined,
+        generateId(),
+        logger,
+        readModelService
+      )
+    ).rejects.toThrow(
+      missingKafkaMessageDataError(
+        "eserviceTemplate",
+        "EServiceTemplateVersionPublished"
+      )
+    );
+  });
+
+  it("should return empty array when no user notification configs exist for the template", async () => {
+    const creatorId = generateId<TenantId>();
+    const creatorTenant = getMockTenant(creatorId);
+    await addOneTenant(creatorTenant);
+
+    mockGetNotificationRecipients.mockResolvedValue([]);
+
+    eserviceTemplate.creatorId = creatorId;
+    const notifications = await handleNewEserviceTemplateVersionToProducer(
+      toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplate.versions[0].id,
+      logger,
+      readModelService
+    );
+
+    expect(notifications).toEqual([]);
+  });
+
+  it("should generate notifications for all tenant users with notification enabled", async () => {
+    const creatorId = generateId<TenantId>();
+    const creatorTenant = getMockTenant(creatorId);
+    await addOneTenant(creatorTenant);
+
+    const users = [
+      { userId: generateId(), tenantId: creatorId },
+      { userId: generateId(), tenantId: creatorId },
+    ];
+    mockGetNotificationRecipients.mockResolvedValue(users);
+
+    eserviceTemplate.creatorId = creatorId;
+    const notifications = await handleNewEserviceTemplateVersionToProducer(
+      toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplate.versions[0].id,
+      logger,
+      readModelService
+    );
+
+    const body = inAppTemplates.newEserviceTemplateVersionToProducer(
+      eserviceTemplate.versions[0].version.toString(),
+      eserviceTemplate.name
+    );
+    const expectedNotifications = users.map((user) => ({
+      userId: user.userId,
+      tenantId: creatorId,
+      body,
+      notificationType: "templateStatusChangedToProducer",
+      entityId: `${eserviceTemplate.id}/${eserviceTemplate.versions[0].id}`,
+    }));
+    expect(notifications).toHaveLength(users.length);
+    expect(notifications).toEqual(
+      expect.arrayContaining(expectedNotifications)
+    );
+  });
+});

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-template-version-published-to-creator-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-template-version-published-to-creator-mail.html
@@ -1,0 +1,88 @@
+{{> common-header }}
+<tr>
+  <td
+    align="left"
+    class="title"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 24px;
+      padding-right: 0px;
+      padding-bottom: 8px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        line-height: 1;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- H4 Desktop (from MUI Italia)-->
+      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 8px;
+      padding-right: 0px;
+      padding-bottom: 0px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <p style="margin-bottom: 0px">
+        Gentile
+        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+      </p>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="font-size: 0px; padding: 0px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- Body 1 Desktop (from MUI Italia)-->
+      <p>
+        È stata pubblicata una nuova versione ({{ version }}) del tuo template
+        "{{ templateName }}". La versione precedente, se presente, è stata
+        deprecata e non sarà più possibile generare nuove istanze a partire da
+        essa.
+      </p>
+    </div>
+  </td>
+</tr>
+{{> common-footer }}

--- a/packages/notification-commons/src/templates/email/templates.ts
+++ b/packages/notification-commons/src/templates/email/templates.ts
@@ -56,6 +56,8 @@ export const eventMailTemplateType = {
     "eservice-template-version-suspended-to-creator-mail",
   eserviceTemplateVersionPublishedMailTemplate:
     "eservice-template-version-published-mail",
+  eserviceTemplateVersionPublishedToCreatorMailTemplate:
+    "eservice-template-version-published-to-creator-mail",
   eserviceTemplateNameUpdatedMailTemplate:
     "eservice-template-name-updated-mail",
   eserviceTemplateVersionSuspendedToInstantiatorMailTemplate:

--- a/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
+++ b/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
@@ -239,6 +239,11 @@ export const inAppTemplates = {
   },
   templateStatusChangedToProducer: (templateName: string): string =>
     `È stato sospeso il tuo template "${templateName}".`,
+  newEserviceTemplateVersionToProducer: (
+    eserviceTemplateVersion: string,
+    eserviceTemplateName: string
+  ): string =>
+    `È stata pubblicata una nuova versione ${eserviceTemplateVersion} del tuo template "${eserviceTemplateName}".`,
   newEserviceTemplateVersionToInstantiator: (
     creatorName: string,
     eserviceTemplateVersion: string,


### PR DESCRIPTION
## Context

When a new version of an e-service template was published (`EServiceTemplateVersionPublished`), only the **instantiators** (tenants that derived an e-service from the template) were notified. The template **creator/producer** received no notification — neither email nor in-app — even with notifications enabled.

## Change

Adds an email + in-app notification to the template **creator** on `EServiceTemplateVersionPublished`, alongside the existing instantiator notifications.

The notification reuses the existing `templateStatusChangedToProducer` notification type — the same type already used for the suspend-to-creator flow — rather than introducing a new type. Publishing a version is a template lifecycle/status change for the producer, so the existing type, admitted roles, config, and BFF wiring apply unchanged.

### Email dispatcher
- New handler `handleEserviceTemplateVersionPublishedToCreator`
- New mail template `eservice-template-version-published-to-creator-mail`
- Publish event now fans out to both the instantiator and creator handlers

### In-app dispatcher
- New handler `handleNewEserviceTemplateVersionToProducer`
- New in-app message body `newEserviceTemplateVersionToProducer`
- Publish event now fans out to both handlers

## Tests
- New unit tests for both handlers, mirroring the existing suspend-to-creator / status-changed tests
- Email dispatcher suite: 485/485 passing
- In-app dispatcher suite: 279/279 passing
- `check` and `lint` clean