### PR TITLE
chore: enable complexity lint warning (PIN-10575)

### DIFF
--- a/packages/eslint-config/node.mjs
+++ b/packages/eslint-config/node.mjs
@@ -55,7 +55,7 @@ export default [
           destructuredArrayIgnorePattern: "^_",
         },
       ],
-      "complexity": "off",
+      "complexity": "warn",
       "max-lines-per-function": "off",
       "perfectionist/sort-array-includes": "off",
       "perfectionist/sort-classes": "off",


### PR DESCRIPTION
## Issue
- [PIN-10575](https://pagopa.atlassian.net/browse/PIN-10575)

## Context / Why
- PR #3009 left high-impact rules disabled so they could be adopted incrementally.
- `complexity` requires targeted refactors, so it is introduced as a warning first.

## Scope
- Enable `complexity` as `warn`.

## Testing / Validation
- [x] Lint
- [x] Type check

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [ ] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10575]: https://pagopa.atlassian.net/browse/PIN-10575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ