### PR TITLE
fix: make server_urls_descriptions nullable in catalog read model (PIN-10355)

### DIFF
--- a/.github/workflows/release-version-validation.yaml
+++ b/.github/workflows/release-version-validation.yaml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 env:
-  ALLOWED_RELEASE_TOWARDS_DEVELOP_BRANCH: "2.21.0"
+  ALLOWED_RELEASE_TOWARDS_DEVELOP_BRANCH: "2.22.0"
 
 jobs:
   validate-develop:

--- a/docker/readmodel-db/catalog.sql
+++ b/docker/readmodel-db/catalog.sql
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS readmodel_catalog.eservice_descriptor (
   agreement_approval_policy VARCHAR,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   server_urls VARCHAR ARRAY NOT NULL,
-  server_urls_descriptions VARCHAR ARRAY NOT NULL,
+  server_urls_descriptions VARCHAR ARRAY,
   published_at TIMESTAMP WITH TIME ZONE,
   suspended_at TIMESTAMP WITH TIME ZONE,
   deprecated_at TIMESTAMP WITH TIME ZONE,

--- a/packages/notification-commons/src/templates/email/resources/templates/eservice-descriptor-suspended-mail.html
+++ b/packages/notification-commons/src/templates/email/resources/templates/eservice-descriptor-suspended-mail.html
@@ -77,10 +77,11 @@
     >
       <!-- Body 1 Desktop (from MUI Italia)-->
       <p>
-        L'ente erogatore {{ producerName }} ha sospeso la versione {{
-        eserviceVersion }} dell'e-service "{{ eserviceName }}", a cui sei
-        iscritto. Le chiamate a questa versione sono temporaneamente bloccate
-        fino alla riattivazione dell'e-service.
+        L'ente erogatore {{ producerName }} ha sospeso la versione
+        <strong>{{ eserviceVersion }}</strong> dell'e-service
+        <strong>{{ eserviceName }}</strong>, a cui sei iscritto. Le chiamate a
+        questa versione sono temporaneamente bloccate fino alla riattivazione
+        dell'e-service.
       </p>
     </div>
   </td>

--- a/packages/readmodel-models/src/drizzle/schema.ts
+++ b/packages/readmodel-models/src/drizzle/schema.ts
@@ -442,9 +442,7 @@ export const eserviceDescriptorInReadmodelCatalog = readmodelCatalog.table(
       mode: "string",
     }).notNull(),
     serverUrls: varchar("server_urls").array().notNull(),
-    serverUrlsDescriptions: varchar("server_urls_descriptions")
-      .array()
-      .notNull(),
+    serverUrlsDescriptions: varchar("server_urls_descriptions").array(),
     publishedAt: timestamp("published_at", {
       withTimezone: true,
       mode: "string",

--- a/packages/readmodel/src/catalog/aggregators.ts
+++ b/packages/readmodel/src/catalog/aggregators.ts
@@ -183,7 +183,7 @@ export const aggregateDescriptor = ({
     dailyCallsTotal: descriptorSQL.dailyCallsTotal,
     createdAt: stringToDate(descriptorSQL.createdAt),
     serverUrls: descriptorSQL.serverUrls,
-    serverUrlsDescriptions: descriptorSQL.serverUrlsDescriptions,
+    serverUrlsDescriptions: descriptorSQL.serverUrlsDescriptions ?? [],
     attributes: {
       certified: certifiedAttributes,
       declared: declaredAttributes,


### PR DESCRIPTION
## DO NOT MERGE
**THIS PR should be closed, because contains commit from develop that should not entered in release branch.**

## 🔗 Issue

[PIN-10355](https://pagopa.atlassian.net/browse/PIN-10355)

## 📝 Description / Context

Follow-up on the `server_urls_descriptions` read-model column introduced in #3546. This makes the column nullable as a defensive measure for event reprocessing, so that a `NULL` can never surface a DB-level `NOT NULL` constraint error regardless of the write path.

## 🛠 List of changes

- `docker/readmodel-db/catalog.sql`: `server_urls_descriptions` is now nullable (dropped `NOT NULL`).
- `packages/readmodel-models/src/drizzle/schema.ts`: removed `.notNull()` from the `serverUrlsDescriptions` column so the Drizzle type matches the DDL.
- `packages/readmodel/src/catalog/aggregators.ts`: normalize a `NULL`/absent value to `[]` when building the domain object, preserving the domain invariant `Descriptor.serverUrlsDescriptions: string[]`. The domain model, the splitter, the protobuf contract and the BFF are unchanged.

## 🧪 How to test

- Typecheck the affected packages: `pnpm turbo run check --filter=pagopa-interop-readmodel --filter=pagopa-interop-catalog-readmodel-writer-sql`.
- Reprocess an old event (V1, or a pre-field-24 V2) through the catalog read-model writer and confirm the descriptor row is written with `server_urls_descriptions = '{}'` (empty array), with no constraint error.
- On a row stored as `NULL`, confirm the aggregator reads it back as `[]` in the domain object.

[PIN-10355]: https://pagopa.atlassian.net/browse/PIN-10355
