### PR TITLE
fix: make server_urls_descriptions optional in model and nullable in readmodel

### DIFF
--- a/docker/domains-analytics-db/domains-init.sql
+++ b/docker/domains-analytics-db/domains-init.sql
@@ -48,7 +48,7 @@ CREATE TABLE domains.eservice_descriptor (
   agreement_approval_policy VARCHAR(2048),
   created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   server_urls VARCHAR(65535) NOT NULL,
-  server_urls_descriptions VARCHAR(65535) NOT NULL,
+  server_urls_descriptions VARCHAR(65535),
   published_at TIMESTAMP WITH TIME ZONE,
   suspended_at TIMESTAMP WITH TIME ZONE,
   deprecated_at TIMESTAMP WITH TIME ZONE,

--- a/docker/readmodel-db/catalog.sql
+++ b/docker/readmodel-db/catalog.sql
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS readmodel_catalog.eservice_descriptor (
   agreement_approval_policy VARCHAR,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   server_urls VARCHAR ARRAY NOT NULL,
-  server_urls_descriptions VARCHAR ARRAY NOT NULL,
+  server_urls_descriptions VARCHAR ARRAY,
   published_at TIMESTAMP WITH TIME ZONE,
   suspended_at TIMESTAMP WITH TIME ZONE,
   deprecated_at TIMESTAMP WITH TIME ZONE,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -524,15 +524,15 @@ async function parseAndCheckAttributesOfKind(
   const attributes =
     kind === attributeKind.certified
       ? [
-          ...(await readModelService.getAttributesByIds(
-            attributesSeedIds,
-            attributeKind.certified
-          )),
-          ...(await readModelService.getAttributesByIds(
-            attributesSeedIds,
-            attributeKind.certifiedDiscrete
-          )),
-        ]
+        ...(await readModelService.getAttributesByIds(
+          attributesSeedIds,
+          attributeKind.certified
+        )),
+        ...(await readModelService.getAttributesByIds(
+          attributesSeedIds,
+          attributeKind.certifiedDiscrete
+        )),
+      ]
       : await readModelService.getAttributesByIds(attributesSeedIds, kind);
 
   const attributesIds = attributes.map((attr) => attr.id);
@@ -613,14 +613,14 @@ async function innerCreateEService(
   }: {
     seed: catalogApi.EServiceSeed;
     template:
-      | {
-          id: EServiceTemplateId;
-          versionId: EServiceTemplateVersionId;
-          attributes: EserviceAttributes;
-          riskAnalysis: RiskAnalysis[] | undefined;
-          asyncExchangeProperties?: AsyncExchangeProperties;
-        }
-      | undefined;
+    | {
+      id: EServiceTemplateId;
+      versionId: EServiceTemplateVersionId;
+      attributes: EserviceAttributes;
+      riskAnalysis: RiskAnalysis[] | undefined;
+      asyncExchangeProperties?: AsyncExchangeProperties;
+    }
+    | undefined;
     instanceLabel?: string | undefined;
   },
   readModelService: ReadModelServiceSQL,
@@ -707,7 +707,7 @@ async function innerCreateEService(
         seed.descriptor.agreementApprovalPolicy
       ),
     serverUrls: [],
-    serverUrlsDescriptions: undefined,
+    serverUrlsDescriptions: [],
     publishedAt: undefined,
     suspendedAt: undefined,
     deprecatedAt: undefined,
@@ -847,23 +847,23 @@ async function innerAddDocumentToEserviceEvent(
 
   const event = isInterface
     ? toCreateEventEServiceInterfaceAdded(
+      eService.data.id,
+      eService.metadata.version,
+      eventPayload,
+      ctx.correlationId
+    )
+    : isAsyncExchangeCallbackInterface
+      ? toCreateEventEServiceAsyncExchangeCallbackInterfaceAdded(
         eService.data.id,
         eService.metadata.version,
         eventPayload,
         ctx.correlationId
       )
-    : isAsyncExchangeCallbackInterface
-      ? toCreateEventEServiceAsyncExchangeCallbackInterfaceAdded(
-          eService.data.id,
-          eService.metadata.version,
-          eventPayload,
-          ctx.correlationId
-        )
       : toCreateEventEServiceDocumentAdded(
-          eService.metadata.version,
-          eventPayload,
-          ctx.correlationId
-        );
+        eService.metadata.version,
+        eventPayload,
+        ctx.correlationId
+      );
 
   return {
     eService: updatedEService,
@@ -903,7 +903,7 @@ function createNextDescriptor(
     dailyCallsTotal: seed.dailyCallsTotal,
     agreementApprovalPolicy: seed.agreementApprovalPolicy,
     serverUrls: [],
-    serverUrlsDescriptions: undefined,
+    serverUrlsDescriptions: [],
     publishedAt: undefined,
     suspendedAt: undefined,
     deprecatedAt: undefined,
@@ -1290,10 +1290,8 @@ export function catalogServiceBuilder(
       ctx: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<WithMetadata<Document>> {
       ctx.logger.info(
-        `Creating EService Document ${document.documentId.toString()} of kind ${
-          document.kind
-        }, name ${document.fileName}, path ${
-          document.filePath
+        `Creating EService Document ${document.documentId.toString()} of kind ${document.kind
+        }, name ${document.fileName}, path ${document.filePath
         } for EService ${eserviceId} and Descriptor ${descriptorId}`
       );
 
@@ -1374,19 +1372,19 @@ export function catalogServiceBuilder(
         descriptors: eservice.data.descriptors.map((d: Descriptor) =>
           d.id === descriptorId
             ? {
-                ...d,
-                interface:
-                  d.interface?.id === documentId ? undefined : d.interface,
-                serverUrls: isInterface ? [] : d.serverUrls,
-                serverUrlsDescriptions: isInterface
-                  ? []
-                  : d.serverUrlsDescriptions,
-                docs: d.docs.filter((doc) => doc.id !== documentId),
-                asyncExchangeCallbackInterface:
-                  d.asyncExchangeCallbackInterface?.id === documentId
-                    ? undefined
-                    : d.asyncExchangeCallbackInterface,
-              }
+              ...d,
+              interface:
+                d.interface?.id === documentId ? undefined : d.interface,
+              serverUrls: isInterface ? [] : d.serverUrls,
+              serverUrlsDescriptions: isInterface
+                ? []
+                : d.serverUrlsDescriptions,
+              docs: d.docs.filter((doc) => doc.id !== documentId),
+              asyncExchangeCallbackInterface:
+                d.asyncExchangeCallbackInterface?.id === documentId
+                  ? undefined
+                  : d.asyncExchangeCallbackInterface,
+            }
             : d
         ),
       };
@@ -1399,24 +1397,24 @@ export function catalogServiceBuilder(
 
       const event = isInterface
         ? toCreateEventEServiceInterfaceDeleted(
+          eserviceId,
+          eservice.metadata.version,
+          eventPayload,
+          correlationId
+        )
+        : isAsyncExchangeCallbackInterface
+          ? toCreateEventEServiceAsyncExchangeCallbackInterfaceDeleted(
             eserviceId,
             eservice.metadata.version,
             eventPayload,
             correlationId
           )
-        : isAsyncExchangeCallbackInterface
-          ? toCreateEventEServiceAsyncExchangeCallbackInterfaceDeleted(
-              eserviceId,
-              eservice.metadata.version,
-              eventPayload,
-              correlationId
-            )
           : toCreateEventEServiceDocumentDeleted(
-              eserviceId,
-              eservice.metadata.version,
-              eventPayload,
-              correlationId
-            );
+            eserviceId,
+            eservice.metadata.version,
+            eventPayload,
+            correlationId
+          );
 
       const createdEvent = await repository.createEvent(event);
 
@@ -1478,7 +1476,7 @@ export function catalogServiceBuilder(
           (d) =>
             d.id !== documentId &&
             d.prettyName.toLowerCase() ===
-              apiEServiceDescriptorDocumentUpdateSeed.prettyName.toLowerCase()
+            apiEServiceDescriptorDocumentUpdateSeed.prettyName.toLowerCase()
         )
       ) {
         throw documentPrettyNameDuplicate(
@@ -1497,15 +1495,15 @@ export function catalogServiceBuilder(
         descriptors: eservice.data.descriptors.map((d: Descriptor) =>
           d.id === descriptorId
             ? {
-                ...d,
-                interface: isInterface ? updatedDocument : d.interface,
-                docs: d.docs.map((doc) =>
-                  doc.id === documentId ? updatedDocument : doc
-                ),
-                asyncExchangeCallbackInterface: isAsyncExchangeCallbackInterface
-                  ? updatedDocument
-                  : d.asyncExchangeCallbackInterface,
-              }
+              ...d,
+              interface: isInterface ? updatedDocument : d.interface,
+              docs: d.docs.map((doc) =>
+                doc.id === documentId ? updatedDocument : doc
+              ),
+              asyncExchangeCallbackInterface: isAsyncExchangeCallbackInterface
+                ? updatedDocument
+                : d.asyncExchangeCallbackInterface,
+            }
             : d
         ),
       };
@@ -1518,24 +1516,24 @@ export function catalogServiceBuilder(
 
       const event = isInterface
         ? toCreateEventEServiceInterfaceUpdated(
+          eserviceId,
+          eservice.metadata.version,
+          eventPayload,
+          correlationId
+        )
+        : isAsyncExchangeCallbackInterface
+          ? toCreateEventEServiceAsyncExchangeCallbackInterfaceUpdated(
             eserviceId,
             eservice.metadata.version,
             eventPayload,
             correlationId
           )
-        : isAsyncExchangeCallbackInterface
-          ? toCreateEventEServiceAsyncExchangeCallbackInterfaceUpdated(
-              eserviceId,
-              eservice.metadata.version,
-              eventPayload,
-              correlationId
-            )
           : toCreateEventEServiceDocumentUpdated(
-              eserviceId,
-              eservice.metadata.version,
-              eventPayload,
-              correlationId
-            );
+            eserviceId,
+            eservice.metadata.version,
+            eventPayload,
+            correlationId
+          );
 
       await repository.createEvent(event);
       return updatedDocument;
@@ -1609,17 +1607,17 @@ export function catalogServiceBuilder(
         asyncExchangeProperties:
           asyncExchangeEnabled && eserviceDescriptorSeed.asyncExchangeProperties
             ? {
-                responseTime:
-                  eserviceDescriptorSeed.asyncExchangeProperties.responseTime,
-                resourceAvailableTime:
-                  eserviceDescriptorSeed.asyncExchangeProperties
-                    .resourceAvailableTime,
-                confirmation:
-                  eserviceDescriptorSeed.asyncExchangeProperties.confirmation,
-                bulk: eserviceDescriptorSeed.asyncExchangeProperties.bulk,
-                maxResultSet:
-                  eserviceDescriptorSeed.asyncExchangeProperties.maxResultSet,
-              }
+              responseTime:
+                eserviceDescriptorSeed.asyncExchangeProperties.responseTime,
+              resourceAvailableTime:
+                eserviceDescriptorSeed.asyncExchangeProperties
+                  .resourceAvailableTime,
+              confirmation:
+                eserviceDescriptorSeed.asyncExchangeProperties.confirmation,
+              bulk: eserviceDescriptorSeed.asyncExchangeProperties.bulk,
+              maxResultSet:
+                eserviceDescriptorSeed.asyncExchangeProperties.maxResultSet,
+            }
             : undefined,
       });
 
@@ -1876,17 +1874,17 @@ export function catalogServiceBuilder(
         asyncExchangeProperties:
           asyncExchangeEnabled && descriptor.asyncExchangeProperties
             ? {
-                ...descriptor.asyncExchangeProperties,
-                responseTime:
-                  seed.asyncExchangeProperties?.responseTime ??
-                  descriptor.asyncExchangeProperties.responseTime,
-                resourceAvailableTime:
-                  seed.asyncExchangeProperties?.resourceAvailableTime ??
-                  descriptor.asyncExchangeProperties.resourceAvailableTime,
-                maxResultSet:
-                  seed.asyncExchangeProperties?.maxResultSet ??
-                  descriptor.asyncExchangeProperties.maxResultSet,
-              }
+              ...descriptor.asyncExchangeProperties,
+              responseTime:
+                seed.asyncExchangeProperties?.responseTime ??
+                descriptor.asyncExchangeProperties.responseTime,
+              resourceAvailableTime:
+                seed.asyncExchangeProperties?.resourceAvailableTime ??
+                descriptor.asyncExchangeProperties.resourceAvailableTime,
+              maxResultSet:
+                seed.asyncExchangeProperties?.maxResultSet ??
+                descriptor.asyncExchangeProperties.maxResultSet,
+            }
             : descriptor.asyncExchangeProperties,
       };
 
@@ -2181,26 +2179,26 @@ export function catalogServiceBuilder(
       const clonedInterfacePath =
         descriptor.interface !== undefined
           ? await fileManager.copy(
-              config.s3Bucket,
-              descriptor.interface.path,
-              config.eserviceDocumentsPath,
-              clonedInterfaceId,
-              descriptor.interface.name,
-              logger
-            )
+            config.s3Bucket,
+            descriptor.interface.path,
+            config.eserviceDocumentsPath,
+            clonedInterfaceId,
+            descriptor.interface.name,
+            logger
+          )
           : undefined;
 
       const clonedInterfaceDocument: Document | undefined =
         descriptor.interface !== undefined && clonedInterfacePath !== undefined
           ? {
-              id: clonedInterfaceId,
-              name: descriptor.interface.name,
-              contentType: descriptor.interface.contentType,
-              prettyName: descriptor.interface.prettyName,
-              path: clonedInterfacePath,
-              checksum: descriptor.interface.checksum,
-              uploadDate: new Date(),
-            }
+            id: clonedInterfaceId,
+            name: descriptor.interface.name,
+            contentType: descriptor.interface.contentType,
+            prettyName: descriptor.interface.prettyName,
+            path: clonedInterfacePath,
+            checksum: descriptor.interface.checksum,
+            uploadDate: new Date(),
+          }
           : undefined;
 
       const clonedDocuments = await Promise.all(
@@ -2290,19 +2288,19 @@ export function catalogServiceBuilder(
       const event =
         archivingKindSeed.kind === "AUTOMATIC"
           ? toCreateEventEServiceDescriptorArchived(
-              eserviceId,
-              eservice.metadata.version,
-              descriptorId,
-              newEservice,
-              correlationId
-            )
+            eserviceId,
+            eservice.metadata.version,
+            descriptorId,
+            newEservice,
+            correlationId
+          )
           : toCreateEventEServiceDescriptorArchivingCompleted(
-              eserviceId,
-              eservice.metadata.version,
-              descriptorId,
-              newEservice,
-              correlationId
-            );
+            eserviceId,
+            eservice.metadata.version,
+            descriptorId,
+            newEservice,
+            correlationId
+          );
 
       await repository.createEvent(event);
     },
@@ -2997,15 +2995,15 @@ export function catalogServiceBuilder(
           ? undefined
           : isConsumerDelegable
             ? toCreateEventEServiceIsConsumerDelegableEnabled(
-                eservice.metadata.version,
-                updatedEservice,
-                correlationId
-              )
+              eservice.metadata.version,
+              updatedEservice,
+              correlationId
+            )
             : toCreateEventEServiceIsConsumerDelegableDisabled(
-                eservice.metadata.version,
-                updatedEservice,
-                correlationId
-              );
+              eservice.metadata.version,
+              updatedEservice,
+              correlationId
+            );
 
       const clientAccessEventVersion =
         eservice.metadata.version + (consumerDelegableEvent ? 1 : 0);
@@ -3015,15 +3013,15 @@ export function catalogServiceBuilder(
           ? undefined
           : isClientAccessDelegable
             ? toCreateEventEServiceIsClientAccessDelegableEnabled(
-                clientAccessEventVersion,
-                updatedEservice,
-                correlationId
-              )
+              clientAccessEventVersion,
+              updatedEservice,
+              correlationId
+            )
             : toCreateEventEServiceIsClientAccessDelegableDisabled(
-                clientAccessEventVersion,
-                updatedEservice,
-                correlationId
-              );
+              clientAccessEventVersion,
+              updatedEservice,
+              correlationId
+            );
 
       const events = [
         consumerDelegableEvent,
@@ -4015,21 +4013,21 @@ export function catalogServiceBuilder(
             riskAnalysis,
             asyncExchangeProperties:
               isFeatureFlagEnabled(config, "featureFlagAsyncExchange") &&
-              template.asyncExchange === true &&
-              publishedVersion.asyncExchangeProperties
+                template.asyncExchange === true &&
+                publishedVersion.asyncExchangeProperties
                 ? {
-                    ...publishedVersion.asyncExchangeProperties,
-                    responseTime:
-                      seed.asyncExchangeProperties?.responseTime ??
-                      publishedVersion.asyncExchangeProperties.responseTime,
-                    resourceAvailableTime:
-                      seed.asyncExchangeProperties?.resourceAvailableTime ??
-                      publishedVersion.asyncExchangeProperties
-                        .resourceAvailableTime,
-                    maxResultSet:
-                      seed.asyncExchangeProperties?.maxResultSet ??
-                      publishedVersion.asyncExchangeProperties.maxResultSet,
-                  }
+                  ...publishedVersion.asyncExchangeProperties,
+                  responseTime:
+                    seed.asyncExchangeProperties?.responseTime ??
+                    publishedVersion.asyncExchangeProperties.responseTime,
+                  resourceAvailableTime:
+                    seed.asyncExchangeProperties?.resourceAvailableTime ??
+                    publishedVersion.asyncExchangeProperties
+                      .resourceAvailableTime,
+                  maxResultSet:
+                    seed.asyncExchangeProperties?.maxResultSet ??
+                    publishedVersion.asyncExchangeProperties.maxResultSet,
+                }
                 : undefined,
           },
           instanceLabel: parsedInstanceLabel,
@@ -4223,8 +4221,8 @@ export function catalogServiceBuilder(
       const agreementApprovalPolicySeed =
         eserviceInstanceDescriptorSeed.agreementApprovalPolicy
           ? apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-              eserviceInstanceDescriptorSeed.agreementApprovalPolicy
-            )
+            eserviceInstanceDescriptorSeed.agreementApprovalPolicy
+          )
           : undefined;
 
       assertConsistentDailyCalls(eserviceInstanceDescriptorSeed);
@@ -4441,15 +4439,15 @@ export function catalogServiceBuilder(
       const updatedDescriptor =
         latestDescriptor.archivingSchedule?.scope === archivingScope.eservice
           ? {
-              ...descriptor,
-              archivingSchedule: latestDescriptor.archivingSchedule,
-            }
+            ...descriptor,
+            archivingSchedule: latestDescriptor.archivingSchedule,
+          }
           : updateDescriptorState(
-              { ...descriptor, archivingSchedule: undefined },
-              descriptor.state === descriptorState.archivingSuspended
-                ? descriptorState.suspended
-                : descriptorState.deprecated
-            );
+            { ...descriptor, archivingSchedule: undefined },
+            descriptor.state === descriptorState.archivingSuspended
+              ? descriptorState.suspended
+              : descriptorState.deprecated
+          );
 
       const updatedEService = replaceDescriptor(
         eservice.data,
@@ -4574,11 +4572,11 @@ async function processEserviceArchiving(
 
   const eserviceAfterCleanup = draftOrWaiting
     ? await deleteInactiveDescriptorLogic(
-        eservice,
-        draftOrWaiting,
-        fileManager,
-        logger
-      )
+      eservice,
+      draftOrWaiting,
+      fileManager,
+      logger
+    )
     : eservice;
 
   const requestDate = new Date();
@@ -4663,11 +4661,11 @@ async function createOpenApiInterfaceByTemplate(
   serverUrls: Array<{ url: string; description?: string }>,
   eserviceInstanceInterfaceRestData:
     | {
-        contactEmail: string;
-        contactName: string;
-        contactUrl?: string;
-        termsAndConditionsUrl?: string;
-      }
+      contactEmail: string;
+      contactName: string;
+      contactUrl?: string;
+      termsAndConditionsUrl?: string;
+    }
     | undefined,
   bucket: string,
   fileManager: FileManager,
@@ -5077,11 +5075,11 @@ function hasCertifiedAttributeConfigurationChanged(
         getEServiceAttributeDiscreteConfig(descriptorAttribute);
       return (
         seedAttribute?.dailyCallsPerConsumer !==
-          descriptorAttribute.dailyCallsPerConsumer ||
+        descriptorAttribute.dailyCallsPerConsumer ||
         seedAttribute?.discreteConfig?.threshold !==
-          descriptorDiscreteConfig?.threshold ||
+        descriptorDiscreteConfig?.threshold ||
         seedAttribute?.discreteConfig?.comparator !==
-          descriptorDiscreteConfig?.comparator
+        descriptorDiscreteConfig?.comparator
       );
     });
   });
@@ -5170,13 +5168,13 @@ async function updateDraftEService(
   eserviceId: EServiceId,
   typeAndSeed:
     | {
-        type: "put";
-        seed: catalogApi.UpdateEServiceSeed;
-      }
+      type: "put";
+      seed: catalogApi.UpdateEServiceSeed;
+    }
     | {
-        type: "patch";
-        seed: catalogApi.PatchUpdateEServiceSeed;
-      },
+      type: "patch";
+      seed: catalogApi.PatchUpdateEServiceSeed;
+    },
   readModelService: ReadModelServiceSQL,
   fileManager: FileManager,
   repository: ReturnType<typeof eventRepository<EServiceEvent>>,
@@ -5250,9 +5248,9 @@ async function updateDraftEService(
   // - personalData flag is changed from true to false or vice versa
   const checkedRiskAnalysis =
     updatedMode === eserviceMode.deliver ||
-    (typeAndSeed.seed.personalData != null &&
-      eservice.data.personalData != null &&
-      typeAndSeed.seed.personalData !== eservice.data.personalData)
+      (typeAndSeed.seed.personalData != null &&
+        eservice.data.personalData != null &&
+        typeAndSeed.seed.personalData !== eservice.data.personalData)
       ? []
       : eservice.data.riskAnalysis;
 
@@ -5311,12 +5309,12 @@ async function updateDraftEService(
     riskAnalysis: checkedRiskAnalysis,
     descriptors: interfaceHasToBeDeleted
       ? eservice.data.descriptors.map((d) => ({
-          ...d,
-          interface: undefined,
-          asyncExchangeCallbackInterface: undefined,
-          serverUrls: [],
-          serverUrlsDescriptions: undefined,
-        }))
+        ...d,
+        interface: undefined,
+        asyncExchangeCallbackInterface: undefined,
+        serverUrls: [],
+        serverUrlsDescriptions: [],
+      }))
       : eservice.data.descriptors,
     isSignalHubEnabled: updatedIsSignalHubEnabled,
     isConsumerDelegable: updatedIsConsumerDelegable,
@@ -5401,13 +5399,13 @@ async function updateDraftDescriptor(
 
   const updatedAttributes = attributes
     ? await parseAndCheckAttributes(
-        {
-          certified: attributes.certified ?? descriptor.attributes.certified,
-          declared: attributes.declared ?? descriptor.attributes.declared,
-          verified: attributes.verified ?? descriptor.attributes.verified,
-        },
-        readModelService
-      )
+      {
+        certified: attributes.certified ?? descriptor.attributes.certified,
+        declared: attributes.declared ?? descriptor.attributes.declared,
+        verified: attributes.verified ?? descriptor.attributes.verified,
+      },
+      readModelService
+    )
     : descriptor.attributes;
 
   assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
@@ -5419,8 +5417,8 @@ async function updateDraftDescriptor(
 
   const updatedAgreementApprovalPolicy = agreementApprovalPolicy
     ? apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-        agreementApprovalPolicy
-      )
+      agreementApprovalPolicy
+    )
     : descriptor.agreementApprovalPolicy;
 
   const asyncExchangeEnabled =

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -707,7 +707,7 @@ async function innerCreateEService(
         seed.descriptor.agreementApprovalPolicy
       ),
     serverUrls: [],
-    serverUrlsDescriptions: [],
+    serverUrlsDescriptions: undefined,
     publishedAt: undefined,
     suspendedAt: undefined,
     deprecatedAt: undefined,
@@ -903,7 +903,7 @@ function createNextDescriptor(
     dailyCallsTotal: seed.dailyCallsTotal,
     agreementApprovalPolicy: seed.agreementApprovalPolicy,
     serverUrls: [],
-    serverUrlsDescriptions: [],
+    serverUrlsDescriptions: undefined,
     publishedAt: undefined,
     suspendedAt: undefined,
     deprecatedAt: undefined,
@@ -5315,7 +5315,7 @@ async function updateDraftEService(
           interface: undefined,
           asyncExchangeCallbackInterface: undefined,
           serverUrls: [],
-          serverUrlsDescriptions: [],
+          serverUrlsDescriptions: undefined,
         }))
       : eservice.data.descriptors,
     isSignalHubEnabled: updatedIsSignalHubEnabled,

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -524,15 +524,15 @@ async function parseAndCheckAttributesOfKind(
   const attributes =
     kind === attributeKind.certified
       ? [
-        ...(await readModelService.getAttributesByIds(
-          attributesSeedIds,
-          attributeKind.certified
-        )),
-        ...(await readModelService.getAttributesByIds(
-          attributesSeedIds,
-          attributeKind.certifiedDiscrete
-        )),
-      ]
+          ...(await readModelService.getAttributesByIds(
+            attributesSeedIds,
+            attributeKind.certified
+          )),
+          ...(await readModelService.getAttributesByIds(
+            attributesSeedIds,
+            attributeKind.certifiedDiscrete
+          )),
+        ]
       : await readModelService.getAttributesByIds(attributesSeedIds, kind);
 
   const attributesIds = attributes.map((attr) => attr.id);
@@ -613,14 +613,14 @@ async function innerCreateEService(
   }: {
     seed: catalogApi.EServiceSeed;
     template:
-    | {
-      id: EServiceTemplateId;
-      versionId: EServiceTemplateVersionId;
-      attributes: EserviceAttributes;
-      riskAnalysis: RiskAnalysis[] | undefined;
-      asyncExchangeProperties?: AsyncExchangeProperties;
-    }
-    | undefined;
+      | {
+          id: EServiceTemplateId;
+          versionId: EServiceTemplateVersionId;
+          attributes: EserviceAttributes;
+          riskAnalysis: RiskAnalysis[] | undefined;
+          asyncExchangeProperties?: AsyncExchangeProperties;
+        }
+      | undefined;
     instanceLabel?: string | undefined;
   },
   readModelService: ReadModelServiceSQL,
@@ -847,23 +847,23 @@ async function innerAddDocumentToEserviceEvent(
 
   const event = isInterface
     ? toCreateEventEServiceInterfaceAdded(
-      eService.data.id,
-      eService.metadata.version,
-      eventPayload,
-      ctx.correlationId
-    )
-    : isAsyncExchangeCallbackInterface
-      ? toCreateEventEServiceAsyncExchangeCallbackInterfaceAdded(
         eService.data.id,
         eService.metadata.version,
         eventPayload,
         ctx.correlationId
       )
+    : isAsyncExchangeCallbackInterface
+      ? toCreateEventEServiceAsyncExchangeCallbackInterfaceAdded(
+          eService.data.id,
+          eService.metadata.version,
+          eventPayload,
+          ctx.correlationId
+        )
       : toCreateEventEServiceDocumentAdded(
-        eService.metadata.version,
-        eventPayload,
-        ctx.correlationId
-      );
+          eService.metadata.version,
+          eventPayload,
+          ctx.correlationId
+        );
 
   return {
     eService: updatedEService,
@@ -1290,8 +1290,10 @@ export function catalogServiceBuilder(
       ctx: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
     ): Promise<WithMetadata<Document>> {
       ctx.logger.info(
-        `Creating EService Document ${document.documentId.toString()} of kind ${document.kind
-        }, name ${document.fileName}, path ${document.filePath
+        `Creating EService Document ${document.documentId.toString()} of kind ${
+          document.kind
+        }, name ${document.fileName}, path ${
+          document.filePath
         } for EService ${eserviceId} and Descriptor ${descriptorId}`
       );
 
@@ -1372,19 +1374,19 @@ export function catalogServiceBuilder(
         descriptors: eservice.data.descriptors.map((d: Descriptor) =>
           d.id === descriptorId
             ? {
-              ...d,
-              interface:
-                d.interface?.id === documentId ? undefined : d.interface,
-              serverUrls: isInterface ? [] : d.serverUrls,
-              serverUrlsDescriptions: isInterface
-                ? []
-                : d.serverUrlsDescriptions,
-              docs: d.docs.filter((doc) => doc.id !== documentId),
-              asyncExchangeCallbackInterface:
-                d.asyncExchangeCallbackInterface?.id === documentId
-                  ? undefined
-                  : d.asyncExchangeCallbackInterface,
-            }
+                ...d,
+                interface:
+                  d.interface?.id === documentId ? undefined : d.interface,
+                serverUrls: isInterface ? [] : d.serverUrls,
+                serverUrlsDescriptions: isInterface
+                  ? []
+                  : d.serverUrlsDescriptions,
+                docs: d.docs.filter((doc) => doc.id !== documentId),
+                asyncExchangeCallbackInterface:
+                  d.asyncExchangeCallbackInterface?.id === documentId
+                    ? undefined
+                    : d.asyncExchangeCallbackInterface,
+              }
             : d
         ),
       };
@@ -1397,24 +1399,24 @@ export function catalogServiceBuilder(
 
       const event = isInterface
         ? toCreateEventEServiceInterfaceDeleted(
-          eserviceId,
-          eservice.metadata.version,
-          eventPayload,
-          correlationId
-        )
-        : isAsyncExchangeCallbackInterface
-          ? toCreateEventEServiceAsyncExchangeCallbackInterfaceDeleted(
             eserviceId,
             eservice.metadata.version,
             eventPayload,
             correlationId
           )
+        : isAsyncExchangeCallbackInterface
+          ? toCreateEventEServiceAsyncExchangeCallbackInterfaceDeleted(
+              eserviceId,
+              eservice.metadata.version,
+              eventPayload,
+              correlationId
+            )
           : toCreateEventEServiceDocumentDeleted(
-            eserviceId,
-            eservice.metadata.version,
-            eventPayload,
-            correlationId
-          );
+              eserviceId,
+              eservice.metadata.version,
+              eventPayload,
+              correlationId
+            );
 
       const createdEvent = await repository.createEvent(event);
 
@@ -1476,7 +1478,7 @@ export function catalogServiceBuilder(
           (d) =>
             d.id !== documentId &&
             d.prettyName.toLowerCase() ===
-            apiEServiceDescriptorDocumentUpdateSeed.prettyName.toLowerCase()
+              apiEServiceDescriptorDocumentUpdateSeed.prettyName.toLowerCase()
         )
       ) {
         throw documentPrettyNameDuplicate(
@@ -1495,15 +1497,15 @@ export function catalogServiceBuilder(
         descriptors: eservice.data.descriptors.map((d: Descriptor) =>
           d.id === descriptorId
             ? {
-              ...d,
-              interface: isInterface ? updatedDocument : d.interface,
-              docs: d.docs.map((doc) =>
-                doc.id === documentId ? updatedDocument : doc
-              ),
-              asyncExchangeCallbackInterface: isAsyncExchangeCallbackInterface
-                ? updatedDocument
-                : d.asyncExchangeCallbackInterface,
-            }
+                ...d,
+                interface: isInterface ? updatedDocument : d.interface,
+                docs: d.docs.map((doc) =>
+                  doc.id === documentId ? updatedDocument : doc
+                ),
+                asyncExchangeCallbackInterface: isAsyncExchangeCallbackInterface
+                  ? updatedDocument
+                  : d.asyncExchangeCallbackInterface,
+              }
             : d
         ),
       };
@@ -1516,24 +1518,24 @@ export function catalogServiceBuilder(
 
       const event = isInterface
         ? toCreateEventEServiceInterfaceUpdated(
-          eserviceId,
-          eservice.metadata.version,
-          eventPayload,
-          correlationId
-        )
-        : isAsyncExchangeCallbackInterface
-          ? toCreateEventEServiceAsyncExchangeCallbackInterfaceUpdated(
             eserviceId,
             eservice.metadata.version,
             eventPayload,
             correlationId
           )
+        : isAsyncExchangeCallbackInterface
+          ? toCreateEventEServiceAsyncExchangeCallbackInterfaceUpdated(
+              eserviceId,
+              eservice.metadata.version,
+              eventPayload,
+              correlationId
+            )
           : toCreateEventEServiceDocumentUpdated(
-            eserviceId,
-            eservice.metadata.version,
-            eventPayload,
-            correlationId
-          );
+              eserviceId,
+              eservice.metadata.version,
+              eventPayload,
+              correlationId
+            );
 
       await repository.createEvent(event);
       return updatedDocument;
@@ -1607,17 +1609,17 @@ export function catalogServiceBuilder(
         asyncExchangeProperties:
           asyncExchangeEnabled && eserviceDescriptorSeed.asyncExchangeProperties
             ? {
-              responseTime:
-                eserviceDescriptorSeed.asyncExchangeProperties.responseTime,
-              resourceAvailableTime:
-                eserviceDescriptorSeed.asyncExchangeProperties
-                  .resourceAvailableTime,
-              confirmation:
-                eserviceDescriptorSeed.asyncExchangeProperties.confirmation,
-              bulk: eserviceDescriptorSeed.asyncExchangeProperties.bulk,
-              maxResultSet:
-                eserviceDescriptorSeed.asyncExchangeProperties.maxResultSet,
-            }
+                responseTime:
+                  eserviceDescriptorSeed.asyncExchangeProperties.responseTime,
+                resourceAvailableTime:
+                  eserviceDescriptorSeed.asyncExchangeProperties
+                    .resourceAvailableTime,
+                confirmation:
+                  eserviceDescriptorSeed.asyncExchangeProperties.confirmation,
+                bulk: eserviceDescriptorSeed.asyncExchangeProperties.bulk,
+                maxResultSet:
+                  eserviceDescriptorSeed.asyncExchangeProperties.maxResultSet,
+              }
             : undefined,
       });
 
@@ -1874,17 +1876,17 @@ export function catalogServiceBuilder(
         asyncExchangeProperties:
           asyncExchangeEnabled && descriptor.asyncExchangeProperties
             ? {
-              ...descriptor.asyncExchangeProperties,
-              responseTime:
-                seed.asyncExchangeProperties?.responseTime ??
-                descriptor.asyncExchangeProperties.responseTime,
-              resourceAvailableTime:
-                seed.asyncExchangeProperties?.resourceAvailableTime ??
-                descriptor.asyncExchangeProperties.resourceAvailableTime,
-              maxResultSet:
-                seed.asyncExchangeProperties?.maxResultSet ??
-                descriptor.asyncExchangeProperties.maxResultSet,
-            }
+                ...descriptor.asyncExchangeProperties,
+                responseTime:
+                  seed.asyncExchangeProperties?.responseTime ??
+                  descriptor.asyncExchangeProperties.responseTime,
+                resourceAvailableTime:
+                  seed.asyncExchangeProperties?.resourceAvailableTime ??
+                  descriptor.asyncExchangeProperties.resourceAvailableTime,
+                maxResultSet:
+                  seed.asyncExchangeProperties?.maxResultSet ??
+                  descriptor.asyncExchangeProperties.maxResultSet,
+              }
             : descriptor.asyncExchangeProperties,
       };
 
@@ -2179,26 +2181,26 @@ export function catalogServiceBuilder(
       const clonedInterfacePath =
         descriptor.interface !== undefined
           ? await fileManager.copy(
-            config.s3Bucket,
-            descriptor.interface.path,
-            config.eserviceDocumentsPath,
-            clonedInterfaceId,
-            descriptor.interface.name,
-            logger
-          )
+              config.s3Bucket,
+              descriptor.interface.path,
+              config.eserviceDocumentsPath,
+              clonedInterfaceId,
+              descriptor.interface.name,
+              logger
+            )
           : undefined;
 
       const clonedInterfaceDocument: Document | undefined =
         descriptor.interface !== undefined && clonedInterfacePath !== undefined
           ? {
-            id: clonedInterfaceId,
-            name: descriptor.interface.name,
-            contentType: descriptor.interface.contentType,
-            prettyName: descriptor.interface.prettyName,
-            path: clonedInterfacePath,
-            checksum: descriptor.interface.checksum,
-            uploadDate: new Date(),
-          }
+              id: clonedInterfaceId,
+              name: descriptor.interface.name,
+              contentType: descriptor.interface.contentType,
+              prettyName: descriptor.interface.prettyName,
+              path: clonedInterfacePath,
+              checksum: descriptor.interface.checksum,
+              uploadDate: new Date(),
+            }
           : undefined;
 
       const clonedDocuments = await Promise.all(
@@ -2288,19 +2290,19 @@ export function catalogServiceBuilder(
       const event =
         archivingKindSeed.kind === "AUTOMATIC"
           ? toCreateEventEServiceDescriptorArchived(
-            eserviceId,
-            eservice.metadata.version,
-            descriptorId,
-            newEservice,
-            correlationId
-          )
+              eserviceId,
+              eservice.metadata.version,
+              descriptorId,
+              newEservice,
+              correlationId
+            )
           : toCreateEventEServiceDescriptorArchivingCompleted(
-            eserviceId,
-            eservice.metadata.version,
-            descriptorId,
-            newEservice,
-            correlationId
-          );
+              eserviceId,
+              eservice.metadata.version,
+              descriptorId,
+              newEservice,
+              correlationId
+            );
 
       await repository.createEvent(event);
     },
@@ -2995,15 +2997,15 @@ export function catalogServiceBuilder(
           ? undefined
           : isConsumerDelegable
             ? toCreateEventEServiceIsConsumerDelegableEnabled(
-              eservice.metadata.version,
-              updatedEservice,
-              correlationId
-            )
+                eservice.metadata.version,
+                updatedEservice,
+                correlationId
+              )
             : toCreateEventEServiceIsConsumerDelegableDisabled(
-              eservice.metadata.version,
-              updatedEservice,
-              correlationId
-            );
+                eservice.metadata.version,
+                updatedEservice,
+                correlationId
+              );
 
       const clientAccessEventVersion =
         eservice.metadata.version + (consumerDelegableEvent ? 1 : 0);
@@ -3013,15 +3015,15 @@ export function catalogServiceBuilder(
           ? undefined
           : isClientAccessDelegable
             ? toCreateEventEServiceIsClientAccessDelegableEnabled(
-              clientAccessEventVersion,
-              updatedEservice,
-              correlationId
-            )
+                clientAccessEventVersion,
+                updatedEservice,
+                correlationId
+              )
             : toCreateEventEServiceIsClientAccessDelegableDisabled(
-              clientAccessEventVersion,
-              updatedEservice,
-              correlationId
-            );
+                clientAccessEventVersion,
+                updatedEservice,
+                correlationId
+              );
 
       const events = [
         consumerDelegableEvent,
@@ -4013,21 +4015,21 @@ export function catalogServiceBuilder(
             riskAnalysis,
             asyncExchangeProperties:
               isFeatureFlagEnabled(config, "featureFlagAsyncExchange") &&
-                template.asyncExchange === true &&
-                publishedVersion.asyncExchangeProperties
+              template.asyncExchange === true &&
+              publishedVersion.asyncExchangeProperties
                 ? {
-                  ...publishedVersion.asyncExchangeProperties,
-                  responseTime:
-                    seed.asyncExchangeProperties?.responseTime ??
-                    publishedVersion.asyncExchangeProperties.responseTime,
-                  resourceAvailableTime:
-                    seed.asyncExchangeProperties?.resourceAvailableTime ??
-                    publishedVersion.asyncExchangeProperties
-                      .resourceAvailableTime,
-                  maxResultSet:
-                    seed.asyncExchangeProperties?.maxResultSet ??
-                    publishedVersion.asyncExchangeProperties.maxResultSet,
-                }
+                    ...publishedVersion.asyncExchangeProperties,
+                    responseTime:
+                      seed.asyncExchangeProperties?.responseTime ??
+                      publishedVersion.asyncExchangeProperties.responseTime,
+                    resourceAvailableTime:
+                      seed.asyncExchangeProperties?.resourceAvailableTime ??
+                      publishedVersion.asyncExchangeProperties
+                        .resourceAvailableTime,
+                    maxResultSet:
+                      seed.asyncExchangeProperties?.maxResultSet ??
+                      publishedVersion.asyncExchangeProperties.maxResultSet,
+                  }
                 : undefined,
           },
           instanceLabel: parsedInstanceLabel,
@@ -4221,8 +4223,8 @@ export function catalogServiceBuilder(
       const agreementApprovalPolicySeed =
         eserviceInstanceDescriptorSeed.agreementApprovalPolicy
           ? apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-            eserviceInstanceDescriptorSeed.agreementApprovalPolicy
-          )
+              eserviceInstanceDescriptorSeed.agreementApprovalPolicy
+            )
           : undefined;
 
       assertConsistentDailyCalls(eserviceInstanceDescriptorSeed);
@@ -4439,15 +4441,15 @@ export function catalogServiceBuilder(
       const updatedDescriptor =
         latestDescriptor.archivingSchedule?.scope === archivingScope.eservice
           ? {
-            ...descriptor,
-            archivingSchedule: latestDescriptor.archivingSchedule,
-          }
+              ...descriptor,
+              archivingSchedule: latestDescriptor.archivingSchedule,
+            }
           : updateDescriptorState(
-            { ...descriptor, archivingSchedule: undefined },
-            descriptor.state === descriptorState.archivingSuspended
-              ? descriptorState.suspended
-              : descriptorState.deprecated
-          );
+              { ...descriptor, archivingSchedule: undefined },
+              descriptor.state === descriptorState.archivingSuspended
+                ? descriptorState.suspended
+                : descriptorState.deprecated
+            );
 
       const updatedEService = replaceDescriptor(
         eservice.data,
@@ -4572,11 +4574,11 @@ async function processEserviceArchiving(
 
   const eserviceAfterCleanup = draftOrWaiting
     ? await deleteInactiveDescriptorLogic(
-      eservice,
-      draftOrWaiting,
-      fileManager,
-      logger
-    )
+        eservice,
+        draftOrWaiting,
+        fileManager,
+        logger
+      )
     : eservice;
 
   const requestDate = new Date();
@@ -4661,11 +4663,11 @@ async function createOpenApiInterfaceByTemplate(
   serverUrls: Array<{ url: string; description?: string }>,
   eserviceInstanceInterfaceRestData:
     | {
-      contactEmail: string;
-      contactName: string;
-      contactUrl?: string;
-      termsAndConditionsUrl?: string;
-    }
+        contactEmail: string;
+        contactName: string;
+        contactUrl?: string;
+        termsAndConditionsUrl?: string;
+      }
     | undefined,
   bucket: string,
   fileManager: FileManager,
@@ -5075,11 +5077,11 @@ function hasCertifiedAttributeConfigurationChanged(
         getEServiceAttributeDiscreteConfig(descriptorAttribute);
       return (
         seedAttribute?.dailyCallsPerConsumer !==
-        descriptorAttribute.dailyCallsPerConsumer ||
+          descriptorAttribute.dailyCallsPerConsumer ||
         seedAttribute?.discreteConfig?.threshold !==
-        descriptorDiscreteConfig?.threshold ||
+          descriptorDiscreteConfig?.threshold ||
         seedAttribute?.discreteConfig?.comparator !==
-        descriptorDiscreteConfig?.comparator
+          descriptorDiscreteConfig?.comparator
       );
     });
   });
@@ -5168,13 +5170,13 @@ async function updateDraftEService(
   eserviceId: EServiceId,
   typeAndSeed:
     | {
-      type: "put";
-      seed: catalogApi.UpdateEServiceSeed;
-    }
+        type: "put";
+        seed: catalogApi.UpdateEServiceSeed;
+      }
     | {
-      type: "patch";
-      seed: catalogApi.PatchUpdateEServiceSeed;
-    },
+        type: "patch";
+        seed: catalogApi.PatchUpdateEServiceSeed;
+      },
   readModelService: ReadModelServiceSQL,
   fileManager: FileManager,
   repository: ReturnType<typeof eventRepository<EServiceEvent>>,
@@ -5248,9 +5250,9 @@ async function updateDraftEService(
   // - personalData flag is changed from true to false or vice versa
   const checkedRiskAnalysis =
     updatedMode === eserviceMode.deliver ||
-      (typeAndSeed.seed.personalData != null &&
-        eservice.data.personalData != null &&
-        typeAndSeed.seed.personalData !== eservice.data.personalData)
+    (typeAndSeed.seed.personalData != null &&
+      eservice.data.personalData != null &&
+      typeAndSeed.seed.personalData !== eservice.data.personalData)
       ? []
       : eservice.data.riskAnalysis;
 
@@ -5309,12 +5311,12 @@ async function updateDraftEService(
     riskAnalysis: checkedRiskAnalysis,
     descriptors: interfaceHasToBeDeleted
       ? eservice.data.descriptors.map((d) => ({
-        ...d,
-        interface: undefined,
-        asyncExchangeCallbackInterface: undefined,
-        serverUrls: [],
-        serverUrlsDescriptions: [],
-      }))
+          ...d,
+          interface: undefined,
+          asyncExchangeCallbackInterface: undefined,
+          serverUrls: [],
+          serverUrlsDescriptions: [],
+        }))
       : eservice.data.descriptors,
     isSignalHubEnabled: updatedIsSignalHubEnabled,
     isConsumerDelegable: updatedIsConsumerDelegable,
@@ -5399,13 +5401,13 @@ async function updateDraftDescriptor(
 
   const updatedAttributes = attributes
     ? await parseAndCheckAttributes(
-      {
-        certified: attributes.certified ?? descriptor.attributes.certified,
-        declared: attributes.declared ?? descriptor.attributes.declared,
-        verified: attributes.verified ?? descriptor.attributes.verified,
-      },
-      readModelService
-    )
+        {
+          certified: attributes.certified ?? descriptor.attributes.certified,
+          declared: attributes.declared ?? descriptor.attributes.declared,
+          verified: attributes.verified ?? descriptor.attributes.verified,
+        },
+        readModelService
+      )
     : descriptor.attributes;
 
   assertDailyCallsForCertifiedAttributesOnly(updatedAttributes);
@@ -5417,8 +5419,8 @@ async function updateDraftDescriptor(
 
   const updatedAgreementApprovalPolicy = agreementApprovalPolicy
     ? apiAgreementApprovalPolicyToAgreementApprovalPolicy(
-      agreementApprovalPolicy
-    )
+        agreementApprovalPolicy
+      )
     : descriptor.agreementApprovalPolicy;
 
   const asyncExchangeEnabled =

--- a/packages/catalog-readmodel-writer-sql/test/catalogReadmodelWriter.integration.test.ts
+++ b/packages/catalog-readmodel-writer-sql/test/catalogReadmodelWriter.integration.test.ts
@@ -1703,7 +1703,6 @@ export const getMockDescriptor = (): Descriptor => ({
   dailyCallsTotal: 1000,
   createdAt: new Date(),
   serverUrls: ["pagopa.it"],
-  serverUrlsDescriptions: [],
   agreementApprovalPolicy: "Automatic",
   attributes: {
     certified: [],

--- a/packages/domains-analytics-writer/src/model/catalog/eserviceDescriptor.ts
+++ b/packages/domains-analytics-writer/src/model/catalog/eserviceDescriptor.ts
@@ -25,7 +25,8 @@ export const EserviceDescriptorSchema = createSelectSchema(
       .pipe(z.string()),
     serverUrlsDescriptions: z
       .array(z.string())
-      .transform((val) => JSON.stringify(val))
+      .nullable()
+      .transform((val) => JSON.stringify(val ?? []))
       .pipe(z.string()),
   });
 export type EserviceDescriptorSchema = z.infer<typeof EserviceDescriptorSchema>;

--- a/packages/kpi-domains-readmodel-checker/src/model/catalog/eserviceDescriptor.ts
+++ b/packages/kpi-domains-readmodel-checker/src/model/catalog/eserviceDescriptor.ts
@@ -18,7 +18,8 @@ export const EserviceDescriptorSchema = createSelectSchema(
       .pipe(z.string()),
     serverUrlsDescriptions: z
       .array(z.string())
-      .transform((val) => JSON.stringify(val))
+      .nullable()
+      .transform((val) => JSON.stringify(val ?? []))
       .pipe(z.string()),
   });
 export type EserviceDescriptorSchema = z.infer<typeof EserviceDescriptorSchema>;

--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -187,7 +187,7 @@ export const Descriptor = z.object({
   agreementApprovalPolicy: AgreementApprovalPolicy.optional(),
   createdAt: z.coerce.date(),
   serverUrls: z.array(z.string()),
-  serverUrlsDescriptions: z.array(z.string()),
+  serverUrlsDescriptions: z.array(z.string()).optional(),
   publishedAt: z.coerce.date().optional(),
   suspendedAt: z.coerce.date().optional(),
   deprecatedAt: z.coerce.date().optional(),

--- a/packages/models/src/eservice/protobufConverterFromV1.ts
+++ b/packages/models/src/eservice/protobufConverterFromV1.ts
@@ -154,7 +154,7 @@ export const fromDescriptorV1 = (input: EServiceDescriptorV1): Descriptor => {
     deprecatedAt: bigIntToDate(input.deprecatedAt),
     archivedAt: bigIntToDate(input.archivedAt),
     // serverUrlsDescriptions is not present in V1 events
-    serverUrlsDescriptions: [],
+    serverUrlsDescriptions: undefined,
   };
 };
 

--- a/packages/models/src/eservice/protobufConverterFromV2.ts
+++ b/packages/models/src/eservice/protobufConverterFromV2.ts
@@ -251,6 +251,10 @@ export const fromDescriptorV2 = (input: EServiceDescriptorV2): Descriptor => ({
         ),
       }
     : undefined,
+  serverUrlsDescriptions:
+    input.serverUrlsDescriptions.length > 0
+      ? input.serverUrlsDescriptions
+      : undefined,
 });
 
 export const fromRiskAnalysisFormV2 = (

--- a/packages/models/src/eservice/protobufConverterToV2.ts
+++ b/packages/models/src/eservice/protobufConverterToV2.ts
@@ -207,6 +207,7 @@ export const toDescriptorV2 = (input: Descriptor): EServiceDescriptorV2 => ({
         ),
       }
     : undefined,
+  serverUrlsDescriptions: input.serverUrlsDescriptions ?? [],
   asyncExchangeCallbackInterface: input.asyncExchangeCallbackInterface
     ? toDocumentV2(input.asyncExchangeCallbackInterface)
     : undefined,

--- a/packages/readmodel-models/src/drizzle/schema.ts
+++ b/packages/readmodel-models/src/drizzle/schema.ts
@@ -442,9 +442,7 @@ export const eserviceDescriptorInReadmodelCatalog = readmodelCatalog.table(
       mode: "string",
     }).notNull(),
     serverUrls: varchar("server_urls").array().notNull(),
-    serverUrlsDescriptions: varchar("server_urls_descriptions")
-      .array()
-      .notNull(),
+    serverUrlsDescriptions: varchar("server_urls_descriptions").array(),
     publishedAt: timestamp("published_at", {
       withTimezone: true,
       mode: "string",

--- a/packages/readmodel/src/catalog/aggregators.ts
+++ b/packages/readmodel/src/catalog/aggregators.ts
@@ -183,7 +183,7 @@ export const aggregateDescriptor = ({
     dailyCallsTotal: descriptorSQL.dailyCallsTotal,
     createdAt: stringToDate(descriptorSQL.createdAt),
     serverUrls: descriptorSQL.serverUrls,
-    serverUrlsDescriptions: descriptorSQL.serverUrlsDescriptions,
+    serverUrlsDescriptions: descriptorSQL.serverUrlsDescriptions ?? undefined,
     attributes: {
       certified: certifiedAttributes,
       declared: declaredAttributes,

--- a/packages/readmodel/src/catalog/splitters.ts
+++ b/packages/readmodel/src/catalog/splitters.ts
@@ -462,7 +462,7 @@ export const descriptorToDescriptorSQL = (
   dailyCallsPerConsumer: descriptor.dailyCallsPerConsumer,
   dailyCallsTotal: descriptor.dailyCallsTotal,
   serverUrls: descriptor.serverUrls,
-  serverUrlsDescriptions: descriptor.serverUrlsDescriptions,
+  serverUrlsDescriptions: descriptor.serverUrlsDescriptions ?? null,
   agreementApprovalPolicy: descriptor.agreementApprovalPolicy || null,
   publishedAt: dateToString(descriptor.publishedAt),
   suspendedAt: dateToString(descriptor.suspendedAt),

--- a/packages/readmodel/test/catalog/eserviceSplitter.test.ts
+++ b/packages/readmodel/test/catalog/eserviceSplitter.test.ts
@@ -194,7 +194,7 @@ describe("E-service splitter", () => {
       dailyCallsPerConsumer: descriptor.dailyCallsPerConsumer,
       dailyCallsTotal: descriptor.dailyCallsTotal,
       serverUrls: descriptor.serverUrls,
-      serverUrlsDescriptions: descriptor.serverUrlsDescriptions,
+      serverUrlsDescriptions: descriptor.serverUrlsDescriptions ?? null,
     };
 
     const expectedAsyncExchangePropertiesSQL: EServiceDescriptorAsyncExchangePropertiesSQL =
@@ -439,7 +439,7 @@ describe("E-service splitter", () => {
       dailyCallsPerConsumer: descriptor.dailyCallsPerConsumer,
       dailyCallsTotal: descriptor.dailyCallsTotal,
       serverUrls: descriptor.serverUrls,
-      serverUrlsDescriptions: descriptor.serverUrlsDescriptions,
+      serverUrlsDescriptions: descriptor.serverUrlsDescriptions ?? null,
     };
 
     const expectedDocumentSQL: EServiceDescriptorDocumentSQL = {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10355](https://pagopa.atlassian.net/browse/PIN-10355)

Follow-up on the `server_urls_descriptions`   introduced in #3546 because  existing events don't contain that field. Setting a default on the read model would mean that the readmodel contains information that isn't aligned with the data source (events/event store).
In theory, we wouldn't be allowed to define the field as mandatory in the ts model since it wouldn't exist in the event, unless we set a default in the decoding, which would mean "modifying" the event when read.

[PIN-10355]: https://pagopa.atlassian.net/browse/PIN-10355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ