### PR TITLE
fix: include discrete attributes in email digest (PIN-10655)

### DIFF
--- a/packages/email-digest-dispatcher/src/services/readModelService.ts
+++ b/packages/email-digest-dispatcher/src/services/readModelService.ts
@@ -32,6 +32,7 @@ import {
   DelegationKind,
   DelegationState,
   delegationState,
+  attributeKind,
 } from "pagopa-interop-models";
 import {
   DrizzleReturnType,
@@ -47,6 +48,7 @@ import {
   tenantVerifiedAttributeVerifierInReadmodelTenant,
   tenantVerifiedAttributeRevokerInReadmodelTenant,
   tenantCertifiedAttributeInReadmodelTenant,
+  tenantCertifiedDiscreteAttributeInReadmodelTenant,
   tenantFeatureInReadmodelTenant,
   attributeInReadmodelAttribute,
   purposeInReadmodelPurpose,
@@ -1270,12 +1272,47 @@ export function readModelServiceBuilder(db: DrizzleReturnType, logger: Logger) {
               ),
           })
         )
-        .from(tenantCertifiedAttributeInReadmodelTenant)
-        .innerJoin(
-          attributeInReadmodelAttribute,
-          eq(
-            tenantCertifiedAttributeInReadmodelTenant.attributeId,
-            attributeInReadmodelAttribute.id
+        .from(attributeInReadmodelAttribute)
+        .leftJoin(
+          tenantCertifiedAttributeInReadmodelTenant,
+          and(
+            eq(
+              tenantCertifiedAttributeInReadmodelTenant.attributeId,
+              attributeInReadmodelAttribute.id
+            ),
+            eq(attributeInReadmodelAttribute.kind, attributeKind.certified),
+            eq(tenantCertifiedAttributeInReadmodelTenant.tenantId, tenantId),
+            gte(
+              tenantCertifiedAttributeInReadmodelTenant.assignmentTimestamp,
+              dateThreshold.toISOString()
+            ),
+            isNull(
+              tenantCertifiedAttributeInReadmodelTenant.revocationTimestamp
+            )
+          )
+        )
+        .leftJoin(
+          tenantCertifiedDiscreteAttributeInReadmodelTenant,
+          and(
+            eq(
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.attributeId,
+              attributeInReadmodelAttribute.id
+            ),
+            eq(
+              attributeInReadmodelAttribute.kind,
+              attributeKind.certifiedDiscrete
+            ),
+            eq(
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.tenantId,
+              tenantId
+            ),
+            gte(
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.assignmentTimestamp,
+              dateThreshold.toISOString()
+            ),
+            isNull(
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.revocationTimestamp
+            )
           )
         )
         .leftJoin(
@@ -1293,18 +1330,14 @@ export function readModelServiceBuilder(db: DrizzleReturnType, logger: Logger) {
           eq(certifierTenant.id, tenantFeatureInReadmodelTenant.tenantId)
         )
         .where(
-          and(
-            eq(tenantCertifiedAttributeInReadmodelTenant.tenantId, tenantId),
-            gte(
-              tenantCertifiedAttributeInReadmodelTenant.assignmentTimestamp,
-              dateThreshold.toISOString()
-            ),
-            isNull(
-              tenantCertifiedAttributeInReadmodelTenant.revocationTimestamp
+          or(
+            isNotNull(tenantCertifiedAttributeInReadmodelTenant.attributeId),
+            isNotNull(
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.attributeId
             )
           )
         )
-        .limit(5);
+        .limit(SECTION_LIST_LIMIT);
 
       logger.info(
         `Retrieved ${results.length} certified assigned attributes for tenant ${tenantId}`
@@ -1344,12 +1377,41 @@ export function readModelServiceBuilder(db: DrizzleReturnType, logger: Logger) {
               ),
           })
         )
-        .from(tenantCertifiedAttributeInReadmodelTenant)
-        .innerJoin(
-          attributeInReadmodelAttribute,
-          eq(
-            tenantCertifiedAttributeInReadmodelTenant.attributeId,
-            attributeInReadmodelAttribute.id
+        .from(attributeInReadmodelAttribute)
+        .leftJoin(
+          tenantCertifiedAttributeInReadmodelTenant,
+          and(
+            eq(
+              tenantCertifiedAttributeInReadmodelTenant.attributeId,
+              attributeInReadmodelAttribute.id
+            ),
+            eq(attributeInReadmodelAttribute.kind, attributeKind.certified),
+            eq(tenantCertifiedAttributeInReadmodelTenant.tenantId, tenantId),
+            gte(
+              tenantCertifiedAttributeInReadmodelTenant.revocationTimestamp,
+              dateThreshold.toISOString()
+            )
+          )
+        )
+        .leftJoin(
+          tenantCertifiedDiscreteAttributeInReadmodelTenant,
+          and(
+            eq(
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.attributeId,
+              attributeInReadmodelAttribute.id
+            ),
+            eq(
+              attributeInReadmodelAttribute.kind,
+              attributeKind.certifiedDiscrete
+            ),
+            eq(
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.tenantId,
+              tenantId
+            ),
+            gte(
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.revocationTimestamp,
+              dateThreshold.toISOString()
+            )
           )
         )
         .leftJoin(
@@ -1367,15 +1429,14 @@ export function readModelServiceBuilder(db: DrizzleReturnType, logger: Logger) {
           eq(certifierTenant.id, tenantFeatureInReadmodelTenant.tenantId)
         )
         .where(
-          and(
-            eq(tenantCertifiedAttributeInReadmodelTenant.tenantId, tenantId),
-            gte(
-              tenantCertifiedAttributeInReadmodelTenant.revocationTimestamp,
-              dateThreshold.toISOString()
+          or(
+            isNotNull(tenantCertifiedAttributeInReadmodelTenant.attributeId),
+            isNotNull(
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.attributeId
             )
           )
         )
-        .limit(5);
+        .limit(SECTION_LIST_LIMIT);
 
       logger.info(
         `Retrieved ${results.length} certified revoked attributes for tenant ${tenantId}`

--- a/packages/email-digest-dispatcher/test/attributeQueries.test.ts
+++ b/packages/email-digest-dispatcher/test/attributeQueries.test.ts
@@ -8,6 +8,7 @@ import {
   createVerifiedAttributeScenario,
   createRevokedAttributeScenario,
   createCertifiedAssignedAttributeScenario,
+  createCertifiedDiscreteAttributeScenario,
   createCertifiedRevokedAttributeScenario,
   createTenantWithMultipleAttributes,
   TEST_TIME_WINDOWS,
@@ -465,6 +466,29 @@ describe("ReadModelService - getCertifiedAssignedAttributes", () => {
       });
     });
 
+    test("should return discrete certified assigned attributes within the 7-day window", async () => {
+      const tenantId = generateId<TenantId>();
+
+      const { attribute, certifier } =
+        await createCertifiedDiscreteAttributeScenario({
+          tenantId,
+          attributeName: "Test Discrete Certified Assigned",
+          assignmentDaysAgo: TEST_TIME_WINDOWS.WITHIN_RANGE,
+        });
+
+      const result =
+        await readModelService.getCertifiedAssignedAttributes(tenantId);
+
+      expect(result).toEqual([
+        {
+          attributeName: attribute.name,
+          certifierName: certifier.name,
+          state: "assigned",
+          totalCount: 1,
+        },
+      ]);
+    });
+
     test("should not return certified attributes assigned more than 7 days ago", async () => {
       const tenantId = generateId<TenantId>();
 
@@ -554,6 +578,30 @@ describe("ReadModelService - getCertifiedRevokedAttributes", () => {
         state: "revoked",
         totalCount: 1,
       });
+    });
+
+    test("should return discrete certified revoked attributes within the 7-day window", async () => {
+      const tenantId = generateId<TenantId>();
+
+      const { attribute, certifier } =
+        await createCertifiedDiscreteAttributeScenario({
+          tenantId,
+          attributeName: "Test Discrete Certified Revoked",
+          assignmentDaysAgo: TEST_TIME_WINDOWS.OUTSIDE_RANGE,
+          revocationDaysAgo: TEST_TIME_WINDOWS.WITHIN_RANGE,
+        });
+
+      const result =
+        await readModelService.getCertifiedRevokedAttributes(tenantId);
+
+      expect(result).toEqual([
+        {
+          attributeName: attribute.name,
+          certifierName: certifier.name,
+          state: "revoked",
+          totalCount: 1,
+        },
+      ]);
     });
 
     test("should not return certified attributes revoked more than 7 days ago", async () => {

--- a/packages/email-digest-dispatcher/test/integrationUtils.ts
+++ b/packages/email-digest-dispatcher/test/integrationUtils.ts
@@ -32,6 +32,7 @@ import {
   Attribute,
   AttributeId,
   attributeKind,
+  CertifiedDiscreteTenantAttribute,
   VerifiedTenantAttribute,
   CertifiedTenantAttribute,
   tenantAttributeType,
@@ -741,6 +742,18 @@ const createMockCertifiedTenantAttribute = (
   revocationTimestamp,
 });
 
+const createMockCertifiedDiscreteTenantAttribute = (
+  attributeId: AttributeId,
+  assignmentTimestamp: Date,
+  revocationTimestamp?: Date
+): CertifiedDiscreteTenantAttribute => ({
+  id: attributeId,
+  type: tenantAttributeType.CERTIFIED_DISCRETE,
+  assignmentTimestamp,
+  revocationTimestamp,
+  discreteValue: 42,
+});
+
 /**
  * Creates a tenant with a certified assigned attribute
  */
@@ -778,6 +791,25 @@ const createTenantWithCertifiedRevokedAttribute = (
   return createMockTenant({
     id: tenantId,
     attributes: [certifiedAttribute],
+  });
+};
+
+const createTenantWithCertifiedDiscreteAttribute = (
+  tenantId: TenantId,
+  attributeId: AttributeId,
+  assignmentTimestamp: Date,
+  revocationTimestamp?: Date
+): Tenant => {
+  const certifiedDiscreteAttribute: CertifiedDiscreteTenantAttribute =
+    createMockCertifiedDiscreteTenantAttribute(
+      attributeId,
+      assignmentTimestamp,
+      revocationTimestamp
+    );
+
+  return createMockTenant({
+    id: tenantId,
+    attributes: [certifiedDiscreteAttribute],
   });
 };
 
@@ -866,6 +898,54 @@ export const createCertifiedRevokedAttributeScenario = async (config: {
   await addOneTenant(certifier);
 
   const tenant = createTenantWithCertifiedRevokedAttribute(
+    config.tenantId,
+    attribute.id,
+    assignmentTimestamp,
+    revocationTimestamp
+  );
+  await addOneTenant(tenant);
+
+  return { tenant, attribute, certifier };
+};
+
+export const createCertifiedDiscreteAttributeScenario = async (config: {
+  tenantId: TenantId;
+  attributeName?: string;
+  assignmentDaysAgo: number;
+  revocationDaysAgo?: number;
+  certifierId?: string;
+  certifierName?: string;
+}): Promise<{
+  tenant: Tenant;
+  attribute: Attribute;
+  certifier: Tenant;
+}> => {
+  const assignmentTimestamp: Date = daysAgo(config.assignmentDaysAgo);
+  const revocationTimestamp: Date | undefined =
+    config.revocationDaysAgo === undefined
+      ? undefined
+      : daysAgo(config.revocationDaysAgo);
+  const certifierId: string = config.certifierId ?? generateId<TenantId>();
+  const attribute: Attribute = createMockAttribute({
+    kind: attributeKind.certifiedDiscrete,
+    origin: certifierId,
+    ...(config.attributeName ? { name: config.attributeName } : {}),
+  });
+
+  await addOneAttribute(attribute);
+
+  const certifier: Tenant = createMockTenant({
+    name: config.certifierName ?? `Certifier ${certifierId}`,
+    features: [
+      {
+        type: tenantFeatureType.persistentCertifier,
+        certifierId,
+      },
+    ],
+  });
+  await addOneTenant(certifier);
+
+  const tenant: Tenant = createTenantWithCertifiedDiscreteAttribute(
     config.tenantId,
     attribute.id,
     assignmentTimestamp,


### PR DESCRIPTION
## Jira Issue
[PIN-10655](https://pagopa.atlassian.net/browse/PIN-10655)

## Context
- The email digest read only standard certified-attribute assignments and revocations.
- Recent discrete certified-attribute activity was omitted from the digest.

## Services Affected
- email-digest-dispatcher

## Key Changes
- Include standard and discrete certified attributes in assigned digest queries.
- Include standard and discrete certified attributes in revoked digest queries.
- Preserve the existing time window and section limit on the combined result.
- Add regression fixtures and tests for discrete assignment and revocation.

## Validation
- Email digest attribute-query tests: 35 passed.
- TypeScript check passed.
- ESLint passed.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [x] Service labels applied
- [ ] Fix Version set in Jira
- [x] Integration tests updated
- [x] OpenAPI spec update not required
- [x] Bruno collection or endpoint definition update not required


[PIN-10655]: https://pagopa.atlassian.net/browse/PIN-10655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ