### PR TITLE
feat(PIN-7452): align catalog risk analysis API with purpose and M2M models

### DIFF
--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -3474,55 +3474,22 @@ components:
       required:
         - id
         - version
-        - singleAnswers
-        - multiAnswers
+        - answers
       properties:
         id:
           type: string
           format: uuid
         version:
           type: string
-        singleAnswers:
-          type: array
-          items:
-            $ref: "#/components/schemas/EServiceRiskAnalysisSingleAnswer"
-        multiAnswers:
-          type: array
-          items:
-            $ref: "#/components/schemas/EServiceRiskAnalysisMultiAnswer"
+        answers:
+          additionalProperties:
+            type: array
+            items:
+              type: string
+              minLength: 1
+              maxLength: 2000
         tenantKind:
           $ref: "#/components/schemas/TenantKind"
-    EServiceRiskAnalysisSingleAnswer:
-      type: object
-      additionalProperties: false
-      required:
-        - id
-        - key
-      properties:
-        id:
-          type: string
-          format: uuid
-        key:
-          type: string
-        value:
-          type: string
-    EServiceRiskAnalysisMultiAnswer:
-      type: object
-      additionalProperties: false
-      required:
-        - id
-        - key
-        - values
-      properties:
-        id:
-          type: string
-          format: uuid
-        key:
-          type: string
-        values:
-          type: array
-          items:
-            type: string
     EServiceConsumers:
       type: object
       additionalProperties: false

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -15,7 +15,10 @@ import {
   unsafeBrandId,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
-import { getRulesetExpiration } from "pagopa-interop-commons";
+import {
+  getRulesetExpiration,
+  riskAnalysisAnswersToApiAnswers,
+} from "pagopa-interop-commons";
 import { attributeNotExists } from "../model/errors.js";
 import {
   getLatestActiveDescriptor,
@@ -202,36 +205,10 @@ export function toBffCatalogApiEserviceRiskAnalysis(
   riskAnalysis: catalogApi.EServiceRiskAnalysis,
   rulesetExpiration: string | undefined
 ): bffApi.EServiceRiskAnalysis {
-  const answers: bffApi.RiskAnalysisForm["answers"] =
-    riskAnalysis.riskAnalysisForm.singleAnswers
-      .concat(
-        riskAnalysis.riskAnalysisForm.multiAnswers.flatMap((multiAnswer) =>
-          multiAnswer.values.map((answerValue) => ({
-            id: multiAnswer.id,
-            value: answerValue,
-            key: multiAnswer.key,
-          }))
-        )
-      )
-      .reduce((answers: bffApi.RiskAnalysisForm["answers"], answer) => {
-        const key = answer.key;
-        if (!answers[key]) {
-          answers[key] = [];
-        }
-
-        if (answer.value) {
-          answers[key] = [...answers[key], answer.value];
-        } else {
-          answers[key] = [];
-        }
-
-        return answers;
-      }, {});
-
   const riskAnalysisForm: bffApi.RiskAnalysisForm = {
     riskAnalysisId: riskAnalysis.id,
     version: riskAnalysis.riskAnalysisForm.version,
-    answers,
+    answers: riskAnalysis.riskAnalysisForm.answers,
   };
 
   return {
@@ -246,40 +223,27 @@ export function toBffCatalogApiEserviceRiskAnalysis(
 export function toBffCatalogApiEserviceRiskAnalysisSeed(
   riskAnalysis: ConfigurationRiskAnalysis
 ): bffApi.EServiceRiskAnalysisSeed {
+  const { riskAnalysisForm } = riskAnalysis;
+
+  // Backward compatibility: configuration files exported before the alignment
+  // to the map format still carry single/multi answers instead of `answers`.
   const answers: bffApi.RiskAnalysisForm["answers"] =
-    riskAnalysis.riskAnalysisForm.singleAnswers
-      .concat(
-        riskAnalysis.riskAnalysisForm.multiAnswers.flatMap((multiAnswer) =>
-          multiAnswer.values.map((answerValue) => ({
-            value: answerValue,
-            key: multiAnswer.key,
-          }))
-        )
-      )
-      // eslint-disable-next-line sonarjs/no-identical-functions
-      .reduce((answers: bffApi.RiskAnalysisForm["answers"], answer) => {
-        const key = answer.key;
-        if (!answers[key]) {
-          answers[key] = [];
-        }
-
-        if (answer.value) {
-          answers[key] = [...answers[key], answer.value];
-        } else {
-          answers[key] = [];
-        }
-
-        return answers;
-      }, {});
-
-  const riskAnalysisForm: bffApi.RiskAnalysisForm = {
-    version: riskAnalysis.riskAnalysisForm.version,
-    answers,
-  };
+    "answers" in riskAnalysisForm
+      ? riskAnalysisForm.answers
+      : riskAnalysisAnswersToApiAnswers(
+          riskAnalysisForm.singleAnswers.map((a) => ({
+            key: a.key,
+            value: a.value ?? undefined,
+          })),
+          riskAnalysisForm.multiAnswers
+        );
 
   return {
     name: riskAnalysis.name,
-    riskAnalysisForm,
+    riskAnalysisForm: {
+      version: riskAnalysisForm.version,
+      answers,
+    },
   };
 }
 

--- a/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/eserviceTemplateApiConverter.ts
@@ -4,12 +4,12 @@ import {
   tenantApi,
 } from "pagopa-interop-api-clients";
 import { genericError } from "pagopa-interop-models";
-import { getRulesetExpiration } from "pagopa-interop-commons";
-import { catalogEServiceTemplatePublishedVersionNotFound } from "../model/errors.js";
 import {
-  toBffCatalogApiEserviceRiskAnalysis,
-  toBffCatalogTenant,
-} from "./catalogApiConverter.js";
+  getRulesetExpiration,
+  riskAnalysisAnswersToApiAnswers,
+} from "pagopa-interop-commons";
+import { catalogEServiceTemplatePublishedVersionNotFound } from "../model/errors.js";
+import { toBffCatalogTenant } from "./catalogApiConverter.js";
 import { toBffCompactOrganization } from "./agreementApiConverter.js";
 
 export function toBffCompactEServiceTemplateVersion(
@@ -143,10 +143,18 @@ function toBffEServiceTemplateApiEServiceTemplateRiskAnalysis(
     riskAnalysis.riskAnalysisForm.version
   );
   return {
-    ...toBffCatalogApiEserviceRiskAnalysis(
-      riskAnalysis,
-      rulesetExpiration?.toJSON()
-    ),
+    id: riskAnalysis.id,
+    name: riskAnalysis.name,
+    createdAt: riskAnalysis.createdAt,
+    riskAnalysisForm: {
+      riskAnalysisId: riskAnalysis.id,
+      version: riskAnalysis.riskAnalysisForm.version,
+      answers: riskAnalysisAnswersToApiAnswers(
+        riskAnalysis.riskAnalysisForm.singleAnswers,
+        riskAnalysis.riskAnalysisForm.multiAnswers
+      ),
+    },
+    rulesetExpiration: rulesetExpiration?.toJSON(),
     tenantKind,
   };
 }

--- a/packages/backend-for-frontend/src/model/types.ts
+++ b/packages/backend-for-frontend/src/model/types.ts
@@ -158,11 +158,21 @@ const ConfigurationMultiAnswer = z.object({
 });
 type ConfigurationMultiAnswer = z.infer<typeof ConfigurationMultiAnswer>;
 
-const ConfigurationRiskAnalysisForm = z.object({
+const ConfigurationRiskAnalysisFormAnswersMap = z.object({
+  version: z.string(),
+  answers: z.record(z.array(z.string())),
+});
+
+const ConfigurationRiskAnalysisFormLegacy = z.object({
   version: z.string(),
   singleAnswers: z.array(ConfigurationSingleAnswer),
   multiAnswers: z.array(ConfigurationMultiAnswer),
 });
+
+const ConfigurationRiskAnalysisForm = z.union([
+  ConfigurationRiskAnalysisFormAnswersMap,
+  ConfigurationRiskAnalysisFormLegacy,
+]);
 
 export const ConfigurationRiskAnalysis = z.object({
   name: z.string(),

--- a/packages/backend-for-frontend/src/utilities/fileUtils.ts
+++ b/packages/backend-for-frontend/src/utilities/fileUtils.ts
@@ -112,14 +112,7 @@ function buildJsonConfig(
       name: ra.name,
       riskAnalysisForm: {
         version: ra.riskAnalysisForm.version,
-        singleAnswers: ra.riskAnalysisForm.singleAnswers.map((sa) => ({
-          key: sa.key,
-          value: sa.value,
-        })),
-        multiAnswers: ra.riskAnalysisForm.multiAnswers.map((ma) => ({
-          key: ma.key,
-          values: ma.values,
-        })),
+        answers: ra.riskAnalysisForm.answers,
       },
     })),
   };

--- a/packages/backend-for-frontend/test/exportEServiceDescriptor.test.ts
+++ b/packages/backend-for-frontend/test/exportEServiceDescriptor.test.ts
@@ -16,6 +16,7 @@ import {
 } from "pagopa-interop-api-clients";
 import { getMockAuthData, getMockContext } from "pagopa-interop-commons-test";
 import { AuthData } from "pagopa-interop-commons";
+import AdmZip from "adm-zip";
 import type {
   AuthorizationProcessClient,
   DelegationProcessClient,
@@ -265,6 +266,70 @@ describe("exportEServiceDescriptor", () => {
         filename: zipFileName,
         url: mockPresignedUrl,
       });
+    });
+
+    it("should export the risk analysis using the answers map format", async () => {
+      const answers = {
+        purpose: ["INSTITUTIONAL"],
+        institutionalPurpose: ["MyPurpose"],
+        personalDataTypes: ["OTHER"],
+      };
+
+      const eServiceWithRiskAnalysis: catalogApi.EService = {
+        ...baseEService,
+        riskAnalysis: [
+          {
+            id: generateId(),
+            name: "my risk analysis",
+            createdAt: new Date(mockDate).toISOString(),
+            riskAnalysisForm: {
+              id: generateId(),
+              version: "1.0",
+              answers,
+              tenantKind: "PA",
+            },
+          },
+        ],
+      };
+
+      const { service } = createTestCatalogService(
+        eServiceWithRiskAnalysis,
+        []
+      );
+
+      const storeBytesSpy = vi
+        .spyOn(fileManager, "storeBytes")
+        .mockResolvedValue("mockResourceId");
+      vi.spyOn(fileManager, "generateGetPresignedUrl").mockResolvedValue(
+        "https://mockpresignedurl.com/file.zip"
+      );
+      vi.spyOn(fileManager, "get").mockResolvedValue(
+        Buffer.from("mock interface content")
+      );
+
+      await service.exportEServiceDescriptor(
+        eServiceId,
+        descriptorId,
+        bffMockContext
+      );
+
+      const storedZip = new AdmZip(storeBytesSpy.mock.calls[0][0].content);
+      const configurationEntry = storedZip.getEntry(
+        `${eServiceId}_${descriptorId}/configuration.json`
+      );
+      const exportedConfiguration = JSON.parse(
+        configurationEntry!.getData().toString()
+      );
+
+      expect(exportedConfiguration.riskAnalysis).toEqual([
+        {
+          name: "my risk analysis",
+          riskAnalysisForm: {
+            version: "1.0",
+            answers,
+          },
+        },
+      ]);
     });
   });
 });

--- a/packages/backend-for-frontend/test/importEService.test.ts
+++ b/packages/backend-for-frontend/test/importEService.test.ts
@@ -241,6 +241,143 @@ describe("importEService", () => {
       });
       fs.unlinkSync(zipPath);
     });
+
+    it("should import the risk analysis of a configuration in the answers map format", async () => {
+      const answers = {
+        purpose: ["INSTITUTIONAL"],
+        institutionalPurpose: ["MyPurpose"],
+        personalDataTypes: ["OTHER"],
+      };
+
+      const configurationWithRiskAnalysis = {
+        ...configuration,
+        riskAnalysis: [
+          {
+            name: "my risk analysis",
+            riskAnalysisForm: { version: "1.0", answers },
+          },
+        ],
+      };
+
+      const mockCreateRiskAnalysis = vi.fn().mockResolvedValue(undefined);
+      mockCatalogProcessClient.createRiskAnalysis = mockCreateRiskAnalysis;
+
+      const zipWithRa = new AdmZip();
+      zipWithRa.addFile(
+        jsonFilename,
+        Buffer.from(JSON.stringify(configurationWithRiskAnalysis))
+      );
+
+      const zipPath = path.join(__dirname, "test_ra_answers.zip");
+      zipWithRa.writeZip(zipPath);
+
+      const raFileResource: bffApi.FileResource = {
+        filename: "test_ra_answers.zip",
+        url: "/import/folder",
+      };
+
+      await fileManager.storeBytes(
+        {
+          bucket: config.importEserviceContainer,
+          path: `${config.importEservicePath}`,
+          resourceId: `${tenantId}`,
+          name: `${raFileResource.filename}`,
+          content: fs.readFileSync(zipPath),
+        },
+        genericLogger
+      );
+
+      await catalogService.importEService(raFileResource, bffMockContext);
+
+      expect(mockCreateRiskAnalysis).toHaveBeenCalledWith(
+        {
+          name: "my risk analysis",
+          riskAnalysisForm: { version: "1.0", answers },
+        },
+        {
+          headers: bffMockContext.headers,
+          params: { eServiceId: baseEService.id },
+        }
+      );
+
+      fs.unlinkSync(zipPath);
+    });
+
+    it("should import the risk analysis of a configuration in the legacy single/multi answers format", async () => {
+      const configurationWithLegacyRiskAnalysis = {
+        ...configuration,
+        riskAnalysis: [
+          {
+            name: "legacy risk analysis",
+            riskAnalysisForm: {
+              version: "1.0",
+              singleAnswers: [
+                { key: "purpose", value: "INSTITUTIONAL" },
+                { key: "institutionalPurpose", value: "MyPurpose" },
+                { key: "missingValue" },
+                { key: "nullValue", value: null },
+              ],
+              multiAnswers: [
+                { key: "personalDataTypes", values: ["OTHER"] },
+                { key: "emptyValues", values: [] },
+              ],
+            },
+          },
+        ],
+      };
+
+      const mockCreateRiskAnalysis = vi.fn().mockResolvedValue(undefined);
+      mockCatalogProcessClient.createRiskAnalysis = mockCreateRiskAnalysis;
+
+      const zipWithRa = new AdmZip();
+      zipWithRa.addFile(
+        jsonFilename,
+        Buffer.from(JSON.stringify(configurationWithLegacyRiskAnalysis))
+      );
+
+      const zipPath = path.join(__dirname, "test_ra_legacy.zip");
+      zipWithRa.writeZip(zipPath);
+
+      const raFileResource: bffApi.FileResource = {
+        filename: "test_ra_legacy.zip",
+        url: "/import/folder",
+      };
+
+      await fileManager.storeBytes(
+        {
+          bucket: config.importEserviceContainer,
+          path: `${config.importEservicePath}`,
+          resourceId: `${tenantId}`,
+          name: `${raFileResource.filename}`,
+          content: fs.readFileSync(zipPath),
+        },
+        genericLogger
+      );
+
+      await catalogService.importEService(raFileResource, bffMockContext);
+
+      // legacy single/multi answers are converted to the map format,
+      // skipping the answers with no value
+      expect(mockCreateRiskAnalysis).toHaveBeenCalledWith(
+        {
+          name: "legacy risk analysis",
+          riskAnalysisForm: {
+            version: "1.0",
+            answers: {
+              purpose: ["INSTITUTIONAL"],
+              institutionalPurpose: ["MyPurpose"],
+              personalDataTypes: ["OTHER"],
+            },
+          },
+        },
+        {
+          headers: bffMockContext.headers,
+          params: { eServiceId: baseEService.id },
+        }
+      );
+
+      fs.unlinkSync(zipPath);
+    });
   });
   describe("error case", () => {
     it("should throw invalidZipStructure error when file name is not configuration.json", async () => {

--- a/packages/catalog-process/src/model/domain/apiConverter.ts
+++ b/packages/catalog-process/src/model/domain/apiConverter.ts
@@ -16,6 +16,7 @@ import {
   ArchivingScope,
 } from "pagopa-interop-models";
 import { catalogApi } from "pagopa-interop-api-clients";
+import { riskAnalysisAnswersToApiAnswers } from "pagopa-interop-commons";
 import { match } from "ts-pattern";
 
 export function technologyToApiTechnology(
@@ -235,8 +236,10 @@ export const eServiceToApiEService = (
     riskAnalysisForm: {
       id: riskAnalysis.riskAnalysisForm.id,
       version: riskAnalysis.riskAnalysisForm.version,
-      singleAnswers: riskAnalysis.riskAnalysisForm.singleAnswers,
-      multiAnswers: riskAnalysis.riskAnalysisForm.multiAnswers,
+      answers: riskAnalysisAnswersToApiAnswers(
+        riskAnalysis.riskAnalysisForm.singleAnswers,
+        riskAnalysis.riskAnalysisForm.multiAnswers
+      ),
       tenantKind: riskAnalysis.riskAnalysisForm.tenantKind,
     },
   })),

--- a/packages/commons-test/src/apiMocks.ts
+++ b/packages/commons-test/src/apiMocks.ts
@@ -455,7 +455,27 @@ export function getMockedApiEServiceTemplate({
     isSignalHubEnabled: generateMock(z.boolean().optional()),
     riskAnalysis: [
       {
-        ...getMockedApiRiskAnalysis(),
+        id: generateId(),
+        createdAt: new Date().toISOString(),
+        name: generateMock(z.string().length(10)),
+        riskAnalysisForm: {
+          id: generateId(),
+          version: "0",
+          singleAnswers: [
+            {
+              id: generateId(),
+              key: generateMock(z.string()),
+              value: generateMock(z.string()),
+            },
+          ],
+          multiAnswers: [
+            {
+              id: generateId(),
+              key: generateMock(z.string()),
+              values: generateMock(z.array(z.string())),
+            },
+          ],
+        },
         tenantKind: generateMock(eserviceTemplateApi.TenantKind),
       },
     ],
@@ -470,21 +490,8 @@ export function getMockedApiRiskAnalysis(): catalogApi.EServiceRiskAnalysis {
     name: generateMock(z.string().length(10)),
     riskAnalysisForm: {
       id: generateId(),
-      multiAnswers: [
-        {
-          id: generateId(),
-          key: generateMock(z.string()),
-          values: generateMock(z.array(z.string())),
-        },
-      ],
-      singleAnswers: [
-        {
-          id: generateId(),
-          key: generateMock(z.string()),
-          value: generateMock(z.string()),
-        },
-      ],
       version: "0",
+      answers: generateMock(z.record(z.array(z.string()))),
     },
   };
 }

--- a/packages/commons-test/test/riskAnalysisAnswersToApiAnswers.unit.test.ts
+++ b/packages/commons-test/test/riskAnalysisAnswersToApiAnswers.unit.test.ts
@@ -1,0 +1,55 @@
+import { riskAnalysisAnswersToApiAnswers } from "pagopa-interop-commons";
+import { describe, it, expect } from "vitest";
+
+describe("riskAnalysisAnswersToApiAnswers", () => {
+  it("should merge single and multi answers into a single key-value map, wrapping single answer values in an array", () => {
+    expect(
+      riskAnalysisAnswersToApiAnswers(
+        [
+          { key: "purpose", value: "INSTITUTIONAL" },
+          { key: "legalBasis", value: "LEGAL_OBLIGATION" },
+        ],
+        [
+          {
+            key: "personalDataTypes",
+            values: ["OTHER", "WITH_NON_IDENTIFYING"],
+          },
+        ]
+      )
+    ).toEqual({
+      purpose: ["INSTITUTIONAL"],
+      legalBasis: ["LEGAL_OBLIGATION"],
+      personalDataTypes: ["OTHER", "WITH_NON_IDENTIFYING"],
+    });
+  });
+
+  it("should skip single answers with no value", () => {
+    expect(
+      riskAnalysisAnswersToApiAnswers(
+        [
+          { key: "answered", value: "YES" },
+          { key: "undefinedValue", value: undefined },
+          { key: "missingValue" },
+          { key: "emptyValue", value: "" },
+        ],
+        []
+      )
+    ).toEqual({ answered: ["YES"] });
+  });
+
+  it("should skip multi answers with no values", () => {
+    expect(
+      riskAnalysisAnswersToApiAnswers(
+        [],
+        [
+          { key: "answered", values: ["A", "B"] },
+          { key: "emptyValues", values: [] },
+        ]
+      )
+    ).toEqual({ answered: ["A", "B"] });
+  });
+
+  it("should return an empty map when there are no answers", () => {
+    expect(riskAnalysisAnswersToApiAnswers([], [])).toEqual({});
+  });
+});

--- a/packages/commons/src/risk-analysis/models.ts
+++ b/packages/commons/src/risk-analysis/models.ts
@@ -102,6 +102,22 @@ export function riskAnalysisValidatedFormToNewRiskAnalysisForm(
   };
 }
 
+export function riskAnalysisAnswersToApiAnswers(
+  singleAnswers: Array<{ key: string; value?: string }>,
+  multiAnswers: Array<{ key: string; values: string[] }>
+): Record<string, string[]> {
+  const singleAnswersMap = singleAnswers.reduce<Record<string, string[]>>(
+    (acc, { key, value }) => (value ? { ...acc, [key]: [value] } : acc),
+    {}
+  );
+  const multiAnswersMap = multiAnswers.reduce<Record<string, string[]>>(
+    (acc, { key, values }) =>
+      values.length === 0 ? acc : { ...acc, [key]: values },
+    {}
+  );
+  return { ...singleAnswersMap, ...multiAnswersMap };
+}
+
 export function riskAnalysisFormToRiskAnalysisFormToValidate(
   form: RiskAnalysisForm
 ): RiskAnalysisFormToValidate {

--- a/packages/m2m-gateway-v3/src/api/eserviceTemplateApiConverter.ts
+++ b/packages/m2m-gateway-v3/src/api/eserviceTemplateApiConverter.ts
@@ -2,7 +2,7 @@ import {
   eserviceTemplateApi,
   m2mGatewayApiV3,
 } from "pagopa-interop-api-clients";
-import { toM2MGatewayApiRiskAnalysisForm } from "./riskAnalysisFormApiConverter.js";
+import { riskAnalysisAnswersToApiAnswers } from "pagopa-interop-commons";
 
 export function toM2MGatewayEServiceTemplate(
   template: eserviceTemplateApi.EServiceTemplate
@@ -46,9 +46,14 @@ export function toM2MGatewayApiEServiceTemplateRiskAnalysis(
     id: riskAnalysis.id,
     name: riskAnalysis.name,
     createdAt: riskAnalysis.createdAt,
-    riskAnalysisForm: toM2MGatewayApiRiskAnalysisForm(
-      riskAnalysis.riskAnalysisForm
-    ),
+    riskAnalysisForm: {
+      id: riskAnalysis.riskAnalysisForm.id,
+      version: riskAnalysis.riskAnalysisForm.version,
+      answers: riskAnalysisAnswersToApiAnswers(
+        riskAnalysis.riskAnalysisForm.singleAnswers,
+        riskAnalysis.riskAnalysisForm.multiAnswers
+      ),
+    },
     tenantKind: riskAnalysis.tenantKind,
   };
 }

--- a/packages/m2m-gateway-v3/src/api/riskAnalysisFormApiConverter.ts
+++ b/packages/m2m-gateway-v3/src/api/riskAnalysisFormApiConverter.ts
@@ -1,8 +1,4 @@
-import {
-  catalogApi,
-  m2mGatewayApiV3,
-  eserviceTemplateApi,
-} from "pagopa-interop-api-clients";
+import { catalogApi, m2mGatewayApiV3 } from "pagopa-interop-api-clients";
 
 export function toM2MGatewayApiRiskAnalysisForm(
   riskAnalysisForm: catalogApi.EServiceRiskAnalysisForm
@@ -10,39 +6,6 @@ export function toM2MGatewayApiRiskAnalysisForm(
   return {
     id: riskAnalysisForm.id,
     version: riskAnalysisForm.version,
-    answers: toM2MGatewayApiRiskAnalysisAnswers(
-      riskAnalysisForm.singleAnswers,
-      riskAnalysisForm.multiAnswers
-    ),
-  };
-}
-
-function toM2MGatewayApiRiskAnalysisAnswers(
-  singleAnswers: eserviceTemplateApi.EServiceRiskAnalysisSingleAnswer[],
-  multiAnswers: eserviceTemplateApi.EServiceRiskAnalysisMultiAnswer[]
-): Record<string, string[]> {
-  const singleAnswersMap = singleAnswers.reduce<Record<string, string[]>>(
-    (map, { key, value }) => {
-      if (!value) {
-        return map;
-      }
-      return { ...map, [key]: [value] };
-    },
-    {}
-  );
-
-  const multiAnswersMap = multiAnswers.reduce<Record<string, string[]>>(
-    (map, { key, values }) => {
-      if (values.length === 0) {
-        return map;
-      }
-      return { ...map, [key]: values };
-    },
-    {}
-  );
-
-  return {
-    ...singleAnswersMap,
-    ...multiAnswersMap,
+    answers: riskAnalysisForm.answers,
   };
 }

--- a/packages/m2m-gateway-v3/test/mockUtils.ts
+++ b/packages/m2m-gateway-v3/test/mockUtils.ts
@@ -18,6 +18,7 @@ import {
   agreementApi,
   authorizationApi,
   catalogApi,
+  eserviceTemplateApi,
   m2mEventApi,
   m2mGatewayApiV3,
   purposeApi,
@@ -109,8 +110,14 @@ export const buildEserviceTemplateRiskAnalysisSeed = (
 };
 
 export function testToM2MEServiceRiskAnalysisAnswers(
-  riskAnalysisForm: catalogApi.EServiceRiskAnalysis["riskAnalysisForm"]
+  riskAnalysisForm:
+    | catalogApi.EServiceRiskAnalysis["riskAnalysisForm"]
+    | eserviceTemplateApi.EServiceTemplateRiskAnalysis["riskAnalysisForm"]
 ): m2mGatewayApiV3.EServiceRiskAnalysis["riskAnalysisForm"]["answers"] {
+  if ("answers" in riskAnalysisForm) {
+    return riskAnalysisForm.answers;
+  }
+
   const expectedSingleAnswers = riskAnalysisForm.singleAnswers.reduce<
     Record<string, string[]>
   >((singleAnswersMap, { key, value }) => {

--- a/packages/m2m-gateway/src/api/eserviceTemplateApiConverter.ts
+++ b/packages/m2m-gateway/src/api/eserviceTemplateApiConverter.ts
@@ -1,5 +1,5 @@
 import { eserviceTemplateApi, m2mGatewayApi } from "pagopa-interop-api-clients";
-import { toM2MGatewayApiRiskAnalysisForm } from "./riskAnalysisFormApiConverter.js";
+import { riskAnalysisAnswersToApiAnswers } from "pagopa-interop-commons";
 
 export function toM2MGatewayEServiceTemplate(
   template: eserviceTemplateApi.EServiceTemplate
@@ -43,9 +43,14 @@ export function toM2MGatewayApiEServiceTemplateRiskAnalysis(
     id: riskAnalysis.id,
     name: riskAnalysis.name,
     createdAt: riskAnalysis.createdAt,
-    riskAnalysisForm: toM2MGatewayApiRiskAnalysisForm(
-      riskAnalysis.riskAnalysisForm
-    ),
+    riskAnalysisForm: {
+      id: riskAnalysis.riskAnalysisForm.id,
+      version: riskAnalysis.riskAnalysisForm.version,
+      answers: riskAnalysisAnswersToApiAnswers(
+        riskAnalysis.riskAnalysisForm.singleAnswers,
+        riskAnalysis.riskAnalysisForm.multiAnswers
+      ),
+    },
     tenantKind: riskAnalysis.tenantKind,
   };
 }

--- a/packages/m2m-gateway/src/api/riskAnalysisFormApiConverter.ts
+++ b/packages/m2m-gateway/src/api/riskAnalysisFormApiConverter.ts
@@ -1,8 +1,4 @@
-import {
-  catalogApi,
-  m2mGatewayApi,
-  eserviceTemplateApi,
-} from "pagopa-interop-api-clients";
+import { catalogApi, m2mGatewayApi } from "pagopa-interop-api-clients";
 
 export function toM2MGatewayApiRiskAnalysisForm(
   riskAnalysisForm: catalogApi.EServiceRiskAnalysisForm
@@ -10,39 +6,6 @@ export function toM2MGatewayApiRiskAnalysisForm(
   return {
     id: riskAnalysisForm.id,
     version: riskAnalysisForm.version,
-    answers: toM2MGatewayApiRiskAnalysisAnswers(
-      riskAnalysisForm.singleAnswers,
-      riskAnalysisForm.multiAnswers
-    ),
-  };
-}
-
-function toM2MGatewayApiRiskAnalysisAnswers(
-  singleAnswers: eserviceTemplateApi.EServiceRiskAnalysisSingleAnswer[],
-  multiAnswers: eserviceTemplateApi.EServiceRiskAnalysisMultiAnswer[]
-): Record<string, string[]> {
-  const singleAnswersMap = singleAnswers.reduce<Record<string, string[]>>(
-    (map, { key, value }) => {
-      if (!value) {
-        return map;
-      }
-      return { ...map, [key]: [value] };
-    },
-    {}
-  );
-
-  const multiAnswersMap = multiAnswers.reduce<Record<string, string[]>>(
-    (map, { key, values }) => {
-      if (values.length === 0) {
-        return map;
-      }
-      return { ...map, [key]: values };
-    },
-    {}
-  );
-
-  return {
-    ...singleAnswersMap,
-    ...multiAnswersMap,
+    answers: riskAnalysisForm.answers,
   };
 }

--- a/packages/m2m-gateway/test/mockUtils.ts
+++ b/packages/m2m-gateway/test/mockUtils.ts
@@ -17,6 +17,7 @@ import {
   agreementApi,
   authorizationApi,
   catalogApi,
+  eserviceTemplateApi,
   m2mEventApi,
   m2mGatewayApi,
   purposeApi,
@@ -108,8 +109,14 @@ export const buildEserviceTemplateRiskAnalysisSeed = (
 };
 
 export function testToM2MEServiceRiskAnalysisAnswers(
-  riskAnalysisForm: catalogApi.EServiceRiskAnalysis["riskAnalysisForm"]
+  riskAnalysisForm:
+    | catalogApi.EServiceRiskAnalysis["riskAnalysisForm"]
+    | eserviceTemplateApi.EServiceTemplateRiskAnalysis["riskAnalysisForm"]
 ): m2mGatewayApi.EServiceRiskAnalysis["riskAnalysisForm"]["answers"] {
+  if ("answers" in riskAnalysisForm) {
+    return riskAnalysisForm.answers;
+  }
+
   const expectedSingleAnswers = riskAnalysisForm.singleAnswers.reduce<
     Record<string, string[]>
   >((singleAnswersMap, { key, value }) => {

--- a/packages/purpose-process/src/model/domain/apiConverter.ts
+++ b/packages/purpose-process/src/model/domain/apiConverter.ts
@@ -7,10 +7,8 @@ import {
   PurposeVersionSignedDocument,
   PurposeVersionState,
   ReviewerWorkflow,
-  RiskAnalysisMultiAnswer,
   RiskAnalysisReviewMode,
   RiskAnalysisSigningState,
-  RiskAnalysisSingleAnswer,
   purposeVersionState,
   riskAnalysisReviewMode,
   riskAnalysisSigningState,
@@ -26,50 +24,22 @@ import {
   FormQuestionRules,
   RiskAnalysisFormRules,
   ValidationOption,
+  riskAnalysisAnswersToApiAnswers,
 } from "pagopa-interop-commons";
 import { purposeApi } from "pagopa-interop-api-clients";
 import { RemainingDailyCalls } from "./models.js";
 
-const singleAnswersToApiSingleAnswers = (
-  singleAnswers: RiskAnalysisSingleAnswer[]
-): Record<string, string[]> =>
-  singleAnswers.reduce<Record<string, string[]>>((acc, curr) => {
-    if (!curr.value) {
-      return acc;
-    }
-    // eslint-disable-next-line functional/immutable-data
-    acc[curr.key] = [curr.value];
-    return acc;
-  }, {});
-
-const multiAnswersToApiMultiAnswers = (
-  multiAnswers: RiskAnalysisMultiAnswer[]
-): Record<string, string[]> =>
-  multiAnswers.reduce<Record<string, string[]>>((acc, curr) => {
-    if (curr.values.length === 0) {
-      return acc;
-    }
-    // eslint-disable-next-line functional/immutable-data
-    acc[curr.key] = curr.values;
-    return acc;
-  }, {});
-
 const riskAnalysisFormToApiRiskAnalysisForm = (
   riskAnalysisForm: PurposeRiskAnalysisForm
-): purposeApi.RiskAnalysisForm => {
-  const apiSingleAnswersMap = singleAnswersToApiSingleAnswers(
-    riskAnalysisForm.singleAnswers
-  );
-  const apiMultiAnswersMap = multiAnswersToApiMultiAnswers(
+): purposeApi.RiskAnalysisForm => ({
+  version: riskAnalysisForm.version,
+  answers: riskAnalysisAnswersToApiAnswers(
+    riskAnalysisForm.singleAnswers,
     riskAnalysisForm.multiAnswers
-  );
-  return {
-    version: riskAnalysisForm.version,
-    answers: { ...apiSingleAnswersMap, ...apiMultiAnswersMap },
-    riskAnalysisId: riskAnalysisForm.riskAnalysisId,
-    tenantKind: riskAnalysisForm.tenantKind,
-  };
-};
+  ),
+  riskAnalysisId: riskAnalysisForm.riskAnalysisId,
+  tenantKind: riskAnalysisForm.tenantKind,
+});
 
 const purposeVersionStateToApiPurposeVersionState = (
   state: PurposeVersionState


### PR DESCRIPTION
## Jira Issue
[PIN-7452](https://pagopa.atlassian.net/browse/PIN-7452)

## Context/Why
- The catalog API exposed the **internal** risk analysis form model (`singleAnswers` / `multiAnswers`), while the purpose API already exposed the key-value map (`answers: Record<string, string[]>`).
- As a consequence, the very same single/multi → map conversion was re-implemented in three places: `m2m-gateway`, `m2m-gateway-v3` and `backend-for-frontend`.
- Only the catalog **output** was misaligned: the input seed (`EServiceRiskAnalysisFormSeed`) already used the map form.
- This PR aligns the catalog output, removes the duplicated conversions and moves the conversion to `commons`.

## Services Impacted
- api-clients (`catalogApi` spec + generated client)
- commons / commons-test
- catalog-process
- purpose-process
- m2m-gateway
- m2m-gateway-v3
- backend-for-frontend

## Key Changes

**Catalog API contract (⚠️ breaking)**
- `EServiceRiskAnalysisForm` is now `{ id, version, answers, tenantKind? }`; `singleAnswers` / `multiAnswers` and the `EServiceRiskAnalysisSingleAnswer` / `EServiceRiskAnalysisMultiAnswer` schemas are removed.
- `id` and `tenantKind` are intentionally kept: M2M relies on the form `id`, the BFF relies on `tenantKind` for `getRulesetExpiration`. The resulting shape is a superset of the M2M `RiskAnalysisForm`, so the M2M converter becomes a plain passthrough.
- The internal/event-sourced model, the protobuf events and the read model are **unchanged**: only the API projection changes.

**Shared conversion moved to commons**
- New `riskAnalysisAnswersToApiAnswers(singleAnswers, multiAnswers)` in `commons/risk-analysis`, with the purpose-API semantics (answers with no value are skipped). It accepts structural types, so it works both with the domain model answers and the API ones.

**Duplicated conversions removed**
- `catalog-process` builds `answers` through the shared helper.
- `purpose-process` uses the shared helper instead of its two local functions.
- `m2m-gateway` / `m2m-gateway-v3`: the catalog risk analysis form converter is now a passthrough.
- `backend-for-frontend`: `toBffCatalogApiEserviceRiskAnalysis` is now a passthrough.

**BFF eservice configuration file**
- The exported configuration now carries `answers` instead of single/multi. The single/multi split was discarded on import anyway (both lists were merged into a single map), so the migration is lossless.
- Import stays **backward compatible**: configuration files exported with the old single/multi format are still accepted.

**Out of scope**
- `eservice-template` still exposes the single/multi model. Since the M2M and BFF **template** converters previously reused the catalog one, they now build the answers map through the shared commons helper. Aligning the eservice-template API can be handled in a separate task.

**Tests**
- `commons-test`: new unit test for `riskAnalysisAnswersToApiAnswers` (merge of single + multi, single values wrapped in an array, answers with no value skipped, empty input).
- `backend-for-frontend` / import: new cases for a configuration in the new `answers` format and for one in the legacy single/multi format (backward compatibility), asserting the seed sent to catalog-process.
- `backend-for-frontend` / export: the exported configuration is now unzipped and inspected, asserting the risk analysis is serialized in the `answers` map format (the export test previously used an empty `riskAnalysis`, so the form was never exercised).
- Existing catalog-process tests are unaffected: they assert the write model / protobuf events and the input seed, none of which changed.

**Note**
- Minor behavioral change on the BFF output: keys whose single answer has no value are no longer emitted as `[]`, they are simply omitted — consistent with the purpose API.
- `catalogApi.yml` changed, so the API clients must be regenerated (`pnpm --filter pagopa-interop-api-clients generate-model`).

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [ ] Service labels applied

[PIN-7452]: https://pagopa.atlassian.net/browse/PIN-7452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ