### PR TITLE
fix: reject mismatched template interface technology (PIN-10642)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -4846,6 +4846,29 @@ paths:
               schema:
                 $ref: "#/components/schemas/Problem"
 
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+
   /templates/eservices/{eServiceId}/descriptors/{descriptorId}/interface/soap:
     post:
       security:
@@ -4922,6 +4945,29 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
 
   /eservices/{eServiceId}/descriptors/{descriptorId}/documents:
     post:

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -1622,6 +1622,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+        "409":
+          $ref: "#/components/responses/Conflict"
   /templates/eservices/{eServiceId}/descriptors/{descriptorId}/interface/soap:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"
@@ -1700,6 +1702,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+        "409":
+          $ref: "#/components/responses/Conflict"
   /eservices/{eServiceId}/riskAnalysis:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"

--- a/packages/catalog-process/src/model/domain/errors.ts
+++ b/packages/catalog-process/src/model/domain/errors.ts
@@ -12,6 +12,7 @@ import {
   RiskAnalysisId,
   TenantId,
   TenantKind,
+  Technology,
   makeApiProblemBuilder,
 } from "pagopa-interop-models";
 
@@ -83,6 +84,7 @@ const errorCodes = {
   certifiedDiscreteAttributeConfigCannotBeChanged: "0066",
   eserviceDescriptorWithActiveOrPendingDelegation: "0067",
   eserviceArchivingWithActiveOrPendingDelegation: "0068",
+  eserviceTemplateInterfaceTechnologyMismatch: "0069",
 };
 
 export type ErrorCodes = keyof typeof errorCodes;
@@ -490,6 +492,18 @@ export function eserviceTemplateInterfaceNotFound(
     detail: `EService template interface for template ${eserviceTemplateId} with version ${eserviceTemplateVersionId} not found`,
     code: "eserviceTemplateInterfaceNotFound",
     title: "EService template interface document not found",
+  });
+}
+
+export function eserviceTemplateInterfaceTechnologyMismatch(
+  eserviceTemplateId: EServiceTemplateId,
+  templateTechnology: Technology,
+  interfaceTechnology: Technology
+): ApiError<ErrorCodes> {
+  return new ApiError({
+    detail: `EService template ${eserviceTemplateId} has technology ${templateTechnology}, which is incompatible with interface technology ${interfaceTechnology}`,
+    code: "eserviceTemplateInterfaceTechnologyMismatch",
+    title: "EService template interface technology mismatch",
   });
 }
 

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -17,6 +17,7 @@ import {
   TenantId,
   unsafeBrandId,
   emptyErrorMapper,
+  technology,
 } from "pagopa-interop-models";
 import {
   agreementStateToApiAgreementState,
@@ -1594,6 +1595,7 @@ const eservicesRouter = (
             await catalogService.addEServiceTemplateInstanceInterface(
               unsafeBrandId(req.params.eServiceId),
               unsafeBrandId(req.params.descriptorId),
+              technology.soap,
               req.body,
               ctx
             );
@@ -1621,6 +1623,7 @@ const eservicesRouter = (
             await catalogService.addEServiceTemplateInstanceInterface(
               unsafeBrandId(req.params.eServiceId),
               unsafeBrandId(req.params.descriptorId),
+              technology.rest,
               req.body,
               ctx
             );

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -68,7 +68,7 @@ import {
   archivingScope,
   ArchivingScope,
   AsyncExchangeProperties,
-  technology,
+  Technology,
 } from "pagopa-interop-models";
 import { match, P } from "ts-pattern";
 import { config } from "../config/config.js";
@@ -4148,6 +4148,7 @@ export function catalogServiceBuilder(
     async addEServiceTemplateInstanceInterface(
       eServiceId: EServiceId,
       descriptorId: DescriptorId,
+      interfaceTechnology: Technology,
       eserviceInstanceInterfaceData:
         | catalogApi.TemplateInstanceInterfaceRESTSeed
         | catalogApi.TemplateInstanceInterfaceSOAPSeed,
@@ -4182,18 +4183,6 @@ export function catalogServiceBuilder(
         readModelService
       );
 
-      const { interfaceTechnology, contactDataRestApi } = match(
-        eserviceInstanceInterfaceData
-      )
-        .with({ contactEmail: P.string, contactName: P.string }, (data) => ({
-          interfaceTechnology: technology.rest,
-          contactDataRestApi: data,
-        }))
-        .otherwise(() => ({
-          interfaceTechnology: technology.soap,
-          contactDataRestApi: undefined,
-        }));
-
       if (eserviceTemplate.technology !== interfaceTechnology) {
         throw eserviceTemplateInterfaceTechnologyMismatch(
           eserviceTemplate.id,
@@ -4201,6 +4190,10 @@ export function catalogServiceBuilder(
           interfaceTechnology
         );
       }
+
+      const contactDataRestApi = match(eserviceInstanceInterfaceData)
+        .with({ contactEmail: P.string, contactName: P.string }, (data) => data)
+        .otherwise(() => undefined);
 
       const eserviceTemplateVersion = eserviceTemplate.versions.find(
         (v) => v.id === eserviceTemplateVersionId

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -68,6 +68,7 @@ import {
   archivingScope,
   ArchivingScope,
   AsyncExchangeProperties,
+  technology,
 } from "pagopa-interop-models";
 import { match, P } from "ts-pattern";
 import { config } from "../config/config.js";
@@ -93,6 +94,7 @@ import {
   eServiceNotFound,
   eServiceRiskAnalysisNotFound,
   eserviceTemplateInterfaceNotFound,
+  eserviceTemplateInterfaceTechnologyMismatch,
   eServiceTemplateNotFound,
   eServiceTemplateWithoutPublishedVersion,
   inconsistentAttributesSeedGroupsCount,
@@ -4180,6 +4182,26 @@ export function catalogServiceBuilder(
         readModelService
       );
 
+      const { interfaceTechnology, contactDataRestApi } = match(
+        eserviceInstanceInterfaceData
+      )
+        .with({ contactEmail: P.string, contactName: P.string }, (data) => ({
+          interfaceTechnology: technology.rest,
+          contactDataRestApi: data,
+        }))
+        .otherwise(() => ({
+          interfaceTechnology: technology.soap,
+          contactDataRestApi: undefined,
+        }));
+
+      if (eserviceTemplate.technology !== interfaceTechnology) {
+        throw eserviceTemplateInterfaceTechnologyMismatch(
+          eserviceTemplate.id,
+          eserviceTemplate.technology,
+          interfaceTechnology
+        );
+      }
+
       const eserviceTemplateVersion = eserviceTemplate.versions.find(
         (v) => v.id === eserviceTemplateVersionId
       );
@@ -4190,10 +4212,6 @@ export function catalogServiceBuilder(
           eserviceTemplateVersionId
         );
       }
-
-      const contactDataRestApi = match(eserviceInstanceInterfaceData)
-        .with({ contactEmail: P.string, contactName: P.string }, (data) => data)
-        .otherwise(() => undefined);
 
       const { eService: updatedEService, event: addDocumentEvent } =
         await createOpenApiInterfaceByTemplate(

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -694,6 +694,7 @@ export const addEServiceTemplateInstanceInterfaceErrorMapper = (
       "eServiceTemplateWithoutPublishedVersion",
       "invalidEserviceInterfaceFileDetected",
       "interfaceAlreadyExists",
+      "eserviceTemplateInterfaceTechnologyMismatch",
       () => HTTP_STATUS_CONFLICT
     )
     .with(

--- a/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
+++ b/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
@@ -123,6 +123,15 @@ describe("addEServiceTemplateInstanceInterface", () => {
 
           expect(res.body).toEqual(eServiceToApiEService(eservice));
           expect(res.status).toBe(200);
+          expect(
+            catalogService.addEServiceTemplateInstanceInterface
+          ).toHaveBeenCalledWith(
+            eservice.id,
+            descriptor.id,
+            technology,
+            technology === "Rest" ? restBody : soapBody,
+            expect.anything()
+          );
         }
       );
 

--- a/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
+++ b/packages/catalog-process/test/api/addEserviceTemplateinstanceInterface.test.ts
@@ -35,6 +35,7 @@ import {
   eServiceNotAnInstance,
   eServiceNotFound,
   eserviceTemplateInterfaceNotFound,
+  eserviceTemplateInterfaceTechnologyMismatch,
   eServiceTemplateNotFound,
   eServiceTemplateWithoutPublishedVersion,
   interfaceAlreadyExists,
@@ -154,6 +155,14 @@ describe("addEServiceTemplateInstanceInterface", () => {
           expectedStatus: 409,
         },
         { error: interfaceAlreadyExists(descriptor.id), expectedStatus: 409 },
+        {
+          error: eserviceTemplateInterfaceTechnologyMismatch(
+            eservice.templateId!,
+            technology,
+            technology === "Rest" ? "Soap" : "Rest"
+          ),
+          expectedStatus: 409,
+        },
         { error: eServiceNotFound(eservice.id), expectedStatus: 404 },
         {
           error: eServiceDescriptorNotFound(eservice.id, descriptor.id),

--- a/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
+++ b/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
@@ -173,6 +173,36 @@ describe("addEServiceTemplateInstanceInterface", () => {
       );
     });
 
+    it("should throw an eserviceTemplateInterfaceTechnologyMismatch when adding a REST interface to a SOAP template instance", async () => {
+      const interfaceDocumentFile = {
+        ...getMockDocument(),
+        name: "interface-test.wsdl",
+        contentType: "wsdl",
+        path: `${config.eserviceDocumentsPath}`,
+      };
+
+      const { eservice, descriptor, template } =
+        await initEserviceTemplateInstance(descriptorState.draft, "Soap", {
+          doc: interfaceDocumentFile,
+          content: await readFileContent("interface-test.wsdl"),
+        });
+
+      await expect(
+        catalogService.addEServiceTemplateInstanceInterface(
+          eservice.id,
+          descriptor.id,
+          {
+            contactName: "John Doe",
+            contactEmail: "john.doe@example.com",
+            serverUrls: [{ url: "https://rest.server.com" }],
+          },
+          getMockContext({ authData: getMockAuthData(eservice.producerId) })
+        )
+      ).rejects.toThrow(
+        eserviceTemplateInterfaceTechnologyMismatch(template.id, "Soap", "Rest")
+      );
+    });
+
     it("should throw an eServiceNotFound if the e-service does not exist", async () => {
       const eserviceId = generateId<EServiceId>();
       await expect(

--- a/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
+++ b/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
@@ -50,6 +50,7 @@ import {
   eserviceInterfaceDataNotValid,
   eServiceNotAnInstance,
   eServiceNotFound,
+  eserviceTemplateInterfaceTechnologyMismatch,
   eserviceTemplateInterfaceNotFound,
   eServiceTemplateNotFound,
 } from "../../src/model/domain/errors.js";
@@ -144,6 +145,34 @@ describe("addEServiceTemplateInstanceInterface", () => {
   });
 
   describe("Invalid data input (Rest/Soap)", () => {
+    it("should throw an eserviceTemplateInterfaceTechnologyMismatch when adding a SOAP interface to a REST template instance", async () => {
+      const interfaceDocumentFile = {
+        ...getMockDocument(),
+        name: "test.openapi.3.0.2.yaml",
+        contentType: "yaml",
+        path: `${config.eserviceDocumentsPath}`,
+      };
+
+      const { eservice, descriptor, template } =
+        await initEserviceTemplateInstance(descriptorState.draft, "Rest", {
+          doc: interfaceDocumentFile,
+          content: await readFileContent("test.openapi.3.0.2.yaml"),
+        });
+
+      await expect(
+        catalogService.addEServiceTemplateInstanceInterface(
+          eservice.id,
+          descriptor.id,
+          {
+            serverUrls: [{ url: "https://soap.server.com" }],
+          },
+          getMockContext({ authData: getMockAuthData(eservice.producerId) })
+        )
+      ).rejects.toThrow(
+        eserviceTemplateInterfaceTechnologyMismatch(template.id, "Rest", "Soap")
+      );
+    });
+
     it("should throw an eServiceNotFound if the e-service does not exist", async () => {
       const eserviceId = generateId<EServiceId>();
       await expect(

--- a/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
+++ b/packages/catalog-process/test/integration/addEServiceTemplateInstanceInterface.test.ts
@@ -163,6 +163,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           eservice.id,
           descriptor.id,
+          "Soap",
           {
             serverUrls: [{ url: "https://soap.server.com" }],
           },
@@ -191,6 +192,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           eservice.id,
           descriptor.id,
+          "Rest",
           {
             contactName: "John Doe",
             contactEmail: "john.doe@example.com",
@@ -209,6 +211,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           eserviceId,
           generateId(),
+          "Rest",
           {
             contactName: "Jhon Doe",
             contactUrl: "https://fun.tester.johnny.info",
@@ -237,6 +240,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           mockEService.id,
           invalidDescriptorId,
+          "Rest",
           {
             contactName: "Jhon Doe",
             contactUrl: "https://fun.tester.johnny.info",
@@ -311,6 +315,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           eserviceId,
           mockDescriptor.id,
+          "Rest",
           {
             contactName: "Jhon Doe",
             contactUrl: "https://fun.tester.johnny.info",
@@ -340,6 +345,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           eserviceId,
           mockDescriptor.id,
+          "Rest",
           {
             contactName: "Jhon Doe",
             contactUrl: "https://fun.tester.johnny.info",
@@ -403,6 +409,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           eserviceId,
           mockDescriptor.id,
+          "Rest",
           {
             contactName: "Jhon Doe",
             contactUrl: "https://fun.tester.johnny.info",
@@ -455,6 +462,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           eserviceId,
           mockDescriptor.id,
+          "Rest",
           {
             contactName: "Jhon Doe",
             contactUrl: "https://fun.tester.johnny.info",
@@ -525,6 +533,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
         catalogService.addEServiceTemplateInstanceInterface(
           eserviceId,
           mockDescriptor.id,
+          "Rest",
           {
             contactName: "Jhon Doe",
             contactUrl: "https://fun.tester.johnny.info",
@@ -580,6 +589,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
       const res = await catalogService.addEServiceTemplateInstanceInterface(
         eservice.id,
         descriptor.id,
+        "Rest",
         requestPayload,
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       );
@@ -676,6 +686,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
       const res = await catalogService.addEServiceTemplateInstanceInterface(
         eservice.id,
         descriptor.id,
+        "Rest",
         requestPayload,
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       );
@@ -765,6 +776,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
       const res = await catalogService.addEServiceTemplateInstanceInterface(
         eservice.id,
         descriptor.id,
+        "Soap",
         requestPayload,
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       );
@@ -852,6 +864,7 @@ describe("addEServiceTemplateInstanceInterface", () => {
       const res = await catalogService.addEServiceTemplateInstanceInterface(
         eservice.id,
         descriptor.id,
+        "Soap",
         requestPayload,
         getMockContext({ authData: getMockAuthData(eservice.producerId) })
       );


### PR DESCRIPTION
## Issue

- [PIN-10642](https://pagopa.atlassian.net/browse/PIN-10642)

## Context / Why

- Adding a SOAP interface to a REST e-service template instance produced a generic 500 error.
- Technology incompatibility should instead return a specific 409 Conflict response.

## Scope

- Validate the requested interface technology against the e-service template technology.
- Return a dedicated domain error mapped to HTTP 409 when they do not match.
- Document the conflict response in the Catalog and BFF OpenAPI specifications.
- Add regression coverage for SOAP interfaces submitted to REST template instances.

## Key Changes

- Added the `eserviceTemplateInterfaceTechnologyMismatch` domain error.
- Perform the compatibility check before interpolating the template interface.
- Preserve the 409 response through the BFF downstream error passthrough.

## Testing / Validation

- [x] Lint
- [x] Type check
- [x] Integration tests
- [x] Api tests

## Traceability Checklist

- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [x] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [x] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10642]: https://pagopa.atlassian.net/browse/PIN-10642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ