### PR TITLE
chore: enable max lines lint warning (PIN-10576)

### DIFF
--- a/packages/eslint-config/node.mjs
+++ b/packages/eslint-config/node.mjs
@@ -56,7 +56,7 @@ export default [
         },
       ],
       "complexity": "off",
-      "max-lines-per-function": "off",
+      "max-lines-per-function": "warn",
       "perfectionist/sort-array-includes": "off",
       "perfectionist/sort-classes": "off",
       "perfectionist/sort-decorators": "off",


### PR DESCRIPTION
## Issue
- [PIN-10576](https://pagopa.atlassian.net/browse/PIN-10576)

## Context / Why
- PR #3009 left high-impact rules disabled so they could be adopted incrementally.
- `max-lines-per-function` requires targeted refactors, so it is introduced as a warning first.

## Scope
- Enable `max-lines-per-function` as `warn`.

## Testing / Validation
- [x] Lint
- [x] Type Check

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [ ] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10576]: https://pagopa.atlassian.net/browse/PIN-10576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ