### PR TITLE
fix: return 400 for invalid OpenAPI interface files (PIN-8244)

### DIFF
--- a/packages/commons-test/test/retrieveServerUrlsAPI.test.ts
+++ b/packages/commons-test/test/retrieveServerUrlsAPI.test.ts
@@ -243,6 +243,28 @@ describe("retrieveServerUrlsAPI", () => {
       retrieveServerUrlsAPI(invalidDoc, "INTERFACE", "Rest", resource)
     ).rejects.toThrow(invalidInterfaceFileDetected(resource));
   });
+  it("should throw invalidInterfaceFileDetected for OpenAPI 3.x REST interface without servers", async () => {
+    const resource = { id: generateId(), isEserviceTemplate: false };
+    const noServersDoc = {
+      name: "test.yaml",
+      text: vi.fn().mockResolvedValue("openapi: 3.0.0\n"),
+    } as unknown as File;
+
+    await expect(
+      retrieveServerUrlsAPI(noServersDoc, "INTERFACE", "Rest", resource)
+    ).rejects.toThrow(invalidInterfaceFileDetected(resource));
+  });
+  it("should throw invalidInterfaceFileDetected for OpenAPI 2.0 REST interface without host", async () => {
+    const resource = { id: generateId(), isEserviceTemplate: false };
+    const noHostDoc = {
+      name: "test.json",
+      text: vi.fn().mockResolvedValue(JSON.stringify({ openapi: "2.0" })),
+    } as unknown as File;
+
+    await expect(
+      retrieveServerUrlsAPI(noHostDoc, "INTERFACE", "Rest", resource)
+    ).rejects.toThrow(invalidInterfaceFileDetected(resource));
+  });
   it("should return an empty array for DOCUMENT kind", async () => {
     const documentDoc = {
       ...mockFile,

--- a/packages/commons/src/eservice-documents/eserviceDocumentUtils.ts
+++ b/packages/commons/src/eservice-documents/eserviceDocumentUtils.ts
@@ -22,7 +22,7 @@ import {
   Technology,
 } from "pagopa-interop-models";
 import { match, P } from "ts-pattern";
-import { z, ZodError } from "zod";
+import { z } from "zod";
 import { calculateChecksum, isValidFile } from "../utils/fileUtils.js";
 import { FileManager } from "../file-manager/fileManager.js";
 import { Logger } from "../logging/index.js";
@@ -372,11 +372,7 @@ export const retrieveServerUrlsAPI = async (
     return serverUrls;
   } catch (error) {
     throw match(error)
-      .with(
-        P.instanceOf(ApiError<CommonErrorCodes>),
-        P.instanceOf(ZodError),
-        () => error
-      )
+      .with(P.instanceOf(ApiError<CommonErrorCodes>), () => error)
       .otherwise(() => invalidInterfaceFileDetected(resource));
   }
 };


### PR DESCRIPTION
## Issue
- [PIN-8244](https://pagopa.atlassian.net/browse/PIN-8244)

## Context / Why
- Uploading an OpenAPI interface missing required structural fields caused a raw Zod validation error to propagate.
- The BFF converted this error into a `500 Internal Server Error` instead of reporting an invalid interface with `400 Bad Request`.

## Scope
- Convert OpenAPI parsing and structural validation errors into `invalidInterfaceFileDetected`.
- Cover OpenAPI 3 interfaces without `servers` and Swagger 2 interfaces without `host`.

## Testing / Validation
- [x] Lint
- [x] Type Check
- [x] Unit tests
- [x] Api tests

## Traceability Checklist
- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-8244]: https://pagopa.atlassian.net/browse/PIN-8244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ