### PR TITLE
refactor: simplify agreement suspension state logic (PIN-5581)

### DIFF
--- a/packages/agreement-process/src/services/agreementService.ts
+++ b/packages/agreement-process/src/services/agreementService.ts
@@ -1127,21 +1127,17 @@ export function agreementServiceBuilder(
         authData
       );
 
-      const [eservice, consumer] = await Promise.all([
+      /* The EService, the Descriptor and the consumer Tenant are not needed to
+      suspend the Agreement, but they are retrieved to validate that they exist */
+      const [eservice] = await Promise.all([
         retrieveEService(agreement.data.eserviceId, readModelService),
         retrieveTenant(agreement.data.consumerId, readModelService),
       ]);
-
-      const descriptor = retrieveDescriptor(
-        agreement.data.descriptorId,
-        eservice
-      );
+      retrieveDescriptor(agreement.data.descriptorId, eservice);
 
       const updatedAgreement: Agreement = createSuspensionUpdatedAgreement({
         agreement: agreement.data,
         authData,
-        descriptor,
-        consumer,
         activeDelegations,
         agreementOwnership,
       });

--- a/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
+++ b/packages/agreement-process/src/services/agreementSuspensionProcessor.ts
@@ -9,8 +9,6 @@ import {
   Agreement,
   AgreementEventV2,
   CorrelationId,
-  Descriptor,
-  Tenant,
   WithMetadata,
   agreementState,
 } from "pagopa-interop-models";
@@ -26,36 +24,24 @@ import {
 } from "../model/domain/toEvent.js";
 import { getSuspensionFlags } from "./agreementService.js";
 import { createStamp, getSuspensionStamps } from "./agreementStampUtils.js";
-import {
-  agreementStateByFlags,
-  nextStateByAttributesFSM,
-} from "./agreementStateProcessor.js";
 
 export function createSuspensionUpdatedAgreement({
   agreement,
   authData,
-  descriptor,
-  consumer,
   activeDelegations,
   agreementOwnership,
 }: {
   agreement: Agreement;
   authData: UIAuthData | M2MAdminAuthData;
-  descriptor: Descriptor;
-  consumer: Tenant;
   activeDelegations: ActiveDelegations;
   agreementOwnership: Ownership;
 }): Agreement {
-  /* nextAttributesState VS targetDestinationState
-  -- targetDestinationState is the state where the caller wants to go (suspended, in this case)
-  -- nextStateByAttributes is the next state of the Agreement based the attributes of the consumer
-  */
+  /* The Agreement is always suspended by this operation: suspension is only
+  allowed from active or suspended (see agreementSuspendableStates), and the
+  requester is always the producer, the consumer, or one of their delegates,
+  so at least one suspension flag is set. Therefore the next state by
+  attributes would always be overridden, and it is not computed here. */
   const targetDestinationState = agreementState.suspended;
-  const nextStateByAttributes = nextStateByAttributesFSM(
-    agreement,
-    descriptor,
-    consumer
-  );
 
   const { suspendedByConsumer, suspendedByProducer } = getSuspensionFlags(
     agreementOwnership,
@@ -63,13 +49,6 @@ export function createSuspensionUpdatedAgreement({
     authData,
     targetDestinationState,
     activeDelegations
-  );
-
-  const newState = agreementStateByFlags(
-    nextStateByAttributes,
-    suspendedByProducer,
-    suspendedByConsumer,
-    agreement.suspendedByPlatform
   );
 
   const stamp = createStamp(authData, activeDelegations);
@@ -84,7 +63,7 @@ export function createSuspensionUpdatedAgreement({
   });
 
   const updateSeed: UpdateAgreementSeed = {
-    state: newState,
+    state: targetDestinationState,
     suspendedByConsumer,
     suspendedByProducer,
     stamps: {


### PR DESCRIPTION
## Jira Issue
[PIN-5581](https://pagopa.atlassian.net/browse/PIN-5581)

## Context
- In `suspendAgreement` the state computed from the consumer attributes was always discarded: the operation is only allowed from `active` or `suspended`, and the requester always sets a suspension flag, so the result was always `suspended`.
- Leftover from the removal of the `suspendedByPlatform` checks in #296.

## Services Affected
- agreement-process

## Key Changes
- `createSuspensionUpdatedAgreement` no longer computes the next state from the attributes: the state is `suspended` by construction.
- Removed the unused `descriptor` and `consumer` parameters.
- EService, Descriptor and Tenant are still retrieved, to preserve the `eServiceNotFound`, `descriptorNotFound` and `tenantNotFound` errors.
- No behavior change. No test changes needed: `suspendAgreement.test.ts` already asserts that suspension ignores the attributes.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [x] Service labels applied
- [x] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [x] OpenAPI spec updated (if required)
- [x] Bruno collection or endpoint definition updated (if required)


[PIN-5581]: https://pagopa.atlassian.net/browse/PIN-5581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ