### PR TITLE
fix: prevent certifier changes with discrete attributes (PIN-10656)

### DIFF
--- a/packages/tenant-process/src/services/readModelServiceSQL.ts
+++ b/packages/tenant-process/src/services/readModelServiceSQL.ts
@@ -464,7 +464,10 @@ export function readModelServiceBuilderSQL(
       const attributesWithMetadata =
         await attributeReadModelService.getAttributesByFilter(
           and(
-            eq(attributeInReadmodelAttribute.kind, attributeKind.certified),
+            inArray(attributeInReadmodelAttribute.kind, [
+              attributeKind.certified,
+              attributeKind.certifiedDiscrete,
+            ]),
             eq(attributeInReadmodelAttribute.origin, certifierId)
           )
         );

--- a/packages/tenant-process/test/integration/addCertifierId.test.ts
+++ b/packages/tenant-process/test/integration/addCertifierId.test.ts
@@ -7,6 +7,7 @@ import {
 } from "pagopa-interop-commons-test";
 import {
   Attribute,
+  attributeKind,
   MaintenanceTenantPromotedToCertifierV2,
   Tenant,
   generateId,
@@ -143,6 +144,39 @@ describe("addCertifierId", async () => {
     await addOneTenant(certifierTenant);
     await addOneAttribute(attribute);
     expect(
+      tenantService.addCertifierId(
+        {
+          tenantId: certifierTenant.id,
+          certifierId,
+        },
+        getMockContextMaintenance({})
+      )
+    ).rejects.toThrowError(
+      certifierWithExistingAttributes(certifierTenant.id, previousCertifierId)
+    );
+  });
+
+  it("Should throw certifierWithExistingAttributes if the organization has already created discrete attributes", async () => {
+    const previousCertifierId: string = generateId();
+
+    const attribute: Attribute = {
+      ...getMockAttribute(attributeKind.certifiedDiscrete),
+      origin: previousCertifierId,
+    };
+
+    const certifierTenant: Tenant = {
+      ...getMockTenant(),
+      features: [
+        {
+          type: "PersistentCertifier",
+          certifierId: previousCertifierId,
+        },
+      ],
+    };
+
+    await addOneTenant(certifierTenant);
+    await addOneAttribute(attribute);
+    await expect(
       tenantService.addCertifierId(
         {
           tenantId: certifierTenant.id,


### PR DESCRIPTION
## Jira Issue
[PIN-10656](https://pagopa.atlassian.net/browse/PIN-10656)

## Context
- The certifier ID consistency check considered only standard certified attributes.
- A certifier with only discrete attributes could change its identifier despite existing registry attributes.

## Services Affected
- tenant-process

## Key Changes
- Check both `Certified` and `CertifiedDiscrete` registry kinds before changing `certifierId`.
- Preserve the existing `certifierWithExistingAttributes` invariant.
- Add a regression test for a certifier with only discrete attributes.

## Validation
- addCertifierId integration tests: 5 passed.
- TypeScript check passed.
- ESLint passed.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [x] Service labels applied
- [ ] Fix Version set in Jira
- [x] Integration tests updated
- [x] OpenAPI spec update not required
- [x] Bruno collection or endpoint definition update not required


[PIN-10656]: https://pagopa.atlassian.net/browse/PIN-10656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ