### PR TITLE
feat(backend-for-frontend): log identity token jti and uid on token exchange (PIN-10707)

### DIFF
--- a/packages/backend-for-frontend/src/services/authorizationService.ts
+++ b/packages/backend-for-frontend/src/services/authorizationService.ts
@@ -12,6 +12,7 @@ import {
   UserClaims,
   UserRole,
   WithLogger,
+  decodeJwtToken,
   userRole,
   verifyJwtToken,
 } from "pagopa-interop-commons";
@@ -21,6 +22,7 @@ import {
   invalidClaim,
   unsafeBrandId,
 } from "pagopa-interop-models";
+import { z } from "zod";
 
 import { PagoPAInteropBeClients } from "../clients/clientsProvider.js";
 import { config } from "../config/config.js";
@@ -34,6 +36,26 @@ import { BffAppContext, Headers } from "../utilities/context.js";
 import { validateSamlResponse } from "../utilities/samlValidator.js";
 
 const { HTTP_STATUS_NOT_FOUND } = constants;
+
+/*
+  The identity token is logged without being verified, so each claim is accepted
+  only if it looks like an identifier: a claim containing newlines would be
+  turned into additional log lines by the log format. Claims are parsed one by
+  one, so that one is still logged when the other is missing or malformed.
+*/
+const LoggedIdentityTokenClaim = z
+  .string()
+  .max(64)
+  .regex(/^[A-Za-z0-9._:-]+$/)
+  .optional()
+  .catch(undefined);
+
+const LoggedIdentityTokenClaims = z
+  .object({
+    jti: LoggedIdentityTokenClaim,
+    uid: LoggedIdentityTokenClaim,
+  })
+  .catch({ jti: undefined, uid: undefined });
 
 export type GetSessionTokenReturnType =
   | {
@@ -84,6 +106,32 @@ export function authorizationServiceBuilder(
       sessionClaims,
       selfcareId: sessionClaims.organization.id,
     };
+  };
+
+  /*
+    The identity token is only decoded here, never verified: verification
+    happens in readJwt, and the logins that fail it must be traced as well.
+  */
+  const logIdentityTokenClaims = (
+    identityToken: string,
+    logger: Logger
+  ): void => {
+    try {
+      const { jti, uid } = LoggedIdentityTokenClaims.parse(
+        decodeJwtToken(identityToken, logger)
+      );
+
+      if (!jti && !uid) {
+        logger.warn("No loggable jti and uid claims in the identity token");
+        return;
+      }
+
+      logger.info(`[JTI=${jti}][UID=${uid}] Identity token claims`);
+    } catch {
+      // The decoding error is already logged by decodeJwtToken, and it embeds
+      // part of the token payload, so it is not reported again here.
+      logger.warn("Unable to decode the identity token to log its claims");
+    }
   };
 
   const assertTenantAllowed = (
@@ -162,6 +210,7 @@ export function authorizationServiceBuilder(
       { headers, logger }: WithLogger<BffAppContext>
     ): Promise<GetSessionTokenReturnType> => {
       logger.info("Received session token exchange request");
+      logIdentityTokenClaims(identityToken, logger);
 
       const { sessionClaims, roles, selfcareId } = await readJwt(
         identityToken,

--- a/packages/backend-for-frontend/test/getSessionToken.test.ts
+++ b/packages/backend-for-frontend/test/getSessionToken.test.ts
@@ -14,6 +14,7 @@ import {
   invalidClaim,
   SelfcareId,
   TenantId,
+  UserId,
   userRole,
 } from "pagopa-interop-models";
 import { match } from "ts-pattern";
@@ -33,7 +34,36 @@ const validSelfcareId = generateId<SelfcareId>();
 const selfcareIdNotFound = generateId<SelfcareId>();
 const selfcareIdTokenLoginNotAllowed = generateId<SelfcareId>();
 
-const validIdentityToken = "validIdentityToken";
+const identityTokenJti = "identity-token-jti";
+const identityTokenUid = generateId<UserId>();
+
+const b64UrlEncode = (payload: object): string =>
+  Buffer.from(JSON.stringify(payload)).toString("base64url");
+
+// The signature is irrelevant, verifyJwtToken is mocked below
+const jwtShapedIdentityToken = (claims: object): string =>
+  [
+    b64UrlEncode({ alg: "RS256", typ: "JWT" }),
+    b64UrlEncode(claims),
+    "signature",
+  ].join(".");
+
+const validIdentityToken = jwtShapedIdentityToken({
+  jti: identityTokenJti,
+  uid: identityTokenUid,
+});
+
+// Not among the tokens known by the verifyJwtToken mock, so its verification fails
+const unverifiableIdentityTokenJti = "unverifiable-identity-token-jti";
+const unverifiableIdentityToken = jwtShapedIdentityToken({
+  jti: unverifiableIdentityTokenJti,
+  uid: identityTokenUid,
+});
+
+const identityTokenWithForgingClaims = jwtShapedIdentityToken({
+  jti: `${identityTokenJti}\nForged log line`,
+  uid: identityTokenUid,
+});
 
 const identityTokenTenantNotFound = "identityTokenTenantNotFound";
 const identityTokenTenantLoginNotAllowed = "identityTokenTenantLoginNotAllowed";
@@ -156,6 +186,8 @@ const mockContext = {
 
 afterEach(() => {
   verifyJwtTokenMockFn.mockClear();
+  // The context logger is shared, its spies must not leak into other tests
+  vi.restoreAllMocks();
 });
 
 describe("getSessionToken", async () => {
@@ -221,6 +253,73 @@ describe("getSessionToken", async () => {
       )
     ).rejects.toThrowError(
       tenantLoginNotAllowed(selfcareIdTokenLoginNotAllowed)
+    );
+  });
+
+  it("should log the jti and uid claims of the identity token", async () => {
+    const loggerSpy = vi.spyOn(mockContext.logger, "info");
+
+    await authorizationService.getSessionToken(validIdentityToken, mockContext);
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `[JTI=${identityTokenJti}][UID=${identityTokenUid}]`
+      )
+    );
+  });
+
+  it("should log the identity token claims before verifying it, so that failed exchanges are traced too", async () => {
+    const loggerSpy = vi.spyOn(mockContext.logger, "info");
+
+    await expect(
+      authorizationService.getSessionToken(
+        unverifiableIdentityToken,
+        mockContext
+      )
+    ).rejects.toThrowError();
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `[JTI=${unverifiableIdentityTokenJti}][UID=${identityTokenUid}]`
+      )
+    );
+  });
+
+  it("should not log identity token claims that could forge log lines", async () => {
+    const infoSpy = vi.spyOn(mockContext.logger, "info");
+
+    await expect(
+      authorizationService.getSessionToken(
+        identityTokenWithForgingClaims,
+        mockContext
+      )
+    ).rejects.toThrowError();
+
+    // The jti carries a newline, so it is discarded, while the uid is still logged
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`[JTI=undefined][UID=${identityTokenUid}]`)
+    );
+    expect(infoSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Forged log line")
+    );
+  });
+
+  it("should not fail the exchange when the identity token claims cannot be read", async () => {
+    const loggerSpy = vi.spyOn(mockContext.logger, "warn");
+
+    // This token is not JWT shaped: the exchange must still fail on its own
+    // validation, not on the logging
+    await expect(
+      authorizationService.getSessionToken(
+        identityTokenTenantLoginNotAllowed,
+        mockContext
+      )
+    ).rejects.toThrowError(
+      tenantLoginNotAllowed(selfcareIdTokenLoginNotAllowed)
+    );
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      "No loggable jti and uid claims in the identity token"
     );
   });
 });


### PR DESCRIPTION
## Why

We need to correlate a login on Selfcare (area riservata) with the access to the platform (PIN-10707). The link between the two is the Selfcare identity token that the frontend sends to the BFF during the session token exchange, so its `jti` and the `uid` of the logged user are now logged on `POST /session/tokens`.

## What

All in `packages/backend-for-frontend`, `authorizationService.getSessionToken`:

- Log the `jti` and `uid` claims of the identity token as soon as the exchange request is received, in the `[JTI=..][UID=..]` form already used elsewhere for these ids, on the request logger, so the line carries the correlation id.
- The token is **decoded, not verified**, at that point. Verification keeps happening in `readJwt`, so the claims are logged before the signature, claims, tenant and rate limit checks and the exchange failures are traced as well, which is the point of the ticket ("queste informazioni vanno loggate appena possibile, in modo da intercettare anche situazioni di errore").
- Since the claims come from a token that has not been verified yet, each one is accepted only if it looks like an identifier (max 64 chars, `[A-Za-z0-9._:-]`). A claim containing newlines would otherwise be turned into additional, apparently genuine, log lines by the log format, on an endpoint that is reachable without authentication. Claims are parsed one by one, so a malformed `jti` does not discard a valid `uid`.
- Logging can never make the exchange fail: an undecodable token or unreadable claims produce a warning and the request goes on to its normal validation.

## Notes

- Nothing else of the identity token is logged. The token also carries `name`, `family_name` and `email`, which are deliberately left out. `uid` is an opaque uuid and is already part of the log metadata (`[UID=..]`) on every authenticated request.
- The chain for an operator is: Selfcare `jti` -> this line -> `uid`, which is copied into the session token and appears as `[UID=..]` on every following request.
- Failures that happen before the route handler (malformed JSON body, request body validation) are not covered, since there is no identity token to read yet. Moving the log to the router would not change this, because the body validation runs before the handlers.
- A malformed token now produces two `error` lines instead of one, because `decodeJwtToken` logs the decoding failure itself and it is called once more by `verifyJwtToken` on the failure path.
- Tests: the happy path asserts the logged claims, one case asserts they are logged even when verification fails, one asserts a claim carrying a newline is dropped while the valid `uid` of the same token is still logged, one asserts an unreadable token does not change the outcome of the exchange.
