### PR TITLE
test: re-enable multipart file upload checks (PIN-7956)

### DIFF
--- a/packages/commons/src/router/multipartMiddlewares.ts
+++ b/packages/commons/src/router/multipartMiddlewares.ts
@@ -17,6 +17,9 @@ export const fromFilesToBodyMiddleware: ZodiosRouterContextRequestHandler<
       // eslint-disable-next-line functional/immutable-data
       req.body[file.fieldname] = new File([file.buffer], file.originalname, {
         type: file.mimetype,
+        // Use new Date() (instead of the default lower-level clock) so that the
+        // lastModified timestamp can be mocked via fake timers in tests.
+        lastModified: new Date().getTime(),
       });
     });
   }

--- a/packages/m2m-gateway-v3/test/api/agreements/uploadAgreementConsumerDocument.test.ts
+++ b/packages/m2m-gateway-v3/test/api/agreements/uploadAgreementConsumerDocument.test.ts
@@ -11,6 +11,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileUpload,
   addMultipartFileToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -71,7 +72,7 @@ describe("POST /agreements/:agreementId/consumerDocuments router test", () => {
       ).toHaveBeenCalledWith(
         agreementId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
         }),
         expect.any(Object) // Context object

--- a/packages/m2m-gateway-v3/test/api/eServiceTemplates/uploadEServiceTemplateVersionDocument.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eServiceTemplates/uploadEServiceTemplateVersionDocument.test.ts
@@ -10,6 +10,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileUpload,
   addMultipartFileToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -80,7 +81,7 @@ describe("POST /eserviceTemplates/:templateId/versions/:versionId/documents rout
         templateId,
         versionId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
         }),
         expect.any(Object) // Context object

--- a/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorAsyncExchangeCallbackInterface.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorAsyncExchangeCallbackInterface.test.ts
@@ -10,6 +10,7 @@ import { appBasePath } from "../../../src/config/appBasePath.js";
 import {
   TestMultipartFileUpload,
   addMultipartFileToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 
 describe("POST /eservices/:eserviceId/descriptors/:descriptorId/asyncExchangeCallbackInterface router test", () => {
@@ -78,7 +79,7 @@ describe("POST /eservices/:eserviceId/descriptors/:descriptorId/asyncExchangeCal
         eserviceId,
         descriptorId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
         }),
         expect.any(Object)

--- a/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorDocument.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorDocument.test.ts
@@ -10,6 +10,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileUpload,
   addMultipartFileToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -80,7 +81,7 @@ describe("POST /eservices/:eserviceId/descriptors/:descriptorId/documents router
         eserviceId,
         descriptorId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
         }),
         expect.any(Object) // Context object

--- a/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
@@ -15,6 +15,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileUpload,
   addMultipartFileToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -85,7 +86,7 @@ describe("POST /eservices/:eserviceId/descriptors/:descriptorId/interface router
         eserviceId,
         descriptorId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
         }),
         expect.any(Object) // Context object

--- a/packages/m2m-gateway-v3/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
+++ b/packages/m2m-gateway-v3/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
@@ -15,6 +15,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileAnnotationDocumentUpload,
   addTestMultipartFileAnnotationDocumentToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -79,7 +80,7 @@ describe("POST /purposeTemplates/:purposeTemplateId/riskAnalysis/annotationDocum
       ).toHaveBeenCalledWith(
         purposeTemplateId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
           answerId: mockFileUpload.answerId,
         }),

--- a/packages/m2m-gateway-v3/test/multipartTestUtils.ts
+++ b/packages/m2m-gateway-v3/test/multipartTestUtils.ts
@@ -117,6 +117,17 @@ export function addTestMultipartFileAnnotationDocumentToSupertestRequest(
   return req;
 }
 
+export function fileFromTestMultipartFileUpload(
+  file: TestMultipartFileUpload
+): File {
+  return new File([file.fileContent], file.filename, {
+    type: file.contentType,
+    // Must match the lastModified set in the multipart middleware. Both use
+    // new Date() so the timestamp is mocked consistently via fake timers.
+    lastModified: new Date().getTime(),
+  });
+}
+
 async function expectFilesToBeEqual(file1: File, file2: File): Promise<void> {
   expect(file1.name).toEqual(file2.name);
   expect(file1.type).toEqual(file2.type);

--- a/packages/m2m-gateway/test/api/agreements/uploadAgreementConsumerDocument.test.ts
+++ b/packages/m2m-gateway/test/api/agreements/uploadAgreementConsumerDocument.test.ts
@@ -11,6 +11,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileUpload,
   addMultipartFileToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -70,7 +71,7 @@ describe("POST /agreements/:agreementId/consumerDocuments router test", () => {
       ).toHaveBeenCalledWith(
         agreementId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
         }),
         expect.any(Object) // Context object

--- a/packages/m2m-gateway/test/api/eServiceTemplates/uploadEServiceTemplateVersionDocument.test.ts
+++ b/packages/m2m-gateway/test/api/eServiceTemplates/uploadEServiceTemplateVersionDocument.test.ts
@@ -10,6 +10,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileUpload,
   addMultipartFileToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -79,7 +80,7 @@ describe("POST /eserviceTemplates/:templateId/versions/:versionId/documents rout
         templateId,
         versionId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
         }),
         expect.any(Object) // Context object

--- a/packages/m2m-gateway/test/api/eservices/uploadEServiceDescriptorDocument.test.ts
+++ b/packages/m2m-gateway/test/api/eservices/uploadEServiceDescriptorDocument.test.ts
@@ -10,6 +10,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileUpload,
   addMultipartFileToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -79,7 +80,7 @@ describe("POST /eservices/:eserviceId/descriptors/:descriptorId/documents router
         eserviceId,
         descriptorId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
         }),
         expect.any(Object) // Context object

--- a/packages/m2m-gateway/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
+++ b/packages/m2m-gateway/test/api/eservices/uploadEServiceDescriptorInterface.test.ts
@@ -11,6 +11,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileUpload,
   addMultipartFileToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -80,7 +81,7 @@ describe("POST /eservices/:eserviceId/descriptors/:descriptorId/interface router
         eserviceId,
         descriptorId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
         }),
         expect.any(Object) // Context object

--- a/packages/m2m-gateway/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
+++ b/packages/m2m-gateway/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
@@ -15,6 +15,7 @@ import { missingMetadata } from "../../../src/model/errors.js";
 import {
   TestMultipartFileAnnotationDocumentUpload,
   addTestMultipartFileAnnotationDocumentToSupertestRequest,
+  fileFromTestMultipartFileUpload,
 } from "../../multipartTestUtils.js";
 import { config } from "../../../src/config/config.js";
 
@@ -78,7 +79,7 @@ describe("POST /purposeTemplates/:purposeTemplateId/riskAnalysis/annotationDocum
       ).toHaveBeenCalledWith(
         purposeTemplateId,
         expect.objectContaining({
-          file: expect.any(File),
+          file: fileFromTestMultipartFileUpload(mockFileUpload),
           prettyName: mockFileUpload.prettyName,
           answerId: mockFileUpload.answerId,
         }),

--- a/packages/m2m-gateway/test/multipartTestUtils.ts
+++ b/packages/m2m-gateway/test/multipartTestUtils.ts
@@ -117,6 +117,17 @@ export function addTestMultipartFileAnnotationDocumentToSupertestRequest(
   return req;
 }
 
+export function fileFromTestMultipartFileUpload(
+  file: TestMultipartFileUpload
+): File {
+  return new File([file.fileContent], file.filename, {
+    type: file.contentType,
+    // Must match the lastModified set in the multipart middleware. Both use
+    // new Date() so the timestamp is mocked consistently via fake timers.
+    lastModified: new Date().getTime(),
+  });
+}
+
 async function expectFilesToBeEqual(file1: File, file2: File): Promise<void> {
   expect(file1.name).toEqual(file2.name);
   expect(file1.type).toEqual(file2.type);


### PR DESCRIPTION
## Issue

Multipart file upload API tests had their file assertion weakened to `expect.any(File)` (PRs #2486 / #2586, tracked in PIN-7956) because they were flaky in CI.

Root cause: the `File` built by the multipart middleware and the expected `File` in the test got different `lastModified` timestamps. `File.lastModified` defaults to a low-level clock that `vi.setSystemTime` cannot mock, so mocking system time alone did not make the two timestamps match — the deep `File` comparison in `toHaveBeenCalledWith` flaked.

## Fix

Pass an explicit `lastModified: new Date().getTime()` in both:
- the multipart middleware (`packages/commons/src/router/multipartMiddlewares.ts`), and
- the re-added `fileFromTestMultipartFileUpload` test helper (both `m2m-gateway` and `m2m-gateway-v3`).

`new Date().getTime()` is mockable by `vi.setSystemTime`, and both call sites use the identical expression, so under fake timers the two `File`s carry the same `lastModified` and the full comparison is deterministic.

The 11 upload API tests already mock system time; their assertions are restored from `file: expect.any(File)` to a full `File` comparison via `file: fileFromTestMultipartFileUpload(mockFileUpload)`.

## Changes

- `commons`: explicit `lastModified` on the middleware `File`.
- `m2m-gateway` + `m2m-gateway-v3`: re-added `fileFromTestMultipartFileUpload` helper with explicit `lastModified`.
- 11 upload API tests across both packages: restored strict `File` assertion + import.

## Verification

- Upload API test suites pass in both packages (v3: 151, m2m-gateway: 130).
- `tsc` check + `eslint` clean on `commons`, `m2m-gateway`, `m2m-gateway-v3`.
- No remaining `expect.any(File)` in upload/multipart tests.
