### PR TITLE
fix: forward full version seed on eservice template creation (PIN-9924)

### DIFF
--- a/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
@@ -129,7 +129,8 @@ export function toCatalogCreateEServiceTemplateSeed(
   return {
     ...eServiceTemplateSeed,
     version: {
-      voucherLifespan: 60,
+      ...eServiceTemplateSeed.version,
+      voucherLifespan: eServiceTemplateSeed.version?.voucherLifespan ?? 60,
     },
   };
 }

--- a/packages/backend-for-frontend/test/api/eserviceTemplateRouter/createEServiceTemplate.test.ts
+++ b/packages/backend-for-frontend/test/api/eserviceTemplateRouter/createEServiceTemplate.test.ts
@@ -44,6 +44,28 @@ describe("API POST /eservices/templates", () => {
     expect(res.body).toEqual(mockEServiceTemplate);
   });
 
+  it("Should forward the whole version seed (voucherLifespan, dailyCallsPerConsumer, dailyCallsTotal, description, agreementApprovalPolicy) to the process (PIN-9924)", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const version: bffApi.VersionSeedForEServiceTemplateCreation = {
+      description: "a".repeat(10),
+      voucherLifespan: 86400,
+      dailyCallsPerConsumer: 3,
+      dailyCallsTotal: 7,
+      agreementApprovalPolicy: "MANUAL",
+    };
+    const res = await makeRequest(token, {
+      ...mockEServiceTemplateSeed,
+      version,
+    });
+    expect(res.status).toBe(200);
+    expect(
+      clients.eserviceTemplateProcessClient.createEServiceTemplate
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ version }),
+      expect.anything()
+    );
+  });
+
   it.each([
     { body: {} },
     {


### PR DESCRIPTION
## Jira Issue

[PIN-9924](https://pagopa.atlassian.net/browse/PIN-9924)

## Context

When creating an e-service template via `POST /eservices/templates` with `dailyCallsPerConsumer` and `dailyCallsTotal` in the seed's `version`, those fields were not returned by the subsequent `GET /eservices/templates/{id}/versions/{versionId}`. The submitted `voucherLifespan` was also always replaced with `60`. This was not an eventual consistency issue: the BFF dropped the data before it reached `eservice-template-process`, so it was never persisted. The root cause was `toCatalogCreateEServiceTemplateSeed`, which overwrote the whole `version` object with a hardcoded `{ voucherLifespan: 60 }`.

## Services Affected

- backend-for-frontend

## Key Changes

- Changed `toCatalogCreateEServiceTemplateSeed` to forward the entire received `version` seed (`dailyCallsPerConsumer`, `dailyCallsTotal`, `description`, `agreementApprovalPolicy` and the real `voucherLifespan`) instead of the hardcoded `{ voucherLifespan: 60 }`, keeping `60` only as a fallback for `voucherLifespan`.
- Added a regression test on `POST /eservices/templates` asserting that the full version seed is forwarded to the process client.

## Checklist

- [x] Branch name contains the Jira key
- [x] PR title follows the format: type: description (KEY)
- [x] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection updated (if required)

[PIN-9924]: https://pagopa.atlassian.net/browse/PIN-9924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ