### PR TITLE
feature: expose discreteValue in requester certified attributes (PIN-10731)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -30411,6 +30411,11 @@ components:
           type: string
         kind:
           $ref: "#/components/schemas/AttributeKind"
+        discreteValue:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
       required:
         - tenantId
         - tenantName

--- a/packages/api-clients/open-api/tenantApi.yml
+++ b/packages/api-clients/open-api/tenantApi.yml
@@ -1723,6 +1723,11 @@ components:
           type: string
         kind:
           $ref: "#/components/schemas/CertifiedAttributeKind"
+        discreteValue:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
       required:
         - id
         - name

--- a/packages/backend-for-frontend/src/api/tenantApiConverter.ts
+++ b/packages/backend-for-frontend/src/api/tenantApiConverter.ts
@@ -103,6 +103,7 @@ export const toBffApiRequesterCertifiedAttributes = (
   attributeId: input.attributeId,
   attributeName: input.attributeName,
   kind: input.kind,
+  discreteValue: input.discreteValue,
 });
 
 export type RegistryAttributesMap = Map<

--- a/packages/backend-for-frontend/test/tenantService.test.ts
+++ b/packages/backend-for-frontend/test/tenantService.test.ts
@@ -406,7 +406,25 @@ describe("toBffApiRequesterCertifiedAttributes", () => {
         attributeId: input.attributeId,
         attributeName: input.attributeName,
         kind: expectedKind,
+        discreteValue: undefined,
       });
     }
   );
+
+  it("should preserve the discreteValue of a discrete assignment", () => {
+    const input: tenantApi.CertifiedAttribute = {
+      id: generateId(),
+      name: "tenant",
+      attributeId: generateId(),
+      attributeName: "attribute",
+      kind: "CERTIFIED_DISCRETE",
+      discreteValue: 42,
+    };
+
+    const result: bffApi.RequesterCertifiedAttribute =
+      toBffApiRequesterCertifiedAttributes(input);
+    bffApi.RequesterCertifiedAttribute.parse(result);
+
+    expect(result.discreteValue).toBe(input.discreteValue);
+  });
 });

--- a/packages/tenant-process/src/services/readModelServiceSQL.ts
+++ b/packages/tenant-process/src/services/readModelServiceSQL.ts
@@ -427,6 +427,8 @@ export function readModelServiceBuilderSQL(
                 THEN ${certifiedAttributeKind.standard}
               ELSE ${certifiedAttributeKind.discrete}
             END`.as("kind"),
+            discreteValue:
+              tenantCertifiedDiscreteAttributeInReadmodelTenant.discreteValue,
           })
         )
         .from(attributeInReadmodelAttribute)
@@ -495,6 +497,7 @@ export function readModelServiceBuilderSQL(
           attributeId: row.attributeId,
           attributeName: row.attributeName,
           kind: row.kind,
+          discreteValue: row.discreteValue ?? undefined,
         })),
         res[0]?.totalCount
       );

--- a/packages/tenant-process/test/integration/getCertifiedAttributes.test.ts
+++ b/packages/tenant-process/test/integration/getCertifiedAttributes.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   Attribute,
   attributeKind,
+  CertifiedDiscreteTenantAttribute,
   Tenant,
   TenantAttribute,
 } from "pagopa-interop-models";
@@ -37,7 +38,7 @@ describe("getCertifiedAttributes", () => {
       ...getMockCertifiedTenantAttribute(),
       revocationTimestamp: undefined,
     };
-    const tenantCertifiedDiscreteAttribute: TenantAttribute = {
+    const tenantCertifiedDiscreteAttribute: CertifiedDiscreteTenantAttribute = {
       ...getMockCertifiedDiscreteTenantAttribute(),
       revocationTimestamp: undefined,
     };
@@ -80,6 +81,7 @@ describe("getCertifiedAttributes", () => {
           id: tenant.id,
           kind: "CERTIFIED_DISCRETE",
           name: tenant.name,
+          discreteValue: tenantCertifiedDiscreteAttribute.discreteValue,
         },
       ]),
       totalCount: 2,
@@ -98,7 +100,7 @@ describe("getCertifiedAttributes", () => {
       ...getMockCertifiedTenantAttribute(),
       revocationTimestamp: undefined,
     };
-    const tenantCertifiedDiscreteAttribute: TenantAttribute = {
+    const tenantCertifiedDiscreteAttribute: CertifiedDiscreteTenantAttribute = {
       ...getMockCertifiedDiscreteTenantAttribute(),
       revocationTimestamp: undefined,
     };
@@ -152,6 +154,7 @@ describe("getCertifiedAttributes", () => {
           id: tenant.id,
           kind: "CERTIFIED_DISCRETE",
           name: tenant.name,
+          discreteValue: tenantCertifiedDiscreteAttribute.discreteValue,
         },
       ],
       totalCount: 2,


### PR DESCRIPTION
## Jira Issue
[PIN-10731](https://pagopa.atlassian.net/browse/PIN-10731)

## Context
- `GET /tenants/attributes/certified` returned the `CERTIFIED_DISCRETE` rows added by PIN-10654 without their value.

## Services Affected
- pagopa-interop-tenant-process
- pagopa-interop-backend-for-frontend
- pagopa-interop-api-clients

## Key Changes
- `tenantApi.yml`: `CertifiedAttribute` declares an optional `discreteValue` (integer int32, 1..1000000000).
- `bffApi.yml`: `RequesterCertifiedAttribute` declares the same field with the same constraints.
- `readModelServiceSQL.ts`: `getCertifiedAttributes` selects `tenantCertifiedDiscreteAttributeInReadmodelTenant.discreteValue` and maps it, so it stays undefined on the rows coming from the standard certified table.
- `tenantApiConverter.ts`: `toBffApiRequesterCertifiedAttributes` forwards the field untransformed.
- Tests: the tenant-process integration tests on mixed and paginated results now assert the threshold on the discrete row and its absence on the standard one; a new BFF unit test covers the converter.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [x] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)


[PIN-10731]: https://pagopa.atlassian.net/browse/PIN-10731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ