### PR TITLE
fix: return 201 on process create endpoints (PIN-7407)

### DIFF
--- a/packages/agreement-process/src/routers/AgreementRouter.ts
+++ b/packages/agreement-process/src/routers/AgreementRouter.ts
@@ -398,7 +398,7 @@ const agreementRouter = (
         setMetadataVersionHeader(res, metadata);
 
         return res
-          .status(200)
+          .status(201)
           .send(
             agreementApi.Agreement.parse(agreementToApiAgreement(agreement))
           );

--- a/packages/agreement-process/test/api/createAgreement.test.ts
+++ b/packages/agreement-process/test/api/createAgreement.test.ts
@@ -61,11 +61,11 @@ describe("API POST /agreements test", () => {
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiResponse);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/api-clients/open-api/agreementApi.yml
+++ b/packages/api-clients/open-api/agreementApi.yml
@@ -402,7 +402,7 @@ paths:
       summary: Agreement Creation
       operationId: createAgreement
       responses:
-        "200":
+        "201":
           description: Agreement created.
           headers:
             X-Metadata-Version:

--- a/packages/api-clients/open-api/attributeRegistryApi.yml
+++ b/packages/api-clients/open-api/attributeRegistryApi.yml
@@ -41,7 +41,7 @@ paths:
         - attribute
       operationId: createCertifiedAttribute
       responses:
-        "200":
+        "201":
           description: Certified attribute created
           headers:
             X-Metadata-Version:
@@ -117,7 +117,7 @@ paths:
         - attribute
       operationId: createDeclaredAttribute
       responses:
-        "200":
+        "201":
           description: Declared attribute created
           headers:
             X-Metadata-Version:
@@ -149,7 +149,7 @@ paths:
         - attribute
       operationId: createVerifiedAttribute
       responses:
-        "200":
+        "201":
           description: Verified attribute created
           headers:
             X-Metadata-Version:
@@ -181,7 +181,7 @@ paths:
         - attribute
       operationId: createInternalCertifiedAttribute
       responses:
-        "200":
+        "201":
           description: Certified attribute created
           content:
             application/json:
@@ -211,7 +211,7 @@ paths:
       operationId: createInternalCertifiedDiscreteAttribute
       description: Creates the certified discrete attribute passed as payload
       responses:
-        "200":
+        "201":
           description: Certified discrete attribute created
           content:
             application/json:

--- a/packages/api-clients/open-api/authorizationApi.yml
+++ b/packages/api-clients/open-api/authorizationApi.yml
@@ -64,7 +64,7 @@ paths:
             schema:
               $ref: "#/components/schemas/ClientSeed"
       responses:
-        "200":
+        "201":
           description: Client created
           headers:
             X-Metadata-Version:
@@ -91,7 +91,7 @@ paths:
             schema:
               $ref: "#/components/schemas/ClientSeed"
       responses:
-        "200":
+        "201":
           description: Client created
           content:
             application/json:
@@ -473,7 +473,7 @@ paths:
       summary: Create Key for the specific clientId.
       operationId: createKey
       responses:
-        "200":
+        "201":
           description: Key created
           headers:
             X-Metadata-Version:
@@ -891,7 +891,7 @@ paths:
             schema:
               $ref: "#/components/schemas/ProducerKeychainSeed"
       responses:
-        "200":
+        "201":
           description: Producer keychain created
           headers:
             X-Metadata-Version:
@@ -1185,7 +1185,7 @@ paths:
       summary: Create Key for the specific producerKeychainId.
       operationId: createProducerKey
       responses:
-        "200":
+        "201":
           description: Key created
           headers:
             X-Metadata-Version:

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -192,7 +192,7 @@ paths:
               $ref: "#/components/schemas/EServiceSeed"
         required: true
       responses:
-        "200":
+        "201":
           description: EService created
           headers:
             X-Metadata-Version:
@@ -496,7 +496,7 @@ paths:
             schema:
               $ref: "#/components/schemas/InstanceEServiceSeed"
       responses:
-        "200":
+        "201":
           description: EService created from template
           content:
             application/json:
@@ -648,7 +648,7 @@ paths:
               $ref: "#/components/schemas/EServiceDescriptorSeed"
         required: true
       responses:
-        "200":
+        "201":
           description: EService Descriptor created.
           headers:
             X-Metadata-Version:
@@ -687,7 +687,7 @@ paths:
               $ref: "#/components/schemas/EServiceInstanceDescriptorSeed"
         required: true
       responses:
-        "200":
+        "201":
           description: EService Instance Descriptor created.
           content:
             application/json:
@@ -1365,7 +1365,7 @@ paths:
             schema:
               $ref: "#/components/schemas/CreateEServiceDescriptorDocumentSeed"
       responses:
-        "200":
+        "201":
           description: EService Document created
           headers:
             X-Metadata-Version:
@@ -1737,7 +1737,7 @@ paths:
             schema:
               $ref: "#/components/schemas/EServiceRiskAnalysisSeed"
       responses:
-        "200":
+        "201":
           description: EService Risk Analysis created
           headers:
             X-Metadata-Version:

--- a/packages/api-clients/open-api/delegationApi.yml
+++ b/packages/api-clients/open-api/delegationApi.yml
@@ -394,7 +394,7 @@ paths:
         description: Payload for delegation creation
         required: true
       responses:
-        "200":
+        "201":
           description: Delegation created.
           headers:
             X-Metadata-Version:
@@ -534,7 +534,7 @@ paths:
         description: Payload for delegation creation
         required: true
       responses:
-        "200":
+        "201":
           description: Delegation created.
           headers:
             X-Metadata-Version:

--- a/packages/api-clients/open-api/eserviceTemplateApi.yml
+++ b/packages/api-clients/open-api/eserviceTemplateApi.yml
@@ -123,7 +123,7 @@ paths:
               $ref: "#/components/schemas/EServiceTemplateSeed"
         required: true
       responses:
-        "200":
+        "201":
           description: EService template created
           headers:
             X-Metadata-Version:
@@ -271,7 +271,7 @@ paths:
               $ref: "#/components/schemas/EServiceTemplateVersionSeed"
         required: true
       responses:
-        "200":
+        "201":
           description: EService template version created.
           headers:
             X-Metadata-Version:
@@ -609,7 +609,7 @@ paths:
             schema:
               $ref: "#/components/schemas/CreateEServiceTemplateVersionDocumentSeed"
       responses:
-        "200":
+        "201":
           description: EService Template Document created
           headers:
             X-Metadata-Version:
@@ -798,7 +798,7 @@ paths:
             schema:
               $ref: "#/components/schemas/EServiceTemplateRiskAnalysisSeed"
       responses:
-        "200":
+        "201":
           description: EService Template Risk Analysis created
           headers:
             X-Metadata-Version:

--- a/packages/api-clients/open-api/notificationConfigApi.yml
+++ b/packages/api-clients/open-api/notificationConfigApi.yml
@@ -100,7 +100,7 @@ paths:
               $ref: "#/components/schemas/TenantNotificationConfigSeed"
         required: true
       responses:
-        "200":
+        "201":
           description: The tenant's newly created notification configuration
           content:
             application/json:

--- a/packages/api-clients/open-api/purposeApi.yml
+++ b/packages/api-clients/open-api/purposeApi.yml
@@ -285,7 +285,7 @@ paths:
       operationId: createPurpose
       description: Creates the Purpose
       responses:
-        "200":
+        "201":
           description: Purpose created
           headers:
             X-Metadata-Version:
@@ -323,7 +323,7 @@ paths:
               $ref: "#/components/schemas/ReversePurposeSeed"
         required: true
       responses:
-        "200":
+        "201":
           description: Purpose created
           headers:
             X-Metadata-Version:
@@ -525,7 +525,7 @@ paths:
       operationId: createPurposeVersion
       description: Creates a draft Purpose Version
       responses:
-        "200":
+        "201":
           description: Purpose version created
           headers:
             X-Metadata-Version:
@@ -1162,7 +1162,7 @@ paths:
               $ref: "#/components/schemas/PurposeFromTemplateSeed"
         required: true
       responses:
-        "200":
+        "201":
           description: Purpose created
           headers:
             X-Metadata-Version:

--- a/packages/attribute-registry-process/src/routers/AttributeRouter.ts
+++ b/packages/attribute-registry-process/src/routers/AttributeRouter.ts
@@ -276,7 +276,7 @@ const attributeRouter = (
 
         setMetadataVersionHeader(res, metadata);
         return res
-          .status(200)
+          .status(201)
           .send(attributeRegistryApi.Attribute.parse(toApiAttribute(data)));
       } catch (error) {
         const errorRes = makeApiProblem(
@@ -324,7 +324,7 @@ const attributeRouter = (
         setMetadataVersionHeader(res, metadata);
 
         return res
-          .status(200)
+          .status(201)
           .send(
             attributeRegistryApi.Attribute.parse(toApiAttribute(attribute))
           );
@@ -349,7 +349,7 @@ const attributeRouter = (
         setMetadataVersionHeader(res, metadata);
 
         return res
-          .status(200)
+          .status(201)
           .send(
             attributeRegistryApi.Attribute.parse(toApiAttribute(attribute))
           );
@@ -374,7 +374,7 @@ const attributeRouter = (
             ctx
           );
         return res
-          .status(200)
+          .status(201)
           .send(
             attributeRegistryApi.Attribute.parse(toApiAttribute(attribute))
           );
@@ -400,7 +400,7 @@ const attributeRouter = (
           );
 
         return res
-          .status(200)
+          .status(201)
           .send(
             attributeRegistryApi.Attribute.parse(toApiAttribute(attribute))
           );

--- a/packages/attribute-registry-process/test/api/createCertifiedAttribute.test.ts
+++ b/packages/attribute-registry-process/test/api/createCertifiedAttribute.test.ts
@@ -40,11 +40,11 @@ describe("API /certifiedAttributes authorization test", () => {
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiAttribute);
       expect(res.headers["x-metadata-version"]).toBe("0");
     }

--- a/packages/attribute-registry-process/test/api/createDeclaredAttribute.test.ts
+++ b/packages/attribute-registry-process/test/api/createDeclaredAttribute.test.ts
@@ -49,12 +49,12 @@ describe("API /declaredAttributes authorization test", () => {
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiAttribute);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/attribute-registry-process/test/api/createInternalCertifiedAttribute.test.ts
+++ b/packages/attribute-registry-process/test/api/createInternalCertifiedAttribute.test.ts
@@ -36,11 +36,11 @@ describe("API /internal/certifiedAttributes authorization test", () => {
       .set("X-Correlation-Id", generateId())
       .send(mockInternalCertifiedAttributeSeed);
 
-  it("Should return 200 for user with role Internal", async () => {
+  it("Should return 201 for user with role Internal", async () => {
     const token = generateToken(authRole.INTERNAL_ROLE);
     const res = await makeRequest(token);
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     expect(res.body).toEqual(apiAttribute);
   });
 

--- a/packages/attribute-registry-process/test/api/createInternalCertifiedDiscreteAttribute.test.ts
+++ b/packages/attribute-registry-process/test/api/createInternalCertifiedDiscreteAttribute.test.ts
@@ -36,11 +36,11 @@ describe("API /internal/certifiedDiscreteAttributes authorization test", () => {
       .set("X-Correlation-Id", generateId())
       .send(mockInternalCertifiedDiscreteAttributeSeed);
 
-  it("Should return 200 for user with role Internal", async () => {
+  it("Should return 201 for user with role Internal", async () => {
     const token = generateToken(authRole.INTERNAL_ROLE);
     const res = await makeRequest(token);
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     expect(res.body).toEqual(apiAttribute);
     expect(
       attributeRegistryService.internalCreateCertifiedDiscreteAttribute

--- a/packages/attribute-registry-process/test/api/createVerifiedAttribute.test.ts
+++ b/packages/attribute-registry-process/test/api/createVerifiedAttribute.test.ts
@@ -48,12 +48,12 @@ describe("API /verifiedAttributes authorization test", () => {
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiAttribute);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/authorization-process/src/routers/AuthorizationRouter.ts
+++ b/packages/authorization-process/src/routers/AuthorizationRouter.ts
@@ -103,7 +103,7 @@ const authorizationRouter = (
           );
         setMetadataVersionHeader(res, metadata);
         return res
-          .status(200)
+          .status(201)
           .send(
             authorizationApi.FullClient.parse(
               clientToApiFullVisibilityClient(client)
@@ -131,7 +131,7 @@ const authorizationRouter = (
           ctx
         );
         return res
-          .status(200)
+          .status(201)
           .send(
             authorizationApi.FullClient.parse(
               clientToApiFullVisibilityClient(client)
@@ -411,7 +411,7 @@ const authorizationRouter = (
         );
         setMetadataVersionHeader(res, metadata);
         return res
-          .status(200)
+          .status(201)
           .send(authorizationApi.Key.parse(keyToApiKey(key)));
       } catch (error) {
         const errorRes = makeApiProblem(error, createKeyErrorMapper, ctx);
@@ -664,7 +664,7 @@ const authorizationRouter = (
 
         setMetadataVersionHeader(res, metadata);
         return res
-          .status(200)
+          .status(201)
           .send(
             authorizationApi.FullProducerKeychain.parse(
               producerKeychainToApiFullVisibilityProducerKeychain(
@@ -952,7 +952,7 @@ const authorizationRouter = (
           );
         setMetadataVersionHeader(res, metadata);
         return res
-          .status(200)
+          .status(201)
           .send(authorizationApi.Key.parse(keyToApiKey(key)));
       } catch (error) {
         const errorRes = makeApiProblem(

--- a/packages/authorization-process/test/api/createApiClient.test.ts
+++ b/packages/authorization-process/test/api/createApiClient.test.ts
@@ -43,11 +43,11 @@ describe("API /clientsApi authorization test", () => {
   const authorizedRoles: AuthRole[] = [authRole.ADMIN_ROLE];
 
   it.each(authorizedRoles)(
-    "Should return 200 with a full client for user with role %s",
+    "Should return 201 with a full client for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, clientSeed);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(testToFullClient(mockClient));
     }
   );

--- a/packages/authorization-process/test/api/createConsumerClient.test.ts
+++ b/packages/authorization-process/test/api/createConsumerClient.test.ts
@@ -51,11 +51,11 @@ describe("API /clientsConsumer authorization test", () => {
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 with a full client for user with role %s",
+    "Should return 201 with a full client for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, clientSeed);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(testToFullClient(mockClient.data));
     }
   );

--- a/packages/authorization-process/test/api/createKey.test.ts
+++ b/packages/authorization-process/test/api/createKey.test.ts
@@ -83,11 +83,11 @@ describe("API /clients/{clientId}/keys authorization test", () => {
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, mockClient.data.id);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiKey);
     }
   );

--- a/packages/authorization-process/test/api/createProducerKeychain.test.ts
+++ b/packages/authorization-process/test/api/createProducerKeychain.test.ts
@@ -50,11 +50,11 @@ describe("API /producerKeychains authorization test", () => {
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, producerKeychainSeed);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(
         testToFullProducerKeychain(mockProducerKeychain.data)
       );

--- a/packages/authorization-process/test/api/createProducerKeychainKey.test.ts
+++ b/packages/authorization-process/test/api/createProducerKeychainKey.test.ts
@@ -61,11 +61,11 @@ describe("API /producerKeychains/{producerKeychainId}/keys authorization test", 
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, mockProducerKeychain.data.id);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiKey);
     }
   );

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -215,7 +215,7 @@ const eservicesRouter = (
             ctx
           );
         return res
-          .status(200)
+          .status(201)
           .send(catalogApi.EService.parse(eServiceToApiEService(eService)));
       } catch (error) {
         const errorRes = makeApiProblem(
@@ -510,7 +510,7 @@ const eservicesRouter = (
           setMetadataVersionHeader(res, metadata);
 
           return res
-            .status(200)
+            .status(201)
             .send(
               catalogApi.EServiceDoc.parse(documentToApiDocument(document))
             );
@@ -602,7 +602,7 @@ const eservicesRouter = (
 
         setMetadataVersionHeader(res, metadata);
 
-        return res.status(200).send(
+        return res.status(201).send(
           catalogApi.CreatedEServiceDescriptor.parse({
             eservice: eServiceToApiEService(eservice),
             createdDescriptorId,
@@ -998,7 +998,7 @@ const eservicesRouter = (
         );
 
         setMetadataVersionHeader(res, metadata);
-        return res.status(200).send(
+        return res.status(201).send(
           catalogApi.CreatedEServiceRiskAnalysis.parse({
             eservice: eServiceToApiEService(eservice),
             createdRiskAnalysisId,
@@ -1653,7 +1653,7 @@ const eservicesRouter = (
             ctx
           );
         return res
-          .status(200)
+          .status(201)
           .send(
             catalogApi.EServiceDescriptor.parse(
               descriptorToApiDescriptor(descriptor)

--- a/packages/catalog-process/test/api/createDescriptor.test.ts
+++ b/packages/catalog-process/test/api/createDescriptor.test.ts
@@ -103,12 +103,12 @@ describe("API /eservices/{eServiceId}/descriptors authorization test", () => {
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, eservice.id);
       expect(res.body).toEqual(apiCreatedDescriptor);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()
       );

--- a/packages/catalog-process/test/api/createEServiceInstanceFromTemplate.test.ts
+++ b/packages/catalog-process/test/api/createEServiceInstanceFromTemplate.test.ts
@@ -76,12 +76,12 @@ describe("API /templates/{templateId}/eservices authorization test", () => {
 
   const authorizedRoles: AuthRole[] = [authRole.ADMIN_ROLE, authRole.API_ROLE];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, eServiceTemplate.id);
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(mockApiEservice);
     }
   );

--- a/packages/catalog-process/test/api/createRiskAnalysis.test.ts
+++ b/packages/catalog-process/test/api/createRiskAnalysis.test.ts
@@ -71,12 +71,12 @@ describe("API /eservices/{eServiceId}/riskAnalysis authorization test", () => {
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, mockEService.id);
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiResponse);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/catalog-process/test/api/createTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/api/createTemplateInstanceDescriptor.test.ts
@@ -87,12 +87,12 @@ describe("API /templates/eservices/{eServiceId}/descriptors authorization test",
 
   const authorizedRoles: AuthRole[] = [authRole.ADMIN_ROLE, authRole.API_ROLE];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, mockEService.id);
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiDescriptor);
     }
   );

--- a/packages/catalog-process/test/api/uploadDocument.test.ts
+++ b/packages/catalog-process/test/api/uploadDocument.test.ts
@@ -79,11 +79,11 @@ describe("API /eservices/{eServiceId}/descriptors/{descriptorId}/documents autho
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, mockEService.id, descriptor.id);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiDocument);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/delegation-process/src/routers/DelegationRouter.ts
+++ b/packages/delegation-process/src/routers/DelegationRouter.ts
@@ -265,7 +265,7 @@ const delegationRouter = (
 
         setMetadataVersionHeader(res, metadata);
         return res
-          .status(200)
+          .status(201)
           .json(
             delegationApi.Delegation.parse(delegationToApiDelegation(data))
           );
@@ -385,7 +385,7 @@ const delegationRouter = (
 
         setMetadataVersionHeader(res, metadata);
         return res
-          .status(200)
+          .status(201)
           .json(
             delegationApi.Delegation.parse(delegationToApiDelegation(data))
           );

--- a/packages/delegation-process/test/api/createConsumerDelegation.test.ts
+++ b/packages/delegation-process/test/api/createConsumerDelegation.test.ts
@@ -69,11 +69,11 @@ describe("API POST /consumer/delegations test", () => {
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiDelegation);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/delegation-process/test/api/createProducerDelegation.test.ts
+++ b/packages/delegation-process/test/api/createProducerDelegation.test.ts
@@ -68,11 +68,11 @@ describe("API POST /producer/delegations test", () => {
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiDelegation);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
+++ b/packages/eservice-template-process/src/routers/EServiceTemplateRouter.ts
@@ -142,12 +142,12 @@ const eserviceTemplatesRouter = (
         setMetadataVersionHeader(res, metadata);
 
         return res
+          .status(201)
           .send(
             eserviceTemplateApi.EServiceTemplate.parse(
               eserviceTemplateToApiEServiceTemplate(eserviceTemplate)
             )
-          )
-          .status(200);
+          );
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
@@ -320,7 +320,7 @@ const eserviceTemplatesRouter = (
           ctx
         );
         setMetadataVersionHeader(res, metadata);
-        return res.status(200).send(
+        return res.status(201).send(
           eserviceTemplateApi.CreatedEServiceTemplateVersion.parse({
             eserviceTemplate:
               eserviceTemplateToApiEServiceTemplate(eserviceTemplate),
@@ -531,7 +531,7 @@ const eserviceTemplatesRouter = (
             );
           setMetadataVersionHeader(res, metadata);
           return res
-            .status(200)
+            .status(201)
             .send(
               eserviceTemplateApi.EServiceDoc.parse(
                 documentToApiDocument(document)
@@ -659,7 +659,7 @@ const eserviceTemplatesRouter = (
           ctx
         );
         setMetadataVersionHeader(res, metadata);
-        return res.status(200).send(
+        return res.status(201).send(
           eserviceTemplateApi.CreatedEServiceTemplateRiskAnalysis.parse({
             eserviceTemplate:
               eserviceTemplateToApiEServiceTemplate(eserviceTemplate),

--- a/packages/eservice-template-process/test/api/createEServiceTemplate.test.ts
+++ b/packages/eservice-template-process/test/api/createEServiceTemplate.test.ts
@@ -50,14 +50,14 @@ describe("API POST /templates", () => {
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
       expect(res.body).toEqual(
         eserviceTemplateToApiEServiceTemplate(mockEserviceTemplate)
       );
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()
       );

--- a/packages/eservice-template-process/test/api/createEServiceTemplateDocument.test.ts
+++ b/packages/eservice-template-process/test/api/createEServiceTemplateDocument.test.ts
@@ -75,11 +75,11 @@ describe("API POST /templates/:templateId/versions/:templateVersionId/documents"
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiDocument);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/eservice-template-process/test/api/createEServiceTemplateVersion.test.ts
+++ b/packages/eservice-template-process/test/api/createEServiceTemplateVersion.test.ts
@@ -99,12 +99,12 @@ describe("API POST /templates/:templateId/versions", () => {
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token, eserviceTemplate.id);
       expect(res.body).toEqual(apiCreatedVersion);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()
       );

--- a/packages/eservice-template-process/test/api/createRiskAnalysis.test.ts
+++ b/packages/eservice-template-process/test/api/createRiskAnalysis.test.ts
@@ -78,11 +78,11 @@ describe("API POST /templates/:templateId/riskAnalysis", () => {
     authRole.M2M_ADMIN_ROLE,
   ];
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiResponse);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/notification-config-process/src/routers/NotificationConfigRouter.ts
+++ b/packages/notification-config-process/src/routers/NotificationConfigRouter.ts
@@ -155,7 +155,7 @@ const notificationConfigRouter = (
             ctx
           );
         return res
-          .status(200)
+          .status(201)
           .send(
             notificationConfigApi.TenantNotificationConfig.parse(
               tenantNotificationConfigToApiTenantNotificationConfig(

--- a/packages/notification-config-process/test/api/createTenantDefaultNotificationConfig.test.ts
+++ b/packages/notification-config-process/test/api/createTenantDefaultNotificationConfig.test.ts
@@ -49,11 +49,11 @@ describe("API POST /internal/tenantNotificationConfigs test", () => {
   const authorizedRoles: AuthRole[] = [authRole.INTERNAL_ROLE];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiResponse);
       expect(
         notificationConfigService.createTenantDefaultNotificationConfig

--- a/packages/purpose-process/src/routers/PurposeRouter.ts
+++ b/packages/purpose-process/src/routers/PurposeRouter.ts
@@ -157,7 +157,7 @@ const purposeRouter = (
         setMetadataVersionHeader(res, metadata);
 
         return res
-          .status(200)
+          .status(201)
           .send(purposeApi.Purpose.parse(purposeToApiPurpose(purpose)));
       } catch (error) {
         const errorRes = makeApiProblem(error, createPurposeErrorMapper, ctx);
@@ -176,7 +176,7 @@ const purposeRouter = (
         setMetadataVersionHeader(res, metadata);
 
         return res
-          .status(200)
+          .status(201)
           .send(purposeApi.Purpose.parse(purposeToApiPurpose(purpose)));
       } catch (error) {
         const errorRes = makeApiProblem(
@@ -395,7 +395,7 @@ const purposeRouter = (
 
         setMetadataVersionHeader(res, metadata);
 
-        return res.status(200).send(
+        return res.status(201).send(
           purposeApi.CreatedPurposeVersion.parse({
             purpose: purposeToApiPurpose(purpose),
             createdVersionId,
@@ -906,7 +906,7 @@ const purposeRouter = (
         setMetadataVersionHeader(res, metadata);
 
         return res
-          .status(200)
+          .status(201)
           .send(purposeApi.Purpose.parse(purposeToApiPurpose(purpose)));
       } catch (error) {
         const errorRes = makeApiProblem(

--- a/packages/purpose-process/test/api/createPurpose.test.ts
+++ b/packages/purpose-process/test/api/createPurpose.test.ts
@@ -54,11 +54,11 @@ describe("API POST /purposes test", () => {
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiResponse);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/purpose-process/test/api/createPurposeFromTemplate.test.ts
+++ b/packages/purpose-process/test/api/createPurposeFromTemplate.test.ts
@@ -84,11 +84,11 @@ describe("API POST /templates/{purposeTemplateId}/purposes test", () => {
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiResponse);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/purpose-process/test/api/createPurposeVersion.test.ts
+++ b/packages/purpose-process/test/api/createPurposeVersion.test.ts
@@ -64,11 +64,11 @@ describe("API POST /purposes/{purposeId}/versions test", () => {
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body).toEqual(apiResponse);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()

--- a/packages/purpose-process/test/api/createReversePurpose.test.ts
+++ b/packages/purpose-process/test/api/createReversePurpose.test.ts
@@ -66,12 +66,12 @@ describe("API POST /reverse/purposes test", () => {
   ];
 
   it.each(authorizedRoles)(
-    "Should return 200 for user with role %s",
+    "Should return 201 for user with role %s",
     async (role) => {
       const token = generateToken(role);
       const res = await makeRequest(token);
       expect(res.body).toEqual(apiResponse);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.headers["x-metadata-version"]).toBe(
         serviceResponse.metadata.version.toString()
       );


### PR DESCRIPTION
## Jira Issue
[PIN-7407](https://pagopa.atlassian.net/browse/PIN-7407)

## Context
- Creation endpoints in the process services returned `200`, while the M2M gateway API (the reference) already returns `201` for creations. This aligns the process layer to `201 Created` for create calls.
- It also removes a pre-existing drift where some routers already returned `201` (e.g. `createEService`) while their OpenAPI spec still declared `200`.
- Scope is limited to the process services on purpose: BFF and apiGateway are external/product contracts and are left unchanged to avoid breaking the frontend and public M2M clients.

## Services Affected
- catalog-process
- agreement-process
- attribute-registry-process
- authorization-process
- delegation-process
- eservice-template-process
- notification-config-process
- purpose-process
- api-clients (OpenAPI specs only)

## Key Changes
- 28 create endpoints moved from `200` to `201` across the 8 process services, on all three surfaces: OpenAPI spec, router status, and api tests.
- Fixed `createEServiceTemplate`, which chained `.send(...).status(201)` (status after send is a no-op in Express, so it still returned `200`): reordered to `.status(201).send(...)`.
- `createTemplateInstanceDescriptorDocument` is left as `204 No Content` (not a `200`, out of scope).
- `add*` association endpoints (e.g. `addClientPurpose`, `addCertifiedAttribute`) are intentionally out of scope: they append to a collection/relationship rather than creating a new resource, and the M2M reference standardized only `create*` to `201`.
- api-clients regenerated: no diff, because the generated zodios client does not encode the success status (any 2xx is treated as success), so consumers are unaffected.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [x] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required): not required (no status assertions on these creates)


[PIN-7407]: https://pagopa.atlassian.net/browse/PIN-7407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ