### PR TITLE
chore(renovate): unblock PR creation for stable updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,13 +6,20 @@
     ":rebaseStalePrs",
     ":dependencyDashboard"
   ],
-  "prConcurrentLimit": 2,
   "labels": [
     "dependencies"
   ],
   "ignorePaths": [
     "docker/docker-compose.yml"
   ],
+  "internalChecksFilter": "strict",
+  "internalChecksAsSuccess": true,
+  "prCreation": "immediate",
+  "minimumReleaseAge": null,
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "prConcurrentLimit": 4,
+  "branchConcurrentLimit": 4,
+  "prHourlyLimit": 0,
   "packageRules": [
     {
       "groupName": "protobuf-ts monorepo",
@@ -25,6 +32,16 @@
       "matchDepTypes": [
         "devDependencies"
       ]
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchPackageNames": ["*"],
+      "prCreation": "immediate",
+      "internalChecksFilter": "strict",
+      "internalChecksAsSuccess": true
     }
   ],
   "major": {
@@ -41,7 +58,9 @@
     "enabled": true
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "prCreation": "immediate",
+    "minimumReleaseAge": null
   },
   "rollback": {
     "enabled": true


### PR DESCRIPTION
# Description

Renovate hasn't opened npm dependency PRs here in a long time: the shared preset (`config:best-practices` → `security:minimumReleaseAgeNpm`) sets `prCreation: "not-pending"` for npm, but this repo's CI only runs on `pull_request`, so update branches never turn green (their only check is Renovate's own stability check, which it ignores by default) and the stuck branches clog the PR slots — the dashboard (#599) currently shows ~90 rate-limited updates and zero open dependency PRs ([renovate#15764](https://github.com/renovatebot/renovate/discussions/15764)). Only `packageRules` can override manager-scoped preset config, so top-level options alone can't fix it. Same fix already applied to knodia (pagopa/knodia#689).

- Catch-all packageRule with `prCreation: "immediate"` + `internalChecksFilter: "strict"`: PRs open as soon as a branch exists, and too-fresh releases create nothing — the newest already-aged one is proposed instead — so the stability window is fully preserved (npm keeps the preset's 3 days, pinned explicitly) while the queue drains oldest-stable first. `internalChecksAsSuccess: true` is a backstop if any path reverts to `not-pending`. Security/OER PRs are unaffected (they bypass packageRules and age gates by design).
- `lockFileMaintenance` gets the same overrides in-block (lockfile updates have no package name/datasource, so no packageRule can reach them); top-level `minimumReleaseAge: null` + `minimumReleaseAgeBehaviour` pinned so no inherited age gate can leak to timestamp-less datasources (docker/GHA digests would be suppressed entirely).
- `prHourlyLimit: 0` + concurrency limits raised 2 → 4 and pinned: one daily run fills all slots, minor/patch first (majors last via Renovate's built-in ordering) — with ~90 updates queued, 2 slots would take months to drain.

# Test Plan

- [x] `renovate-config-validator` passes
- [ ] Next scheduled Renovate run: branches under "Pending Status Checks" on dashboard #599 convert to PRs and the rate-limited queue starts draining oldest-stable first