### PR TITLE
fix(delegation-process, backend-for-frontend): allow api role to view catalog and producer e-services (PIN-10622)

### DIFF
--- a/packages/backend-for-frontend/src/routers/delegationRouter.ts
+++ b/packages/backend-for-frontend/src/routers/delegationRouter.ts
@@ -2,7 +2,9 @@ import { ZodiosEndpointDefinitions } from "@zodios/core";
 import { ZodiosRouter } from "@zodios/express";
 import { bffApi } from "pagopa-interop-api-clients";
 import {
+  authRole,
   ExpressContext,
+  validateAuthorization,
   ZodiosContext,
   zodiosValidationErrorToApiProblem,
 } from "pagopa-interop-commons";
@@ -28,6 +30,14 @@ const delegationRouter = (
     .get("/delegations", async (req, res) => {
       const ctx = fromBffAppContext(req.ctx, req.headers);
       try {
+        validateAuthorization(ctx, [
+          authRole.ADMIN_ROLE,
+          authRole.SECURITY_ROLE,
+          authRole.SUPPORT_ROLE,
+          authRole.REVIEWER_ROLE,
+          authRole.VIEWER_ROLE,
+        ]);
+
         const {
           limit,
           offset,

--- a/packages/backend-for-frontend/test/api/delegationRouter/getDelegations.test.ts
+++ b/packages/backend-for-frontend/test/api/delegationRouter/getDelegations.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { authRole } from "pagopa-interop-commons";
+import { authRole, AuthRole } from "pagopa-interop-commons";
 import { generateToken } from "pagopa-interop-commons-test";
 import { generateId } from "pagopa-interop-models";
 import request from "supertest";
@@ -41,11 +41,30 @@ describe("API GET /delegations", () => {
       .set("X-Correlation-Id", generateId())
       .query(query);
 
-  it("Should return 200 for user with role Admin", async () => {
-    const token = generateToken(authRole.ADMIN_ROLE);
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.SECURITY_ROLE,
+    authRole.SUPPORT_ROLE,
+    authRole.REVIEWER_ROLE,
+    authRole.VIEWER_ROLE,
+  ];
+
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockCompactDelegations);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
     const res = await makeRequest(token);
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual(mockCompactDelegations);
+    expect(res.status).toBe(403);
   });
 
   it("Should return 404 for delegationNotFound", async () => {

--- a/packages/delegation-process/src/routers/DelegationRouter.ts
+++ b/packages/delegation-process/src/routers/DelegationRouter.ts
@@ -78,6 +78,7 @@ const delegationRouter = (
       try {
         validateAuthorization(ctx, [
           ADMIN_ROLE,
+          API_ROLE,
           SECURITY_ROLE,
           M2M_ROLE,
           M2M_ADMIN_ROLE,

--- a/packages/delegation-process/test/api/getDelegations.test.ts
+++ b/packages/delegation-process/test/api/getDelegations.test.ts
@@ -58,6 +58,7 @@ describe("API GET /delegations test", () => {
 
   const authorizedRoles: AuthRole[] = [
     authRole.ADMIN_ROLE,
+    authRole.API_ROLE,
     authRole.SECURITY_ROLE,
     authRole.M2M_ROLE,
     authRole.M2M_ADMIN_ROLE,


### PR DESCRIPTION
## Jira Issue
[PIN-10622](https://pagopa.atlassian.net/browse/PIN-10622)

## Context/Why
Users with the `api` role get a `403` on both "Catalogo e-service" and "Erogazione > I miei e-service". The response payload shows the internal error `010-9993` — `Invalid roles ["api"] for this operation`.

The root cause is server-side, in **delegation-process**. Commit `ef44ca80f` (PR #3362, PIN-9962) removed the `api` role from `GET /delegations` to prevent API operators from listing delegations. However, the **BFF calls `GET /delegations` internally, with the user's token**, to enrich catalog and producer e-service responses with delegation info (e.g. `getCatalogEServiceDescriptor`, `getProducerEServices`, `assertRequesterCanActAsProducer`). Once the role was removed, those internal calls started failing with `403`, breaking the whole page for `api`-role users.

The frontend cannot fix this: the failing call is internal (BFF → delegation-process) and drives authorization logic. A FE-only workaround could only hide the sections from the API operator, which contradicts the expected result of the issue.

## Services Impacted
- delegation-process
- backend-for-frontend

## Key Changes
- **delegation-process**: restore the `api` role on `GET /delegations`, so the BFF's internal enrichment calls work again.
- **backend-for-frontend**: relocate the PIN-9962 restriction to the BFF, which is the only surface reachable by end users. `GET /delegations` on the BFF now rejects the `api` role, while the internal enrichment calls keep working. The user-facing behavior intended by PIN-9962 is unchanged.
- Updated API tests in both services (role matrix + 403 coverage).

## Open Points
- **Business rationale**: PR #3362 states API operators must not list delegations, but does not explain why. Confirmation of the intended rule is needed.
- **Where to enforce**: this PR enforces the restriction at the BFF edge rather than in delegation-process. To be validated with the PIN-9962 author whether this is acceptable, or whether delegation-process itself must keep rejecting the `api` role (in which case the BFF would need a dedicated internal/service token for enrichment calls instead of the user token — larger change).

## Traceability Checklist
- [x] Branch name contains the Jira key
- [x] PR title is compliant with the standard (type(scope): descrizione (KEY))


[PIN-10622]: https://pagopa.atlassian.net/browse/PIN-10622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ