### PR TITLE
feature: Approve and Reject EService descriptor archiving request (PIN-10693)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -2422,6 +2422,114 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /eservices/{eServiceId}/descriptors/{descriptorId}/approveDelegatedArchiving:
+    parameters:
+      - name: eServiceId
+        in: path
+        description: the eservice id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: descriptorId
+        in: path
+        description: the descriptor Id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - eservices
+      summary: Approve a delegated archiving request for a Descriptor
+      description: Allows the owner (delegator) to approve a delegate's descriptor archiving request
+      operationId: approveDelegatedDescriptorArchiving
+      responses:
+        "204":
+          description: Delegated archiving request approved
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /eservices/{eServiceId}/descriptors/{descriptorId}/rejectDelegatedArchiving:
+    parameters:
+      - name: eServiceId
+        in: path
+        description: the eservice id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: descriptorId
+        in: path
+        description: the descriptor Id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - eservices
+      summary: Reject a delegated archiving request for a Descriptor
+      description: Allows the owner (delegator) to reject a delegate's descriptor archiving request
+      operationId: rejectDelegatedDescriptorArchiving
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RejectDelegatedDescriptorArchivingSeed"
+      responses:
+        "204":
+          description: Delegated archiving request rejected
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /templates/eservices/{eServiceId}/descriptors/{descriptorId}/update:
     post:
       security:
@@ -18392,6 +18500,16 @@ components:
       type: object
       additionalProperties: false
       description: Seed for an owner to reject a delegated archiving request
+      properties:
+        rejectionReason:
+          type: string
+          minLength: 1
+      required:
+        - rejectionReason
+    RejectDelegatedDescriptorArchivingSeed:
+      type: object
+      additionalProperties: false
+      description: Seed for an owner to reject a delegated descriptor archiving request
       properties:
         rejectionReason:
           type: string

--- a/packages/api-clients/open-api/catalogApi.yml
+++ b/packages/api-clients/open-api/catalogApi.yml
@@ -605,6 +605,98 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /eservices/{eServiceId}/descriptors/{descriptorId}/approveDelegatedArchiving:
+    parameters:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+      - name: eServiceId
+        in: path
+        description: the eservice id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: descriptorId
+        in: path
+        description: the descriptor Id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - process
+      summary: Approve a delegated archiving request for a descriptor
+      operationId: approveDelegatedDescriptorArchiving
+      description: Allows the delegator producer to approve a delegate's descriptor archiving request, starting the regular archiving grace period.
+      responses:
+        "200":
+          description: Delegated archiving request approved.
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EService"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /eservices/{eServiceId}/descriptors/{descriptorId}/rejectDelegatedArchiving:
+    parameters:
+      - $ref: "#/components/parameters/CorrelationIdHeader"
+      - name: eServiceId
+        in: path
+        description: the eservice id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: descriptorId
+        in: path
+        description: the descriptor Id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - process
+      summary: Reject a delegated archiving request for a descriptor
+      operationId: rejectDelegatedDescriptorArchiving
+      description: Allows the delegator producer to reject a delegate's descriptor archiving request.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RejectDelegatedDescriptorArchivingSeed"
+      responses:
+        "200":
+          description: Delegated archiving request rejected.
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EService"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /templates/eservices/{eServiceId}:
     post:
       security:
@@ -3539,6 +3631,10 @@ components:
           type: string
         asyncExchange:
           type: boolean
+        delegatedArchivingRequest:
+          type: array
+          items:
+            $ref: "#/components/schemas/DelegatedEServiceArchivingRequest"
     CreatedEServiceRiskAnalysis:
       type: object
       additionalProperties: false
@@ -3930,6 +4026,10 @@ components:
           $ref: "#/components/schemas/EServiceDoc"
         archivingSchedule:
           $ref: "#/components/schemas/ArchivingSchedule"
+        delegatedArchivingRequest:
+          type: array
+          items:
+            $ref: "#/components/schemas/DelegatedArchivingRequest"
     ArchivingSchedule:
       type: object
       additionalProperties: false
@@ -3972,6 +4072,41 @@ components:
       type: integer
       format: int32
       enum: [30, 60, 90, 120]
+    DelegatedArchivingRequest:
+      type: object
+      additionalProperties: false
+      description: A delegate's request to archive a descriptor, pending the delegator's approval or rejection
+      properties:
+        requestedAt:
+          type: string
+          format: date-time
+        requesterId:
+          type: string
+          format: uuid
+        gracePeriodDays:
+          $ref: "#/components/schemas/GracePeriodDays"
+        acceptedAt:
+          type: string
+          format: date-time
+        rejectedAt:
+          type: string
+          format: date-time
+        rejectionReason:
+          type: string
+      required:
+        - requestedAt
+        - requesterId
+        - gracePeriodDays
+    DelegatedEServiceArchivingRequest:
+      allOf:
+        - $ref: "#/components/schemas/DelegatedArchivingRequest"
+        - type: object
+          additionalProperties: false
+          properties:
+            archivingReason:
+              type: string
+          required:
+            - archivingReason
     GracePeriodDaysSeed:
       type: object
       additionalProperties: false
@@ -4004,6 +4139,14 @@ components:
           minLength: 1
       required:
         - rejectionReason
+    RejectDelegatedDescriptorArchivingSeed:
+      type: object
+      additionalProperties: false
+      description: Seed for the delegator to reject a delegate's descriptor archiving request
+      properties:
+        rejectionReason:
+          type: string
+          minLength: 1
     ForceTargetState:
       type: object
       additionalProperties: false

--- a/packages/api-clients/open-api/m2mGatewayApiV3.yml
+++ b/packages/api-clients/open-api/m2mGatewayApiV3.yml
@@ -13849,12 +13849,17 @@ components:
           $ref: "#/components/schemas/GracePeriodDays"
       required:
         - archivingReason
+    DelegateGracePeriodDays:
+      description: Number of days for the archiving grace period, explicitly chosen by the delegate requesting the archiving
+      type: integer
+      format: int32
+      enum: [30, 60, 90, 120]
     DelegateGracePeriodDaysSeed:
       type: object
       additionalProperties: false
       properties:
         gracePeriodDays:
-          $ref: "#/components/schemas/GracePeriodDays"
+          $ref: "#/components/schemas/DelegateGracePeriodDays"
       required:
         - gracePeriodDays
     DelegateEServiceArchivingSeed:
@@ -13867,7 +13872,7 @@ components:
           minLength: 10
           maxLength: 250
         gracePeriodDays:
-          $ref: "#/components/schemas/GracePeriodDays"
+          $ref: "#/components/schemas/DelegateGracePeriodDays"
       required:
         - archivingReason
         - gracePeriodDays

--- a/packages/backend-for-frontend/src/routers/catalogRouter.ts
+++ b/packages/backend-for-frontend/src/routers/catalogRouter.ts
@@ -502,6 +502,51 @@ const catalogRouter = (
       }
     )
     .post(
+      "/eservices/:eServiceId/descriptors/:descriptorId/approveDelegatedArchiving",
+      async (req, res) => {
+        const ctx = fromBffAppContext(req.ctx, req.headers);
+        try {
+          await catalogService.approveDelegatedDescriptorArchiving(
+            unsafeBrandId(req.params.eServiceId),
+            unsafeBrandId(req.params.descriptorId),
+            ctx
+          );
+          return res.status(204).send();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error approving delegated archiving request for descriptor ${req.params.descriptorId} of eservice ${req.params.eServiceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/eservices/:eServiceId/descriptors/:descriptorId/rejectDelegatedArchiving",
+      async (req, res) => {
+        const ctx = fromBffAppContext(req.ctx, req.headers);
+        try {
+          await catalogService.rejectDelegatedDescriptorArchiving(
+            unsafeBrandId(req.params.eServiceId),
+            unsafeBrandId(req.params.descriptorId),
+            req.body,
+            ctx
+          );
+          return res.status(204).send();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error rejecting delegated archiving request for descriptor ${req.params.descriptorId} of eservice ${req.params.eServiceId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
       "/eservices/:eServiceId/descriptors/:descriptorId/agreementApprovalPolicy/update",
       async (req, res) => {
         const ctx = fromBffAppContext(req.ctx, req.headers);

--- a/packages/backend-for-frontend/src/services/catalogService.ts
+++ b/packages/backend-for-frontend/src/services/catalogService.ts
@@ -1521,6 +1521,42 @@ export function catalogServiceBuilder(
         },
       });
     },
+    approveDelegatedDescriptorArchiving: async (
+      eServiceId: EServiceId,
+      descriptorId: DescriptorId,
+      { headers, logger }: WithLogger<BffAppContext>
+    ): Promise<void> => {
+      logger.info(
+        `Approving delegated archiving request for descriptor ${descriptorId} of EService ${eServiceId}`
+      );
+      await catalogProcessClient.approveDelegatedDescriptorArchiving(
+        undefined,
+        {
+          headers,
+          params: {
+            eServiceId,
+            descriptorId,
+          },
+        }
+      );
+    },
+    rejectDelegatedDescriptorArchiving: async (
+      eServiceId: EServiceId,
+      descriptorId: DescriptorId,
+      body: catalogApi.RejectDelegatedDescriptorArchivingSeed,
+      { headers, logger }: WithLogger<BffAppContext>
+    ): Promise<void> => {
+      logger.info(
+        `Rejecting delegated archiving request for descriptor ${descriptorId} of EService ${eServiceId}`
+      );
+      await catalogProcessClient.rejectDelegatedDescriptorArchiving(body, {
+        headers,
+        params: {
+          eServiceId,
+          descriptorId,
+        },
+      });
+    },
     updateAgreementApprovalPolicy: async (
       eServiceId: EServiceId,
       descriptorId: DescriptorId,

--- a/packages/backend-for-frontend/test/api/catalogRouter/approveDelegatedDescriptorArchiving.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/approveDelegatedDescriptorArchiving.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { authRole } from "pagopa-interop-commons";
+import { generateToken } from "pagopa-interop-commons-test/index.js";
+import { DescriptorId, EServiceId, generateId } from "pagopa-interop-models";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { api, clients } from "../../vitest.api.setup.js";
+
+describe("API POST /eservices/:eServiceId/descriptors/:descriptorId/approveDelegatedArchiving", () => {
+  beforeEach(() => {
+    clients.catalogProcessClient.approveDelegatedDescriptorArchiving = vi
+      .fn()
+      .mockResolvedValue(undefined);
+  });
+
+  const makeRequest = async (
+    token: string,
+    eServiceId: EServiceId = generateId(),
+    descriptorId: DescriptorId = generateId()
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/eservices/${eServiceId}/descriptors/${descriptorId}/approveDelegatedArchiving`
+      )
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId());
+
+  it("Should return 204 if no error is thrown", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(204);
+  });
+
+  it.each([
+    { eServiceId: "invalid" as EServiceId },
+    { descriptorId: "invalid" as DescriptorId },
+  ])(
+    "Should return 400 if passed an invalid parameter: %s",
+    async ({ eServiceId, descriptorId }) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token, eServiceId, descriptorId);
+      expect(res.status).toBe(400);
+    }
+  );
+});

--- a/packages/backend-for-frontend/test/api/catalogRouter/rejectDelegatedDescriptorArchiving.test.ts
+++ b/packages/backend-for-frontend/test/api/catalogRouter/rejectDelegatedDescriptorArchiving.test.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { bffApi } from "pagopa-interop-api-clients";
+import { authRole } from "pagopa-interop-commons";
+import { generateToken } from "pagopa-interop-commons-test/index.js";
+import { DescriptorId, EServiceId, generateId } from "pagopa-interop-models";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { getMockBffApiRejectDelegatedDescriptorArchivingSeed } from "../../mockUtils.js";
+import { api, clients } from "../../vitest.api.setup.js";
+
+describe("API POST /eservices/:eServiceId/descriptors/:descriptorId/rejectDelegatedArchiving", () => {
+  const mockRejectDelegatedDescriptorArchivingSeed =
+    getMockBffApiRejectDelegatedDescriptorArchivingSeed();
+
+  beforeEach(() => {
+    clients.catalogProcessClient.rejectDelegatedDescriptorArchiving = vi
+      .fn()
+      .mockResolvedValue(undefined);
+  });
+
+  const makeRequest = async (
+    token: string,
+    eServiceId: EServiceId = generateId(),
+    descriptorId: DescriptorId = generateId(),
+    body: bffApi.RejectDelegatedDescriptorArchivingSeed = mockRejectDelegatedDescriptorArchivingSeed
+  ) =>
+    request(api)
+      .post(
+        `${appBasePath}/eservices/${eServiceId}/descriptors/${descriptorId}/rejectDelegatedArchiving`
+      )
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send(body);
+
+  it("Should return 204 if no error is thrown", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(204);
+  });
+
+  it.each([
+    { eServiceId: "invalid" as EServiceId },
+    { descriptorId: "invalid" as DescriptorId },
+    { body: {} },
+    {
+      body: { ...mockRejectDelegatedDescriptorArchivingSeed, extraField: 1 },
+    },
+  ])(
+    "Should return 400 if passed an invalid parameter: %s",
+    async ({ eServiceId, descriptorId, body }) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        eServiceId,
+        descriptorId,
+        body as bffApi.RejectDelegatedDescriptorArchivingSeed
+      );
+      expect(res.status).toBe(400);
+    }
+  );
+});

--- a/packages/backend-for-frontend/test/mockUtils.ts
+++ b/packages/backend-for-frontend/test/mockUtils.ts
@@ -411,6 +411,11 @@ export const getMockBffApiRejectDelegatedEServiceDescriptorSeed =
     rejectionReason: generateMock(z.string()),
   });
 
+export const getMockBffApiRejectDelegatedDescriptorArchivingSeed =
+  (): bffApi.RejectDelegatedDescriptorArchivingSeed => ({
+    rejectionReason: generateMock(z.string()),
+  });
+
 export const getMockCatalogApiUpdateEServiceDescriptorQuotasSeed =
   (): catalogApi.UpdateEServiceDescriptorQuotasSeed => ({
     voucherLifespan: generateMock(z.number().int().gte(60).lte(86400)),

--- a/packages/catalog-process/src/model/domain/apiConverter.ts
+++ b/packages/catalog-process/src/model/domain/apiConverter.ts
@@ -218,6 +218,16 @@ export const descriptorToApiDescriptor = (
   asyncExchangeCallbackInterface: descriptor.asyncExchangeCallbackInterface
     ? documentToApiDocument(descriptor.asyncExchangeCallbackInterface)
     : undefined,
+  delegatedArchivingRequest: descriptor.delegatedArchivingRequest?.map(
+    (request) => ({
+      requestedAt: request.requestedAt.toJSON(),
+      requesterId: request.requesterId,
+      gracePeriodDays: request.gracePeriodDays,
+      acceptedAt: request.acceptedAt?.toJSON(),
+      rejectedAt: request.rejectedAt?.toJSON(),
+      rejectionReason: request.rejectionReason,
+    })
+  ),
 });
 
 export const eServiceToApiEService = (
@@ -250,4 +260,15 @@ export const eServiceToApiEService = (
   instanceLabel: eservice.instanceLabel,
   archivingReason: eservice.archivingReason,
   asyncExchange: eservice.asyncExchange,
+  delegatedArchivingRequest: eservice.delegatedArchivingRequest?.map(
+    (request) => ({
+      requestedAt: request.requestedAt.toJSON(),
+      requesterId: request.requesterId,
+      gracePeriodDays: request.gracePeriodDays,
+      acceptedAt: request.acceptedAt?.toJSON(),
+      rejectedAt: request.rejectedAt?.toJSON(),
+      rejectionReason: request.rejectionReason,
+      archivingReason: request.archivingReason,
+    })
+  ),
 });

--- a/packages/catalog-process/src/model/domain/toEvent.ts
+++ b/packages/catalog-process/src/model/domain/toEvent.ts
@@ -1254,3 +1254,43 @@ export const toCreateEventEServiceArchivingRequestRejectedByDelegator = (
   },
   correlationId,
 });
+
+export const toCreateEventEServiceDescriptorArchivingRequestRejectedByDelegator =
+  (
+    version: number,
+    descriptorId: DescriptorId,
+    eservice: EService,
+    correlationId: CorrelationId
+  ): CreateEvent<EServiceEvent> => ({
+    streamId: eservice.id,
+    version,
+    event: {
+      type: "EServiceDescriptorArchivingRequestRejectedByDelegator",
+      event_version: 2,
+      data: {
+        descriptorId,
+        eservice: toEServiceV2(eservice),
+      },
+    },
+    correlationId,
+  });
+
+export const toCreateEventEServiceDescriptorArchivingRequestApprovedByDelegator =
+  (
+    version: number,
+    descriptorId: DescriptorId,
+    eservice: EService,
+    correlationId: CorrelationId
+  ): CreateEvent<EServiceEvent> => ({
+    streamId: eservice.id,
+    version,
+    event: {
+      type: "EServiceDescriptorArchivingRequestApprovedByDelegator",
+      event_version: 2,
+      data: {
+        descriptorId,
+        eservice: toEServiceV2(eservice),
+      },
+    },
+    correlationId,
+  });

--- a/packages/catalog-process/src/routers/EServiceRouter.ts
+++ b/packages/catalog-process/src/routers/EServiceRouter.ts
@@ -91,6 +91,8 @@ import {
   submitDelegatedEServiceArchivingErrorMapper,
   approveDelegatedEServiceArchivingErrorMapper,
   rejectDelegatedEServiceArchivingErrorMapper,
+  approveDelegatedArchivingErrorMapper,
+  rejectDelegatedArchivingErrorMapper,
 } from "../utilities/errorMappers.js";
 
 const eservicesRouter = (
@@ -518,6 +520,63 @@ const eservicesRouter = (
           const errorRes = makeApiProblem(
             error,
             submitDelegatedEServiceArchivingErrorMapper,
+            ctx
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/eservices/:eServiceId/descriptors/:descriptorId/approveDelegatedArchiving",
+      async (req, res) => {
+        const ctx = fromAppContext(req.ctx);
+        try {
+          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
+          const { data: updatedEService, metadata } =
+            await catalogService.approveDelegatedDescriptorArchiving(
+              unsafeBrandId(req.params.eServiceId),
+              unsafeBrandId(req.params.descriptorId),
+              ctx
+            );
+          setMetadataVersionHeader(res, metadata);
+          return res
+            .status(200)
+            .send(
+              catalogApi.EService.parse(eServiceToApiEService(updatedEService))
+            );
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            approveDelegatedArchivingErrorMapper,
+            ctx
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
+    .post(
+      "/eservices/:eServiceId/descriptors/:descriptorId/rejectDelegatedArchiving",
+      async (req, res) => {
+        const ctx = fromAppContext(req.ctx);
+        try {
+          validateAuthorization(ctx, [ADMIN_ROLE, API_ROLE, M2M_ADMIN_ROLE]);
+          const { data: updatedEService, metadata } =
+            await catalogService.rejectDelegatedDescriptorArchiving(
+              unsafeBrandId(req.params.eServiceId),
+              unsafeBrandId(req.params.descriptorId),
+              req.body,
+              ctx
+            );
+          setMetadataVersionHeader(res, metadata);
+          return res
+            .status(200)
+            .send(
+              catalogApi.EService.parse(eServiceToApiEService(updatedEService))
+            );
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            rejectDelegatedArchivingErrorMapper,
             ctx
           );
           return res.status(errorRes.status).send(errorRes);

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -260,6 +260,7 @@ import {
   assertDelegatedEserviceHasAtLeastOneArchivingRequests,
   assertDelegatedEserviceHasActiveArchivingRequests,
   assertDelegatedDescriptorHasAtLeastOneArchivingRequests,
+  assertDelegatedDescriptorHasActiveArchivingRequests,
   assertDelegatedArchivingRequestDelegationIsStillValid,
 } from "./validators.js";
 
@@ -3660,6 +3661,11 @@ export function catalogServiceBuilder(
         eserviceId
       );
 
+      assertDelegatedDescriptorHasActiveArchivingRequests(
+        descriptor,
+        eserviceId
+      );
+
       const producerDelegation = await retrieveActiveProducerDelegation(
         eservice.data,
         readModelService
@@ -3726,6 +3732,11 @@ export function catalogServiceBuilder(
 
       const descriptor = retrieveDescriptor(descriptorId, eservice);
       assertDelegatedDescriptorHasAtLeastOneArchivingRequests(
+        descriptor,
+        eserviceId
+      );
+
+      assertDelegatedDescriptorHasActiveArchivingRequests(
         descriptor,
         eserviceId
       );

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -190,6 +190,8 @@ import {
   toCreateEventEServiceDescriptorArchivingRequestedByDelegate,
   toCreateEventEServiceArchivingRequestApprovedByDelegator,
   toCreateEventEServiceArchivingRequestRejectedByDelegator,
+  toCreateEventEServiceDescriptorArchivingRequestRejectedByDelegator,
+  toCreateEventEServiceDescriptorArchivingRequestApprovedByDelegator,
 } from "../model/domain/toEvent.js";
 import {
   appendArchivingRequest,
@@ -257,6 +259,7 @@ import {
   assertDelegatedDescriptorHasNoActiveArchivingRequests,
   assertDelegatedEserviceHasAtLeastOneArchivingRequests,
   assertDelegatedEserviceHasActiveArchivingRequests,
+  assertDelegatedDescriptorHasAtLeastOneArchivingRequests,
   assertDelegatedArchivingRequestDelegationIsStillValid,
 } from "./validators.js";
 
@@ -3621,6 +3624,165 @@ export function catalogServiceBuilder(
 
       const event = await repository.createEvent(
         toCreateEventEServiceDescriptorArchivingRequestedByDelegate(
+          eservice.metadata.version,
+          descriptorId,
+          updatedEService,
+          correlationId
+        )
+      );
+      return {
+        data: updatedEService,
+        metadata: {
+          version: event.newVersion,
+        },
+      };
+    },
+    async rejectDelegatedDescriptorArchiving(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      body: catalogApi.RejectDelegatedDescriptorArchivingSeed,
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
+    ): Promise<WithMetadata<EService>> {
+      logger.info(
+        `Rejecting delegated archiving request for Descriptor ${descriptorId} of EService ${eserviceId}`
+      );
+      const eservice = await retrieveEService(eserviceId, readModelService);
+
+      assertRequesterIsProducer(eservice.data.producerId, authData);
+
+      const descriptor = retrieveDescriptor(descriptorId, eservice);
+      assertDelegatedDescriptorHasAtLeastOneArchivingRequests(
+        descriptor,
+        eserviceId
+      );
+
+      const producerDelegation = await retrieveActiveProducerDelegation(
+        eservice.data,
+        readModelService
+      );
+
+      const latestActiveRequest = getLatestActiveArchivingRequest(
+        descriptor.delegatedArchivingRequest,
+        eserviceId,
+        descriptorId
+      );
+
+      assertDelegatedArchivingRequestDelegationIsStillValid(
+        producerDelegation,
+        latestActiveRequest,
+        eserviceId,
+        descriptorId
+      );
+
+      const updatedRequests = updateLatestActiveArchivingRequest(
+        descriptor.delegatedArchivingRequest ?? [],
+        {
+          rejectedAt: new Date(),
+          rejectionReason: body.rejectionReason,
+        },
+        eserviceId,
+        descriptorId
+      );
+
+      const updatedEService = replaceDescriptor(eservice.data, {
+        ...descriptor,
+        delegatedArchivingRequest: updatedRequests,
+      });
+
+      const event = await repository.createEvent(
+        toCreateEventEServiceDescriptorArchivingRequestRejectedByDelegator(
+          eservice.metadata.version,
+          descriptorId,
+          updatedEService,
+          correlationId
+        )
+      );
+      return {
+        data: updatedEService,
+        metadata: {
+          version: event.newVersion,
+        },
+      };
+    },
+    async approveDelegatedDescriptorArchiving(
+      eserviceId: EServiceId,
+      descriptorId: DescriptorId,
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAdminAuthData>>
+    ): Promise<WithMetadata<EService>> {
+      logger.info(
+        `Approving delegated archiving request for Descriptor ${descriptorId} of EService ${eserviceId}`
+      );
+      const eservice = await retrieveEService(eserviceId, readModelService);
+
+      assertRequesterIsProducer(eservice.data.producerId, authData);
+
+      const descriptor = retrieveDescriptor(descriptorId, eservice);
+      assertDelegatedDescriptorHasAtLeastOneArchivingRequests(
+        descriptor,
+        eserviceId
+      );
+
+      const producerDelegation = await retrieveActiveProducerDelegation(
+        eservice.data,
+        readModelService
+      );
+
+      const latestActiveRequest = getLatestActiveArchivingRequest(
+        descriptor.delegatedArchivingRequest,
+        eserviceId,
+        descriptorId
+      );
+
+      assertDelegatedArchivingRequestDelegationIsStillValid(
+        producerDelegation,
+        latestActiveRequest,
+        eserviceId,
+        descriptorId
+      );
+
+      assertDescriptorArchivable(descriptor, eservice.data);
+
+      const updatedRequests = updateLatestActiveArchivingRequest(
+        descriptor.delegatedArchivingRequest ?? [],
+        {
+          acceptedAt: new Date(),
+        },
+        eserviceId,
+        descriptorId
+      );
+
+      const acceptedRequest = getLatestArchivingRequest(
+        updatedRequests,
+        eserviceId,
+        descriptorId
+      );
+
+      const newState =
+        descriptor.state === descriptorState.suspended
+          ? descriptorState.archivingSuspended
+          : descriptorState.archiving;
+
+      const archivedDescriptor = await processDescriptorArchiving(
+        { ...descriptor, delegatedArchivingRequest: updatedRequests },
+        newState,
+        acceptedRequest.gracePeriodDays
+      );
+
+      const updatedEService = replaceDescriptor(
+        eservice.data,
+        archivedDescriptor
+      );
+
+      const event = await repository.createEvent(
+        toCreateEventEServiceDescriptorArchivingRequestApprovedByDelegator(
           eservice.metadata.version,
           descriptorId,
           updatedEService,

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -21,6 +21,8 @@ import {
   DelegatedDescriptorArchivingRequest,
   DelegatedEServiceArchivingRequest,
   Delegation,
+  DelegatedDescriptorArchivingRequest,
+  DelegatedEServiceArchivingRequest,
   delegationKind,
   delegationState,
   Descriptor,
@@ -1039,6 +1041,25 @@ export function assertDelegatedEserviceHasActiveArchivingRequests(
 ): void {
   if (!hasActiveArchivingRequest(eservice.delegatedArchivingRequest)) {
     throw delegatedArchivingRequestNotActive(eservice.id);
+  }
+}
+
+export function assertDelegatedDescriptorHasAtLeastOneArchivingRequests(
+  descriptor: Descriptor,
+  eserviceId: EServiceId
+): void {
+  const archivingRequests = descriptor.delegatedArchivingRequest;
+  if (!archivingRequests || archivingRequests.length === 0) {
+    throw noDelegatedArchivingRequestFound(eserviceId, descriptor.id);
+  }
+}
+
+export function assertDelegatedDescriptorHasActiveArchivingRequests(
+  descriptor: Descriptor,
+  eserviceId: EServiceId
+): void {
+  if (!hasActiveArchivingRequest(descriptor.delegatedArchivingRequest)) {
+    throw delegatedArchivingRequestNotActive(eserviceId, descriptor.id);
   }
 }
 

--- a/packages/catalog-process/src/services/validators.ts
+++ b/packages/catalog-process/src/services/validators.ts
@@ -21,8 +21,6 @@ import {
   DelegatedDescriptorArchivingRequest,
   DelegatedEServiceArchivingRequest,
   Delegation,
-  DelegatedDescriptorArchivingRequest,
-  DelegatedEServiceArchivingRequest,
   delegationKind,
   delegationState,
   Descriptor,

--- a/packages/catalog-process/src/utilities/errorMappers.ts
+++ b/packages/catalog-process/src/utilities/errorMappers.ts
@@ -924,3 +924,47 @@ export const rejectDelegatedEServiceArchivingErrorMapper = (
     .with("noDelegatedArchivingRequestFound", () => HTTP_STATUS_BAD_REQUEST)
     .with("delegatedArchivingRequestNotActive", () => HTTP_STATUS_CONFLICT)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const rejectDelegatedArchivingErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "eServiceNotFound",
+      "eServiceDescriptorNotFound", // Descriptor only
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
+    .with("noDelegatedArchivingRequestFound", () => HTTP_STATUS_BAD_REQUEST)
+    .with(
+      "delegatedArchivingRequestNotActive",
+      "noActiveDelegationFound",
+      "delegatedArchiveRequestForIncorrectDelegateProducer",
+      () => HTTP_STATUS_CONFLICT
+    )
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+export const approveDelegatedArchivingErrorMapper = (
+  error: ApiError<ErrorCodes>
+): number =>
+  match(error.code)
+    .with(
+      "eServiceNotFound",
+      "eServiceDescriptorNotFound", // Descriptor only
+      () => HTTP_STATUS_NOT_FOUND
+    )
+    .with("operationForbidden", () => HTTP_STATUS_FORBIDDEN)
+    .with(
+      "noDelegatedArchivingRequestFound",
+      "notValidEServiceState", // EService only
+      "notValidDescriptor", // Descriptor only
+      "eserviceWithoutValidDescriptors",
+      () => HTTP_STATUS_BAD_REQUEST
+    )
+    .with(
+      "delegatedArchivingRequestNotActive",
+      "noActiveDelegationFound",
+      "delegatedArchiveRequestForIncorrectDelegateProducer",
+      () => HTTP_STATUS_CONFLICT
+    )
+    .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);

--- a/packages/catalog-process/test/api/approveDelegatedDescriptorArchiving.test.ts
+++ b/packages/catalog-process/test/api/approveDelegatedDescriptorArchiving.test.ts
@@ -23,15 +23,17 @@ import {
   descriptorToApiDescriptor,
 } from "../../src/model/domain/apiConverter.js";
 import {
-  delegatedArchivingRequestAlreadyInProgress,
+  delegatedArchiveRequestForIncorrectDelegateProducer,
+  delegatedArchivingRequestNotActive,
   eServiceDescriptorNotFound,
   eServiceNotFound,
-  noDelegationForArchivingRequest,
+  noActiveDelegationFound,
+  noDelegatedArchivingRequestFound,
   notValidDescriptorState,
 } from "../../src/model/domain/errors.js";
 import { api, catalogService } from "../vitest.api.setup.js";
 
-describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegatedArchiving authorization test", () => {
+describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/approveDelegatedArchiving authorization test", () => {
   const descriptor: Descriptor = {
     ...getMockDescriptorArchiving(),
     version: "1",
@@ -51,27 +53,22 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
 
   const mockEserviceWithMetadata = getMockWithMetadata(mockEService);
 
-  catalogService.submitDelegatedDescriptorArchiving = vi
+  catalogService.approveDelegatedDescriptorArchiving = vi
     .fn()
     .mockResolvedValue(mockEserviceWithMetadata);
 
   const makeRequest = async (
     token: string,
     eServiceId: EServiceId,
-    descriptorId: DescriptorId,
-    body: catalogApi.GracePeriodDaysSeed
+    descriptorId: DescriptorId
   ) =>
     request(api)
       .post(
-        `/eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegatedArchiving`
+        `/eservices/${eServiceId}/descriptors/${descriptorId}/approveDelegatedArchiving`
       )
       .set("Authorization", `Bearer ${token}`)
       .set("X-Correlation-Id", generateId())
-      .send(body);
-
-  const gracePeriodDaysSeed: catalogApi.GracePeriodDaysSeed = {
-    gracePeriodDays: 60,
-  };
+      .send();
 
   const authorizedRoles: AuthRole[] = [
     authRole.ADMIN_ROLE,
@@ -82,12 +79,7 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
     "Should return 200 for user with role %s",
     async (role) => {
       const token = generateToken(role);
-      const res = await makeRequest(
-        token,
-        mockEService.id,
-        descriptor.id,
-        gracePeriodDaysSeed
-      );
+      const res = await makeRequest(token, mockEService.id, descriptor.id);
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual(mockApiEservice);
@@ -101,12 +93,7 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
     Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
   )("Should return 403 for user with role %s", async (role) => {
     const token = generateToken(role);
-    const res = await makeRequest(
-      token,
-      mockEService.id,
-      descriptor.id,
-      gracePeriodDaysSeed
-    );
+    const res = await makeRequest(token, mockEService.id, descriptor.id);
 
     expect(res.status).toBe(403);
   });
@@ -125,7 +112,7 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
       expectedStatus: 403,
     },
     {
-      error: noDelegationForArchivingRequest(mockEService.id),
+      error: noDelegatedArchivingRequestFound(mockEService.id, descriptor.id),
       expectedStatus: 400,
     },
     {
@@ -133,7 +120,15 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
       expectedStatus: 400,
     },
     {
-      error: delegatedArchivingRequestAlreadyInProgress(
+      error: delegatedArchivingRequestNotActive(mockEService.id, descriptor.id),
+      expectedStatus: 409,
+    },
+    {
+      error: noActiveDelegationFound(mockEService.id),
+      expectedStatus: 409,
+    },
+    {
+      error: delegatedArchiveRequestForIncorrectDelegateProducer(
         mockEService.id,
         descriptor.id
       ),
@@ -142,17 +137,12 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
   ])(
     "Should return $expectedStatus for $error.code",
     async ({ error, expectedStatus }) => {
-      catalogService.submitDelegatedDescriptorArchiving = vi
+      catalogService.approveDelegatedDescriptorArchiving = vi
         .fn()
         .mockRejectedValue(error);
 
       const token = generateToken(authRole.ADMIN_ROLE);
-      const res = await makeRequest(
-        token,
-        mockEService.id,
-        descriptor.id,
-        gracePeriodDaysSeed
-      );
+      const res = await makeRequest(token, mockEService.id, descriptor.id);
 
       expect(res.status).toBe(expectedStatus);
     }
@@ -169,21 +159,8 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
       const res = await makeRequest(
         token,
         eServiceId as EServiceId,
-        descriptorId as DescriptorId,
-        gracePeriodDaysSeed
+        descriptorId as DescriptorId
       );
-
-      expect(res.status).toBe(400);
-    }
-  );
-
-  it.each([0, -1, 1, 29, 31, 1066])(
-    "Should return 400 if passed invalid gracePeriodDays: %s",
-    async (gracePeriodDays) => {
-      const token = generateToken(authRole.ADMIN_ROLE);
-      const res = await makeRequest(token, mockEService.id, descriptor.id, {
-        gracePeriodDays,
-      } as catalogApi.GracePeriodDaysSeed);
 
       expect(res.status).toBe(400);
     }

--- a/packages/catalog-process/test/api/rejectDelegatedDescriptorArchiving.test.ts
+++ b/packages/catalog-process/test/api/rejectDelegatedDescriptorArchiving.test.ts
@@ -23,15 +23,15 @@ import {
   descriptorToApiDescriptor,
 } from "../../src/model/domain/apiConverter.js";
 import {
-  delegatedArchivingRequestAlreadyInProgress,
+  delegatedArchiveRequestForIncorrectDelegateProducer,
   eServiceDescriptorNotFound,
   eServiceNotFound,
-  noDelegationForArchivingRequest,
-  notValidDescriptorState,
+  noActiveDelegationFound,
+  noDelegatedArchivingRequestFound,
 } from "../../src/model/domain/errors.js";
 import { api, catalogService } from "../vitest.api.setup.js";
 
-describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegatedArchiving authorization test", () => {
+describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/rejectDelegatedArchiving authorization test", () => {
   const descriptor: Descriptor = {
     ...getMockDescriptorArchiving(),
     version: "1",
@@ -51,7 +51,7 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
 
   const mockEserviceWithMetadata = getMockWithMetadata(mockEService);
 
-  catalogService.submitDelegatedDescriptorArchiving = vi
+  catalogService.rejectDelegatedDescriptorArchiving = vi
     .fn()
     .mockResolvedValue(mockEserviceWithMetadata);
 
@@ -59,18 +59,18 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
     token: string,
     eServiceId: EServiceId,
     descriptorId: DescriptorId,
-    body: catalogApi.GracePeriodDaysSeed
+    body: catalogApi.RejectDelegatedDescriptorArchivingSeed
   ) =>
     request(api)
       .post(
-        `/eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegatedArchiving`
+        `/eservices/${eServiceId}/descriptors/${descriptorId}/rejectDelegatedArchiving`
       )
       .set("Authorization", `Bearer ${token}`)
       .set("X-Correlation-Id", generateId())
       .send(body);
 
-  const gracePeriodDaysSeed: catalogApi.GracePeriodDaysSeed = {
-    gracePeriodDays: 60,
+  const rejectSeed: catalogApi.RejectDelegatedDescriptorArchivingSeed = {
+    rejectionReason: "Not now",
   };
 
   const authorizedRoles: AuthRole[] = [
@@ -86,7 +86,7 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
         token,
         mockEService.id,
         descriptor.id,
-        gracePeriodDaysSeed
+        rejectSeed
       );
 
       expect(res.status).toBe(200);
@@ -97,6 +97,13 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
     }
   );
 
+  it("Should return 200 when rejectionReason is omitted", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token, mockEService.id, descriptor.id, {});
+
+    expect(res.status).toBe(200);
+  });
+
   it.each(
     Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
   )("Should return 403 for user with role %s", async (role) => {
@@ -105,7 +112,7 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
       token,
       mockEService.id,
       descriptor.id,
-      gracePeriodDaysSeed
+      rejectSeed
     );
 
     expect(res.status).toBe(403);
@@ -125,15 +132,15 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
       expectedStatus: 403,
     },
     {
-      error: noDelegationForArchivingRequest(mockEService.id),
+      error: noDelegatedArchivingRequestFound(mockEService.id, descriptor.id),
       expectedStatus: 400,
     },
     {
-      error: notValidDescriptorState(descriptor.id, descriptor.state),
-      expectedStatus: 400,
+      error: noActiveDelegationFound(mockEService.id),
+      expectedStatus: 409,
     },
     {
-      error: delegatedArchivingRequestAlreadyInProgress(
+      error: delegatedArchiveRequestForIncorrectDelegateProducer(
         mockEService.id,
         descriptor.id
       ),
@@ -142,7 +149,7 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
   ])(
     "Should return $expectedStatus for $error.code",
     async ({ error, expectedStatus }) => {
-      catalogService.submitDelegatedDescriptorArchiving = vi
+      catalogService.rejectDelegatedDescriptorArchiving = vi
         .fn()
         .mockRejectedValue(error);
 
@@ -151,7 +158,7 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
         token,
         mockEService.id,
         descriptor.id,
-        gracePeriodDaysSeed
+        rejectSeed
       );
 
       expect(res.status).toBe(expectedStatus);
@@ -170,20 +177,8 @@ describe("API /eservices/${eServiceId}/descriptors/${descriptorId}/submitDelegat
         token,
         eServiceId as EServiceId,
         descriptorId as DescriptorId,
-        gracePeriodDaysSeed
+        rejectSeed
       );
-
-      expect(res.status).toBe(400);
-    }
-  );
-
-  it.each([0, -1, 1, 29, 31, 1066])(
-    "Should return 400 if passed invalid gracePeriodDays: %s",
-    async (gracePeriodDays) => {
-      const token = generateToken(authRole.ADMIN_ROLE);
-      const res = await makeRequest(token, mockEService.id, descriptor.id, {
-        gracePeriodDays,
-      } as catalogApi.GracePeriodDaysSeed);
 
       expect(res.status).toBe(400);
     }

--- a/packages/catalog-process/test/integration/approveAndRejectDelegatedDescriptorArchiving.test.ts
+++ b/packages/catalog-process/test/integration/approveAndRejectDelegatedDescriptorArchiving.test.ts
@@ -1,0 +1,356 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import {
+  getMockContext,
+  getMockAuthData,
+  getMockDelegation,
+  getMockEService,
+  getMockDescriptor,
+  getMockDocument,
+  getMockTenant,
+} from "pagopa-interop-commons-test";
+import {
+  Descriptor,
+  descriptorState,
+  delegationKind,
+  delegationState,
+  DelegatedDescriptorArchivingRequest,
+  EService,
+  operationForbidden,
+} from "pagopa-interop-models";
+import { describe, it, expect } from "vitest";
+
+import {
+  delegatedArchiveRequestForIncorrectDelegateProducer,
+  delegatedArchivingRequestNotActive,
+  noActiveDelegationFound,
+  noDelegatedArchivingRequestFound,
+} from "../../src/model/domain/errors.js";
+import {
+  addOneDelegation,
+  addOneEService,
+  addOneTenant,
+  catalogService,
+} from "../integrationUtils.js";
+
+describe("approve/reject delegated archiving request for a Descriptor", () => {
+  const mockDocument = getMockDocument();
+  const producer = getMockTenant();
+  const mockDelegateTenant = getMockTenant();
+
+  const pendingRequest: DelegatedDescriptorArchivingRequest = {
+    requestedAt: new Date("2026-07-01T00:00:00"),
+    requesterId: mockDelegateTenant.id,
+    gracePeriodDays: 60,
+  };
+
+  const buildEservice = (descriptor: Descriptor): EService => ({
+    ...getMockEService(),
+    producerId: producer.id,
+    descriptors: [descriptor],
+  });
+
+  const setupActiveDelegation = async (eservice: EService): Promise<void> => {
+    const mockDelegation = getMockDelegation({
+      kind: delegationKind.delegatedProducer,
+      eserviceId: eservice.id,
+      delegateId: mockDelegateTenant.id,
+      state: delegationState.active,
+    });
+    await addOneTenant(producer);
+    await addOneTenant(mockDelegateTenant);
+    await addOneEService(eservice);
+    await addOneDelegation(mockDelegation);
+  };
+
+  describe("approve", () => {
+    it("Should approve a pending request and start the archiving grace period on a deprecated descriptor", async () => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.deprecated,
+        interface: mockDocument,
+        delegatedArchivingRequest: [pendingRequest],
+      };
+      const eservice = buildEservice(descriptor);
+      await setupActiveDelegation(eservice);
+
+      const response = await catalogService.approveDelegatedDescriptorArchiving(
+        eservice.id,
+        descriptor.id,
+        getMockContext({ authData: getMockAuthData(producer.id) })
+      );
+
+      const receivedDescriptor = response.data.descriptors[0];
+      expect(receivedDescriptor.state).toBe(descriptorState.archiving);
+      expect(receivedDescriptor.archivingSchedule).toBeDefined();
+      expect(receivedDescriptor.archivingSchedule?.gracePeriodDays).toBe(
+        pendingRequest.gracePeriodDays
+      );
+      expect(
+        receivedDescriptor.delegatedArchivingRequest?.[0].acceptedAt
+      ).toBeDefined();
+    });
+
+    it("Should approve a pending request and start ArchivingSuspended on a suspended descriptor", async () => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        version: "1",
+        state: descriptorState.suspended,
+        interface: mockDocument,
+        delegatedArchivingRequest: [pendingRequest],
+      };
+      const latestDescriptor: Descriptor = {
+        ...getMockDescriptor(),
+        version: "2",
+        state: descriptorState.published,
+        interface: getMockDocument(),
+      };
+      const eservice: EService = {
+        ...getMockEService(),
+        producerId: producer.id,
+        descriptors: [descriptor, latestDescriptor],
+      };
+      await setupActiveDelegation(eservice);
+
+      const response = await catalogService.approveDelegatedDescriptorArchiving(
+        eservice.id,
+        descriptor.id,
+        getMockContext({ authData: getMockAuthData(producer.id) })
+      );
+
+      const receivedDescriptor = response.data.descriptors.find(
+        (d) => d.id === descriptor.id
+      );
+      expect(receivedDescriptor?.state).toBe(
+        descriptorState.archivingSuspended
+      );
+    });
+
+    it("Should throw noDelegatedArchivingRequestFound when there is no request", async () => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.deprecated,
+        interface: mockDocument,
+      };
+      const eservice = buildEservice(descriptor);
+      await setupActiveDelegation(eservice);
+
+      const expectedError = noDelegatedArchivingRequestFound(
+        eservice.id,
+        descriptor.id
+      );
+
+      await expect(
+        catalogService.approveDelegatedDescriptorArchiving(
+          eservice.id,
+          descriptor.id,
+          getMockContext({ authData: getMockAuthData(producer.id) })
+        )
+      ).rejects.toThrow(expectedError);
+    });
+
+    it("Should throw delegatedArchivingRequestNotActive when the latest request was already accepted", async () => {
+      const acceptedRequest: DelegatedDescriptorArchivingRequest = {
+        ...pendingRequest,
+        acceptedAt: new Date("2026-07-02T00:00:00"),
+      };
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.archiving,
+        interface: mockDocument,
+        delegatedArchivingRequest: [acceptedRequest],
+      };
+      const eservice = buildEservice(descriptor);
+      await setupActiveDelegation(eservice);
+
+      const expectedError = delegatedArchivingRequestNotActive(
+        eservice.id,
+        descriptor.id
+      );
+
+      await expect(
+        catalogService.approveDelegatedDescriptorArchiving(
+          eservice.id,
+          descriptor.id,
+          getMockContext({ authData: getMockAuthData(producer.id) })
+        )
+      ).rejects.toThrow(expectedError);
+    });
+
+    it("Should throw noActiveDelegationFound when the delegation is no longer active", async () => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.deprecated,
+        interface: mockDocument,
+        delegatedArchivingRequest: [pendingRequest],
+      };
+      const eservice = buildEservice(descriptor);
+
+      await addOneTenant(producer);
+      await addOneTenant(mockDelegateTenant);
+      await addOneEService(eservice);
+      // No delegation added: it has since been revoked.
+
+      const expectedError = noActiveDelegationFound(eservice.id);
+
+      await expect(
+        catalogService.approveDelegatedDescriptorArchiving(
+          eservice.id,
+          descriptor.id,
+          getMockContext({ authData: getMockAuthData(producer.id) })
+        )
+      ).rejects.toThrow(expectedError);
+    });
+
+    it("Should throw delegatedArchiveRequestForIncorrectDelegateProducer when the active delegation points to a different delegate", async () => {
+      const otherDelegateTenant = getMockTenant();
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.deprecated,
+        interface: mockDocument,
+        delegatedArchivingRequest: [pendingRequest],
+      };
+      const eservice = buildEservice(descriptor);
+
+      const mockDelegation = getMockDelegation({
+        kind: delegationKind.delegatedProducer,
+        eserviceId: eservice.id,
+        delegateId: otherDelegateTenant.id,
+        state: delegationState.active,
+      });
+      await addOneTenant(producer);
+      await addOneTenant(mockDelegateTenant);
+      await addOneTenant(otherDelegateTenant);
+      await addOneEService(eservice);
+      await addOneDelegation(mockDelegation);
+
+      const expectedError = delegatedArchiveRequestForIncorrectDelegateProducer(
+        eservice.id,
+        descriptor.id
+      );
+
+      await expect(
+        catalogService.approveDelegatedDescriptorArchiving(
+          eservice.id,
+          descriptor.id,
+          getMockContext({ authData: getMockAuthData(producer.id) })
+        )
+      ).rejects.toThrow(expectedError);
+    });
+
+    it("Should throw operationForbidden when the requester is not the producer", async () => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.deprecated,
+        interface: mockDocument,
+        delegatedArchivingRequest: [pendingRequest],
+      };
+      const eservice = buildEservice(descriptor);
+      await setupActiveDelegation(eservice);
+
+      await expect(
+        catalogService.approveDelegatedDescriptorArchiving(
+          eservice.id,
+          descriptor.id,
+          getMockContext({ authData: getMockAuthData(mockDelegateTenant.id) })
+        )
+      ).rejects.toThrow(operationForbidden);
+    });
+  });
+
+  describe("reject", () => {
+    it("Should reject a pending request without requiring a rejection reason", async () => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.deprecated,
+        interface: mockDocument,
+        delegatedArchivingRequest: [pendingRequest],
+      };
+      const eservice = buildEservice(descriptor);
+      await setupActiveDelegation(eservice);
+
+      const response = await catalogService.rejectDelegatedDescriptorArchiving(
+        eservice.id,
+        descriptor.id,
+        {},
+        getMockContext({ authData: getMockAuthData(producer.id) })
+      );
+
+      const receivedDescriptor = response.data.descriptors[0];
+      expect(receivedDescriptor.state).toBe(descriptorState.deprecated);
+      expect(
+        receivedDescriptor.delegatedArchivingRequest?.[0].rejectedAt
+      ).toBeDefined();
+      expect(
+        receivedDescriptor.delegatedArchivingRequest?.[0].rejectionReason
+      ).toBeUndefined();
+    });
+
+    it("Should reject a pending request with a rejection reason", async () => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.deprecated,
+        interface: mockDocument,
+        delegatedArchivingRequest: [pendingRequest],
+      };
+      const eservice = buildEservice(descriptor);
+      await setupActiveDelegation(eservice);
+
+      const response = await catalogService.rejectDelegatedDescriptorArchiving(
+        eservice.id,
+        descriptor.id,
+        { rejectionReason: "Not the right time" },
+        getMockContext({ authData: getMockAuthData(producer.id) })
+      );
+
+      const receivedDescriptor = response.data.descriptors[0];
+      expect(
+        receivedDescriptor.delegatedArchivingRequest?.[0].rejectionReason
+      ).toBe("Not the right time");
+    });
+
+    it("Should throw noDelegatedArchivingRequestFound when there is no request", async () => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.deprecated,
+        interface: mockDocument,
+      };
+      const eservice = buildEservice(descriptor);
+      await setupActiveDelegation(eservice);
+
+      const expectedError = noDelegatedArchivingRequestFound(
+        eservice.id,
+        descriptor.id
+      );
+
+      await expect(
+        catalogService.rejectDelegatedDescriptorArchiving(
+          eservice.id,
+          descriptor.id,
+          {},
+          getMockContext({ authData: getMockAuthData(producer.id) })
+        )
+      ).rejects.toThrow(expectedError);
+    });
+
+    it("Should throw operationForbidden when the requester is not the producer", async () => {
+      const descriptor: Descriptor = {
+        ...getMockDescriptor(),
+        state: descriptorState.deprecated,
+        interface: mockDocument,
+        delegatedArchivingRequest: [pendingRequest],
+      };
+      const eservice = buildEservice(descriptor);
+      await setupActiveDelegation(eservice);
+
+      await expect(
+        catalogService.rejectDelegatedDescriptorArchiving(
+          eservice.id,
+          descriptor.id,
+          {},
+          getMockContext({ authData: getMockAuthData(mockDelegateTenant.id) })
+        )
+      ).rejects.toThrow(operationForbidden);
+    });
+  });
+});

--- a/packages/m2m-gateway-v3/test/api/eservices/submitDelegatedDescriptorArchiving.test.ts
+++ b/packages/m2m-gateway-v3/test/api/eservices/submitDelegatedDescriptorArchiving.test.ts
@@ -65,7 +65,7 @@ describe("POST /eservices/:eserviceId/descriptors/:descriptorId/submitDelegatedA
       ).toHaveBeenCalledWith(
         mockApiEservice.id,
         mockApiDescriptor.id,
-        {},
+        mockSeed,
         expect.any(Object) // context
       );
       expect(res.status).toBe(200);

--- a/packages/readmodel/src/testUtils.ts
+++ b/packages/readmodel/src/testUtils.ts
@@ -93,6 +93,7 @@ import {
   purposeTemplateRiskAnalysisFormSignedDocumentInReadmodelPurposeTemplate,
   tenantRemoteIdInReadmodelTenant,
   eserviceDescriptorArchivingScheduleInReadmodelCatalog,
+  eserviceDescriptorArchivingRequestInReadmodelCatalog,
 } from "pagopa-interop-readmodel-models";
 
 import { splitAgreementIntoObjectsSQL } from "./agreement/splitters.js";
@@ -288,6 +289,7 @@ export const upsertEService = async (
       rejectionReasonsSQL,
       templateVersionRefsSQL,
       archivingSchedulesSQL,
+      archivingRequestsSQL,
       asyncExchangePropertiesSQL,
     } = splitEserviceIntoObjectsSQL(eservice, metadataVersion);
 
@@ -345,6 +347,12 @@ export const upsertEService = async (
       await tx
         .insert(eserviceDescriptorArchivingScheduleInReadmodelCatalog)
         .values(archivingScheduleSQL);
+    }
+
+    for (const archivingRequestSQL of archivingRequestsSQL) {
+      await tx
+        .insert(eserviceDescriptorArchivingRequestInReadmodelCatalog)
+        .values(archivingRequestSQL);
     }
 
     for (const asyncExchangePropsSQL of asyncExchangePropertiesSQL) {

--- a/packages/readmodel/src/testUtils.ts
+++ b/packages/readmodel/src/testUtils.ts
@@ -291,7 +291,6 @@ export const upsertEService = async (
       archivingSchedulesSQL,
       archivingRequestsSQL,
       asyncExchangePropertiesSQL,
-      archivingRequestsSQL,
     } = splitEserviceIntoObjectsSQL(eservice, metadataVersion);
 
     await tx.insert(eserviceInReadmodelCatalog).values(eserviceSQL);
@@ -360,11 +359,6 @@ export const upsertEService = async (
       await tx
         .insert(eserviceDescriptorAsyncExchangePropertiesInReadmodelCatalog)
         .values(asyncExchangePropsSQL);
-    }
-    for (const archivingRequestSQL of archivingRequestsSQL) {
-      await tx
-        .insert(eserviceDescriptorArchivingRequestInReadmodelCatalog)
-        .values(archivingRequestSQL);
     }
   });
 };


### PR DESCRIPTION
## Issue
- [PIN-10693](https://pagopa.atlassian.net/browse/PIN-10693)
- [SRS - Archiviazione manuale e-service, Deleghe](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2803302507/SRS+Archiviazione+manuale+e-service#%5BWork-Item-20%5D-Deleghe)

## Context
This PR adds the ability for a delegator producer to approve or reject a delegate's archiving request for a single EService descriptor, mirroring the existing EService-level approve/reject flow (PIN-10692), as specified in the SRS linked above. It introduces two new endpoints (`approveDelegatedArchiving` / `rejectDelegatedArchiving` on `/eservices/{eServiceId}/descriptors/{descriptorId}`), exposes the delegated archiving request status on the EService/Descriptor API models, and fixes a gap in the read model writer where descriptor archiving requests were not being persisted.

## Scope
- catalog-process
- api-clients
- readmodel

## Traceability Checklist
- [X] PR title compliant (type(scope): description (KEY))
- [X] Service labels applied

[PIN-10693]: https://pagopa.atlassian.net/browse/PIN-10693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ