### PR TITLE
fix: allow archiving and archivingSuspended in platform-states (PIN-10519)

### DIFF
--- a/packages/token-generation-readmodel-checker/src/utils/utils.ts
+++ b/packages/token-generation-readmodel-checker/src/utils/utils.ts
@@ -512,12 +512,14 @@ export async function compareReadModelEServicesWithPlatformStates({
       differencesCount++;
       logger.error(`Read model e-service not found for id: ${id}`);
     } else {
-      // Descriptors with a state other than deprecated, published or suspended are not considered because they are not expected to be in the platform-states
+      // Descriptors with a state other than deprecated, published, suspended, archiving or archivingSuspended are not considered because they are not expected to be in the platform-states
       const shouldPlatformStatesCatalogEntriesExist = eservice.descriptors.some(
         (d) =>
           d.state === descriptorState.deprecated ||
           d.state === descriptorState.published ||
-          d.state === descriptorState.suspended
+          d.state === descriptorState.suspended ||
+          d.state === descriptorState.archiving ||
+          d.state === descriptorState.archivingSuspended
       );
       const platformStatesEntries = platformStatesEServiceById.get(id);
 
@@ -559,7 +561,7 @@ export async function compareReadModelEServicesWithPlatformStates({
 
         if (platformStatesEntry && !readModelEntry) {
           logger.error(
-            `platform-states entry with ${platformStatesEntry.PK} should not be in the table because the descriptor state is not published, suspended or deprecated`
+            `platform-states entry with ${platformStatesEntry.PK} should not be in the table because the descriptor state is not published, suspended, deprecated, archiving or archivingSuspended`
           );
           differencesCount++;
         }
@@ -892,7 +894,9 @@ export const clientKindToTokenGenerationStatesClientKind = (
     .exhaustive();
 
 const descriptorStateToItemState = (state: DescriptorState): ItemState =>
-  state === descriptorState.published || state === descriptorState.deprecated
+  state === descriptorState.published ||
+  state === descriptorState.deprecated ||
+  state === descriptorState.archiving
     ? itemState.active
     : itemState.inactive;
 

--- a/packages/token-generation-readmodel-checker/src/utils/utils.ts
+++ b/packages/token-generation-readmodel-checker/src/utils/utils.ts
@@ -11,7 +11,6 @@ import {
   ClientKind,
   ClientKindTokenGenStates,
   clientKindTokenGenStates,
-  Descriptor,
   DescriptorId,
   DescriptorState,
   descriptorState,
@@ -96,15 +95,6 @@ export function getLastAgreement(agreements: Agreement[]): Agreement {
       (agreement1, agreement2) =>
         agreement2.createdAt.getTime() - agreement1.createdAt.getTime()
     )[0];
-}
-
-export function getValidDescriptors(descriptors: Descriptor[]): Descriptor[] {
-  return descriptors.filter(
-    (descriptor) =>
-      descriptor.state === descriptorState.published ||
-      descriptor.state === descriptorState.suspended ||
-      descriptor.state === descriptorState.deprecated
-  );
 }
 
 function getIdFromPlatformStatesPK<

--- a/packages/token-generation-readmodel-checker/test/tokenGenerationReadModelChecker.test.ts
+++ b/packages/token-generation-readmodel-checker/test/tokenGenerationReadModelChecker.test.ts
@@ -764,96 +764,70 @@ describe("Token Generation Read Model Checker tests", () => {
   });
 
   describe("eservices", () => {
-    it("should not detect differences when the catalog platform-states entries are correct", async () => {
-      const descriptor1: Descriptor = {
-        ...getMockDescriptor(),
+    it.each([
+      {
         state: descriptorState.published,
-        audience: ["pagopa.it"],
-      };
-      const descriptor2: Descriptor = {
-        ...getMockDescriptor(),
-        state: descriptorState.published,
-        audience: ["pagopa.it"],
-      };
-      const descriptor3: Descriptor = {
-        ...getMockDescriptor(),
+        expectedPlatformStatesState: itemState.active,
+      },
+      {
         state: descriptorState.deprecated,
-        audience: ["pagopa.it"],
-      };
+        expectedPlatformStatesState: itemState.active,
+      },
+      {
+        state: descriptorState.suspended,
+        expectedPlatformStatesState: itemState.inactive,
+      },
+      {
+        state: descriptorState.archiving,
+        expectedPlatformStatesState: itemState.active,
+      },
+      {
+        state: descriptorState.archivingSuspended,
+        expectedPlatformStatesState: itemState.inactive,
+      },
+    ])(
+      "should not detect differences when the catalog platform-states entries are correct %s",
+      async ({ state, expectedPlatformStatesState }) => {
+        const descriptor: Descriptor = {
+          ...getMockDescriptor(),
+          state: state,
+        };
 
-      const eservice1: EService = {
-        ...getMockEService(),
-        descriptors: [descriptor1],
-      };
-      const eservice2: EService = {
-        ...getMockEService(),
-        descriptors: [descriptor2, descriptor3],
-      };
+        const eservice: EService = {
+          ...getMockEService(),
+          descriptors: [descriptor],
+        };
 
-      // platform-states
-      const catalogEntryPK1 = makePlatformStatesEServiceDescriptorPK({
-        eserviceId: eservice1.id,
-        descriptorId: descriptor1.id,
-      });
-      const platformStatesCatalogEntry1: PlatformStatesCatalogEntry = {
-        PK: catalogEntryPK1,
-        state: itemState.active,
-        descriptorAudience: descriptor1.audience,
-        descriptorVoucherLifespan: descriptor1.voucherLifespan,
-        version: 1,
-        updatedAt: new Date().toISOString(),
-      };
-
-      const catalogEntryPK2 = makePlatformStatesEServiceDescriptorPK({
-        eserviceId: eservice2.id,
-        descriptorId: descriptor2.id,
-      });
-      const platformStatesCatalogEntry2: PlatformStatesCatalogEntry = {
-        PK: catalogEntryPK2,
-        state: itemState.active,
-        descriptorAudience: descriptor2.audience,
-        descriptorVoucherLifespan: descriptor2.voucherLifespan,
-        version: 1,
-        updatedAt: new Date().toISOString(),
-      };
-
-      const catalogEntryPK3 = makePlatformStatesEServiceDescriptorPK({
-        eserviceId: eservice2.id,
-        descriptorId: descriptor3.id,
-      });
-      const platformStatesCatalogEntry3: PlatformStatesCatalogEntry = {
-        PK: catalogEntryPK3,
-        state: itemState.active,
-        descriptorAudience: descriptor3.audience,
-        descriptorVoucherLifespan: descriptor3.voucherLifespan,
-        version: 1,
-        updatedAt: new Date().toISOString(),
-      };
-
-      const expectedDifferencesLength = 0;
-      const catalogDifferences =
-        await compareReadModelEServicesWithPlatformStates({
-          platformStatesEServiceById: new Map([
-            [
-              eservice1.id,
-              new Map([[descriptor1.id, platformStatesCatalogEntry1]]),
-            ],
-            [
-              eservice2.id,
-              new Map([
-                [descriptor2.id, platformStatesCatalogEntry2],
-                [descriptor3.id, platformStatesCatalogEntry3],
-              ]),
-            ],
-          ]),
-          eservicesById: new Map([
-            [eservice1.id, eservice1],
-            [eservice2.id, eservice2],
-          ]),
-          logger: genericLogger,
+        // platform-states
+        const catalogEntryPK = makePlatformStatesEServiceDescriptorPK({
+          eserviceId: eservice.id,
+          descriptorId: descriptor.id,
         });
-      expect(catalogDifferences).toEqual(expectedDifferencesLength);
-    });
+        const platformStatesCatalogEntry: PlatformStatesCatalogEntry = {
+          PK: catalogEntryPK,
+          state: expectedPlatformStatesState,
+          descriptorAudience: descriptor.audience,
+          descriptorVoucherLifespan: descriptor.voucherLifespan,
+          version: 1,
+          updatedAt: new Date().toISOString(),
+        };
+
+        const expectedDifferencesLength = 0;
+        const catalogDifferences =
+          await compareReadModelEServicesWithPlatformStates({
+            platformStatesEServiceById: new Map([
+              [
+                eservice.id,
+                new Map([[descriptor.id, platformStatesCatalogEntry]]),
+              ],
+            ]),
+            eservicesById: new Map([[eservice.id, eservice]]),
+            logger: genericLogger,
+          });
+
+        expect(catalogDifferences).toEqual(expectedDifferencesLength);
+      }
+    );
 
     it("should detect differences for wrong eservice states", async () => {
       const descriptor1: Descriptor = {
@@ -925,46 +899,52 @@ describe("Token Generation Read Model Checker tests", () => {
       expect(catalogDifferences).toEqual(expectedDifferencesLength);
     });
 
-    it("should detect differences when there's a platform-states catalog entry and the descriptor is not published, deprecated or suspended", async () => {
-      const descriptor: Descriptor = {
-        ...getMockDescriptor(),
-        state: descriptorState.archived,
-        audience: ["pagopa.it"],
-      };
+    it.each([
+      descriptorState.archived,
+      descriptorState.draft,
+      descriptorState.waitingForApproval,
+    ])(
+      "should detect differences when there's a platform-states catalog entry and the descriptor is not published, deprecated, suspended, archiving or archivingSuspended: descriptor state %s",
+      async (state) => {
+        const descriptor: Descriptor = {
+          ...getMockDescriptor(),
+          state: state,
+        };
 
-      const eservice: EService = {
-        ...getMockEService(),
-        descriptors: [descriptor],
-      };
+        const eservice: EService = {
+          ...getMockEService(),
+          descriptors: [descriptor],
+        };
 
-      // platform-states
-      const catalogEntryPK = makePlatformStatesEServiceDescriptorPK({
-        eserviceId: eservice.id,
-        descriptorId: descriptor.id,
-      });
-      const platformStatesCatalogEntry: PlatformStatesCatalogEntry = {
-        PK: catalogEntryPK,
-        state: itemState.inactive,
-        descriptorAudience: descriptor.audience,
-        descriptorVoucherLifespan: descriptor.voucherLifespan,
-        version: 1,
-        updatedAt: new Date().toISOString(),
-      };
-
-      const expectedDifferencesLength = 1;
-      const catalogDifferences =
-        await compareReadModelEServicesWithPlatformStates({
-          platformStatesEServiceById: new Map([
-            [
-              eservice.id,
-              new Map([[descriptor.id, platformStatesCatalogEntry]]),
-            ],
-          ]),
-          eservicesById: new Map([[eservice.id, eservice]]),
-          logger: genericLogger,
+        // platform-states
+        const catalogEntryPK = makePlatformStatesEServiceDescriptorPK({
+          eserviceId: eservice.id,
+          descriptorId: descriptor.id,
         });
-      expect(catalogDifferences).toEqual(expectedDifferencesLength);
-    });
+        const platformStatesCatalogEntry: PlatformStatesCatalogEntry = {
+          PK: catalogEntryPK,
+          state: itemState.inactive,
+          descriptorAudience: descriptor.audience,
+          descriptorVoucherLifespan: descriptor.voucherLifespan,
+          version: 1,
+          updatedAt: new Date().toISOString(),
+        };
+
+        const expectedDifferencesLength = 1;
+        const catalogDifferences =
+          await compareReadModelEServicesWithPlatformStates({
+            platformStatesEServiceById: new Map([
+              [
+                eservice.id,
+                new Map([[descriptor.id, platformStatesCatalogEntry]]),
+              ],
+            ]),
+            eservicesById: new Map([[eservice.id, eservice]]),
+            logger: genericLogger,
+          });
+        expect(catalogDifferences).toEqual(expectedDifferencesLength);
+      }
+    );
 
     it("should detect differences when the platform-states entry is missing and the descriptor is not archived", async () => {
       const descriptor: Descriptor = {

--- a/packages/token-generation-readmodel-checker/test/utils.test.ts
+++ b/packages/token-generation-readmodel-checker/test/utils.test.ts
@@ -569,34 +569,6 @@ describe("Token Generation Read Model Checker utils tests", () => {
 
     expect(getLastAgreement([agreement1, agreement2])).toEqual(agreement1);
   });
-
-  it("getValidDescriptors", () => {
-    const publishedDescriptor = getMockDescriptor(descriptorState.published);
-    const waitingForApprovalDescriptor = getMockDescriptor(
-      descriptorState.waitingForApproval
-    );
-    const deprecatedDescriptor = getMockDescriptor(descriptorState.deprecated);
-    const archivedDescriptor = getMockDescriptor(descriptorState.archived);
-    const suspendedDescriptor = getMockDescriptor(descriptorState.suspended);
-    const draftDescriptor = getMockDescriptor(descriptorState.draft);
-
-    expect(
-      getValidDescriptors([
-        publishedDescriptor,
-        waitingForApprovalDescriptor,
-        deprecatedDescriptor,
-        archivedDescriptor,
-        suspendedDescriptor,
-        draftDescriptor,
-      ])
-    ).toEqual(
-      expect.arrayContaining([
-        publishedDescriptor,
-        deprecatedDescriptor,
-        suspendedDescriptor,
-      ])
-    );
-  });
 });
 
 afterEach(async () => {

--- a/packages/token-generation-readmodel-checker/test/utils.test.ts
+++ b/packages/token-generation-readmodel-checker/test/utils.test.ts
@@ -52,7 +52,6 @@ import {
   compareReadModelPurposesWithPlatformStates,
   getLastAgreement,
   getLastPurposeVersion,
-  getValidDescriptors,
 } from "../src/utils/utils.js";
 import {
   addOneAgreement,


### PR DESCRIPTION
Close [PIN-10519](https://pagopa.atlassian.net/browse/PIN-10519)

# Description

It's correct for the new `archiving` and `archivingSuspended` states to be in the `platform-states` table because they can be reverted to `published`, `deprecated` and `suspended` if the archiving is cancelled.

The `token-generation-readmodel-checker` reported `platform-states entry with ESERVICEDESCRIPTOR#eserviceId#descriptorId should not be in the table because the descriptor state is not published, suspended or deprecated` for a descriptor in state `archivingSuspended`. This PR allows its presence.

[PIN-10519]: https://pagopa.atlassian.net/browse/PIN-10519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ