### PR TITLE
PIN-10457 Remove reviewer role from getRemainingDailyCalls

### DIFF
--- a/packages/purpose-process/src/routers/PurposeRouter.ts
+++ b/packages/purpose-process/src/routers/PurposeRouter.ts
@@ -245,7 +245,7 @@ const purposeRouter = (
       const ctx = fromAppContext(req.ctx);
 
       try {
-        validateAuthorization(ctx, [ADMIN_ROLE, M2M_ADMIN_ROLE, REVIEWER_ROLE]);
+        validateAuthorization(ctx, [ADMIN_ROLE, M2M_ADMIN_ROLE]);
 
         const result = await purposeService.getRemainingDailyCalls({
           purposeId: unsafeBrandId(req.params.purposeId),

--- a/packages/purpose-process/test/api/getRemainingDailyCalls.test.ts
+++ b/packages/purpose-process/test/api/getRemainingDailyCalls.test.ts
@@ -46,7 +46,6 @@ describe("API GET /purposes/{purposeId}/remainingDailyCalls test", () => {
   const authorizedRoles: AuthRole[] = [
     authRole.ADMIN_ROLE,
     authRole.M2M_ADMIN_ROLE,
-    authRole.REVIEWER_ROLE,
   ];
 
   it.each(authorizedRoles)(


### PR DESCRIPTION
This PR is for removing `REVIEWER_ROLE` from the `getRemainingDailyCalls` endpoint.