### PR TITLE
feat: notify template creator on template version reactivation (PIN-10081)

### DIFF
--- a/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateVersionActivatedToCreator.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateVersionActivatedToCreator.ts
@@ -1,0 +1,85 @@
+import {
+  EmailNotificationMessagePayload,
+  EServiceTemplateIdEServiceTemplateVersionId,
+  fromEServiceTemplateV2,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+} from "pagopa-interop-models";
+import {
+  eventMailTemplateType,
+  retrieveHTMLTemplate,
+  retrieveTenant,
+  getRecipientsForTenants,
+  mapRecipientToEmailPayload,
+} from "pagopa-interop-notification-commons";
+import { EserviceTemplateHandlerParams } from "../../models/handlerParams.js";
+
+import { config } from "../../config/config.js";
+
+const notificationType: NotificationType = "templateStatusChangedToProducer";
+
+export async function handleEServiceTemplateVersionActivatedToCreator(
+  params: EserviceTemplateHandlerParams
+): Promise<EmailNotificationMessagePayload[]> {
+  const {
+    eserviceTemplateV2Msg,
+    eserviceTemplateVersionId,
+    readModelService,
+    logger,
+    templateService,
+    correlationId,
+  } = params;
+
+  if (!eserviceTemplateV2Msg) {
+    throw missingKafkaMessageDataError(
+      "eserviceTemplate",
+      "EServiceTemplateVersionActivated"
+    );
+  }
+
+  const eserviceTemplate = fromEServiceTemplateV2(eserviceTemplateV2Msg);
+
+  const [htmlTemplate, creator] = await Promise.all([
+    retrieveHTMLTemplate(
+      eventMailTemplateType.eserviceTemplateVersionActivatedToCreatorMailTemplate
+    ),
+    retrieveTenant(eserviceTemplate.creatorId, readModelService),
+  ]);
+
+  const targets = await getRecipientsForTenants({
+    tenants: [creator],
+    notificationType,
+    readModelService,
+    logger,
+    includeTenantContactEmails: false,
+  });
+
+  if (targets.length === 0) {
+    logger.info(
+      `No users with email notifications enabled for handleEServiceTemplateVersionActivatedToCreator - entityId: ${eserviceTemplate.id}, eventType: ${notificationType}`
+    );
+    return [];
+  }
+
+  return targets.map((t) => ({
+    correlationId: correlationId ?? generateId(),
+    email: {
+      subject: `Hai riattivato un tuo template e-service`,
+      body: templateService.compileHtml(htmlTemplate, {
+        title: "Hai riattivato un tuo template e-service",
+        notificationType,
+        entityId: EServiceTemplateIdEServiceTemplateVersionId.parse(
+          `${eserviceTemplate.id}/${eserviceTemplateVersionId}`
+        ),
+        ...(t.type === "Tenant" ? { recipientName: creator.name } : {}),
+        templateName: eserviceTemplate.name,
+        ctaLabel: `Visualizza template`,
+        selfcareId: t.selfcareId,
+        bffUrl: config.bffUrl,
+      }),
+    },
+    tenantId: t.tenantId,
+    ...mapRecipientToEmailPayload(t),
+  }));
+}

--- a/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplatesEvent.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplatesEvent.ts
@@ -7,6 +7,7 @@ import {
 import { match, P } from "ts-pattern";
 import { HandlerParams } from "../../models/handlerParams.js";
 import { handleEServiceTemplateVersionSuspendedToCreator } from "./handleEserviceTemplateVersionSuspendedToCreator.js";
+import { handleEServiceTemplateVersionActivatedToCreator } from "./handleEserviceTemplateVersionActivatedToCreator.js";
 import { handleEServiceTemplateVersionPublished } from "./handleEserviceTemplateVersionPublished.js";
 import { handleEServiceTemplateNameUpdated } from "./handleEserviceTemplateNameUpdated.js";
 import { handleEServiceTemplateVersionSuspendedToInstantiator } from "./handleEserviceTemplateVersionSuspendedToInstantiator.js";
@@ -62,6 +63,20 @@ export async function handleEServiceTemplateEvent(
         })
     )
     .with(
+      { type: "EServiceTemplateVersionActivated" },
+      async ({ data: { eserviceTemplate, eserviceTemplateVersionId } }) =>
+        handleEServiceTemplateVersionActivatedToCreator({
+          eserviceTemplateV2Msg: eserviceTemplate,
+          eserviceTemplateVersionId: unsafeBrandId<EServiceTemplateVersionId>(
+            eserviceTemplateVersionId
+          ),
+          logger,
+          readModelService,
+          templateService,
+          correlationId,
+        })
+    )
+    .with(
       { type: "EServiceTemplateNameUpdated" },
       async ({ data: { eserviceTemplate, oldName } }) =>
         handleEServiceTemplateNameUpdated({
@@ -96,7 +111,6 @@ export async function handleEServiceTemplateEvent(
           "EServiceTemplateVersionQuotasUpdated",
           "EServiceTemplateVersionAdded",
           "EServiceTemplateVersionAttributesUpdated",
-          "EServiceTemplateVersionActivated",
           "EServiceTemplatePersonalDataFlagUpdatedAfterPublication",
           "EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded",
           "EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdated",

--- a/packages/email-notification-dispatcher/test/handleEserviceTemplateVersionActivatedToCreator.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceTemplateVersionActivatedToCreator.test.ts
@@ -1,0 +1,225 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable sonarjs/no-identical-functions */
+import {
+  getMockContext,
+  getMockDescriptorPublished,
+  getMockEService,
+  getMockEServiceTemplate,
+  getMockEServiceTemplateVersion,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import { authRole } from "pagopa-interop-commons";
+import {
+  CorrelationId,
+  EService,
+  EServiceId,
+  EServiceTemplate,
+  EServiceTemplateId,
+  generateId,
+  descriptorState,
+  missingKafkaMessageDataError,
+  NotificationType,
+  TenantId,
+  TenantNotificationConfigId,
+  toEServiceTemplateV2,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { match } from "ts-pattern";
+import { tenantNotFound } from "pagopa-interop-notification-commons";
+import { handleEServiceTemplateVersionActivatedToCreator } from "../src/handlers/eserviceTemplates/handleEserviceTemplateVersionActivatedToCreator.js";
+import {
+  addOneEService,
+  addOneEServiceTemplate,
+  addOneTenant,
+  getMockUser,
+  readModelService,
+  templateService,
+} from "./utils.js";
+
+describe("handleEServiceTemplateVersionActivatedToCreator", async () => {
+  const creatorId = generateId<TenantId>();
+  const eserviceId = generateId<EServiceId>();
+  const instantiatorId = generateId<TenantId>();
+  const eserviceTemplateId = generateId<EServiceTemplateId>();
+
+  const eserviceTemplate: EServiceTemplate = {
+    ...getMockEServiceTemplate(eserviceTemplateId),
+    creatorId,
+    versions: [
+      {
+        ...getMockEServiceTemplateVersion(),
+        state: descriptorState.published,
+      },
+    ],
+  };
+  const eservice: EService = {
+    ...getMockEService(eserviceId),
+    templateId: eserviceTemplateId,
+    producerId: instantiatorId,
+    descriptors: [getMockDescriptorPublished()],
+  };
+  const eserviceTemplateVersionId = eserviceTemplate.versions[0].id;
+
+  const creatorTenant = getMockTenant(creatorId);
+  const instantiatorTenant = getMockTenant(instantiatorId);
+  const users = [getMockUser(creatorId), getMockUser(creatorId)];
+
+  const { logger } = getMockContext({});
+
+  beforeEach(async () => {
+    await addOneEServiceTemplate(eserviceTemplate);
+    await addOneEService(eservice);
+    await addOneTenant(instantiatorTenant);
+    await addOneTenant(creatorTenant);
+    readModelService.getTenantNotificationConfigByTenantId = vi
+      .fn()
+      .mockResolvedValue({
+        id: generateId<TenantNotificationConfigId>(),
+        tenantId: instantiatorTenant.id,
+        enabled: true,
+        createAt: new Date(),
+      });
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockImplementation((tenantIds: TenantId[], _: NotificationType) =>
+        users
+          .filter((user) =>
+            tenantIds.includes(unsafeBrandId<TenantId>(user.tenantId))
+          )
+          .map((user) => ({
+            userId: user.id,
+            tenantId: user.tenantId,
+            // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+            userRoles: [authRole.ADMIN_ROLE],
+          }))
+      );
+  });
+
+  it("should throw missingKafkaMessageDataError when eserviceTemplate is undefined", async () => {
+    await expect(() =>
+      handleEServiceTemplateVersionActivatedToCreator({
+        eserviceTemplateV2Msg: undefined,
+        eserviceTemplateVersionId,
+        logger,
+        templateService,
+        readModelService,
+        correlationId: generateId<CorrelationId>(),
+      })
+    ).rejects.toThrow(
+      missingKafkaMessageDataError(
+        "eserviceTemplate",
+        "EServiceTemplateVersionActivated"
+      )
+    );
+  });
+
+  it("should throw tenantNotFound when creator is not found", async () => {
+    const unknownCreatorId = generateId<TenantId>();
+    const eserviceTemplateUnknownCreator = {
+      ...getMockEServiceTemplate(),
+      creatorId: unknownCreatorId,
+    };
+    await addOneEServiceTemplate(eserviceTemplateUnknownCreator);
+
+    await expect(() =>
+      handleEServiceTemplateVersionActivatedToCreator({
+        eserviceTemplateV2Msg: toEServiceTemplateV2(
+          eserviceTemplateUnknownCreator
+        ),
+        eserviceTemplateVersionId,
+        logger,
+        templateService,
+        readModelService,
+        correlationId: generateId<CorrelationId>(),
+      })
+    ).rejects.toThrow(tenantNotFound(unknownCreatorId));
+  });
+
+  it("should generate one message per user of the creator", async () => {
+    const messages = await handleEServiceTemplateVersionActivatedToCreator({
+      eserviceTemplateV2Msg: toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplateVersionId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toEqual(2);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[0].id
+      )
+    ).toBe(true);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[1].id
+      )
+    ).toBe(true);
+  });
+
+  it("should not generate a message if the user disabled this email notification", async () => {
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockResolvedValue([
+        {
+          userId: users[0].id,
+          tenantId: users[0].tenantId,
+          // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+          userRoles: [authRole.ADMIN_ROLE],
+        },
+      ]);
+
+    const messages = await handleEServiceTemplateVersionActivatedToCreator({
+      eserviceTemplateV2Msg: toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplateVersionId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toEqual(1);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[0].id
+      )
+    ).toBe(true);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[1].id
+      )
+    ).toBe(false);
+  });
+
+  it("should generate a complete and correct message", async () => {
+    const messages = await handleEServiceTemplateVersionActivatedToCreator({
+      eserviceTemplateV2Msg: toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplateVersionId,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toBe(2);
+    messages.forEach((message) => {
+      expect(message.email.body).toContain("<!-- Footer -->");
+      expect(message.email.body).toContain("<!-- Title & Main Message -->");
+      expect(message.email.body).toContain(
+        `Hai riattivato un tuo template e-service`
+      );
+      match(message.type)
+        .with("User", () => {
+          expect(message.email.body).toContain("{{ recipientName }}");
+        })
+        .with("Tenant", () => {
+          expect(message.email.body).toContain(creatorTenant.name);
+        })
+        .exhaustive();
+      expect(message.email.body).toContain(eserviceTemplate.name);
+      expect(message.email.body).toContain(`Visualizza template`);
+    });
+  });
+});

--- a/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplatesEvent.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplatesEvent.ts
@@ -6,6 +6,7 @@ import { Logger } from "pagopa-interop-commons";
 import { P, match } from "ts-pattern";
 import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
 import { handleTemplateStatusChangedToProducer } from "./handleTemplateStatusChangedToProducer.js";
+import { handleTemplateActivatedToProducer } from "./handleTemplateActivatedToProducer.js";
 import { handleNewEserviceTemplateVersionToInstantiator } from "./handleNewEserviceTemplateVersionToInstantiator.js";
 import { handleEserviceTemplateNameChangedToInstantiator } from "./handleEserviceTemplateNameChangedToInstantiator.js";
 import { handleEserviceTemplateStatusChangedToInstantiator } from "./handleEserviceTemplateStatusChangedToInstantiator.js";
@@ -51,6 +52,19 @@ export async function handleEServiceTemplateEvent(
     )
     .with(
       {
+        type: "EServiceTemplateVersionActivated",
+      },
+      // Producer == creator of the template
+      ({ data: { eserviceTemplate, eserviceTemplateVersionId } }) =>
+        handleTemplateActivatedToProducer(
+          eserviceTemplate,
+          eserviceTemplateVersionId,
+          logger,
+          readModelService
+        )
+    )
+    .with(
+      {
         type: "EServiceTemplateNameUpdated",
       },
       ({ data: { eserviceTemplate, oldName } }) =>
@@ -84,7 +98,6 @@ export async function handleEServiceTemplateEvent(
           "EServiceTemplateVersionQuotasUpdated",
           "EServiceTemplateVersionAdded",
           "EServiceTemplateVersionAttributesUpdated",
-          "EServiceTemplateVersionActivated",
           "EServiceTemplatePersonalDataFlagUpdatedAfterPublication",
           "EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded",
           "EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdated",

--- a/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleTemplateActivatedToProducer.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleTemplateActivatedToProducer.ts
@@ -1,0 +1,54 @@
+import {
+  EServiceTemplateIdEServiceTemplateVersionId,
+  EServiceTemplateV2,
+  fromEServiceTemplateV2,
+  missingKafkaMessageDataError,
+  NewNotification,
+} from "pagopa-interop-models";
+import { Logger } from "pagopa-interop-commons";
+import { ReadModelServiceSQL } from "../../services/readModelServiceSQL.js";
+import {
+  inAppTemplates,
+  getNotificationRecipients,
+} from "pagopa-interop-notification-commons";
+
+export async function handleTemplateActivatedToProducer(
+  eserviceTemplateV2Msg: EServiceTemplateV2 | undefined,
+  eserviceTemplateVersionId: string,
+  logger: Logger,
+  readModelService: ReadModelServiceSQL
+): Promise<NewNotification[]> {
+  if (!eserviceTemplateV2Msg) {
+    throw missingKafkaMessageDataError(
+      "eserviceTemplate",
+      "EServiceTemplateVersionActivated"
+    );
+  }
+
+  logger.info(
+    `Sending in-app notification for handleTemplateActivatedToProducer - entityId: ${eserviceTemplateV2Msg.id}, eventType: EServiceTemplateVersionActivated`
+  );
+
+  const eserviceTemplate = fromEServiceTemplateV2(eserviceTemplateV2Msg);
+
+  const usersWithNotifications = await getNotificationRecipients(
+    [eserviceTemplate.creatorId],
+    "templateStatusChangedToProducer",
+    readModelService,
+    logger
+  );
+  const body = inAppTemplates.templateActivatedToProducer(
+    eserviceTemplate.name
+  );
+
+  const entityId = EServiceTemplateIdEServiceTemplateVersionId.parse(
+    `${eserviceTemplate.id}/${eserviceTemplateVersionId}`
+  );
+  return usersWithNotifications.map(({ userId, tenantId }) => ({
+    userId,
+    tenantId,
+    body,
+    notificationType: "templateStatusChangedToProducer",
+    entityId,
+  }));
+}

--- a/packages/in-app-notification-dispatcher/test/handleTemplateActivatedToProducer.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleTemplateActivatedToProducer.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable functional/immutable-data */
+import { describe, it, expect, beforeEach, Mock } from "vitest";
+import {
+  getMockContext,
+  getMockEServiceTemplate,
+  getMockEServiceTemplateVersion,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import {
+  eserviceTemplateVersionState,
+  generateId,
+  missingKafkaMessageDataError,
+  TenantId,
+  toEServiceTemplateV2,
+} from "pagopa-interop-models";
+import {
+  getNotificationRecipients,
+  inAppTemplates,
+} from "pagopa-interop-notification-commons";
+import { handleTemplateActivatedToProducer } from "../src/handlers/eserviceTemplates/handleTemplateActivatedToProducer.js";
+
+import {
+  addOneEServiceTemplate,
+  addOneTenant,
+  readModelService,
+} from "./utils.js";
+
+describe("handleTemplateActivatedToProducer", async () => {
+  const eserviceTemplate = getMockEServiceTemplate(undefined, undefined, [
+    getMockEServiceTemplateVersion(
+      undefined,
+      eserviceTemplateVersionState.published
+    ),
+  ]);
+  const { logger } = getMockContext({});
+
+  const mockGetNotificationRecipients = getNotificationRecipients as Mock;
+  await addOneEServiceTemplate(eserviceTemplate);
+
+  beforeEach(async () => {
+    mockGetNotificationRecipients.mockReset();
+  });
+
+  it("should throw missingKafkaMessageDataError when eserviceTemplate is undefined", async () => {
+    await expect(() =>
+      handleTemplateActivatedToProducer(
+        undefined,
+        generateId(),
+        logger,
+        readModelService
+      )
+    ).rejects.toThrow(
+      missingKafkaMessageDataError(
+        "eserviceTemplate",
+        "EServiceTemplateVersionActivated"
+      )
+    );
+  });
+
+  it("should return empty array when no user notification configs exist for the template", async () => {
+    const creatorId = generateId<TenantId>();
+    const creatorTenant = getMockTenant(creatorId);
+    await addOneTenant(creatorTenant);
+
+    mockGetNotificationRecipients.mockResolvedValue([]);
+
+    eserviceTemplate.creatorId = creatorId;
+    const notifications = await handleTemplateActivatedToProducer(
+      toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplate.versions[0].id,
+      logger,
+      readModelService
+    );
+
+    expect(notifications).toEqual([]);
+  });
+
+  it("should generate notifications for all tenant users with notification enabled", async () => {
+    const creatorId = generateId<TenantId>();
+    const creatorTenant = getMockTenant(creatorId);
+    await addOneTenant(creatorTenant);
+
+    const users = [
+      { userId: generateId(), tenantId: creatorId },
+      { userId: generateId(), tenantId: creatorId },
+    ];
+    mockGetNotificationRecipients.mockResolvedValue(users);
+
+    eserviceTemplate.creatorId = creatorId;
+    const notifications = await handleTemplateActivatedToProducer(
+      toEServiceTemplateV2(eserviceTemplate),
+      eserviceTemplate.versions[0].id,
+      logger,
+      readModelService
+    );
+
+    const body = inAppTemplates.templateActivatedToProducer(
+      eserviceTemplate.name
+    );
+    const expectedNotifications = users.map((user) => ({
+      userId: user.userId,
+      tenantId: creatorId,
+      body,
+      notificationType: "templateStatusChangedToProducer",
+      entityId: `${eserviceTemplate.id}/${eserviceTemplate.versions[0].id}`,
+    }));
+    expect(notifications).toHaveLength(users.length);
+    expect(notifications).toEqual(
+      expect.arrayContaining(expectedNotifications)
+    );
+  });
+});

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-template-version-activated-to-creator-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-template-version-activated-to-creator-mail.html
@@ -1,0 +1,86 @@
+{{> common-header }}
+<tr>
+  <td
+    align="left"
+    class="title"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 24px;
+      padding-right: 0px;
+      padding-bottom: 8px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        line-height: 1;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- H4 Desktop (from MUI Italia)-->
+      <h1 style="font-size: 32px; line-height: 40px; margin: 0">{{ title }}</h1>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 8px;
+      padding-right: 0px;
+      padding-bottom: 0px;
+      padding-left: 0px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <p style="margin-bottom: 0px">
+        Gentile
+        <strong>{{ preservePlaceholderIfMissing "recipientName" }}</strong>,
+      </p>
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    class="text"
+    style="font-size: 0px; padding: 0px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family: Titillium Web, system-ui, sans-serif;
+        font-size: 16px;
+        font-weight: regular;
+        line-height: 24px;
+        text-align: left;
+        color: #17324d;
+      "
+    >
+      <!-- Body 1 Desktop (from MUI Italia)-->
+      <p>
+        È stato riattivato il tuo template "{{ templateName }}". Sarà nuovamente
+        possibile generare nuove istanze a partire da questo template.
+      </p>
+    </div>
+  </td>
+</tr>
+{{> common-footer }}

--- a/packages/notification-commons/src/templates/email/templates.ts
+++ b/packages/notification-commons/src/templates/email/templates.ts
@@ -54,6 +54,8 @@ export const eventMailTemplateType = {
     "new-purpose-version-waiting-for-approval-mail",
   eserviceTemplateVersionSuspendedToCreatorMailTemplate:
     "eservice-template-version-suspended-to-creator-mail",
+  eserviceTemplateVersionActivatedToCreatorMailTemplate:
+    "eservice-template-version-activated-to-creator-mail",
   eserviceTemplateVersionPublishedMailTemplate:
     "eservice-template-version-published-mail",
   eserviceTemplateNameUpdatedMailTemplate:

--- a/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
+++ b/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
@@ -239,6 +239,8 @@ export const inAppTemplates = {
   },
   templateStatusChangedToProducer: (templateName: string): string =>
     `È stato sospeso il tuo template "${templateName}".`,
+  templateActivatedToProducer: (templateName: string): string =>
+    `È stato riattivato il tuo template "${templateName}".`,
   newEserviceTemplateVersionToInstantiator: (
     creatorName: string,
     eserviceTemplateVersion: string,


### PR DESCRIPTION
## Context

When a Producer reactivates a previously suspended e-service template version (`EServiceTemplateVersionActivated`), no notification was sent — neither email nor in-app — even with the notification toggle ("Avvisami quando un template di mio interesse viene sospeso, archiviato o riattivato") enabled. The suspension notification already worked; reactivation was silently skipped in both dispatcher routers.

## Change

Adds an email + in-app notification to the template **creator (producer)** on `EServiceTemplateVersionActivated`, mirroring the existing suspend-to-creator flow.

It reuses the existing `templateStatusChangedToProducer` notification type — the same type that gates the suspension notification — so a user who receives the suspension email now also receives the reactivation email from the same toggle. No new notification type is introduced.

### Email dispatcher
- New handler `handleEserviceTemplateVersionActivatedToCreator`
- New mail template `eservice-template-version-activated-to-creator-mail` ("Hai riattivato un tuo template e-service")
- `EServiceTemplateVersionActivated` added as a dedicated router arm and removed from the skip union

### In-app dispatcher
- New handler `handleTemplateActivatedToProducer`
- New in-app message body `templateActivatedToProducer`
- `EServiceTemplateVersionActivated` added as a dedicated router arm and removed from the skip union

## Scope note

Per the ticket, this notifies the **producer only**. The suspension flow also notifies instantiators; reactivation intentionally does not, matching the ticket scope. Notifying instantiators on reactivation can be addressed separately if desired.

## Tests
- New unit tests for both handlers, mirroring the existing suspend-to-creator / status-changed tests
- `check` and `lint` clean; email and in-app dispatcher suites passing