### PR TITLE
fix: skip SQS messages with invalid JSON bodies (PIN-10611)

### DIFF
--- a/packages/commons-test/package.json
+++ b/packages/commons-test/package.json
@@ -20,6 +20,7 @@
     "@aws-sdk/client-dynamodb": "catalog:",
     "@aws-sdk/client-kms": "catalog:",
     "@aws-sdk/client-sesv2": "catalog:",
+    "@aws-sdk/client-sqs": "catalog:",
     "@aws-sdk/util-dynamodb": "catalog:",
     "@faker-js/faker": "catalog:",
     "@protobuf-ts/runtime": "catalog:",

--- a/packages/commons-test/test/validateSqsMessage.unit.test.ts
+++ b/packages/commons-test/test/validateSqsMessage.unit.test.ts
@@ -1,0 +1,27 @@
+import { Message } from "@aws-sdk/client-sqs";
+import { Logger } from "pagopa-interop-commons";
+import { describe, expect, it, vi } from "vitest";
+
+import { validateSqsMessage } from "../../commons/src/sqs/queueManagerMessageValidation.js";
+
+const logger: Logger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  isDebugEnabled: vi.fn(),
+};
+
+describe("validateSqsMessage", () => {
+  it("should skip an SQS message whose body is not valid JSON", () => {
+    const message: Message = {
+      MessageId: "message-id",
+      Body: "not-valid-json",
+    };
+
+    expect(validateSqsMessage(message, logger)).toBe("SkipEvent");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/message-id.*not-valid-json/)
+    );
+  });
+});

--- a/packages/commons/src/sqs/queueManagerMessageValidation.ts
+++ b/packages/commons/src/sqs/queueManagerMessageValidation.ts
@@ -1,5 +1,4 @@
 import { Message } from "@aws-sdk/client-sqs";
-import { invalidSqsMessage } from "pagopa-interop-models";
 
 import { Logger } from "../logging/index.js";
 
@@ -22,6 +21,11 @@ export const validateSqsMessage = (
 
     return "ValidEvent";
   } catch (error) {
-    throw invalidSqsMessage(message.MessageId, error);
+    logger.warn(
+      `Skipping SQS message with id ${
+        message.MessageId
+      }: body is not valid JSON. Body: ${message.Body}. Error: ${error}`
+    );
+    return "SkipEvent";
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2076,6 +2076,9 @@ importers:
       '@aws-sdk/client-sesv2':
         specifier: 'catalog:'
         version: 3.840.0
+      '@aws-sdk/client-sqs':
+        specifier: 'catalog:'
+        version: 3.840.0
       '@aws-sdk/util-dynamodb':
         specifier: 'catalog:'
         version: 3.840.0(@aws-sdk/client-dynamodb@3.840.0)


### PR DESCRIPTION
## Issue

- [PIN-10611](https://pagopa.atlassian.net/browse/PIN-10611)

## Context / Why

- SQS messages whose bodies are not valid JSON cannot succeed on retry because the error is not transient.
- These messages should be logged and skipped instead of remaining in the retry loop.

## Scope

- Update the shared SQS message validation to return `SkipEvent` for invalid JSON bodies.
- Log the message ID, original body, and parsing error for troubleshooting.
- Add focused unit coverage for the new behavior.

## Key Changes

- Invalid JSON messages are now handled consistently with other non-processable SQS events and deleted by the shared queue consumer.
- Valid messages and transient consumer errors keep their existing behavior.

## Testing / Validation

- [x] Lint
- [x] Type check
- [x] Unit tests

## Traceability Checklist

- [x] Branch contains Jira key
- [x] PR title respects standard: type: description (KEY)
- [ ] Fix Version set in Jira (if required)
- [x] Service labels applied
- [x] API and integration tests updated
- [ ] OpenAPI spec updated
- [ ] Bruno endpoint definition updated

[PIN-10611]: https://pagopa.atlassian.net/browse/PIN-10611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ