### PR TITLE
fix: return 404 instead of 403 when deleting a draft e-service template as a non-creator (PIN-8052)

### DIFF
--- a/packages/eservice-template-process/src/services/eserviceTemplateService.ts
+++ b/packages/eservice-template-process/src/services/eserviceTemplateService.ts
@@ -120,6 +120,7 @@ import {
   assertIsReceiveTemplate,
   assertIsDraftEServiceTemplate,
   assertRequesterEServiceTemplateCreator,
+  assertEServiceTemplateVisibleToRequester,
   assertNoDraftEServiceTemplateVersions,
   versionStatesNotAllowingDocumentOperations,
   assertConsistentDailyCalls,
@@ -946,6 +947,7 @@ export function eserviceTemplateServiceBuilder(
         readModelService
       );
 
+      assertEServiceTemplateVisibleToRequester(eserviceTemplate.data, authData);
       assertRequesterEServiceTemplateCreator(
         eserviceTemplate.data.creatorId,
         authData
@@ -2151,6 +2153,7 @@ export function eserviceTemplateServiceBuilder(
         templateId,
         readModelService
       );
+      assertEServiceTemplateVisibleToRequester(eserviceTemplate.data, authData);
       assertRequesterEServiceTemplateCreator(
         eserviceTemplate.data.creatorId,
         authData

--- a/packages/eservice-template-process/src/services/validators.ts
+++ b/packages/eservice-template-process/src/services/validators.ts
@@ -24,6 +24,7 @@ import { match } from "ts-pattern";
 import {
   draftEServiceTemplateVersionAlreadyExists,
   templateNotInReceiveMode,
+  eserviceTemplateNotFound,
   eserviceTemplateNotInDraftState,
   inconsistentDailyCalls,
   eserviceTemplateWithoutPublishedVersion,
@@ -44,6 +45,27 @@ export function assertRequesterEServiceTemplateCreator(
 ): void {
   if (authData.organizationId !== creatorId) {
     throw operationForbidden;
+  }
+}
+
+/**
+ * Asserts that the requester can see the e-service template.
+ * Non-creators have no visibility on templates that have only draft
+ * versions, so those must appear as not-found (404) instead of leaking
+ * their existence with a forbidden (403).
+ */
+export function assertEServiceTemplateVisibleToRequester(
+  eserviceTemplate: EServiceTemplate,
+  authData: UIAuthData | M2MAdminAuthData
+): void {
+  const hasPublishedVersions = eserviceTemplate.versions.some(
+    (v) => v.state !== eserviceTemplateVersionState.draft
+  );
+  if (
+    authData.organizationId !== eserviceTemplate.creatorId &&
+    !hasPublishedVersions
+  ) {
+    throw eserviceTemplateNotFound(eserviceTemplate.id);
   }
 }
 

--- a/packages/eservice-template-process/test/integration/deleteEServiceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/integration/deleteEServiceTemplateVersion.test.ts
@@ -346,7 +346,7 @@ describe("deleteEServiceTemplateVersion", () => {
     ).rejects.toThrowError(eserviceTemplateNotFound(mockEServiceTemplate.id));
   });
 
-  it("should throw operationForbidden if the requester is not the eservice template creator", async () => {
+  it("should throw eserviceTemplateNotFound if the requester is not the creator and the eservice template has only draft versions", async () => {
     const eserviceTemplateVersion = getMockEServiceTemplateVersion();
     const eserviceTemplate: EServiceTemplate = {
       ...getMockEServiceTemplate(),
@@ -354,10 +354,37 @@ describe("deleteEServiceTemplateVersion", () => {
     };
     await addOneEServiceTemplate(eserviceTemplate);
 
-    expect(
+    await expect(
       eserviceTemplateService.deleteEServiceTemplateVersion(
         eserviceTemplate.id,
         eserviceTemplateVersion.id,
+        getMockContext({})
+      )
+    ).rejects.toThrowError(eserviceTemplateNotFound(eserviceTemplate.id));
+  });
+
+  it("should throw operationForbidden if the requester is not the creator and the eservice template has published versions", async () => {
+    const publishedVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      version: 1,
+      state: eserviceTemplateVersionState.published,
+      publishedAt: new Date(),
+    };
+    const draftVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      version: 2,
+      state: eserviceTemplateVersionState.draft,
+    };
+    const eserviceTemplate: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      versions: [publishedVersion, draftVersion],
+    };
+    await addOneEServiceTemplate(eserviceTemplate);
+
+    await expect(
+      eserviceTemplateService.deleteEServiceTemplateVersion(
+        eserviceTemplate.id,
+        draftVersion.id,
         getMockContext({})
       )
     ).rejects.toThrowError(operationForbidden);

--- a/packages/eservice-template-process/test/integration/deleteEserviceTemplate.test.ts
+++ b/packages/eservice-template-process/test/integration/deleteEserviceTemplate.test.ts
@@ -231,11 +231,31 @@ describe("delete eserviceTemplate", () => {
     ).rejects.toThrowError(eserviceTemplateNotFound(mockEServiceTemplate.id));
   });
 
-  it("should throw operationForbidden if the requester is not the creator", async () => {
+  it("should throw eserviceTemplateNotFound if the requester is not the creator and the eserviceTemplate has only draft versions", async () => {
     await addOneEServiceTemplate(mockEServiceTemplate);
-    expect(
+    await expect(
       eserviceTemplateService.deleteEServiceTemplate(
         mockEServiceTemplate.id,
+        getMockContext({})
+      )
+    ).rejects.toThrowError(eserviceTemplateNotFound(mockEServiceTemplate.id));
+  });
+
+  it("should throw operationForbidden if the requester is not the creator and the eserviceTemplate has published versions", async () => {
+    const eserviceTemplate: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      versions: [
+        {
+          ...getMockEServiceTemplateVersion(),
+          state: eserviceTemplateVersionState.published,
+          publishedAt: new Date(),
+        },
+      ],
+    };
+    await addOneEServiceTemplate(eserviceTemplate);
+    await expect(
+      eserviceTemplateService.deleteEServiceTemplate(
+        eserviceTemplate.id,
         getMockContext({})
       )
     ).rejects.toThrowError(operationForbidden);


### PR DESCRIPTION
## What

Deleting an e-service template (or a template version) in `DRAFT` state as a user belonging to a tenant different from the creator now returns **404** instead of **403**.

A non-creator tenant has no visibility on unpublished (`DRAFT`) e-service templates of other tenants — a `GET` of such a template already correctly returns 404. Returning 403 on delete implicitly disclosed the template's existence.

## Behavior

- **DRAFT (non-creator):** now `404` (was `403`) — existence is no longer disclosed.
- **non-DRAFT (non-creator):** stays `403` — third parties do have visibility on published templates, so hiding existence is not warranted. Unchanged.
- **Creator:** unchanged.

## Endpoints affected

- M2M: `DELETE /eserviceTemplates/{templateId}`
- BFF: `DELETE /eservices/templates/{eServiceTemplateId}/versions/{eServiceTemplateVersionId}`

## Implementation

- New `assertEServiceTemplateVisibleToRequester` validator, mirroring the existing `GET` visibility rule (`applyVisibilityToEServiceTemplate`): a non-creator viewing a template with only draft versions gets `eserviceTemplateNotFound` (404).
- Applied before the creator check in `deleteEServiceTemplate` and `deleteEServiceTemplateVersion`.
- The 404 propagates unchanged through the m2m-gateway and BFF (`problemErrorsPassthrough`).

## Tests

Updated/added integration tests for both delete functions:
- non-creator + draft-only → 404
- non-creator + published version → 403

Full `eservice-template-process` suite passes (332 tests).

TA: `[INTEROP-EST-M2M-DELETE_05_A]`, `[INTEROP-EST-080]`
