### PR TITLE
feat: compact catalog eservices endpoint for selects (PIN-10670)

### DIFF
--- a/collections/bff/catalog/Retrieves a lightweight list of catalog EServices.bru
+++ b/collections/bff/catalog/Retrieves a lightweight list of catalog EServices.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Retrieves a lightweight list of catalog EServices
+  type: http
+  seq: 47
+}
+
+get {
+  url: {{host-bff}}/catalog/eservices
+  body: none
+  auth: none
+}
+
+params:query {
+  offset: 0
+  limit: 10
+  ~q: <string>
+  ~states:
+  ~agreementStates:
+  ~mode: RECEIVE
+  ~isConsumerDelegable: true
+  ~personalData: "FALSE"
+}
+
+headers {
+  Authorization: {{JWT}}
+}
+
+docs {
+  Retrieves a lightweight list of catalog EServices, meant to populate selects and autocomplete inputs
+}

--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -2939,7 +2939,7 @@ paths:
             type: integer
             format: int32
             minimum: 1
-            maximum: 200
+            maximum: 50
       responses:
         "200":
           description: A list of EServices
@@ -2947,6 +2947,135 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CatalogEServices"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "400":
+          description: Invalid input
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+  "/catalog/eservices":
+    get:
+      tags:
+        - eservices
+      summary: Retrieves a lightweight list of catalog EServices
+      description: Retrieves a lightweight list of catalog EServices, meant to populate selects and autocomplete inputs
+      operationId: getCompactCatalogEServices
+      parameters:
+        - in: query
+          name: q
+          description: Query to filter EServices by name
+          schema:
+            type: string
+        - in: query
+          name: states
+          description: comma separated sequence of states
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/EServiceDescriptorState"
+            default: []
+          explode: false
+        - in: query
+          name: agreementStates
+          description: comma separated sequence of agreement states to filter the response with
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/AgreementState"
+            default: []
+          explode: false
+        - in: query
+          name: mode
+          description: EService Mode filter
+          schema:
+            $ref: "#/components/schemas/EServiceMode"
+        - in: query
+          name: isConsumerDelegable
+          description: EService isConsumerDelegable filter
+          schema:
+            type: boolean
+        - in: query
+          name: personalData
+          description: if "TRUE" only e-services that handle personal data will be returned, if "FALSE" only non-personal data e-services will be returned, if not present all e-services will be returned, if "DEFINED" all e-services with a defined personal data flag will be returned
+          required: false
+          schema:
+            $ref: "#/components/schemas/PersonalDataFilter"
+        - in: query
+          name: offset
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 200
+      responses:
+        "200":
+          description: A lightweight list of EServices
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompactCatalogEServices"
           headers:
             "X-Rate-Limit-Limit":
               schema:
@@ -28595,6 +28724,38 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CompactEService"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+      required:
+        - results
+        - pagination
+    CompactCatalogEService:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - producer
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        producer:
+          $ref: "#/components/schemas/CompactOrganization"
+        personalData:
+          type: boolean
+        activeDescriptor:
+          $ref: "#/components/schemas/CompactDescriptor"
+    CompactCatalogEServices:
+      type: object
+      additionalProperties: false
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/CompactCatalogEService"
         pagination:
           $ref: "#/components/schemas/Pagination"
       required:

--- a/packages/api-clients/src/bffApi.ts
+++ b/packages/api-clients/src/bffApi.ts
@@ -9,6 +9,11 @@ export type BffGetCatalogQueryParam = QueryParametersByAlias<
   "getEServicesCatalog"
 >;
 
+export type BffGetCompactCatalogEServicesQueryParam = QueryParametersByAlias<
+  BffEservicesApi,
+  "getCompactCatalogEServices"
+>;
+
 export type BffGetProducersEservicesQueryParam = QueryParametersByAlias<
   BffEservicesApi,
   "getProducerEServices"

--- a/packages/backend-for-frontend/src/api/catalogApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/catalogApiConverter.ts
@@ -45,6 +45,39 @@ export function toEserviceCatalogProcessQueryParams(
   };
 }
 
+export function toCompactCatalogEServicesQueryParams(
+  queryParams: bffApi.BffGetCompactCatalogEServicesQueryParam
+): catalogApi.GetEServicesQueryParams {
+  return {
+    ...queryParams,
+    name: queryParams.q,
+    eservicesIds: [],
+    producersIds: [],
+    attributesIds: [],
+    consumersIds: [],
+    templatesIds: [],
+  };
+}
+
+export function toCompactCatalogEService(
+  eservice: catalogApi.EService,
+  producerTenant: tenantApi.Tenant,
+  activeDescriptor?: catalogApi.EServiceDescriptor
+): bffApi.CompactCatalogEService {
+  return {
+    id: eservice.id,
+    name: eservice.name,
+    producer: {
+      id: producerTenant.id,
+      name: producerTenant.name,
+    },
+    personalData: eservice.personalData,
+    activeDescriptor: activeDescriptor
+      ? toCompactDescriptor(activeDescriptor)
+      : undefined,
+  };
+}
+
 export function toBffCatalogTenant(
   organization: tenantApi.Tenant,
   hasNotifications?: boolean

--- a/packages/backend-for-frontend/src/routers/catalogRouter.ts
+++ b/packages/backend-for-frontend/src/routers/catalogRouter.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   toBffCatalogApiDescriptorDoc,
+  toCompactCatalogEServicesQueryParams,
   toEserviceCatalogProcessQueryParams,
 } from "../api/catalogApiConverter.js";
 import { makeApiProblem } from "../model/errors.js";
@@ -56,6 +57,28 @@ const catalogRouter = (
           bffGetCatalogErrorMapper,
           ctx,
           "Error retrieving Catalog EServices"
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
+    .get("/catalog/eservices", async (req, res) => {
+      const ctx = fromBffAppContext(req.ctx, req.headers);
+      const queryParams = toCompactCatalogEServicesQueryParams(req.query);
+      try {
+        const response = await catalogService.getCompactCatalogEServices(
+          ctx,
+          queryParams
+        );
+
+        return res
+          .status(200)
+          .send(bffApi.CompactCatalogEServices.parse(response));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          bffGetCatalogErrorMapper,
+          ctx,
+          "Error retrieving compact Catalog EServices"
         );
         return res.status(errorRes.status).send(errorRes);
       }

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -44,6 +44,7 @@ import {
   toBffCatalogDescriptorEService,
   toBffEServiceTemplateInstance,
   toCatalogCreateEServiceSeed,
+  toCompactCatalogEService,
   toCompactProducerDescriptor,
   enhanceEServiceToBffCatalogApiProducerDescriptorEService,
   enhanceEServiceRiskAnalysisArray,
@@ -374,6 +375,66 @@ export function catalogServiceBuilder(
         },
       };
       return response;
+    },
+    getCompactCatalogEServices: async (
+      ctx: WithLogger<BffAppContext>,
+      queries: catalogApi.GetEServicesQueryParams
+    ): Promise<bffApi.CompactCatalogEServices> => {
+      const {
+        offset,
+        limit,
+        states,
+        name,
+        mode,
+        agreementStates,
+        isConsumerDelegable,
+        personalData,
+      } = queries;
+      ctx.logger.info(
+        `Retrieving compact catalog EServices for name = ${name}, states = ${states}, agreementStates = ${agreementStates}, isConsumerDelegable = ${isConsumerDelegable}, mode = ${mode}, personalData = ${personalData}, offset = ${offset}, limit = ${limit}`
+      );
+
+      const eservicesResponse: catalogApi.EServices =
+        await catalogProcessClient.getEServices({
+          headers: ctx.headers,
+          queries,
+        });
+
+      const producersIds = new Set(
+        eservicesResponse.results.map((e) => e.producerId)
+      );
+      const producers = new Map(
+        await Promise.all(
+          Array.from(producersIds).map(
+            async (producerId): Promise<[string, tenantApi.Tenant]> => [
+              producerId,
+              await tenantProcessClient.tenant.getTenant({
+                headers: ctx.headers,
+                params: { id: producerId },
+              }),
+            ]
+          )
+        )
+      );
+
+      return {
+        results: eservicesResponse.results.map((eservice) => {
+          const producer = producers.get(eservice.producerId);
+          if (!producer) {
+            throw tenantNotFound(unsafeBrandId<TenantId>(eservice.producerId));
+          }
+          return toCompactCatalogEService(
+            eservice,
+            producer,
+            getLatestActiveDescriptor(eservice)
+          );
+        }),
+        pagination: {
+          offset,
+          limit,
+          totalCount: eservicesResponse.totalCount,
+        },
+      };
     },
     getProducerEServiceDescriptor: async (
       eserviceId: EServiceId,

--- a/packages/backend-for-frontend/test/api/catalogRouter/getCatalog.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/getCatalog.test.ts
@@ -56,6 +56,12 @@ describe("API GET /catalog", () => {
     expect(res.body).toEqual(mockApiCatalogEServices);
   });
 
+  it("Should accept a limit up to 50", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, { offset: 0, limit: 50 });
+    expect(res.status).toBe(200);
+  });
+
   it.each([
     {
       error: eserviceRiskNotFound(generateId(), generateId()),
@@ -85,7 +91,7 @@ describe("API GET /catalog", () => {
     { query: { limit: 10 } },
     { query: { offset: -1, limit: 10 } },
     { query: { offset: 0, limit: -2 } },
-    { query: { offset: 0, limit: 201 } },
+    { query: { offset: 0, limit: 51 } },
     { query: { offset: "invalid", limit: 10 } },
     { query: { offset: 0, limit: "invalid" } },
     { query: { ...defaultQuery, personalData: "invalid" } },

--- a/packages/backend-for-frontend/test/api/catalogRouter/getCompactCatalogEServices.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/getCompactCatalogEServices.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { authRole } from "pagopa-interop-commons";
+import { generateToken } from "pagopa-interop-commons-test/index.js";
+import { generateId } from "pagopa-interop-models";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { tenantNotFound } from "../../../src/model/errors.js";
+import { getMockBffApiCompactCatalogEService } from "../../mockUtils.js";
+import { api, services } from "../../vitest.api.setup.js";
+
+describe("API GET /catalog/eservices", () => {
+  const defaultQuery = {
+    offset: 0,
+    limit: 5,
+  };
+  const mockApiCompactCatalogEServices = {
+    results: [
+      getMockBffApiCompactCatalogEService(),
+      getMockBffApiCompactCatalogEService(),
+      getMockBffApiCompactCatalogEService(),
+    ],
+    pagination: {
+      offset: defaultQuery.offset,
+      limit: defaultQuery.limit,
+      totalCount: 3,
+    },
+  };
+
+  beforeEach(() => {
+    services.catalogService.getCompactCatalogEServices = vi
+      .fn()
+      .mockResolvedValue(mockApiCompactCatalogEServices);
+  });
+
+  const makeRequest = async (
+    token: string,
+    query: typeof defaultQuery = defaultQuery
+  ) =>
+    request(api)
+      .get(`${appBasePath}/catalog/eservices`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .query(query)
+      .send();
+
+  it("Should return 200 if no error is thrown", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockApiCompactCatalogEServices);
+  });
+
+  it("Should reject a payload containing fields excluded from the compact contract", async () => {
+    services.catalogService.getCompactCatalogEServices = vi
+      .fn()
+      .mockResolvedValue({
+        ...mockApiCompactCatalogEServices,
+        results: mockApiCompactCatalogEServices.results.map((result) => ({
+          ...result,
+          description: "a description",
+          isMine: true,
+          hasUnreadNotifications: true,
+          asyncExchange: true,
+        })),
+      });
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(500);
+  });
+
+  it("Should forward all the supported filters to the service", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, {
+      ...defaultQuery,
+      q: "eservice name",
+      states: "PUBLISHED,SUSPENDED",
+      agreementStates: "ACTIVE",
+      mode: "DELIVER",
+      isConsumerDelegable: true,
+      personalData: "TRUE",
+    } as unknown as typeof defaultQuery);
+
+    expect(res.status).toBe(200);
+    expect(
+      services.catalogService.getCompactCatalogEServices
+    ).toHaveBeenCalledWith(expect.anything(), {
+      offset: defaultQuery.offset,
+      limit: defaultQuery.limit,
+      q: "eservice name",
+      name: "eservice name",
+      states: ["PUBLISHED", "SUSPENDED"],
+      agreementStates: ["ACTIVE"],
+      mode: "DELIVER",
+      isConsumerDelegable: true,
+      personalData: "TRUE",
+      eservicesIds: [],
+      producersIds: [],
+      attributesIds: [],
+      consumersIds: [],
+      templatesIds: [],
+    });
+  });
+
+  it("Should accept a limit up to 200", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, { offset: 0, limit: 200 });
+    expect(res.status).toBe(200);
+  });
+
+  it.each([
+    authRole.ADMIN_ROLE,
+    authRole.API_ROLE,
+    authRole.SECURITY_ROLE,
+    authRole.SUPPORT_ROLE,
+    authRole.REVIEWER_ROLE,
+    authRole.VIEWER_ROLE,
+  ])("Should return 200 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(200);
+  });
+
+  it("Should return 500 for 'tenantNotFound'", async () => {
+    services.catalogService.getCompactCatalogEServices = vi
+      .fn()
+      .mockRejectedValue(tenantNotFound(generateId()));
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(500);
+  });
+
+  it.each([
+    { query: {} },
+    { query: { offset: 0 } },
+    { query: { limit: 10 } },
+    { query: { offset: -1, limit: 10 } },
+    { query: { offset: 0, limit: -2 } },
+    { query: { offset: 0, limit: 201 } },
+    { query: { offset: "invalid", limit: 10 } },
+    { query: { offset: 0, limit: "invalid" } },
+    { query: { ...defaultQuery, states: "invalid" } },
+    { query: { ...defaultQuery, agreementStates: "invalid" } },
+    { query: { ...defaultQuery, mode: "invalid" } },
+    { query: { ...defaultQuery, personalData: "invalid" } },
+  ])(
+    "Should return 400 if passed an invalid parameter $query",
+    async ({ query }) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, query as typeof defaultQuery);
+      expect(res.status).toBe(400);
+    }
+  );
+});

--- a/packages/backend-for-frontend/test/getCompactCatalogEServices.test.ts
+++ b/packages/backend-for-frontend/test/getCompactCatalogEServices.test.ts
@@ -1,0 +1,249 @@
+import {
+  agreementApi,
+  attributeRegistryApi,
+  catalogApi,
+  eserviceTemplateApi,
+  inAppNotificationApi,
+} from "pagopa-interop-api-clients";
+import { AuthData } from "pagopa-interop-commons";
+import { getMockAuthData, getMockContext } from "pagopa-interop-commons-test";
+import { generateId, TenantId } from "pagopa-interop-models";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  AuthorizationProcessClient,
+  DelegationProcessClient,
+  TenantProcessClient,
+} from "../src/clients/clientsProvider.js";
+
+import { config } from "../src/config/config.js";
+import { catalogServiceBuilder } from "../src/services/catalogService.js";
+import {
+  getMockCatalogApiEService,
+  getMockCatalogApiEServiceDescriptor,
+} from "./mockUtils.js";
+import { fileManager, getBffMockContext } from "./utils.js";
+
+describe("getCompactCatalogEServices", () => {
+  const requesterId: TenantId = generateId<TenantId>();
+  const producerId: TenantId = generateId<TenantId>();
+  const otherProducerId: TenantId = generateId<TenantId>();
+
+  const authData: AuthData = {
+    ...getMockAuthData(),
+    organizationId: requesterId,
+  };
+  const bffMockContext = getBffMockContext(getMockContext({ authData }));
+
+  const publishedDescriptor: catalogApi.EServiceDescriptor = {
+    ...getMockCatalogApiEServiceDescriptor(),
+    version: "1",
+    state: catalogApi.EServiceDescriptorState.Values.PUBLISHED,
+    templateVersionRef: { id: generateId() },
+    archivingSchedule: undefined,
+  };
+
+  const draftDescriptor: catalogApi.EServiceDescriptor = {
+    ...getMockCatalogApiEServiceDescriptor(),
+    version: "2",
+    state: catalogApi.EServiceDescriptorState.Values.DRAFT,
+    templateVersionRef: undefined,
+  };
+
+  const eservice1: catalogApi.EService = {
+    ...getMockCatalogApiEService(),
+    producerId,
+    personalData: true,
+    descriptors: [publishedDescriptor, draftDescriptor],
+  };
+
+  const eservice2: catalogApi.EService = {
+    ...getMockCatalogApiEService(),
+    producerId,
+    personalData: false,
+    descriptors: [],
+  };
+
+  const eservice3: catalogApi.EService = {
+    ...getMockCatalogApiEService(),
+    producerId: otherProducerId,
+    personalData: undefined,
+    descriptors: [publishedDescriptor],
+  };
+
+  const tenantsById: Record<string, { id: string; name: string }> = {
+    [producerId]: { id: producerId, name: "Producer One" },
+    [otherProducerId]: { id: otherProducerId, name: "Producer Two" },
+  };
+
+  const mockGetEServices = vi.fn();
+  const mockGetTenant = vi.fn();
+  const mockFilterUnreadNotifications = vi.fn();
+
+  const mockCatalogProcessClient = {
+    getEServices: mockGetEServices,
+  } as unknown as catalogApi.CatalogProcessClient;
+
+  const mockTenantProcessClient = {
+    tenant: {
+      getTenant: mockGetTenant,
+    },
+  } as unknown as TenantProcessClient;
+
+  const mockInAppNotificationManagerClient = {
+    filterUnreadNotifications: mockFilterUnreadNotifications,
+  } as unknown as inAppNotificationApi.InAppNotificationManagerClient;
+
+  const catalogService = catalogServiceBuilder(
+    mockCatalogProcessClient,
+    mockTenantProcessClient,
+    {} as unknown as agreementApi.AgreementProcessClient,
+    {} as unknown as attributeRegistryApi.AttributeProcessClient,
+    {} as unknown as AuthorizationProcessClient,
+    {} as unknown as DelegationProcessClient,
+    {} as unknown as eserviceTemplateApi.EServiceTemplateProcessClient,
+    mockInAppNotificationManagerClient,
+    fileManager,
+    config
+  );
+
+  const defaultQueries: catalogApi.GetEServicesQueryParams = {
+    offset: 0,
+    limit: 50,
+    eservicesIds: [],
+    producersIds: [],
+    attributesIds: [],
+    consumersIds: [],
+    templatesIds: [],
+    states: [],
+    agreementStates: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEServices.mockResolvedValue({
+      results: [eservice1, eservice2, eservice3],
+      totalCount: 3,
+    });
+    mockGetTenant.mockImplementation(
+      async ({ params }: { params: { id: string } }) => ({
+        ...tenantsById[params.id],
+        attributes: [],
+      })
+    );
+  });
+
+  it("should return the compact eservices with pagination", async () => {
+    const result = await catalogService.getCompactCatalogEServices(
+      bffMockContext,
+      defaultQueries
+    );
+
+    expect(result.pagination).toEqual({
+      offset: 0,
+      limit: 50,
+      totalCount: 3,
+    });
+    expect(result.results).toEqual([
+      {
+        id: eservice1.id,
+        name: eservice1.name,
+        producer: { id: producerId, name: "Producer One" },
+        personalData: true,
+        activeDescriptor: {
+          id: publishedDescriptor.id,
+          version: publishedDescriptor.version,
+          audience: publishedDescriptor.audience,
+          state: publishedDescriptor.state,
+          templateVersionId: publishedDescriptor.templateVersionRef?.id,
+          archivableOn: undefined,
+        },
+      },
+      {
+        id: eservice2.id,
+        name: eservice2.name,
+        producer: { id: producerId, name: "Producer One" },
+        personalData: false,
+      },
+      {
+        id: eservice3.id,
+        name: eservice3.name,
+        producer: { id: otherProducerId, name: "Producer Two" },
+        personalData: undefined,
+        activeDescriptor: {
+          id: publishedDescriptor.id,
+          version: publishedDescriptor.version,
+          audience: publishedDescriptor.audience,
+          state: publishedDescriptor.state,
+          templateVersionId: publishedDescriptor.templateVersionRef?.id,
+          archivableOn: undefined,
+        },
+      },
+    ]);
+  });
+
+  it("should not return the fields excluded from the compact payload", async () => {
+    const result = await catalogService.getCompactCatalogEServices(
+      bffMockContext,
+      defaultQueries
+    );
+
+    for (const eservice of result.results) {
+      expect(eservice).not.toHaveProperty("description");
+      expect(eservice).not.toHaveProperty("isMine");
+      expect(eservice).not.toHaveProperty("hasUnreadNotifications");
+      expect(eservice).not.toHaveProperty("asyncExchange");
+      expect(eservice.producer).not.toHaveProperty("selfcareId");
+      expect(eservice.producer).not.toHaveProperty("hasUnreadNotifications");
+    }
+  });
+
+  it("should not call the in-app notification manager", async () => {
+    await catalogService.getCompactCatalogEServices(
+      bffMockContext,
+      defaultQueries
+    );
+
+    expect(mockFilterUnreadNotifications).not.toHaveBeenCalled();
+  });
+
+  it("should retrieve each distinct producer only once and skip the requester", async () => {
+    await catalogService.getCompactCatalogEServices(
+      bffMockContext,
+      defaultQueries
+    );
+
+    expect(mockGetTenant).toHaveBeenCalledTimes(2);
+    expect(mockGetTenant).toHaveBeenCalledWith({
+      headers: bffMockContext.headers,
+      params: { id: producerId },
+    });
+    expect(mockGetTenant).toHaveBeenCalledWith({
+      headers: bffMockContext.headers,
+      params: { id: otherProducerId },
+    });
+    expect(mockGetTenant).not.toHaveBeenCalledWith({
+      headers: bffMockContext.headers,
+      params: { id: requesterId },
+    });
+  });
+
+  it("should forward the queries to catalog process unchanged", async () => {
+    const queries: catalogApi.GetEServicesQueryParams = {
+      ...defaultQueries,
+      name: "eservice name",
+      states: [catalogApi.EServiceDescriptorState.Values.PUBLISHED],
+      agreementStates: [catalogApi.AgreementState.Values.ACTIVE],
+      mode: catalogApi.EServiceMode.Values.DELIVER,
+      isConsumerDelegable: true,
+      personalData: "TRUE",
+    };
+
+    await catalogService.getCompactCatalogEServices(bffMockContext, queries);
+
+    expect(mockGetEServices).toHaveBeenCalledWith({
+      headers: bffMockContext.headers,
+      queries,
+    });
+  });
+});

--- a/packages/backend-for-frontend/test/mockUtils.ts
+++ b/packages/backend-for-frontend/test/mockUtils.ts
@@ -156,6 +156,18 @@ export const getMockBffApiCatalogEService = (): bffApi.CatalogEService => ({
   activeDescriptor: generateMock(bffApi.CompactDescriptor.optional()),
 });
 
+export const getMockBffApiCompactCatalogEService =
+  (): bffApi.CompactCatalogEService => ({
+    id: generateId(),
+    name: generateMock(z.string()),
+    producer: {
+      id: generateId(),
+      name: generateMock(z.string()),
+    },
+    personalData: generateMock(z.boolean().optional()),
+    activeDescriptor: generateMock(bffApi.CompactDescriptor.optional()),
+  });
+
 export const getMockBffApiProducerEServiceDescriptor =
   (): bffApi.ProducerEServiceDescriptor => ({
     id: generateId(),


### PR DESCRIPTION
## Jira Issue
[PIN-10670](https://pagopa.atlassian.net/browse/PIN-10670)

## Context
Nine frontend call sites use `GET /catalog` to populate selects and table filters, not to render the catalog. That endpoint is expensive for the purpose: for every page, `enhanceCatalogEservices` resolves one tenant per distinct producer and calls `filterUnreadNotifications` to populate `hasUnreadNotifications`, a field no select reads. None of those call sites uses `description`, `isMine`, `hasUnreadNotifications`, `asyncExchange`, nor the `attributesIds` and `producersIds` filters. The cost was amplified by PR #2312, which raised the maximum `limit` from 50 to 200 to solve the "more than 50 e-services with the same name" case in purpose creation.

This PR adds a dedicated lightweight endpoint for that use case and restores the maximum `limit` of `GET /catalog` to 50. The rollback is limited to the BFF: `catalogApi.yml` stays at 200, because it is an internal contract not generated for the frontend, the new endpoint proxies `catalog-process GET /eservices` with a high `limit`, and lowering it would break `purposeTemplateService.ts:170`, which passes `limit: eserviceIds.length`.

The N+1 on `getTenant` is not removed: `tenant-process` exposes no lookup by list of ids. The new endpoint is still cheaper than `GET /catalog` at equal `limit` — no notification call, one `getTenant` less (the requester's, only needed for `isMine`), smaller payload. A bulk lookup in `tenant-process` or denormalising the producer name in the `catalog-process` readmodel remain options for a follow-up.

**Release coordination.** `GET /catalog` with `limit > 50` now returns 400, it does not truncate. PR #2312 was made precisely because the frontend was requesting 200, so before merging confirm that no production frontend call still uses `limit > 50` on `/catalog`, or stage the release: new endpoint first, limit rollback after. No internal consumer is affected: `getAllFromPaginated` uses a fixed limit of 50 and every other caller goes through `catalogApi.yml`.

## Services Affected
backend-for-frontend

## Key Changes
- Added `GET /catalog/eservices` (`getCompactCatalogEServices`) to `bffApi.yml`, exposing only the filters the selects actually use: `q`, `states`, `agreementStates`, `mode`, `isConsumerDelegable`, `personalData`, with a maximum `limit` of 200.
- Added the `CompactCatalogEService` / `CompactCatalogEServices` schemas: `id`, `name`, `producer` (the existing `CompactOrganization`, with only `id` and `name` populated), `personalData` and `activeDescriptor`. No `description`, `isMine`, `hasUnreadNotifications` or `asyncExchange`.
- Implemented `getCompactCatalogEServices` in `catalogService` without going through `enhanceCatalogEservices`: no call to `inAppNotificationManagerClient`, producers deduplicated before resolution, requester never resolved.
- Populated `activeDescriptor.templateVersionId` through the existing `toCompactDescriptor`, which `GET /catalog` does not expose and which the purpose-template resource-linking select needs.
- Lowered the maximum `limit` of `GET /catalog` from 200 to 50 in `bffApi.yml`, leaving `catalogApi.yml` at 200.
- Named the route after the existing `/{context}/eservices` pattern (`/producers/agreements/eservices`, `/consumers/agreements/eservices`) rather than `/x/filter/y`, which in this repo returns filter *values* rather than the entity itself.
- Added API tests (filter forwarding, response shape enforced by the strict schema, role matrix, `limit` validation on both routes) and service tests (no notification call, producer deduplication, `templateVersionId` mapping).
- Added the Bruno request under `collections/bff/catalog/`.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [x] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [x] OpenAPI spec updated (if required)
- [x] Bruno collection updated (if required)

[PIN-10670]: https://pagopa.atlassian.net/browse/PIN-10670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ