### PR TITLE
refactor(purpose-template-process): avoid one catalog query per eserviceId in getPurposeTemplates by joining in the main query

### DIFF
--- a/packages/purpose-template-process/src/services/readModelServiceSQL.ts
+++ b/packages/purpose-template-process/src/services/readModelServiceSQL.ts
@@ -99,8 +99,7 @@ export type GetPurposeTemplateEServiceTemplatesFilters = {
 
 const getPurposeTemplatesFilters = (
   filters: GetPurposeTemplatesFilters,
-  authData: UIAuthData | M2MAuthData | M2MAdminAuthData,
-  resolvedEServiceTemplateIds: EServiceTemplateId[]
+  authData: UIAuthData | M2MAuthData | M2MAdminAuthData
 ): SQL | undefined => {
   const {
     purposeTitle,
@@ -132,12 +131,13 @@ const getPurposeTemplatesFilters = (
         )
       : undefined;
 
+  // Template-based purpose templates reference an e-service template, not a
+  // concrete e-service. To match by the eserviceIds filter we resolve the
+  // eserviceId -> templateId link directly in SQL via the catalog join added
+  // to the query below (see the leftJoin on eserviceInReadmodelCatalog).
   const templateEserviceMatch =
-    resolvedEServiceTemplateIds.length > 0
-      ? inArray(
-          eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate.eserviceTemplateId,
-          resolvedEServiceTemplateIds
-        )
+    eserviceIds.length > 0
+      ? inArray(eserviceInReadmodelCatalog.id, eserviceIds)
       : undefined;
 
   const eserviceIdsFilter = or(concreteEserviceMatch, templateEserviceMatch);
@@ -269,23 +269,7 @@ export function readModelServiceBuilderSQL({
       { limit, offset }: { limit: number; offset: number },
       authData: UIAuthData | M2MAuthData | M2MAdminAuthData
     ): Promise<ListResult<PurposeTemplate>> {
-      const resolvedEServiceTemplateIds: EServiceTemplateId[] =
-        filters.eserviceIds.length > 0
-          ? (
-              await Promise.all(
-                filters.eserviceIds.map((id) =>
-                  catalogReadModelServiceSQL.getEServiceById(id)
-                )
-              )
-            )
-              .map((e) => e?.data.templateId)
-              .filter(
-                (templateId): templateId is EServiceTemplateId =>
-                  templateId !== undefined
-              )
-          : [];
-
-      const subquery = readModelDB
+      const subqueryBase = readModelDB
         .select(
           withTotalCount({
             purposeTemplateId: purposeTemplateInReadmodelPurposeTemplate.id,
@@ -313,13 +297,24 @@ export function readModelServiceBuilderSQL({
             purposeTemplateRiskAnalysisFormInReadmodelPurposeTemplate.purposeTemplateId
           )
         )
-        .where(
-          getPurposeTemplatesFilters(
-            filters,
-            authData,
-            resolvedEServiceTemplateIds
-          )
-        )
+        .$dynamic();
+
+      // Resolve eserviceId -> templateId inline via the catalog table so that
+      // template-based purpose templates can be matched by the eserviceIds
+      // filter without a separate N+1 round of getEServiceById calls.
+      const subqueryWithCatalog =
+        filters.eserviceIds.length > 0
+          ? subqueryBase.leftJoin(
+              eserviceInReadmodelCatalog,
+              eq(
+                eserviceInReadmodelCatalog.templateId,
+                eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate.eserviceTemplateId
+              )
+            )
+          : subqueryBase;
+
+      const subquery = subqueryWithCatalog
+        .where(getPurposeTemplatesFilters(filters, authData))
         .groupBy(purposeTemplateInReadmodelPurposeTemplate.id)
         .orderBy(
           ascLower(purposeTemplateInReadmodelPurposeTemplate.purposeTitle)


### PR DESCRIPTION
## What

`getPurposeTemplates` in `readModelServiceSQL.ts` resolved `eserviceId -> templateId` with one `getEServiceById` call per `eserviceId` (parallelized, but still N+1) before running the main list query.

This folds the resolution into the main SQL query: a conditional `leftJoin` on the catalog e-service table (`catalog.templateId = eserviceTemplateVersion.eserviceTemplateId`), matching template-linked purpose templates via `inArray(catalog.id, eserviceIds)`.

## Details

- The join is added only when `eserviceIds` filter is present, avoiding row multiplication when unused.
- `groupBy(purposeTemplate.id)` collapses join duplicates; the `or(concreteMatch, templateMatch)` OR logic is preserved.
- `totalCount` unaffected: `COUNT(*) OVER()` is evaluated after `GROUP BY`, so the extra join multiplies only pre-collapse rows.

## Behavior

Unchanged. Template-based purpose templates are still matched version-independently through their originating template. Queries drop from `1 + N` to `1`.

## Testing

Typecheck passes. Existing integration tests in `test/integration/getPurposeTemplates.test.ts` cover concrete links, template-instance resolution, both, and multi-id cases.