### PR TITLE
refactor(readmodel): sort descriptor rejectionReasons by rejectedAt

### DIFF
--- a/packages/readmodel/src/catalog/aggregators.ts
+++ b/packages/readmodel/src/catalog/aggregators.ts
@@ -132,10 +132,12 @@ export const aggregateDescriptor = ({
   const declaredAttributes = attributesSQLtoAttributes(declaredAttributesSQL);
   const verifiedAttributes = attributesSQLtoAttributes(verifiedAttributesSQL);
 
-  const rejectionReasonsArray = rejectionReasonsSQL.map((rejectionReason) => ({
-    rejectionReason: rejectionReason.rejectionReason,
-    rejectedAt: stringToDate(rejectionReason.rejectedAt),
-  }));
+  const rejectionReasonsArray = rejectionReasonsSQL
+    .map((rejectionReason) => ({
+      rejectionReason: rejectionReason.rejectionReason,
+      rejectedAt: stringToDate(rejectionReason.rejectedAt),
+    }))
+    .sort((r1, r2) => r1.rejectedAt.getTime() - r2.rejectedAt.getTime());
   const rejectionReasons =
     rejectionReasonsArray.length > 0 ? rejectionReasonsArray : undefined;
 

--- a/packages/readmodel/test/catalog/eserviceAggregator.test.ts
+++ b/packages/readmodel/test/catalog/eserviceAggregator.test.ts
@@ -12,6 +12,7 @@ import {
   ArchivingSchedule,
   archivingScope,
   Descriptor,
+  DescriptorRejectionReason,
   EService,
   EServiceAddedV2,
   EServiceAttribute,
@@ -302,5 +303,71 @@ describe("E-service aggregator", () => {
         eservice: toEServiceV2(aggregatedEservice.data),
       });
     }
+  });
+
+  it("should sort the descriptor rejectionReasons by rejectedAt ascending", () => {
+    const rejectionReasonOld: DescriptorRejectionReason = {
+      rejectionReason: "old",
+      rejectedAt: new Date("2020-01-01T00:00:00.000Z"),
+    };
+    const rejectionReasonMiddle: DescriptorRejectionReason = {
+      rejectionReason: "middle",
+      rejectedAt: new Date("2021-06-15T00:00:00.000Z"),
+    };
+    const rejectionReasonRecent: DescriptorRejectionReason = {
+      rejectionReason: "recent",
+      rejectedAt: new Date("2023-12-31T00:00:00.000Z"),
+    };
+
+    const descriptor: Descriptor = {
+      ...getMockDescriptor(),
+      // Intentionally unsorted
+      rejectionReasons: [
+        rejectionReasonRecent,
+        rejectionReasonOld,
+        rejectionReasonMiddle,
+      ],
+    };
+
+    const eservice: EService = {
+      ...getMockEService(),
+      descriptors: [descriptor],
+    };
+
+    const {
+      eserviceSQL,
+      riskAnalysesSQL,
+      riskAnalysisAnswersSQL,
+      descriptorsSQL,
+      attributesSQL,
+      interfacesSQL,
+      documentsSQL,
+      rejectionReasonsSQL,
+      templateVersionRefsSQL,
+      archivingSchedulesSQL,
+      asyncExchangePropertiesSQL,
+    } = splitEserviceIntoObjectsSQL(eservice, 1);
+
+    const aggregatedEservice = aggregateEservice({
+      eserviceSQL,
+      riskAnalysesSQL,
+      riskAnalysisAnswersSQL,
+      descriptorsSQL,
+      attributesSQL,
+      interfacesSQL,
+      documentsSQL,
+      rejectionReasonsSQL,
+      templateVersionRefsSQL,
+      archivingSchedulesSQL,
+      asyncExchangePropertiesSQL,
+    });
+
+    expect(
+      aggregatedEservice.data.descriptors[0].rejectionReasons
+    ).toStrictEqual([
+      rejectionReasonOld,
+      rejectionReasonMiddle,
+      rejectionReasonRecent,
+    ]);
   });
 });


### PR DESCRIPTION
## Description

Sort the `rejectionReasons` array of the descriptor ascending by `rejectedAt` inside `aggregateDescriptor`, so the aggregated descriptor has a deterministic, chronological ordering.

Added a test asserting that unsorted rejection reasons come out ordered by `rejectedAt` ascending.

## Reference
https://github.com/pagopa/interop-be-monorepo/pull/2216#discussion_r2318935377