### PR TITLE
fix: remove duplicate OneTrust mobile menu (PIN-4776)

### DIFF
--- a/packages/one-trust-notices/src/services/htmlParser.ts
+++ b/packages/one-trust-notices/src/services/htmlParser.ts
@@ -9,13 +9,20 @@ interface HtmlJsonNode {
   attr?: Record<string, string | string[]>;
 }
 
+const oneTrustMobileMenuClasses = new Set([
+  "otnotice-menu-mobile",
+  "otnotice-menu-mobile-container",
+]);
+
 export function parseAndSanitizeHtml(html: string): HtmlJsonNode {
   const document = parseDocument(html);
-  const children = document.childNodes.map(convertNode);
+  const children = document.childNodes
+    .map(convertNode)
+    .filter((node): node is HtmlJsonNode => node !== undefined);
   return { node: "root", child: children };
 }
 
-function convertNode(domNode: ChildNode): HtmlJsonNode {
+function convertNode(domNode: ChildNode): HtmlJsonNode | undefined {
   if (domNode instanceof Text) {
     return { node: "text", text: domNode.data };
   }
@@ -31,13 +38,19 @@ function convertNode(domNode: ChildNode): HtmlJsonNode {
   return { node: "text", text: "" };
 }
 
-function convertElement(el: Element): HtmlJsonNode {
+function convertElement(el: Element): HtmlJsonNode | undefined {
+  if (isOneTrustMobileMenu(el)) {
+    return undefined;
+  }
+
   if (el.name === "script") {
     return { node: "element", tag: el.name, child: [] };
   }
 
   const attr = sanitizeAttributes(el.attribs);
-  const children = el.childNodes.map(convertNode);
+  const children = el.childNodes
+    .map(convertNode)
+    .filter((node): node is HtmlJsonNode => node !== undefined);
 
   return {
     node: "element",
@@ -45,6 +58,17 @@ function convertElement(el: Element): HtmlJsonNode {
     ...(attr !== undefined ? { attr } : {}),
     ...(children.length > 0 ? { child: children } : {}),
   };
+}
+
+function isOneTrustMobileMenu(el: Element): boolean {
+  const classAttribute = el.attribs.class;
+  if (classAttribute === undefined) {
+    return false;
+  }
+
+  return classAttribute
+    .split(/\s+/)
+    .some((className) => oneTrustMobileMenuClasses.has(className));
 }
 
 function isAllowedAttribute(key: string, value: string): boolean {

--- a/packages/one-trust-notices/test/htmlParser.test.ts
+++ b/packages/one-trust-notices/test/htmlParser.test.ts
@@ -426,5 +426,58 @@ describe("parseAndSanitizeHtml", () => {
         ],
       });
     });
+
+    it("should remove the OneTrust mobile menu before sanitizing attributes", () => {
+      const html = [
+        '<ul class="otnotice-menu">',
+        '<li><a href="#section-one">Section one</a></li>',
+        "</ul>",
+        '<div class="otnotice-menu-mobile">',
+        '<button class="otnotice-menu-mobile-toggle">Menu</button>',
+        '<ul class="otnotice-menu-mobile-container">',
+        '<li><a href="#section-one">Section one</a></li>',
+        "</ul>",
+        "</div>",
+        '<section id="section-one"><h2>Section one</h2></section>',
+      ].join("");
+
+      const result = parseAndSanitizeHtml(html);
+
+      expect(result).toEqual({
+        node: "root",
+        child: [
+          {
+            node: "element",
+            tag: "ul",
+            child: [
+              {
+                node: "element",
+                tag: "li",
+                child: [
+                  {
+                    node: "element",
+                    tag: "a",
+                    attr: { href: "#section-one" },
+                    child: [{ node: "text", text: "Section one" }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            node: "element",
+            tag: "section",
+            attr: { id: "section-one" },
+            child: [
+              {
+                node: "element",
+                tag: "h2",
+                child: [{ node: "text", text: "Section one" }],
+              },
+            ],
+          },
+        ],
+      });
+    });
   });
 });


### PR DESCRIPTION
## Issue
- [PIN-4776](https://pagopa.atlassian.net/browse/PIN-4776)

## Context / Why
- OneTrust returns both a desktop menu and a mobile menu in the notice HTML.
- The sanitizer removes classes and styles, making both menus visible in the generated content.

## Scope
- Remove OneTrust mobile menu nodes before sanitizing attributes.
- Add a regression test covering desktop and mobile menu duplication.

## Key Changes
- Added detection for OneTrust mobile menu classes in the HTML parser.
- Filtered removed nodes from root and nested children during conversion.

## Testing / Validation
- [x] Unit tests
- [x] Type check
- [x] Lint

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-4776]: https://pagopa.atlassian.net/browse/PIN-4776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ