### PR TITLE
feature: add support for certified discrete attribute in M2M v3 attributeRouter contract (PIN-10716)

### DIFF
--- a/collections/m2m gateway-v3/attributes/Create certified discrete attribute.bru
+++ b/collections/m2m gateway-v3/attributes/Create certified discrete attribute.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Create certified discrete attribute
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{host-m2m-gw-v3}}/certifiedDiscreteAttributes
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M-ADMIN}}
+  DPoP: {{DPOP-PROOF}}
+}
+
+body:json {
+  {
+    "code": "{{randomCode}}",
+    "name": "{{randomName}}",
+    "description": "{{randomDescription}}"
+  }
+}
+
+script:pre-request {
+  const randomCode = Math.round(Math.random() * 10000)
+  
+  bru.setVar("randomCode", randomCode)
+  bru.setVar("randomName", `test name ${randomCode}`)
+  bru.setVar("randomDescription", `test description ${randomCode}`)
+}
+
+docs {
+  Creates a new certified discrete attribute.
+}

--- a/collections/m2m gateway-v3/attributes/Get certified discrete attribute.bru
+++ b/collections/m2m gateway-v3/attributes/Get certified discrete attribute.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Get certified discrete ttribute
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host-m2m-gw-v3}}/certifiedDiscreteAttributes/:attributeId
+  body: none
+  auth: none
+}
+
+params:path {
+  attributeId: {{attributeId}}
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M}}
+  DPoP: {{DPOP-PROOF}}
+}
+
+docs {
+  Retrieves a certified discrete attribute by its ID.
+}

--- a/collections/m2m gateway-v3/attributes/List certified discrete attributes.bru
+++ b/collections/m2m gateway-v3/attributes/List certified discrete attributes.bru
@@ -1,0 +1,21 @@
+meta {
+  name: List certified discrete attributes
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{host-m2m-gw-v3}}/certifiedDiscreteAttributes?offset=0&limit=10
+  body: none
+  auth: none
+}
+
+params:query {
+  offset: 0
+  limit: 10
+}
+
+headers {
+  Authorization: {{DPOP-JWT-M2M}}
+  DPoP: {{DPOP-PROOF}}
+}

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -1413,6 +1413,124 @@ paths:
           $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+  /certifiedDiscreteAttributes:
+    get:
+      tags:
+        - attributes
+      summary: List Certified Discrete Attributes
+      description: Retrieve a list of Certified Discrete Attributes
+      operationId: getCertifiedDiscreteAttributes
+      parameters:
+        - $ref: "#/components/parameters/OffsetParam"
+        - $ref: "#/components/parameters/LimitParam"
+      responses:
+        "200":
+          description: Certified Discrete Attributes retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertifiedDiscreteAttributes"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+    post:
+      tags:
+        - attributes
+      summary: Create a certified Discrete Attribute
+      description: |
+        Create a certified Discrete Attribute
+        The Attribute must
+          - have a unique name across all Attributes in the Platform
+          - have a unique code across certified Discrete Attributes owned by the requester
+      operationId: createCertifiedDiscreteAttribute
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CertifiedDiscreteAttributeSeed"
+      responses:
+        "201":
+          description: Certified Discrete Attribute created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertifiedDiscreteAttribute"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /certifiedDiscreteAttributes/{attributeId}:
+    parameters:
+      - name: attributeId
+        in: path
+        description: The ID of the Attribute to retrieve
+        required: true
+        schema:
+          $ref: "#/components/schemas/AttributeId"
+    get:
+      tags:
+        - attributes
+      summary: Retrieve a certified Discrete Attribute
+      description: Retrieve a certified Discrete Attribute
+      operationId: getCertifiedDiscreteAttribute
+      responses:
+        "200":
+          description: Certified Discrete attribute retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertifiedDiscreteAttribute"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            X-Rate-Limit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            X-Rate-Limit-Interval:
+              $ref: "#/components/headers/RateLimitIntervalHeader"
+            Digest:
+              $ref: "#/components/headers/IntegrityRest02DigestHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/IntegrityRest02AgidJwtSignatureHeader"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
   /declaredAttributes/{attributeId}:
     parameters:
       - name: attributeId
@@ -11860,6 +11978,68 @@ components:
       required:
         - attributeIds
     CertifiedAttributeSeed:
+      type: object
+      additionalProperties: false
+      description: Models the attribute registry entry as payload response
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 500
+        description:
+          type: string
+          minLength: 1
+          maxLength: 500
+        code:
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: The identifier of the attribute on the source registry
+      required:
+        - description
+        - name
+        - code
+    CertifiedDiscreteAttribute:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+          description: The identifier of the attribute on the source registry
+        description:
+          type: string
+        origin:
+          type: string
+          description: Identifier of the origin of this attribute, e.g. "ISTAT"
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - description
+        - code
+        - origin
+        - createdAt
+    CertifiedDiscreteAttributes:
+      type: object
+      additionalProperties: false
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertifiedDiscreteAttribute"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+      required:
+        - results
+        - pagination
+    CertifiedDiscreteAttributeSeed:
       type: object
       additionalProperties: false
       description: Models the attribute registry entry as payload response

--- a/packages/api-clients/src/m2mGatewayApiV3.ts
+++ b/packages/api-clients/src/m2mGatewayApiV3.ts
@@ -32,6 +32,10 @@ export type GetCertifiedAttributesQueryParams = QueryParametersByAlias<
   AttributeApi,
   "getCertifiedAttributes"
 >;
+export type GetCertifiedDiscreteAttributesQueryParams = QueryParametersByAlias<
+  AttributeApi,
+  "getCertifiedDiscreteAttributes"
+>;
 export type GetDeclaredAttributesQueryParams = QueryParametersByAlias<
   AttributeApi,
   "getDeclaredAttributes"

--- a/packages/m2m-gateway-v3/src/api/attributeApiConverter.ts
+++ b/packages/m2m-gateway-v3/src/api/attributeApiConverter.ts
@@ -21,6 +21,13 @@ function convertAttribute(
 
 function convertAttribute(
   attribute: attributeRegistryApi.Attribute,
+  attributeKind: typeof attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+  logger: Logger,
+  mapThrownErrorsToNotFound?: boolean
+): m2mGatewayApiV3.CertifiedDiscreteAttribute;
+
+function convertAttribute(
+  attribute: attributeRegistryApi.Attribute,
   attributeKind: typeof attributeRegistryApi.AttributeKind.Values.DECLARED,
   logger: Logger,
   mapThrownErrorsToNotFound?: boolean
@@ -35,12 +42,7 @@ function convertAttribute(
 
 function convertAttribute(
   attribute: attributeRegistryApi.Attribute,
-  // TODO(PIN-10074): remove this exclusion when the future M2M work item adds
-  // CERTIFIED_DISCRETE support to the M2M v3 contract.
-  attributeKind: Exclude<
-    attributeRegistryApi.AttributeKind,
-    "CERTIFIED_DISCRETE"
-  >,
+  attributeKind: attributeRegistryApi.AttributeKind,
   logger: Logger,
   mapThrownErrorsToNotFound = false
 ):
@@ -57,14 +59,18 @@ function convertAttribute(
       createdAt: attribute.creationTime,
     };
     return match(attributeKind)
-      .with(attributeRegistryApi.AttributeKind.Values.CERTIFIED, () => {
-        assertAttributeOriginAndCodeAreDefined(attribute);
-        return {
-          ...baseFields,
-          code: attribute.code,
-          origin: attribute.origin,
-        };
-      })
+      .with(
+        attributeRegistryApi.AttributeKind.Values.CERTIFIED,
+        attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+        () => {
+          assertAttributeOriginAndCodeAreDefined(attribute);
+          return {
+            ...baseFields,
+            code: attribute.code,
+            origin: attribute.origin,
+          };
+        }
+      )
       .with(
         attributeRegistryApi.AttributeKind.Values.DECLARED,
         attributeRegistryApi.AttributeKind.Values.VERIFIED,
@@ -97,6 +103,23 @@ export function toM2MGatewayApiCertifiedAttribute({
   return convertAttribute(
     attribute,
     attributeRegistryApi.AttributeKind.Values.CERTIFIED,
+    logger,
+    mapThrownErrorsToNotFound
+  );
+}
+
+export function toM2MGatewayApiCertifiedDiscreteAttribute({
+  attribute,
+  logger,
+  mapThrownErrorsToNotFound = false,
+}: {
+  attribute: attributeRegistryApi.Attribute;
+  logger: Logger;
+  mapThrownErrorsToNotFound?: boolean;
+}): m2mGatewayApiV3.CertifiedDiscreteAttribute {
+  return convertAttribute(
+    attribute,
+    attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
     logger,
     mapThrownErrorsToNotFound
   );
@@ -143,6 +166,16 @@ export function toGetCertifiedAttributesApiQueryParams(
     limit: params.limit,
     offset: params.offset,
     kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED],
+  };
+}
+
+export function toGetCertifiedDiscreteAttributesApiQueryParams(
+  params: m2mGatewayApiV3.GetCertifiedDiscreteAttributesQueryParams
+): attributeRegistryApi.GetAttributesQueryParams {
+  return {
+    limit: params.limit,
+    offset: params.offset,
+    kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE],
   };
 }
 

--- a/packages/m2m-gateway-v3/src/routers/attributeRouter.ts
+++ b/packages/m2m-gateway-v3/src/routers/attributeRouter.ts
@@ -50,6 +50,30 @@ const attributeRouter = (
         return res.status(errorRes.status).send(errorRes);
       }
     })
+    .get("/certifiedDiscreteAttributes/:attributeId", async (req, res) => {
+      const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+      try {
+        validateAuthorization(ctx, [M2M_ROLE, M2M_ADMIN_ROLE]);
+
+        const attribute = await attributeService.getCertifiedDiscreteAttribute(
+          req.params.attributeId,
+          ctx
+        );
+
+        return res
+          .status(200)
+          .send(m2mGatewayApiV3.CertifiedDiscreteAttribute.parse(attribute));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          getAttributeErrorMapper,
+          ctx,
+          `Error retrieving certified discrete attribute with id ${req.params.attributeId}`
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
     .get("/declaredAttributes/:attributeId", async (req, res) => {
       const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
 
@@ -140,6 +164,51 @@ const attributeRouter = (
           emptyErrorMapper,
           ctx,
           "Error retrieving certified attributes"
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
+    .post("/certifiedDiscreteAttributes", async (req, res) => {
+      const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+
+      try {
+        validateAuthorization(ctx, [M2M_ADMIN_ROLE]);
+
+        const attribute =
+          await attributeService.createCertifiedDiscreteAttribute(
+            req.body,
+            ctx
+          );
+        return res
+          .status(201)
+          .send(m2mGatewayApiV3.CertifiedDiscreteAttribute.parse(attribute));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx,
+          "Error creating certified discrete attribute"
+        );
+        return res.status(errorRes.status).send(errorRes);
+      }
+    })
+    .get("/certifiedDiscreteAttributes", async (req, res) => {
+      const ctx = fromM2MGatewayAppContext(req.ctx, req.headers);
+      try {
+        validateAuthorization(ctx, [M2M_ROLE, M2M_ADMIN_ROLE]);
+
+        const attributes =
+          await attributeService.getCertifiedDiscreteAttributes(req.query, ctx);
+
+        return res
+          .status(200)
+          .send(m2mGatewayApiV3.CertifiedDiscreteAttributes.parse(attributes));
+      } catch (error) {
+        const errorRes = makeApiProblem(
+          error,
+          emptyErrorMapper,
+          ctx,
+          "Error retrieving certified discrete attributes"
         );
         return res.status(errorRes.status).send(errorRes);
       }

--- a/packages/m2m-gateway-v3/src/services/attributeService.ts
+++ b/packages/m2m-gateway-v3/src/services/attributeService.ts
@@ -6,9 +6,11 @@ import { WithLogger } from "pagopa-interop-commons";
 
 import {
   toGetCertifiedAttributesApiQueryParams,
+  toGetCertifiedDiscreteAttributesApiQueryParams,
   toGetDeclaredAttributesApiQueryParams,
   toGetVerifiedAttributesApiQueryParams,
   toM2MGatewayApiCertifiedAttribute,
+  toM2MGatewayApiCertifiedDiscreteAttribute,
   toM2MGatewayApiDeclaredAttribute,
   toM2MGatewayApiVerifiedAttribute,
 } from "../api/attributeApiConverter.js";
@@ -52,6 +54,27 @@ export function attributeServiceBuilder(clients: PagoPAInteropBeClients) {
       });
 
       return toM2MGatewayApiCertifiedAttribute({
+        attribute: response.data,
+        logger,
+        mapThrownErrorsToNotFound: true,
+      });
+    },
+    async getCertifiedDiscreteAttribute(
+      attributeId: string,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.CertifiedDiscreteAttribute> {
+      logger.info(
+        `Retrieving certified discrete attribute with id ${attributeId}`
+      );
+
+      const response = await clients.attributeProcessClient.getAttributeById({
+        params: {
+          attributeId,
+        },
+        headers,
+      });
+
+      return toM2MGatewayApiCertifiedDiscreteAttribute({
         attribute: response.data,
         logger,
         mapThrownErrorsToNotFound: true,
@@ -111,6 +134,29 @@ export function attributeServiceBuilder(clients: PagoPAInteropBeClients) {
       const polledResource = await pollAttribute(response, headers);
 
       return toM2MGatewayApiCertifiedAttribute({
+        attribute: polledResource.data,
+        logger,
+      });
+    },
+    async createCertifiedDiscreteAttribute(
+      seed: m2mGatewayApiV3.CertifiedDiscreteAttributeSeed,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.CertifiedDiscreteAttribute> {
+      logger.info(
+        `Creating certified discrete attribute with code ${seed.code} and name ${seed.name}`
+      );
+
+      const response =
+        await clients.attributeProcessClient.createCertifiedDiscreteAttribute(
+          seed,
+          {
+            headers,
+          }
+        );
+
+      const polledResource = await pollAttribute(response, headers);
+
+      return toM2MGatewayApiCertifiedDiscreteAttribute({
         attribute: polledResource.data,
         logger,
       });
@@ -195,6 +241,36 @@ export function attributeServiceBuilder(clients: PagoPAInteropBeClients) {
       return {
         results: response.data.results.map((attribute) =>
           toM2MGatewayApiVerifiedAttribute({ attribute, logger })
+        ),
+        pagination: {
+          limit,
+          offset,
+          totalCount: response.data.totalCount,
+        },
+      };
+    },
+    async getCertifiedDiscreteAttributes(
+      {
+        limit,
+        offset,
+      }: m2mGatewayApiV3.GetCertifiedDiscreteAttributesQueryParams,
+      { headers, logger }: WithLogger<M2MGatewayAppContext>
+    ): Promise<m2mGatewayApiV3.CertifiedDiscreteAttributes> {
+      logger.info(
+        `Retrieving certified discrete attributes with limit ${limit} and offset ${offset}`
+      );
+
+      const response = await clients.attributeProcessClient.getAttributes({
+        queries: toGetCertifiedDiscreteAttributesApiQueryParams({
+          limit,
+          offset,
+        }),
+        headers,
+      });
+
+      return {
+        results: response.data.results.map((attribute) =>
+          toM2MGatewayApiCertifiedDiscreteAttribute({ attribute, logger })
         ),
         pagination: {
           limit,

--- a/packages/m2m-gateway-v3/test/api/attributes/createCertifiedDiscreteAttribute.test.ts
+++ b/packages/m2m-gateway-v3/test/api/attributes/createCertifiedDiscreteAttribute.test.ts
@@ -1,0 +1,132 @@
+import { generateMock } from "@anatine/zod-mock";
+import {
+  attributeRegistryApi,
+  m2mGatewayApiV3,
+} from "pagopa-interop-api-clients";
+import { AuthRole, authRole, genericLogger } from "pagopa-interop-commons";
+import {
+  generateToken,
+  getMockedApiAttribute,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import { pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import request from "supertest";
+import { describe, it, expect, vi } from "vitest";
+
+import { toM2MGatewayApiCertifiedDiscreteAttribute } from "../../../src/api/attributeApiConverter.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { config } from "../../../src/config/config.js";
+import {
+  missingMetadata,
+  unexpectedAttributeKind,
+  unexpectedUndefinedAttributeOriginOrCode,
+} from "../../../src/model/errors.js";
+import { api, mockAttributeService } from "../../vitest.api.setup.js";
+
+describe("POST /certifiedDiscreteAttributes router test", () => {
+  const mockCertifiedDiscreteAttributeSeed: m2mGatewayApiV3.CertifiedDiscreteAttributeSeed =
+    generateMock(m2mGatewayApiV3.CertifiedDiscreteAttributeSeed);
+
+  const mockApiCertifiedDiscreteAttribute = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+    code: mockCertifiedDiscreteAttributeSeed.code,
+    name: mockCertifiedDiscreteAttributeSeed.name,
+    description: mockCertifiedDiscreteAttributeSeed.description,
+  });
+
+  const mockM2MCertifiedDiscreteAttributeResponse: m2mGatewayApiV3.CertifiedDiscreteAttribute =
+    toM2MGatewayApiCertifiedDiscreteAttribute({
+      attribute: mockApiCertifiedDiscreteAttribute,
+      logger: genericLogger,
+    });
+
+  const makeRequest = async (
+    token: string,
+    body: m2mGatewayApiV3.CertifiedDiscreteAttributeSeed
+  ) =>
+    request(api)
+      .post(`${appBasePath}/certifiedDiscreteAttributes`)
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send(body);
+
+  const authorizedRoles: AuthRole[] = [authRole.M2M_ADMIN_ROLE];
+  it.each(authorizedRoles)(
+    "Should return 201 and perform service calls for user with role %s",
+    async (role) => {
+      mockAttributeService.createCertifiedDiscreteAttribute = vi
+        .fn()
+        .mockResolvedValue(mockM2MCertifiedDiscreteAttributeResponse);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token, mockCertifiedDiscreteAttributeSeed);
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual(mockM2MCertifiedDiscreteAttributeResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, mockCertifiedDiscreteAttributeSeed);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { ...mockCertifiedDiscreteAttributeSeed, invalidParam: "invalidValue" },
+    { ...mockCertifiedDiscreteAttributeSeed, name: undefined },
+    { ...mockCertifiedDiscreteAttributeSeed, code: undefined },
+    { ...mockCertifiedDiscreteAttributeSeed, description: undefined },
+  ])(
+    "Should return 400 if passed an invalid certified discrete attribute seed: %s",
+    async (body) => {
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        body as m2mGatewayApiV3.CertifiedAttributeSeed
+      );
+
+      expect(res.status).toBe(400);
+    }
+  );
+
+  it.each([
+    { ...mockM2MCertifiedDiscreteAttributeResponse, kind: "invalidKind" },
+    {
+      ...mockM2MCertifiedDiscreteAttributeResponse,
+      invalidParam: "invalidValue",
+    },
+    { ...mockM2MCertifiedDiscreteAttributeResponse, createdAt: undefined },
+  ])(
+    "Should return 500 when API model parsing fails for response",
+    async (resp) => {
+      mockAttributeService.createCertifiedDiscreteAttribute = vi
+        .fn()
+        .mockResolvedValueOnce(resp);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token, mockCertifiedDiscreteAttributeSeed);
+
+      expect(res.status).toBe(500);
+    }
+  );
+
+  it.each([
+    missingMetadata(),
+    unexpectedAttributeKind(mockApiCertifiedDiscreteAttribute),
+    unexpectedUndefinedAttributeOriginOrCode(mockApiCertifiedDiscreteAttribute),
+    pollingMaxRetriesExceeded(
+      config.defaultPollingMaxRetries,
+      config.defaultPollingRetryDelay
+    ),
+  ])("Should return 500 in case of $code error", async (error) => {
+    mockAttributeService.createCertifiedDiscreteAttribute = vi
+      .fn()
+      .mockRejectedValue(error);
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, mockCertifiedDiscreteAttributeSeed);
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/attributes/getCertifiedDiscreteAttribute.test.ts
+++ b/packages/m2m-gateway-v3/test/api/attributes/getCertifiedDiscreteAttribute.test.ts
@@ -1,0 +1,106 @@
+import {
+  attributeRegistryApi,
+  m2mGatewayApiV3,
+} from "pagopa-interop-api-clients";
+import { AuthRole, authRole, genericLogger } from "pagopa-interop-commons";
+import {
+  generateToken,
+  getMockedApiAttribute,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import request from "supertest";
+import { describe, it, expect, vi } from "vitest";
+
+import { toM2MGatewayApiCertifiedDiscreteAttribute } from "../../../src/api/attributeApiConverter.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { attributeNotFound } from "../../../src/model/errors.js";
+import { api, mockAttributeService } from "../../vitest.api.setup.js";
+
+describe("GET /certifiedDiscreteAttributes/:attributeId router test", () => {
+  const mockApiCertifiedDiscreteAttribute = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+  });
+
+  const mockM2MCertifiedDiscreteAttributeResponse: m2mGatewayApiV3.CertifiedDiscreteAttribute =
+    toM2MGatewayApiCertifiedDiscreteAttribute({
+      attribute: mockApiCertifiedDiscreteAttribute,
+      logger: genericLogger,
+    });
+
+  const makeRequest = async (token: string, attributeId: string) =>
+    request(api)
+      .get(`${appBasePath}/certifiedDiscreteAttributes/${attributeId}`)
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .send();
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.M2M_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+  it.each(authorizedRoles)(
+    "Should return 200 and perform service calls for user with role %s",
+    async (role) => {
+      mockAttributeService.getCertifiedDiscreteAttribute = vi
+        .fn()
+        .mockResolvedValue(mockM2MCertifiedDiscreteAttributeResponse);
+
+      const token = generateToken(role);
+      const res = await makeRequest(
+        token,
+        mockApiCertifiedDiscreteAttribute.id
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockM2MCertifiedDiscreteAttributeResponse);
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, mockApiCertifiedDiscreteAttribute.id);
+    expect(res.status).toBe(403);
+  });
+
+  it("Should return 400 if passed an invalid attribute id", async () => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, "invalidId");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("Should return 404 in case of attributeNotFound error", async () => {
+    mockAttributeService.getCertifiedDiscreteAttribute = vi
+      .fn()
+      .mockRejectedValue(attributeNotFound(mockApiCertifiedDiscreteAttribute));
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(token, mockApiCertifiedDiscreteAttribute.id);
+
+    expect(res.status).toBe(404);
+  });
+
+  it.each([
+    { ...mockM2MCertifiedDiscreteAttributeResponse, kind: "invalidKind" },
+    {
+      ...mockM2MCertifiedDiscreteAttributeResponse,
+      invalidParam: "invalidValue",
+    },
+    { ...mockM2MCertifiedDiscreteAttributeResponse, createdAt: undefined },
+  ])(
+    "Should return 500 when API model parsing fails for response",
+    async (resp) => {
+      mockAttributeService.getCertifiedDiscreteAttribute = vi
+        .fn()
+        .mockResolvedValueOnce(resp);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        mockApiCertifiedDiscreteAttribute.id
+      );
+
+      expect(res.status).toBe(500);
+    }
+  );
+});

--- a/packages/m2m-gateway-v3/test/api/attributes/getCertifiedDiscreteAttributes.test.ts
+++ b/packages/m2m-gateway-v3/test/api/attributes/getCertifiedDiscreteAttributes.test.ts
@@ -1,0 +1,143 @@
+import {
+  attributeRegistryApi,
+  m2mGatewayApiV3,
+} from "pagopa-interop-api-clients";
+import { AuthRole, authRole, genericLogger } from "pagopa-interop-commons";
+import {
+  generateToken,
+  getMockedApiAttribute,
+  getMockDPoPProof,
+} from "pagopa-interop-commons-test";
+import request from "supertest";
+import { describe, it, expect, vi } from "vitest";
+
+import { toM2MGatewayApiCertifiedDiscreteAttribute } from "../../../src/api/attributeApiConverter.js";
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { api, mockAttributeService } from "../../vitest.api.setup.js";
+
+describe("GET /certifiedDiscreteAttributes router test", () => {
+  const mockApiAttribute1 = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+  });
+
+  const mockApiAttribute2 = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+  });
+
+  const mockCertifiedDiscreteAttributesResponse: m2mGatewayApiV3.CertifiedDiscreteAttributes =
+    {
+      results: [
+        toM2MGatewayApiCertifiedDiscreteAttribute({
+          attribute: mockApiAttribute1,
+          logger: genericLogger,
+        }),
+        toM2MGatewayApiCertifiedDiscreteAttribute({
+          attribute: mockApiAttribute2,
+          logger: genericLogger,
+        }),
+      ],
+      pagination: {
+        limit: 10,
+        offset: 0,
+        totalCount: 2,
+      },
+    };
+
+  const mockQueryParams: m2mGatewayApiV3.GetCertifiedDiscreteAttributesQueryParams =
+    {
+      offset: 0,
+      limit: 10,
+    };
+
+  const makeRequest = async (
+    token: string,
+    query: m2mGatewayApiV3.GetCertifiedDiscreteAttributesQueryParams
+  ) =>
+    request(api)
+      .get(`${appBasePath}/certifiedDiscreteAttributes`)
+      .set("Authorization", `DPoP ${token}`)
+      .set("DPoP", (await getMockDPoPProof()).dpopProofJWS)
+      .query(query)
+      .send();
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.M2M_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+
+  it.each(authorizedRoles)(
+    "Should return 200 and perform service calls for user with role %s",
+    async (role) => {
+      mockAttributeService.getCertifiedDiscreteAttributes = vi
+        .fn()
+        .mockResolvedValue(mockCertifiedDiscreteAttributesResponse);
+
+      const token = generateToken(role);
+      const res = await makeRequest(token, mockQueryParams);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockCertifiedDiscreteAttributesResponse);
+      expect(
+        mockAttributeService.getCertifiedDiscreteAttributes
+      ).toHaveBeenCalledWith(mockQueryParams, expect.any(Object));
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token, mockQueryParams);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    {},
+    { ...mockQueryParams, offset: -1 },
+    { ...mockQueryParams, limit: 0 },
+    { ...mockQueryParams, limit: 51 },
+    { ...mockQueryParams, offset: "invalidOffset" },
+    { ...mockQueryParams, limit: "invalidLimit" },
+    { ...mockQueryParams, offset: undefined },
+    { ...mockQueryParams, limit: undefined },
+  ])("Should return 400 if passed invalid query params", async (query) => {
+    const token = generateToken(authRole.M2M_ADMIN_ROLE);
+    const res = await makeRequest(
+      token,
+      query as m2mGatewayApiV3.GetCertifiedDiscreteAttributesQueryParams
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    {
+      ...mockCertifiedDiscreteAttributesResponse,
+      results: [
+        {
+          ...mockCertifiedDiscreteAttributesResponse.results[0],
+          code: undefined,
+        },
+      ],
+    },
+    {
+      ...mockCertifiedDiscreteAttributesResponse,
+      pagination: {
+        offset: "invalidOffset",
+        limit: "invalidLimit",
+        totalCount: 0,
+      },
+    },
+  ])(
+    "Should return 500 when API model parsing fails for response",
+    async (resp) => {
+      mockAttributeService.getCertifiedDiscreteAttributes = vi
+        .fn()
+        .mockResolvedValueOnce(resp);
+      const token = generateToken(authRole.M2M_ADMIN_ROLE);
+      const res = await makeRequest(token, mockQueryParams);
+
+      expect(res.status).toBe(500);
+    }
+  );
+});

--- a/packages/m2m-gateway-v3/test/integration/attributes/createCertifiedDiscreteAttribute.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/attributes/createCertifiedDiscreteAttribute.test.ts
@@ -1,0 +1,201 @@
+import { generateMock } from "@anatine/zod-mock";
+import {
+  attributeRegistryApi,
+  m2mGatewayApiV3,
+} from "pagopa-interop-api-clients";
+import {
+  getMockedApiAttribute,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import { pollingMaxRetriesExceeded } from "pagopa-interop-models";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import { config } from "../../../src/config/config.js";
+import {
+  missingMetadata,
+  unexpectedAttributeKind,
+  unexpectedUndefinedAttributeOriginOrCode,
+} from "../../../src/model/errors.js";
+import {
+  attributeService,
+  expectApiClientGetToHaveBeenCalledWith,
+  expectApiClientPostToHaveBeenCalledWith,
+  mockInteropBeClients,
+  mockPollingResponse,
+} from "../../integrationUtils.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("createCertifiedAttribute", () => {
+  const mockCertifiedDiscreteAttributeSeed: m2mGatewayApiV3.CertifiedDiscreteAttributeSeed =
+    generateMock(m2mGatewayApiV3.CertifiedDiscreteAttributeSeed);
+
+  const mockAttributeProcessResponse = getMockWithMetadata(
+    getMockedApiAttribute({
+      kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+      code: mockCertifiedDiscreteAttributeSeed.code,
+      name: mockCertifiedDiscreteAttributeSeed.name,
+      description: mockCertifiedDiscreteAttributeSeed.description,
+    })
+  );
+
+  const mockCreateCertifiedDiscreteAttribute = vi
+    .fn()
+    .mockResolvedValue(mockAttributeProcessResponse);
+
+  const mockGetAttribute = vi.fn(
+    mockPollingResponse(mockAttributeProcessResponse, 2)
+  );
+
+  mockInteropBeClients.attributeProcessClient = {
+    createCertifiedDiscreteAttribute: mockCreateCertifiedDiscreteAttribute,
+    getAttributeById: mockGetAttribute,
+  } as unknown as PagoPAInteropBeClients["attributeProcessClient"];
+
+  beforeEach(() => {
+    // Clear mock counters and call information before each test
+    mockCreateCertifiedDiscreteAttribute.mockClear();
+    mockGetAttribute.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const m2mAttributeResponse: m2mGatewayApiV3.CertifiedDiscreteAttribute = {
+      id: mockAttributeProcessResponse.data.id,
+      code: mockAttributeProcessResponse.data.code!,
+      description: mockAttributeProcessResponse.data.description,
+      origin: mockAttributeProcessResponse.data.origin!,
+      name: mockAttributeProcessResponse.data.name,
+      createdAt: mockAttributeProcessResponse.data.creationTime,
+    };
+
+    const result = await attributeService.createCertifiedDiscreteAttribute(
+      mockCertifiedDiscreteAttributeSeed,
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(m2mAttributeResponse);
+    expectApiClientPostToHaveBeenCalledWith({
+      mockPost:
+        mockInteropBeClients.attributeProcessClient
+          .createCertifiedDiscreteAttribute,
+      body: mockCertifiedDiscreteAttributeSeed,
+    });
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributeById,
+      params: { attributeId: mockAttributeProcessResponse.data.id },
+    });
+    expect(
+      mockInteropBeClients.attributeProcessClient.getAttributeById
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [attributeRegistryApi.AttributeKind.Values.VERIFIED],
+    [attributeRegistryApi.AttributeKind.Values.DECLARED],
+    [attributeRegistryApi.AttributeKind.Values.CERTIFIED],
+  ])(
+    "Should throw unexpectedAttributeKind in case the returned attribute has unexpected kind: %s",
+    async (kind) => {
+      const mockResponse = {
+        ...mockAttributeProcessResponse,
+        data: {
+          ...mockAttributeProcessResponse.data,
+          kind,
+        },
+      };
+
+      console.log("mockResponse", mockResponse.data);
+
+      mockInteropBeClients.attributeProcessClient.getAttributeById =
+        mockGetAttribute.mockResolvedValueOnce(mockResponse);
+
+      await expect(
+        attributeService.createCertifiedDiscreteAttribute(
+          mockCertifiedDiscreteAttributeSeed,
+          getMockM2MAdminAppContext()
+        )
+      ).rejects.toThrow(unexpectedAttributeKind(mockResponse.data));
+    }
+  );
+
+  it.each([
+    { origin: undefined, code: "validCode" },
+    { origin: "validOrigin", code: undefined },
+    { origin: undefined, code: undefined },
+  ])(
+    "Should throw unexpectedUndefinedAttributeOriginOrCode in case the returned attribute has an unexpected kind",
+    async (originAndCodeOverride) => {
+      const mockResponse = {
+        ...mockAttributeProcessResponse,
+        data: {
+          ...mockAttributeProcessResponse.data,
+          ...originAndCodeOverride,
+        },
+      };
+
+      mockInteropBeClients.attributeProcessClient.getAttributeById =
+        mockGetAttribute.mockResolvedValueOnce(mockResponse);
+
+      await expect(
+        attributeService.createCertifiedDiscreteAttribute(
+          mockCertifiedDiscreteAttributeSeed,
+          getMockM2MAdminAppContext()
+        )
+      ).rejects.toThrow(
+        unexpectedUndefinedAttributeOriginOrCode(mockResponse.data)
+      );
+    }
+  );
+
+  it("Should throw missingMetadata in case the attribute returned by the creation POST call has no metadata", async () => {
+    mockCreateCertifiedDiscreteAttribute.mockResolvedValueOnce({
+      ...mockAttributeProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      attributeService.createCertifiedDiscreteAttribute(
+        mockCertifiedDiscreteAttributeSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrow(missingMetadata());
+  });
+
+  it("Should throw missingMetadata in case the attribute returned by the polling GET call has no metadata", async () => {
+    mockGetAttribute.mockResolvedValueOnce({
+      ...mockAttributeProcessResponse,
+      metadata: undefined,
+    });
+
+    await expect(
+      attributeService.createCertifiedDiscreteAttribute(
+        mockCertifiedDiscreteAttributeSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrow(missingMetadata());
+  });
+
+  it("Should throw pollingMaxRetriesExceeded in case of polling max attempts", async () => {
+    mockGetAttribute.mockImplementation(
+      mockPollingResponse(
+        mockAttributeProcessResponse,
+        config.defaultPollingMaxRetries + 1
+      )
+    );
+
+    await expect(
+      attributeService.createCertifiedDiscreteAttribute(
+        mockCertifiedDiscreteAttributeSeed,
+        getMockM2MAdminAppContext()
+      )
+    ).rejects.toThrow(
+      pollingMaxRetriesExceeded(
+        config.defaultPollingMaxRetries,
+        config.defaultPollingRetryDelay
+      )
+    );
+    expect(mockGetAttribute).toHaveBeenCalledTimes(
+      config.defaultPollingMaxRetries
+    );
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/attributes/getCertifiedDiscreteAttribute.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/attributes/getCertifiedDiscreteAttribute.test.ts
@@ -1,0 +1,224 @@
+import {
+  attributeRegistryApi,
+  m2mGatewayApiV3,
+} from "pagopa-interop-api-clients";
+import {
+  getMockedApiAttribute,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import {
+  attributeService,
+  expectApiClientGetToHaveBeenCalledWith,
+  mockInteropBeClients,
+} from "../../integrationUtils.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("getCertifiedAttributes integration", () => {
+  const mockAttribute1 = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+    name: "Certified Discrete Attribute 1",
+    code: "CERT001",
+    description: "First certified discrete attribute",
+  });
+
+  const mockAttribute2 = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+    name: "Certified Discrete Attribute 2",
+    code: "CERT002",
+    description: "Second certified discrete attribute",
+  });
+
+  const mockAttribute3 = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+    name: "Certified Discrete Attribute 3",
+    code: "CERT003",
+    description: "Third certified discrete attribute",
+  });
+
+  const mockAttributeProcessResponse = getMockWithMetadata({
+    results: [mockAttribute1, mockAttribute2, mockAttribute3],
+    totalCount: 3,
+  });
+
+  const testToM2MGatewayApiCertifiedDiscreteAttribute = (
+    attribute: attributeRegistryApi.Attribute
+  ): m2mGatewayApiV3.CertifiedDiscreteAttribute => ({
+    id: attribute.id,
+    code: attribute.code!,
+    description: attribute.description,
+    origin: attribute.origin!,
+    name: attribute.name,
+    createdAt: attribute.creationTime,
+  });
+
+  const m2mCertifiedDiscreteAttributeResponse1 =
+    testToM2MGatewayApiCertifiedDiscreteAttribute(mockAttribute1);
+
+  const m2mCertifiedDiscreteAttributeResponse2 =
+    testToM2MGatewayApiCertifiedDiscreteAttribute(mockAttribute2);
+
+  const m2mCertifiedDiscreteAttributeResponse3 =
+    testToM2MGatewayApiCertifiedDiscreteAttribute(mockAttribute3);
+
+  const mockGetAttributes = vi
+    .fn()
+    .mockResolvedValue(mockAttributeProcessResponse);
+
+  mockInteropBeClients.attributeProcessClient = {
+    getAttributes: mockGetAttributes,
+  } as unknown as PagoPAInteropBeClients["attributeProcessClient"];
+
+  beforeEach(() => {
+    mockGetAttributes.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const m2mAttributesResponse: m2mGatewayApiV3.CertifiedDiscreteAttributes = {
+      pagination: {
+        limit: 10,
+        offset: 0,
+        totalCount: 3,
+      },
+      results: [
+        m2mCertifiedDiscreteAttributeResponse1,
+        m2mCertifiedDiscreteAttributeResponse2,
+        m2mCertifiedDiscreteAttributeResponse3,
+      ],
+    };
+
+    const result = await attributeService.getCertifiedDiscreteAttributes(
+      {
+        offset: 0,
+        limit: 10,
+      },
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(m2mAttributesResponse);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributes,
+      queries: {
+        offset: 0,
+        limit: 10,
+        kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE],
+      },
+    });
+  });
+
+  it("Should apply filters (offset, limit)", async () => {
+    const mockPaginatedResponse1 = getMockWithMetadata({
+      results: [mockAttribute1, mockAttribute2],
+      totalCount: 3,
+    });
+
+    mockInteropBeClients.attributeProcessClient.getAttributes =
+      mockGetAttributes.mockResolvedValueOnce(mockPaginatedResponse1);
+
+    const m2mCertifiedDiscreteAttributesResponse1: m2mGatewayApiV3.CertifiedDiscreteAttributes =
+      {
+        pagination: {
+          offset: 0,
+          limit: 2,
+          totalCount: 3,
+        },
+        results: [
+          m2mCertifiedDiscreteAttributeResponse1,
+          m2mCertifiedDiscreteAttributeResponse2,
+        ],
+      };
+
+    const result1 = await attributeService.getCertifiedDiscreteAttributes(
+      {
+        offset: 0,
+        limit: 2,
+      },
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result1).toStrictEqual(m2mCertifiedDiscreteAttributesResponse1);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributes,
+      queries: {
+        offset: 0,
+        limit: 2,
+        kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE],
+      },
+    });
+
+    const mockPaginatedResponse2 = getMockWithMetadata({
+      results: [mockAttribute3],
+      totalCount: 3,
+    });
+
+    mockInteropBeClients.attributeProcessClient.getAttributes =
+      mockGetAttributes.mockResolvedValueOnce(mockPaginatedResponse2);
+
+    const m2mCertifiedDiscreteAttributesResponse2: m2mGatewayApiV3.CertifiedDiscreteAttributes =
+      {
+        pagination: {
+          offset: 2,
+          limit: 2,
+          totalCount: 3,
+        },
+        results: [m2mCertifiedDiscreteAttributeResponse3],
+      };
+
+    const result2 = await attributeService.getCertifiedDiscreteAttributes(
+      {
+        offset: 2,
+        limit: 2,
+      },
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result2).toStrictEqual(m2mCertifiedDiscreteAttributesResponse2);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributes,
+      queries: {
+        offset: 2,
+        limit: 2,
+        kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE],
+      },
+    });
+  });
+
+  it("Should handle empty results", async () => {
+    const mockEmptyResponse = getMockWithMetadata({
+      results: [],
+      totalCount: 0,
+    });
+
+    mockInteropBeClients.attributeProcessClient.getAttributes =
+      mockGetAttributes.mockResolvedValueOnce(mockEmptyResponse);
+
+    const m2mEmptyResponse: m2mGatewayApiV3.CertifiedDiscreteAttributes = {
+      pagination: {
+        offset: 0,
+        limit: 10,
+        totalCount: 0,
+      },
+      results: [],
+    };
+
+    const result = await attributeService.getCertifiedDiscreteAttributes(
+      {
+        offset: 0,
+        limit: 10,
+      },
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(m2mEmptyResponse);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributes,
+      queries: {
+        offset: 0,
+        limit: 10,
+        kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE],
+      },
+    });
+  });
+});

--- a/packages/m2m-gateway-v3/test/integration/attributes/getCertifiedDiscreteAttributes.test.ts
+++ b/packages/m2m-gateway-v3/test/integration/attributes/getCertifiedDiscreteAttributes.test.ts
@@ -1,0 +1,224 @@
+import {
+  attributeRegistryApi,
+  m2mGatewayApiV3,
+} from "pagopa-interop-api-clients";
+import {
+  getMockedApiAttribute,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { PagoPAInteropBeClients } from "../../../src/clients/clientsProvider.js";
+import {
+  attributeService,
+  expectApiClientGetToHaveBeenCalledWith,
+  mockInteropBeClients,
+} from "../../integrationUtils.js";
+import { getMockM2MAdminAppContext } from "../../mockUtils.js";
+
+describe("getCertifiedDiscreteAttributes integration", () => {
+  const mockAttribute1 = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+    name: "Certified Discrete Attribute 1",
+    code: "CERT001",
+    description: "First certified discrete attribute",
+  });
+
+  const mockAttribute2 = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+    name: "Certified Discrete Attribute 2",
+    code: "CERT002",
+    description: "Second certified discrete attribute",
+  });
+
+  const mockAttribute3 = getMockedApiAttribute({
+    kind: attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE,
+    name: "Certified Discrete Attribute 3",
+    code: "CERT003",
+    description: "Third certified discrete attribute",
+  });
+
+  const mockAttributeProcessResponse = getMockWithMetadata({
+    results: [mockAttribute1, mockAttribute2, mockAttribute3],
+    totalCount: 3,
+  });
+
+  const testToM2MGatewayApiCertifiedDiscreteAttribute = (
+    attribute: attributeRegistryApi.Attribute
+  ): m2mGatewayApiV3.CertifiedDiscreteAttribute => ({
+    id: attribute.id,
+    code: attribute.code!,
+    description: attribute.description,
+    origin: attribute.origin!,
+    name: attribute.name,
+    createdAt: attribute.creationTime,
+  });
+
+  const m2mCertifiedDiscreteAttributeResponse1 =
+    testToM2MGatewayApiCertifiedDiscreteAttribute(mockAttribute1);
+
+  const m2mCertifiedDiscreteAttributeResponse2 =
+    testToM2MGatewayApiCertifiedDiscreteAttribute(mockAttribute2);
+
+  const m2mCertifiedDiscreteAttributeResponse3 =
+    testToM2MGatewayApiCertifiedDiscreteAttribute(mockAttribute3);
+
+  const mockGetAttributes = vi
+    .fn()
+    .mockResolvedValue(mockAttributeProcessResponse);
+
+  mockInteropBeClients.attributeProcessClient = {
+    getAttributes: mockGetAttributes,
+  } as unknown as PagoPAInteropBeClients["attributeProcessClient"];
+
+  beforeEach(() => {
+    mockGetAttributes.mockClear();
+  });
+
+  it("Should succeed and perform API clients calls", async () => {
+    const m2mAttributesResponse: m2mGatewayApiV3.CertifiedDiscreteAttributes = {
+      pagination: {
+        limit: 10,
+        offset: 0,
+        totalCount: 3,
+      },
+      results: [
+        m2mCertifiedDiscreteAttributeResponse1,
+        m2mCertifiedDiscreteAttributeResponse2,
+        m2mCertifiedDiscreteAttributeResponse3,
+      ],
+    };
+
+    const result = await attributeService.getCertifiedDiscreteAttributes(
+      {
+        offset: 0,
+        limit: 10,
+      },
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(m2mAttributesResponse);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributes,
+      queries: {
+        offset: 0,
+        limit: 10,
+        kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE],
+      },
+    });
+  });
+
+  it("Should apply filters (offset, limit)", async () => {
+    const mockPaginatedResponse1 = getMockWithMetadata({
+      results: [mockAttribute1, mockAttribute2],
+      totalCount: 3,
+    });
+
+    mockInteropBeClients.attributeProcessClient.getAttributes =
+      mockGetAttributes.mockResolvedValueOnce(mockPaginatedResponse1);
+
+    const m2mCertifiedDiscreteAttributesResponse1: m2mGatewayApiV3.CertifiedDiscreteAttributes =
+      {
+        pagination: {
+          offset: 0,
+          limit: 2,
+          totalCount: 3,
+        },
+        results: [
+          m2mCertifiedDiscreteAttributeResponse1,
+          m2mCertifiedDiscreteAttributeResponse2,
+        ],
+      };
+
+    const result1 = await attributeService.getCertifiedDiscreteAttributes(
+      {
+        offset: 0,
+        limit: 2,
+      },
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result1).toStrictEqual(m2mCertifiedDiscreteAttributesResponse1);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributes,
+      queries: {
+        offset: 0,
+        limit: 2,
+        kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE],
+      },
+    });
+
+    const mockPaginatedResponse2 = getMockWithMetadata({
+      results: [mockAttribute3],
+      totalCount: 3,
+    });
+
+    mockInteropBeClients.attributeProcessClient.getAttributes =
+      mockGetAttributes.mockResolvedValueOnce(mockPaginatedResponse2);
+
+    const m2mCertifiedDiscreteAttributesResponse2: m2mGatewayApiV3.CertifiedDiscreteAttributes =
+      {
+        pagination: {
+          offset: 2,
+          limit: 2,
+          totalCount: 3,
+        },
+        results: [m2mCertifiedDiscreteAttributeResponse3],
+      };
+
+    const result2 = await attributeService.getCertifiedDiscreteAttributes(
+      {
+        offset: 2,
+        limit: 2,
+      },
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result2).toStrictEqual(m2mCertifiedDiscreteAttributesResponse2);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributes,
+      queries: {
+        offset: 2,
+        limit: 2,
+        kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE],
+      },
+    });
+  });
+
+  it("Should handle empty results", async () => {
+    const mockEmptyResponse = getMockWithMetadata({
+      results: [],
+      totalCount: 0,
+    });
+
+    mockInteropBeClients.attributeProcessClient.getAttributes =
+      mockGetAttributes.mockResolvedValueOnce(mockEmptyResponse);
+
+    const m2mEmptyResponse: m2mGatewayApiV3.CertifiedDiscreteAttributes = {
+      pagination: {
+        offset: 0,
+        limit: 10,
+        totalCount: 0,
+      },
+      results: [],
+    };
+
+    const result = await attributeService.getCertifiedDiscreteAttributes(
+      {
+        offset: 0,
+        limit: 10,
+      },
+      getMockM2MAdminAppContext()
+    );
+
+    expect(result).toStrictEqual(m2mEmptyResponse);
+    expectApiClientGetToHaveBeenCalledWith({
+      mockGet: mockInteropBeClients.attributeProcessClient.getAttributes,
+      queries: {
+        offset: 0,
+        limit: 10,
+        kinds: [attributeRegistryApi.AttributeKind.Values.CERTIFIED_DISCRETE],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Jira Issue
[PIN-10716](https://pagopa.atlassian.net/browse/PIN-10716)

## Context/Why
This PR updates the M2M v3 OpenAPI contract to support the new certified discrete attribute type while maintaining full backward compatibility (no API version bump).

## Services Impacted
- api-clients
- m2m-gateway-m3

## Key Changes
The following endpoints have been added to the M2MGatewayApiV3 OpenAPI definition:
	
Attributes
- GET /certifiedDiscreteAttributes/:attributeId
- POST /certifiedDiscreteAttributes
- GET /certifiedDiscreteAttributes

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard (type(scope): descrizione (KEY))
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [x] OpenAPI spec updated (if required)
- [x] Bruno endpoint definition updated


[PIN-10716]: https://pagopa.atlassian.net/browse/PIN-10716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ