### PR TITLE
fix: allow configured token batch size per partition (PIN-9009)

### DIFF
--- a/packages/commons/src/config/consumerServiceConfig.ts
+++ b/packages/commons/src/config/consumerServiceConfig.ts
@@ -29,11 +29,13 @@ export const KafkaBatchConsumerConfig = z
   .transform((c) => {
     const minBytes =
       c.AVERAGE_KAFKA_MESSAGE_SIZE_IN_BYTES * c.MESSAGES_TO_READ_PER_BATCH;
+    const maxBytes = Math.round(minBytes * 1.25);
     return {
       minBytes,
       maxWaitKafkaBatchMillis: c.MAX_WAIT_KAFKA_BATCH_MILLIS,
       sessionTimeoutMillis: Math.round(c.MAX_WAIT_KAFKA_BATCH_MILLIS * 1.5),
-      maxBytes: Math.round(minBytes * 1.25),
+      maxBytes,
+      maxBytesPerPartition: maxBytes,
     };
   });
 export type KafkaBatchConsumerConfig = z.infer<typeof KafkaBatchConsumerConfig>;

--- a/packages/kafka-iam-auth/src/index.ts
+++ b/packages/kafka-iam-auth/src/index.ts
@@ -275,6 +275,7 @@ const initCustomConsumer = async ({
     maxWaitTimeInMs: batchConsumerConfig?.maxWaitKafkaBatchMillis,
     minBytes: batchConsumerConfig?.minBytes,
     maxBytes: batchConsumerConfig?.maxBytes,
+    maxBytesPerPartition: batchConsumerConfig?.maxBytesPerPartition,
     sessionTimeout: batchConsumerConfig?.sessionTimeoutMillis,
   });
 

--- a/packages/token-details-persister/test/batchConsumerConfig.test.ts
+++ b/packages/token-details-persister/test/batchConsumerConfig.test.ts
@@ -1,0 +1,18 @@
+import { KafkaBatchConsumerConfig } from "pagopa-interop-commons";
+import { describe, expect, it } from "vitest";
+
+describe("KafkaBatchConsumerConfig", () => {
+  it("allows a single partition to return the configured batch size", () => {
+    const batchConsumerConfig = KafkaBatchConsumerConfig.parse({
+      AVERAGE_KAFKA_MESSAGE_SIZE_IN_BYTES: 1_000,
+      MESSAGES_TO_READ_PER_BATCH: 1_000,
+      MAX_WAIT_KAFKA_BATCH_MILLIS: 60_000,
+    });
+
+    expect(batchConsumerConfig).toMatchObject({
+      minBytes: 1_000_000,
+      maxBytes: 1_250_000,
+      maxBytesPerPartition: 1_250_000,
+    });
+  });
+});


### PR DESCRIPTION
## Issue
- [PIN-9009](https://pagopa.atlassian.net/browse/PIN-9009)

## Context / Why
- The token-details-persister was producing more audit files than expected because KafkaJS limited each partition fetch to its default 1 MiB.
- This prevented the consumer from collecting the configured batch size of approximately 1,000 tokens in a single file.

## Scope
- Configure the maximum fetch size for each Kafka partition.
- Propagate the new batch configuration to the shared Kafka consumer.
- Add regression coverage for a 1,000-message batch configuration.

## Key Changes
- Reuse the calculated `maxBytes` value as `maxBytesPerPartition`.
- Allow a single partition to return the full configured batch instead of being constrained by KafkaJS's default per-partition limit.

## Testing / Validation
- [x] Lint
- [x] Type Check
- [x] Unit tests
- [x] Integration tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-9009]: https://pagopa.atlassian.net/browse/PIN-9009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ