### PR TITLE
adding comments to explicit fallback value for legacy events

### DIFF
--- a/packages/models/proto/v2/eservice/eservice.proto
+++ b/packages/models/proto/v2/eservice/eservice.proto
@@ -183,6 +183,9 @@ enum ArchivingScopeV2 {
 }
 
 enum GracePeriodDaysV2 {
+  // Must remain at index 0 for backwards compatibility.
+  // Legacy events without this field will decode directly to GRACE_PERIOD_90_DAYS (0),
+  // which is both the fallback for legacy events and a valid domain value.
   GRACE_PERIOD_90_DAYS = 0;
   GRACE_PERIOD_30_DAYS = 1;
   GRACE_PERIOD_60_DAYS = 2;


### PR DESCRIPTION
This PR adds explicit inline documentation to `GracePeriodDaysV2` in the Protobuf definitions (`eservice.v2`).

The goal is to clarify why GRACE_PERIOD_90_DAYS must remain pinned to index 0 and explain the implicit Proto3 deserialization behavior for legacy messages.

In Proto3, fields omitted during serialization default to index 0 upon deserialization.

In our domain:

GRACE_PERIOD_90_DAYS is assigned to index 0.

Legacy events/messages generated prior to the introduction of the gracePeriodDays field do not contain this field.
When legacy messages are parsed, Proto3 automatically defaults gracePeriodDays to 0 (GRACE_PERIOD_90_DAYS).

Since GRACE_PERIOD_90_DAYS is both the fallback default and a valid business value, keeping it at index 0 guarantees full backwards compatibility. Adding these comments prevents accidental refactoring (e.g., inserting an UNSPECIFIED = 0 enum value) that would break compatibility with legacy events.