### PR TITLE
feat(commons): log JWKS kids (read/verify) and KMS signing kid for key-rotation visibility (PIN-10520)

### DIFF
--- a/packages/commons/src/auth/jwt.ts
+++ b/packages/commons/src/auth/jwt.ts
@@ -105,10 +105,18 @@ export const verifyJwtToken = async (
       // expects a synchronous callback. The IIFE is needed to handle the case where the `getSigningKey`
       // function of the jwksClient returns a promise.
       (async (): Promise<void> => {
-        for (const client of jwksClients) {
+        for (const [index, client] of jwksClients.entries()) {
           try {
-            const signingKey = await client.getSigningKey(header.kid);
-            return callback(null, signingKey.getPublicKey());
+            const signingKeys = await client.getSigningKeys();
+            logger.info(
+              `JWKS read from ${
+                config.wellKnownUrls[index]
+              } - kids: [${signingKeys.map((k) => k.kid).join(", ")}]`
+            );
+            const signingKey = signingKeys.find((k) => k.kid === header.kid);
+            if (signingKey) {
+              return callback(null, signingKey.getPublicKey());
+            }
           } catch (error) {
             logger.debug(`Skip Jwks client: ${error}`);
           }
@@ -129,6 +137,9 @@ export const verifyJwtToken = async (
             const { userId, selfcareId } = extractUserInfoForFailedToken();
             return reject(tokenVerificationFailed(userId, selfcareId));
           }
+          const authenticatedKid = jwt.decode(jwtToken, { complete: true })
+            ?.header.kid;
+          logger.info(`Request authenticated with kid ${authenticatedKid}`);
           return resolve({ decoded });
         }
       );

--- a/packages/commons/src/interop-token/interopTokenService.ts
+++ b/packages/commons/src/interop-token/interopTokenService.ts
@@ -39,6 +39,7 @@ import {
   AgidIntegrityRest02TokenPayload,
   IntegrityRest02SignedHeaders,
 } from "./models.js";
+import { genericLogger } from "../logging/index.js";
 import { b64ByteUrlEncode, b64UrlEncode } from "./utils.js";
 import {
   SerializedAuthTokenPayload,
@@ -485,6 +486,7 @@ export class InteropTokenGenerator {
     };
 
     const command = new SignCommand(commandParams);
+    genericLogger.info(`Signing token with KMS kid ${keyId}`);
     const response = await this.kmsClient.send(command);
 
     if (!response.Signature) {


### PR DESCRIPTION
## Why

Infra is splitting the KMS keys so each application flow category gets dedicated keys (context: PIN-10267). This touches almost all flows, so we add logging to gain visibility while verifying the key changes propagate — on both the verification side and the signing side. The well-known URL contents and the KMS signing keys can change without a config change or app deploy, and this logging surfaces those transitions.

## What

All in `packages/commons`:

**Verification / read side** (`auth/jwt.ts`, `verifyJwtToken`):
- On each JWKS well-known URL read, log the KIDs exposed by that URL — confirms infra key config changes reached the application layer.
- On successful authentication, log the KID used to verify the request — with multiple keys/URLs configured, tells us exactly which key authenticated each call.

**Signing side** (`interop-token/interopTokenService.ts`, `createAndSignToken`):
- Log the KMS key id used to sign every produced token, in the shared signing path (covers internal, session, api, consumer, async and integrity tokens across all services). Gives evidence of when the KMS signing-key rotation takes effect per microservice. (Requested by @marco-vit-pagopa.)

## Notes

- JWKS caching is disabled (a fresh client is built per request, see `buildJwksClients` — this avoided PIN-5682), so every read is an actual refresh.
- Verification key selection and all error paths are unchanged: `getSigningKeys().find(kid)` selects the same key `getSigningKey(kid)` did, and every failure case still resolves to `tokenVerificationFailed`.
- KIDs are public key identifiers, not sensitive data.
- Logging is at `info` so it is visible in the environments where the infra migration is verified.