### PR TITLE
hotfix: async-token-generation-readmodel-checker added archiving states and test (PIN-10541)

### DIFF
--- a/packages/async-token-generation-readmodel-checker/src/utils/common.ts
+++ b/packages/async-token-generation-readmodel-checker/src/utils/common.ts
@@ -31,6 +31,8 @@ const validDescriptorStates = [
   descriptorState.published,
   descriptorState.suspended,
   descriptorState.deprecated,
+  descriptorState.archiving,
+  descriptorState.archivingSuspended,
 ] as string[];
 
 const activeOrInactive = (isActive: boolean): ItemState =>
@@ -42,7 +44,11 @@ const hasAsyncExchangeProperties = (
   descriptor.asyncExchangeProperties !== undefined;
 
 export const descriptorItemState = (descriptor: Descriptor): ItemState =>
-  activeOrInactive(descriptor.state === descriptorState.published);
+  activeOrInactive(
+    descriptor.state === descriptorState.published ||
+      descriptor.state === descriptorState.deprecated ||
+      descriptor.state === descriptorState.archiving
+  );
 
 export const purposeVersionItemState = (
   purposeVersion: PurposeVersion

--- a/packages/async-token-generation-readmodel-checker/test/utils.test.ts
+++ b/packages/async-token-generation-readmodel-checker/test/utils.test.ts
@@ -20,6 +20,7 @@ import {
   Client,
   clientKind,
   clientKindTokenGenStates,
+  DescriptorState,
   descriptorState,
   EService,
   generateId,
@@ -93,10 +94,12 @@ type Fixture = {
   interaction: Interaction;
 };
 
-const buildFixture = (): Fixture => {
+const buildFixture = (
+  state: DescriptorState = descriptorState.published
+): Fixture => {
   const descriptor = {
     ...getMockDescriptor(descriptorState.published),
-    state: descriptorState.published,
+    state: state,
     audience: ["pagopa.it"],
     voucherLifespan: 600,
     asyncExchangeProperties,
@@ -331,6 +334,56 @@ describe("Async Token Generation Read Model Checker tests", () => {
       })
     ).toBe(1);
   });
+
+  it.each([
+    {
+      state: descriptorState.published,
+      expectedPlatformStatesState: itemState.active,
+    },
+    {
+      state: descriptorState.suspended,
+      expectedPlatformStatesState: itemState.inactive,
+    },
+    {
+      state: descriptorState.deprecated,
+      expectedPlatformStatesState: itemState.active,
+    },
+    {
+      state: descriptorState.archiving,
+      expectedPlatformStatesState: itemState.active,
+    },
+    {
+      state: descriptorState.archivingSuspended,
+      expectedPlatformStatesState: itemState.inactive,
+    },
+  ])(
+    "should not detect differences on async exchange state in platform-states",
+    ({ state, expectedPlatformStatesState }) => {
+      const fixture = buildFixture(state);
+
+      const catalogDifferences = compareAsyncPlatformStates({
+        eservices: [fixture.eservice],
+        platformStates: [
+          {
+            PK: makePlatformStatesEServiceDescriptorPK({
+              eserviceId: fixture.eservice.id,
+              descriptorId: fixture.descriptor.id,
+            }),
+            state: expectedPlatformStatesState,
+            descriptorAudience: fixture.descriptor.audience,
+            descriptorVoucherLifespan: fixture.descriptor.voucherLifespan,
+            asyncExchange: true,
+            asyncExchangeProperties,
+            version: 1,
+            updatedAt: issuedAt,
+          },
+        ],
+        logger: genericLogger,
+      });
+
+      expect(catalogDifferences).toBe(0);
+    }
+  );
 
   it("should not detect differences when platform-states descriptor audience has different order", () => {
     const fixture = buildFixture();


### PR DESCRIPTION
## Issue
- [PIN-10541](https://pagopa.atlassian.net/browse/PIN-10541)

## Context

This PR updates the async-token-generation-readmodel-checker module to support two new archiving states. It also extends the active/inactive state and includes a test suite to verify state check.

## Scope
- async-token-generation-readmodel-checker

## Traceability Checklist
- [X] PR title compliant (type(scope): description (KEY))
- [X] Service labels applied

[PIN-10541]: https://pagopa.atlassian.net/browse/PIN-10541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ