### PR TITLE
fix(models,m2m-gateways): missing mapping for invalidContentType (PIN-10644)

### DIFF
--- a/packages/m2m-gateway-v3/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
+++ b/packages/m2m-gateway-v3/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
@@ -114,7 +114,6 @@ describe("POST /purposeTemplates/:purposeTemplateId/riskAnalysis/annotationDocum
     { ...mockFileUpload, filename: undefined },
     { ...mockFileUpload, prettyName: undefined },
     { ...mockFileUpload, answerId: undefined },
-    { ...mockFileUpload, contentType: "text/html" },
   ])(
     "Should return 400 if passed an invalid multipart body",
     async (multipartFields) => {
@@ -129,13 +128,22 @@ describe("POST /purposeTemplates/:purposeTemplateId/riskAnalysis/annotationDocum
     }
   );
 
+  it("Should return 400 for invalidDocumentDetected error", async () => {
+    const error = invalidDocumentDetected(generateId());
+    mockPurposeTemplateService.uploadRiskAnalysisTemplateAnswerAnnotationDocument =
+      vi.fn().mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, generateId(), mockFileUpload);
+
+    expect(res.status).toBe(400);
+  });
+
   it.each([
     missingMetadata(),
     pollingMaxRetriesExceeded(
       config.defaultPollingMaxRetries,
       config.defaultPollingRetryDelay
     ),
-    invalidDocumentDetected(generateId()),
   ])("Should return 500 in case of $code error", async (error) => {
     mockPurposeTemplateService.uploadRiskAnalysisTemplateAnswerAnnotationDocument =
       vi.fn().mockRejectedValue(error);

--- a/packages/m2m-gateway-v3/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
+++ b/packages/m2m-gateway-v3/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
@@ -114,6 +114,7 @@ describe("POST /purposeTemplates/:purposeTemplateId/riskAnalysis/annotationDocum
     { ...mockFileUpload, filename: undefined },
     { ...mockFileUpload, prettyName: undefined },
     { ...mockFileUpload, answerId: undefined },
+    { ...mockFileUpload, contentType: "text/html" },
   ])(
     "Should return 400 if passed an invalid multipart body",
     async (multipartFields) => {

--- a/packages/m2m-gateway/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
+++ b/packages/m2m-gateway/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
@@ -113,7 +113,6 @@ describe("POST /purposeTemplates/:purposeTemplateId/riskAnalysis/annotationDocum
     { ...mockFileUpload, filename: undefined },
     { ...mockFileUpload, prettyName: undefined },
     { ...mockFileUpload, answerId: undefined },
-    { ...mockFileUpload, contentType: "text/html" },
   ])(
     "Should return 400 if passed an invalid multipart body",
     async (multipartFields) => {
@@ -128,13 +127,22 @@ describe("POST /purposeTemplates/:purposeTemplateId/riskAnalysis/annotationDocum
     }
   );
 
+  it("Should return 400 for invalidDocumentDetected error", async () => {
+    const error = invalidDocumentDetected(generateId());
+    mockPurposeTemplateService.uploadRiskAnalysisTemplateAnswerAnnotationDocument =
+      vi.fn().mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, generateId(), mockFileUpload);
+
+    expect(res.status).toBe(400);
+  });
+
   it.each([
     missingMetadata(),
     pollingMaxRetriesExceeded(
       config.defaultPollingMaxRetries,
       config.defaultPollingRetryDelay
     ),
-    invalidDocumentDetected(generateId()),
   ])("Should return 500 in case of $code error", async (error) => {
     mockPurposeTemplateService.uploadRiskAnalysisTemplateAnswerAnnotationDocument =
       vi.fn().mockRejectedValue(error);

--- a/packages/m2m-gateway/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
+++ b/packages/m2m-gateway/test/api/purposeTemplates/uploadRiskAnalysisTemplateAnswerAnnotationDocument.test.ts
@@ -113,6 +113,7 @@ describe("POST /purposeTemplates/:purposeTemplateId/riskAnalysis/annotationDocum
     { ...mockFileUpload, filename: undefined },
     { ...mockFileUpload, prettyName: undefined },
     { ...mockFileUpload, answerId: undefined },
+    { ...mockFileUpload, contentType: "text/html" },
   ])(
     "Should return 400 if passed an invalid multipart body",
     async (multipartFields) => {

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -493,6 +493,7 @@ const defaultCommonErrorMapper = (code: CommonErrorCodes): number =>
       "badRequestError",
       "invalidPdfSignatureError",
       "invalidFileUploadError",
+      "invalidContentTypeDetected",
       () => HTTP_STATUS_BAD_REQUEST
     )
     .with("contentTooLargeError", () => HTTP_STATUS_PAYLOAD_TOO_LARGE)


### PR DESCRIPTION
## Jira Issue
<!-- link the Jira Task relate to the PR -->
[PIN-10644](https://pagopa.atlassian.net/browse/PIN-10644)

## Context/Why
We were getting status 500 on `invalidContentTypeDetected` errors because of a missing mapping.

## Services Impacted
- models (common errors)
- m2m-gateway
- m2m-gateway-v3

## Key Changes
<!-- A list of the main changes -->
- Adds new test cases
- Adds the missing error mapping

## Traceability Checklist
- [X] Branch name contain the Jira key
- [X] PR title is compliant with the standard (type(scope): descrizione (KEY))

[PIN-10644]: https://pagopa.atlassian.net/browse/PIN-10644