### PR TITLE
PIN-10591 Fix async interface in cloneDescriptor

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -2196,6 +2196,35 @@ export function catalogServiceBuilder(
             }
           : undefined;
 
+      const clonedAsyncExchangeCallbackInterfaceId =
+        generateId<EServiceDocumentId>();
+      const clonedAsyncExchangeCallbackInterfacePath =
+        descriptor.asyncExchangeCallbackInterface !== undefined
+          ? await fileManager.copy(
+              config.s3Bucket,
+              descriptor.asyncExchangeCallbackInterface.path,
+              config.eserviceDocumentsPath,
+              clonedAsyncExchangeCallbackInterfaceId,
+              descriptor.asyncExchangeCallbackInterface.name,
+              logger
+            )
+          : undefined;
+
+      const clonedAsyncExchangeCallbackInterfaceDocument: Document | undefined =
+        descriptor.asyncExchangeCallbackInterface !== undefined &&
+        clonedAsyncExchangeCallbackInterfacePath !== undefined
+          ? {
+              id: clonedAsyncExchangeCallbackInterfaceId,
+              name: descriptor.asyncExchangeCallbackInterface.name,
+              contentType:
+                descriptor.asyncExchangeCallbackInterface.contentType,
+              prettyName: descriptor.asyncExchangeCallbackInterface.prettyName,
+              path: clonedAsyncExchangeCallbackInterfacePath,
+              checksum: descriptor.asyncExchangeCallbackInterface.checksum,
+              uploadDate: new Date(),
+            }
+          : undefined;
+
       const clonedDocuments = await Promise.all(
         descriptor.docs.map(async (doc: Document) => {
           const clonedDocumentId = generateId<EServiceDocumentId>();
@@ -2236,6 +2265,8 @@ export function catalogServiceBuilder(
             id: generateId(),
             version: "1",
             interface: clonedInterfaceDocument,
+            asyncExchangeCallbackInterface:
+              clonedAsyncExchangeCallbackInterfaceDocument,
             docs: clonedDocuments,
             state: descriptorState.draft,
             createdAt: new Date(),

--- a/packages/catalog-process/test/integration/cloneDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/cloneDescriptor.test.ts
@@ -81,11 +81,19 @@ describe("clone descriptor", () => {
       name: `${mockDocument.name}_interface`,
       path: `${config.eserviceDocumentsPath}/${interfaceId}/${mockDocument.name}_interface`,
     };
+    const asyncExchangeCallbackInterfaceId = generateId<EServiceDocumentId>();
+    const asyncExchangeCallbackInterfaceDoc: Document = {
+      ...mockDocument,
+      id: asyncExchangeCallbackInterfaceId,
+      name: `${mockDocument.name}_async_callback`,
+      path: `${config.eserviceDocumentsPath}/${asyncExchangeCallbackInterfaceId}/${mockDocument.name}_async_callback`,
+    };
 
     const descriptor: Descriptor = {
       ...mockDescriptor,
       state: descriptorState.draft,
       interface: interfaceDocument,
+      asyncExchangeCallbackInterface: asyncExchangeCallbackInterfaceDoc,
       docs: [document1, document2],
     };
     const eservice: EService = {
@@ -129,6 +137,17 @@ describe("clone descriptor", () => {
       genericLogger
     );
 
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.eserviceDocumentsPath,
+        resourceId: asyncExchangeCallbackInterfaceDoc.id,
+        name: asyncExchangeCallbackInterfaceDoc.name,
+        content: Buffer.from("testtest"),
+      },
+      genericLogger
+    );
+
     expect(
       await fileManager.listFiles(config.s3Bucket, genericLogger)
     ).toContain(interfaceDocument.path);
@@ -138,6 +157,9 @@ describe("clone descriptor", () => {
     expect(
       await fileManager.listFiles(config.s3Bucket, genericLogger)
     ).toContain(document2.path);
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).toContain(asyncExchangeCallbackInterfaceDoc.path);
 
     const cloneTimestamp = new Date();
     const newEService = await catalogService.cloneDescriptor(
@@ -180,12 +202,26 @@ describe("clone descriptor", () => {
       ),
       path: writtenPayload.eservice!.descriptors[0].docs[1].path,
     };
+    const expectedAsyncExchangeCallbackInterface: Document = {
+      ...asyncExchangeCallbackInterfaceDoc,
+      id: unsafeBrandId(
+        writtenPayload.eservice!.descriptors[0].asyncExchangeCallbackInterface!
+          .id
+      ),
+      uploadDate: new Date(
+        writtenPayload.eservice!.descriptors[0].asyncExchangeCallbackInterface!
+          .uploadDate
+      ),
+      path: writtenPayload.eservice!.descriptors[0]
+        .asyncExchangeCallbackInterface!.path,
+    };
 
     const expectedDescriptor: Descriptor = {
       ...descriptor,
       id: unsafeBrandId(writtenPayload.eservice!.descriptors[0].id),
       version: "1",
       interface: expectedInterface,
+      asyncExchangeCallbackInterface: expectedAsyncExchangeCallbackInterface,
       createdAt: new Date(
         Number(writtenPayload.eservice?.descriptors[0].createdAt)
       ),
@@ -236,6 +272,14 @@ describe("clone descriptor", () => {
       expectedDocument2.name,
       genericLogger
     );
+    expect(fileManager.copy).toHaveBeenCalledWith(
+      config.s3Bucket,
+      asyncExchangeCallbackInterfaceDoc.path,
+      config.eserviceDocumentsPath,
+      expectedAsyncExchangeCallbackInterface.id,
+      expectedAsyncExchangeCallbackInterface.name,
+      genericLogger
+    );
     expect(
       await fileManager.listFiles(config.s3Bucket, genericLogger)
     ).toContain(expectedInterface.path);
@@ -245,6 +289,9 @@ describe("clone descriptor", () => {
     expect(
       await fileManager.listFiles(config.s3Bucket, genericLogger)
     ).toContain(expectedDocument2.path);
+    expect(
+      await fileManager.listFiles(config.s3Bucket, genericLogger)
+    ).toContain(expectedAsyncExchangeCallbackInterface.path);
   });
   it("should truncate cloned eService name to 60 characters when original name plus suffix exceeds limit", async () => {
     vi.spyOn(fileManager, "copy");


### PR DESCRIPTION
[PIN-10591](https://pagopa.atlassian.net/browse/PIN-10591)

This PR fixes how the async interface is handled in the cloneDescriptor operation. The id of the interface has to be re-generated and the file has to be actually copied. Both of these were missing.

[PIN-10591]: https://pagopa.atlassian.net/browse/PIN-10591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ