### PR TITLE
fix: correct threshold in quota adjustment accepted email (PIN-10072)

### DIFF
--- a/packages/email-notification-dispatcher/src/handlers/purposes/handlePurposeEvent.ts
+++ b/packages/email-notification-dispatcher/src/handlers/purposes/handlePurposeEvent.ts
@@ -1,6 +1,8 @@
 import {
   EmailNotificationMessagePayload,
   PurposeEvent,
+  PurposeVersionId,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { P, match } from "ts-pattern";
 import { HandlerParams } from "../../models/handlerParams.js";
@@ -35,7 +37,7 @@ export async function handlePurposeEvent(
     })
     .with(
       { type: "PurposeVersionActivated" },
-      async ({ data: { purpose } }) => [
+      async ({ data: { purpose, versionId } }) => [
         ...(await handlePurposeVersionActivatedFirstVersion({
           purposeV2Msg: purpose,
           logger,
@@ -45,6 +47,7 @@ export async function handlePurposeEvent(
         })),
         ...(await handlePurposeVersionActivatedOtherVersion({
           purposeV2Msg: purpose,
+          purposeVersionId: unsafeBrandId<PurposeVersionId>(versionId),
           logger,
           readModelService,
           templateService,

--- a/packages/email-notification-dispatcher/src/handlers/purposes/handlePurposeVersionActivatedOtherVersion.ts
+++ b/packages/email-notification-dispatcher/src/handlers/purposes/handlePurposeVersionActivatedOtherVersion.ts
@@ -9,22 +9,22 @@ import {
   eventMailTemplateType,
   retrieveEservice,
   retrieveHTMLTemplate,
-  retrieveLatestDescriptor,
   retrieveTenant,
   getRecipientsForTenants,
   mapRecipientToEmailPayload,
 } from "pagopa-interop-notification-commons";
-import { PurposeHandlerParams } from "../../models/handlerParams.js";
+import { PurposeVersionHandlerParams } from "../../models/handlerParams.js";
 
 import { config } from "../../config/config.js";
 
 const notificationType: NotificationType = "purposeOverQuotaStateToConsumer";
 
 export async function handlePurposeVersionActivatedOtherVersion(
-  data: PurposeHandlerParams
+  data: PurposeVersionHandlerParams
 ): Promise<EmailNotificationMessagePayload[]> {
   const {
     purposeV2Msg,
+    purposeVersionId,
     readModelService,
     logger,
     templateService,
@@ -44,14 +44,23 @@ export async function handlePurposeVersionActivatedOtherVersion(
     return [];
   }
 
+  const activatedVersion = purpose.versions.find(
+    (version) => version.id === purposeVersionId
+  );
+
+  if (!activatedVersion) {
+    logger.error(
+      `No version found in purpose ${purpose.id} with id ${purposeVersionId}`
+    );
+    return [];
+  }
+
   const [htmlTemplate, eservice] = await Promise.all([
     retrieveHTMLTemplate(
       eventMailTemplateType.purposeQuotaAdjustmentResponseMailTemplate
     ),
     retrieveEservice(purpose.eserviceId, readModelService),
   ]);
-
-  const { dailyCallsPerConsumer } = retrieveLatestDescriptor(eservice);
 
   const [consumer, producer] = await Promise.all([
     retrieveTenant(purpose.consumerId, readModelService),
@@ -85,7 +94,7 @@ export async function handlePurposeVersionActivatedOtherVersion(
         producerName: producer.name,
         purposeTitle: purpose.title,
         eserviceName: eservice.name,
-        dailyCalls: dailyCallsPerConsumer,
+        dailyCalls: activatedVersion.dailyCalls,
         isAccepted: true,
         ctaLabel: `Visualizza finalità`,
         selfcareId: consumer.selfcareId,

--- a/packages/email-notification-dispatcher/src/models/handlerParams.ts
+++ b/packages/email-notification-dispatcher/src/models/handlerParams.ts
@@ -10,6 +10,7 @@ import {
   ProducerKeychainV2,
   PurposeId,
   PurposeV2,
+  PurposeVersionId,
   TenantV2,
   UserId,
 } from "pagopa-interop-models";
@@ -47,6 +48,11 @@ export type ClientPurposeHandlerParams = HandlerCommonParams & {
 
 export type PurposeHandlerParams = HandlerCommonParams & {
   purposeV2Msg?: PurposeV2;
+};
+
+export type PurposeVersionHandlerParams = HandlerCommonParams & {
+  purposeV2Msg?: PurposeV2;
+  purposeVersionId: PurposeVersionId;
 };
 
 export type TenantHandlerParams = HandlerCommonParams & {

--- a/packages/email-notification-dispatcher/test/handlePurposeVersionActivatedOtherVersion.test.ts
+++ b/packages/email-notification-dispatcher/test/handlePurposeVersionActivatedOtherVersion.test.ts
@@ -1,0 +1,263 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable sonarjs/no-identical-functions */
+import {
+  getMockContext,
+  getMockDescriptorPublished,
+  getMockEService,
+  getMockPurpose,
+  getMockPurposeVersion,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import { authRole } from "pagopa-interop-commons";
+import {
+  CorrelationId,
+  EService,
+  EServiceId,
+  generateId,
+  missingKafkaMessageDataError,
+  NotificationType,
+  Purpose,
+  PurposeVersion,
+  PurposeVersionId,
+  purposeVersionState,
+  Tenant,
+  TenantId,
+  TenantNotificationConfigId,
+  toPurposeV2,
+  unsafeBrandId,
+} from "pagopa-interop-models";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handlePurposeVersionActivatedOtherVersion } from "../src/handlers/purposes/handlePurposeVersionActivatedOtherVersion.js";
+import {
+  addOneEService,
+  addOnePurpose,
+  addOneTenant,
+  getMockUser,
+  readModelService,
+  templateService,
+} from "./utils.js";
+
+describe("handlePurposeVersionActivatedOtherVersion", async () => {
+  const producerId = generateId<TenantId>();
+  const consumerId = generateId<TenantId>();
+  const eserviceId = generateId<EServiceId>();
+
+  // The e-service descriptor per-consumer threshold is intentionally different
+  // from the activated purpose version's dailyCalls: the email must report the
+  // approved purpose version value, not the descriptor value.
+  const eservice: EService = {
+    ...getMockEService(),
+    id: eserviceId,
+    producerId,
+    descriptors: [
+      { ...getMockDescriptorPublished(), dailyCallsPerConsumer: 1 },
+    ],
+  };
+  const producerTenant: Tenant = {
+    ...getMockTenant(producerId),
+    name: "Producer Tenant",
+  };
+  const consumerTenant: Tenant = {
+    ...getMockTenant(consumerId),
+    name: "Consumer Tenant",
+  };
+  const users = [getMockUser(consumerId), getMockUser(consumerId)];
+
+  // Previous (archived) version with the original threshold, and the newly
+  // activated version with the approved threshold.
+  const previousVersion: PurposeVersion = {
+    ...getMockPurposeVersion(purposeVersionState.archived),
+    dailyCalls: 2,
+  };
+  const activatedVersion: PurposeVersion = {
+    ...getMockPurposeVersion(purposeVersionState.active),
+    dailyCalls: 4,
+  };
+
+  const { logger } = getMockContext({});
+
+  beforeEach(async () => {
+    await addOneEService(eservice);
+    await addOneTenant(producerTenant);
+    await addOneTenant(consumerTenant);
+    readModelService.getTenantNotificationConfigByTenantId = vi
+      .fn()
+      .mockResolvedValue({
+        id: generateId<TenantNotificationConfigId>(),
+        tenantId: consumerTenant.id,
+        enabled: true,
+        createAt: new Date(),
+      });
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockImplementation((tenantIds: TenantId[], _: NotificationType) =>
+        users
+          .filter((user) =>
+            tenantIds.includes(unsafeBrandId<TenantId>(user.tenantId))
+          )
+          .map((user) => ({
+            userId: user.id,
+            tenantId: user.tenantId,
+            // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+            userRoles: [authRole.ADMIN_ROLE],
+          }))
+      );
+  });
+
+  const addPurposeWithVersions = async (): Promise<Purpose> => {
+    const purpose: Purpose = {
+      ...getMockPurpose([previousVersion, activatedVersion]),
+      eserviceId: eservice.id,
+      consumerId: consumerTenant.id,
+    };
+    await addOnePurpose(purpose);
+    return purpose;
+  };
+
+  it("should throw missingKafkaMessageDataError when purpose is undefined", async () => {
+    await expect(() =>
+      handlePurposeVersionActivatedOtherVersion({
+        purposeV2Msg: undefined,
+        purposeVersionId: activatedVersion.id,
+        logger,
+        templateService,
+        readModelService,
+        correlationId: generateId<CorrelationId>(),
+      })
+    ).rejects.toThrow(
+      missingKafkaMessageDataError("purpose", "PurposeVersionActivated")
+    );
+  });
+
+  it("should generate no messages when the purpose has a single version", async () => {
+    const purpose: Purpose = {
+      ...getMockPurpose([activatedVersion]),
+      eserviceId: eservice.id,
+      consumerId: consumerTenant.id,
+    };
+    await addOnePurpose(purpose);
+
+    const messages = await handlePurposeVersionActivatedOtherVersion({
+      purposeV2Msg: toPurposeV2(purpose),
+      purposeVersionId: activatedVersion.id,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toEqual(0);
+  });
+
+  it("should generate no messages when the activated version can't be found", async () => {
+    const purpose = await addPurposeWithVersions();
+
+    const messages = await handlePurposeVersionActivatedOtherVersion({
+      purposeV2Msg: toPurposeV2(purpose),
+      purposeVersionId: generateId<PurposeVersionId>(),
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toEqual(0);
+  });
+
+  it("should generate one message per user of the consumer", async () => {
+    const purpose = await addPurposeWithVersions();
+
+    const messages = await handlePurposeVersionActivatedOtherVersion({
+      purposeV2Msg: toPurposeV2(purpose),
+      purposeVersionId: activatedVersion.id,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toEqual(2);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[0].id
+      )
+    ).toBe(true);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[1].id
+      )
+    ).toBe(true);
+  });
+
+  it("should not generate a message if the user disabled this email notification", async () => {
+    readModelService.getTenantUsersWithNotificationEnabled = vi
+      .fn()
+      .mockResolvedValue([
+        {
+          userId: users[0].id,
+          tenantId: users[0].tenantId,
+          // Only consider ADMIN_ROLE since role restrictions are tested separately in getRecipientsForTenants.test.ts
+          userRoles: [authRole.ADMIN_ROLE],
+        },
+      ]);
+
+    const purpose = await addPurposeWithVersions();
+
+    const messages = await handlePurposeVersionActivatedOtherVersion({
+      purposeV2Msg: toPurposeV2(purpose),
+      purposeVersionId: activatedVersion.id,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toEqual(1);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[0].id
+      )
+    ).toBe(true);
+    expect(
+      messages.some(
+        (message) => message.type === "User" && message.userId === users[1].id
+      )
+    ).toBe(false);
+  });
+
+  it("should report the approved (activated) version dailyCalls, not the descriptor or the previous version", async () => {
+    const purpose = await addPurposeWithVersions();
+
+    const messages = await handlePurposeVersionActivatedOtherVersion({
+      purposeV2Msg: toPurposeV2(purpose),
+      purposeVersionId: activatedVersion.id,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toBe(2);
+    messages.forEach((message) => {
+      expect(message.email.body).toContain("<!-- Title & Main Message -->");
+      expect(message.email.body).toContain("<!-- Footer -->");
+      expect(message.email.body).toContain(
+        `Richiesta di adeguamento piano di carico accettata per la finalità &quot;${purpose.title}&quot;`
+      );
+      // The approved threshold (activated version dailyCalls = 4) must appear,
+      // not the descriptor dailyCallsPerConsumer (1) nor the previous version (2).
+      expect(message.email.body).toContain(
+        "<strong>4</strong> chiamate giornaliere"
+      );
+      expect(message.email.body).not.toContain(
+        "<strong>1</strong> chiamate giornaliere"
+      );
+      expect(message.email.body).not.toContain(
+        "<strong>2</strong> chiamate giornaliere"
+      );
+      expect(message.email.body).toContain(producerTenant.name);
+      expect(message.email.body).toContain(eservice.name);
+      expect(message.email.body).toContain(purpose.title);
+    });
+  });
+});


### PR DESCRIPTION
## Context

The "Richiesta di adeguamento piano di carico accettata" email, sent to the consumer when a producer approves a purpose load-plan adjustment request, reported the wrong value in the sentence "La nuova soglia pari a X chiamate giornaliere è ora attiva".

It rendered the e-service descriptor's `dailyCallsPerConsumer` (a fixed per-consumer cap on the e-service) instead of the newly-approved purpose version's `dailyCalls`. As a result it always showed the descriptor cap (1 in the reported environment) regardless of the requested/approved value.

## Change

`handlePurposeVersionActivatedOtherVersion` now reports the **approved purpose version's** `dailyCalls`.

- The `PurposeVersionActivated` event already carries the activated `versionId`; it is now threaded through the purpose event router to the handler.
- The handler resolves the activated version (`purpose.versions.find(v => v.id === versionId)`) and uses its `dailyCalls`, logging and skipping if the version is not found (consistent with the e-service-template version handlers).
- Removed the now-unused `retrieveLatestDescriptor` lookup.
- Introduced a dedicated `PurposeVersionHandlerParams` type to carry the version id, leaving the shared `PurposeHandlerParams` untouched.

## Scope

- Email only: the rejected variant gates the threshold sentence under `{{#if isAccepted}}` and renders no value, and the in-app quota-adjustment notification carries no threshold — neither was affected.

## Tests

- New unit test for `handlePurposeVersionActivatedOtherVersion` (the handler was previously untested), pinning the regression: with descriptor cap = 1, previous version = 2, approved version = 4, the email must report 4.
- `check` and `lint` clean; email dispatcher suite passing.