### PR TITLE
refactor: extract e-service instance name composition into shared helper (PIN-10729)

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -30,6 +30,7 @@ import {
   agreementApprovalPolicy,
   agreementState,
   AttributeId,
+  buildEServiceInstanceName,
   catalogEventToBinaryData,
   Delegation,
   delegationKind,
@@ -56,6 +57,7 @@ import {
   generateId,
   ListResult,
   operationForbidden,
+  parseEServiceInstanceLabel,
   RiskAnalysis,
   RiskAnalysisId,
   Tenant,
@@ -1154,11 +1156,13 @@ export function catalogServiceBuilder(
         readModelService
       );
 
-      const { parsedInstanceLabel, instanceName: updatedInstanceName } =
-        buildInstanceName({
-          templateName: template.name,
-          instanceLabel: eserviceSeed.instanceLabel,
-        });
+      const parsedInstanceLabel = parseEServiceInstanceLabel(
+        eserviceSeed.instanceLabel
+      );
+      const updatedInstanceName = buildEServiceInstanceName({
+        templateName: template.name,
+        instanceLabel: parsedInstanceLabel,
+      });
 
       if (updatedInstanceName !== eservice.data.name) {
         await assertEServiceNameAvailableForProducer(
@@ -3549,7 +3553,7 @@ export function catalogServiceBuilder(
 
       const eservice = await retrieveEService(eserviceId, readModelService);
 
-      const { instanceName: updatedInstanceName } = buildInstanceName({
+      const updatedInstanceName = buildEServiceInstanceName({
         templateName: updatedTemplateName,
         instanceLabel: eservice.data.instanceLabel,
       });
@@ -3991,9 +3995,12 @@ export function catalogServiceBuilder(
         .with({ mode: eserviceMode.deliver }, () => Promise.resolve([]))
         .exhaustive();
 
-      const { parsedInstanceLabel, instanceName } = buildInstanceName({
+      const parsedInstanceLabel = parseEServiceInstanceLabel(
+        seed.instanceLabel
+      );
+      const instanceName = buildEServiceInstanceName({
         templateName: template.name,
-        instanceLabel: seed.instanceLabel,
+        instanceLabel: parsedInstanceLabel,
       });
 
       const instanceAsyncExchange =
@@ -4441,11 +4448,11 @@ export function catalogServiceBuilder(
 
       assertEServiceUpdatableAfterPublish(eservice.data);
 
-      const { parsedInstanceLabel, instanceName: updatedInstanceName } =
-        buildInstanceName({
-          templateName: template.name,
-          instanceLabel,
-        });
+      const parsedInstanceLabel = parseEServiceInstanceLabel(instanceLabel);
+      const updatedInstanceName = buildEServiceInstanceName({
+        templateName: template.name,
+        instanceLabel: parsedInstanceLabel,
+      });
 
       if (updatedInstanceName !== eservice.data.name) {
         await assertEServiceNameAvailableForProducer(
@@ -5524,31 +5531,4 @@ async function updateDraftDescriptor(
   };
 }
 
-/**
- * Builds the instance name from the template name and optional instance label.
- * - templateName: maxLength 45
- * - separator " - ": 3 characters
- * - instanceLabel: maxLength 12
- * - eservice name (result): maxLength 60
- *
- * Also, empty spaces are removed, and an empty string is treated as undefined
- */
-const buildInstanceName = ({
-  templateName,
-  instanceLabel,
-}: {
-  templateName: string;
-  instanceLabel: string | undefined;
-}): { parsedInstanceLabel?: string; instanceName: string } => {
-  const trimmedInstanceLabel = instanceLabel?.trim();
-  const parsedInstanceLabel =
-    trimmedInstanceLabel && trimmedInstanceLabel.length > 0
-      ? trimmedInstanceLabel
-      : undefined;
-
-  const instanceName = parsedInstanceLabel
-    ? `${templateName} - ${parsedInstanceLabel}`
-    : templateName;
-  return { parsedInstanceLabel, instanceName };
-};
 export type CatalogService = ReturnType<typeof catalogServiceBuilder>;

--- a/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameUpdated.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameUpdated.ts
@@ -1,4 +1,5 @@
 import {
+  buildEServiceInstanceName,
   EmailNotificationMessagePayload,
   EService,
   EServiceIdDescriptorId,
@@ -92,12 +93,16 @@ export async function handleEServiceTemplateNameUpdated(
        * The instance rename happens asynchronously (eservice-template-instances-updater
        * -> catalogProcess.internalUpdateTemplateInstanceName), so `eservice.name` may still
        * hold the old name at this point. Both names are therefore rebuilt from the template
-       * name and the instance label, following the same rule as `buildInstanceName` in
-       * catalog-process (`packages/catalog-process/src/services/catalogService.ts`).
+       * name and the instance label.
        */
-      const instanceLabelSuffix = eservice.instanceLabel
-        ? ` - ${eservice.instanceLabel}`
-        : "";
+      const oldEserviceName = buildEServiceInstanceName({
+        templateName: oldTemplateName,
+        instanceLabel: eservice.instanceLabel,
+      });
+      const newEserviceName = buildEServiceInstanceName({
+        templateName: eserviceTemplate.name,
+        instanceLabel: eservice.instanceLabel,
+      });
       return {
         correlationId: correlationId ?? generateId(),
         email: {
@@ -109,8 +114,8 @@ export async function handleEServiceTemplateNameUpdated(
               `${eservice.id}/${retrieveLatestDescriptor(eservice).id}`
             ),
             ...(t.type === "Tenant" ? { recipientName: tenant.name } : {}),
-            oldName: `${oldTemplateName}${instanceLabelSuffix}`,
-            newName: `${eserviceTemplate.name}${instanceLabelSuffix}`,
+            oldName: oldEserviceName,
+            newName: newEserviceName,
             selfcareId: t.selfcareId,
             bffUrl: config.bffUrl,
           }),

--- a/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameUpdated.ts
+++ b/packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameUpdated.ts
@@ -43,6 +43,9 @@ export async function handleEServiceTemplateNameUpdated(
 
   const eserviceTemplate = fromEServiceTemplateV2(eserviceTemplateV2Msg);
 
+  // Legacy events may not carry the previous name: fall back to the template id
+  const oldTemplateName = oldName ?? eserviceTemplate.id;
+
   const [htmlTemplate, eservices] = await Promise.all([
     retrieveHTMLTemplate(
       eventMailTemplateType.eserviceTemplateNameUpdatedMailTemplate
@@ -84,25 +87,37 @@ export async function handleEServiceTemplateNameUpdated(
       return [];
     }
 
-    return tenantEServices.map((eservice) => ({
-      correlationId: correlationId ?? generateId(),
-      email: {
-        subject: `Aggiornamento nome del template "${oldName}"`,
-        body: templateService.compileHtml(htmlTemplate, {
-          title: `Aggiornamento nome del template "${oldName}"`,
-          notificationType,
-          entityId: EServiceIdDescriptorId.parse(
-            `${eservice.id}/${retrieveLatestDescriptor(eservice).id}`
-          ),
-          ...(t.type === "Tenant" ? { recipientName: tenant.name } : {}),
-          oldName: oldName ?? eserviceTemplate.id,
-          newName: eserviceTemplate.name,
-          selfcareId: t.selfcareId,
-          bffUrl: config.bffUrl,
-        }),
-      },
-      tenantId: t.tenantId,
-      ...mapRecipientToEmailPayload(t),
-    }));
+    return tenantEServices.map((eservice) => {
+      /**
+       * The instance rename happens asynchronously (eservice-template-instances-updater
+       * -> catalogProcess.internalUpdateTemplateInstanceName), so `eservice.name` may still
+       * hold the old name at this point. Both names are therefore rebuilt from the template
+       * name and the instance label, following the same rule as `buildInstanceName` in
+       * catalog-process (`packages/catalog-process/src/services/catalogService.ts`).
+       */
+      const instanceLabelSuffix = eservice.instanceLabel
+        ? ` - ${eservice.instanceLabel}`
+        : "";
+      return {
+        correlationId: correlationId ?? generateId(),
+        email: {
+          subject: `Aggiornamento nome del template "${oldTemplateName}"`,
+          body: templateService.compileHtml(htmlTemplate, {
+            title: `Aggiornamento nome del template "${oldTemplateName}"`,
+            notificationType,
+            entityId: EServiceIdDescriptorId.parse(
+              `${eservice.id}/${retrieveLatestDescriptor(eservice).id}`
+            ),
+            ...(t.type === "Tenant" ? { recipientName: tenant.name } : {}),
+            oldName: `${oldTemplateName}${instanceLabelSuffix}`,
+            newName: `${eserviceTemplate.name}${instanceLabelSuffix}`,
+            selfcareId: t.selfcareId,
+            bffUrl: config.bffUrl,
+          }),
+        },
+        tenantId: t.tenantId,
+        ...mapRecipientToEmailPayload(t),
+      };
+    });
   });
 }

--- a/packages/email-notification-dispatcher/test/handleEserviceTemplateNameUpdated.test.ts
+++ b/packages/email-notification-dispatcher/test/handleEserviceTemplateNameUpdated.test.ts
@@ -192,4 +192,59 @@ describe("handleEServiceTemplateNameUpdated", async () => {
       expect(message.email.body).toContain(eserviceTemplate.name);
     });
   });
+
+  it("should include the instance label in the old and new e-service names", async () => {
+    const instanceLabel = "istanza";
+    const labeledInstance: EService = {
+      ...getMockEService(
+        generateId<EServiceId>(),
+        instantiatorId,
+        [getMockDescriptorPublished()],
+        eserviceTemplateId
+      ),
+      name: `${oldName} - ${instanceLabel}`,
+      instanceLabel,
+    };
+    await addOneEService(labeledInstance);
+
+    const messages = await handleEServiceTemplateNameUpdated({
+      eserviceTemplateV2Msg: toEServiceTemplateV2(eserviceTemplate),
+      oldName,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(
+      messages.some(
+        (message) =>
+          message.email.body.includes(
+            `Ti informiamo che il tuo e-service ${oldName} - ${instanceLabel} è stato rinominato in`
+          ) &&
+          message.email.body.includes(
+            `${eserviceTemplate.name} - ${instanceLabel} in quanto`
+          )
+      )
+    ).toBe(true);
+  });
+
+  it("should fall back to the template id in the subject when the old name is missing", async () => {
+    const messages = await handleEServiceTemplateNameUpdated({
+      eserviceTemplateV2Msg: toEServiceTemplateV2(eserviceTemplate),
+      oldName: undefined,
+      logger,
+      templateService,
+      readModelService,
+      correlationId: generateId<CorrelationId>(),
+    });
+
+    expect(messages.length).toBe(2);
+    messages.forEach((message) => {
+      expect(message.email.subject).toBe(
+        `Aggiornamento nome del template "${eserviceTemplateId}"`
+      );
+      expect(message.email.body).not.toContain("undefined");
+    });
+  });
 });

--- a/packages/eservice-template-process/src/services/readModelServiceSQL.ts
+++ b/packages/eservice-template-process/src/services/readModelServiceSQL.ts
@@ -24,6 +24,7 @@ import {
   Attribute,
   AttributeId,
   AttributeKind,
+  ESERVICE_INSTANCE_NAME_SEPARATOR,
   EServiceTemplate,
   EServiceTemplateId,
   ListResult,
@@ -345,7 +346,7 @@ export function readModelServiceBuilderSQL({
                     ne(eserviceInReadmodelCatalog.id, templateInstances.id),
                     sql`${eserviceInReadmodelCatalog.name} ILIKE CASE
                       WHEN ${templateInstances.instanceLabel} IS NOT NULL
-                        THEN ${escapedNewName} || ' - ' || ${templateInstances.instanceLabel}
+                        THEN ${escapedNewName} || ${ESERVICE_INSTANCE_NAME_SEPARATOR} || ${templateInstances.instanceLabel}
                       ELSE ${escapedNewName}
                     END ESCAPE '\\'`
                   )

--- a/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameChangedToInstantiator.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameChangedToInstantiator.ts
@@ -70,12 +70,19 @@ export async function handleEserviceTemplateNameChangedToInstantiator(
       const entityId = EServiceIdDescriptorId.parse(
         `${eservice.id}/${retrieveLatestDescriptor(eservice).id}`
       );
+      const instanceLabelSuffix: string = eservice.instanceLabel
+        ? ` - ${eservice.instanceLabel}`
+        : "";
+      const oldEserviceName: string = `${
+        oldName ?? eserviceTemplate.id
+      }${instanceLabelSuffix}`;
+      const newEserviceName: string = `${eserviceTemplate.name}${instanceLabelSuffix}`;
       return {
         userId,
         tenantId,
         body: inAppTemplates.eserviceTemplateNameChangedToInstantiator(
-          eserviceTemplate,
-          oldName
+          oldEserviceName,
+          newEserviceName
         ),
         notificationType: "eserviceTemplateNameChangedToInstantiator",
         entityId,

--- a/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameChangedToInstantiator.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameChangedToInstantiator.ts
@@ -1,5 +1,6 @@
 import { Logger } from "pagopa-interop-commons";
 import {
+  buildEServiceInstanceName,
   EService,
   EServiceIdDescriptorId,
   EServiceTemplateV2,
@@ -74,16 +75,16 @@ export async function handleEserviceTemplateNameChangedToInstantiator(
        * The instance rename happens asynchronously (eservice-template-instances-updater
        * -> catalogProcess.internalUpdateTemplateInstanceName), so `eservice.name` may still
        * hold the old name at this point. Both names are therefore rebuilt from the template
-       * name and the instance label, following the same rule as `buildInstanceName` in
-       * catalog-process (`packages/catalog-process/src/services/catalogService.ts`).
+       * name and the instance label.
        */
-      const instanceLabelSuffix = eservice.instanceLabel
-        ? ` - ${eservice.instanceLabel}`
-        : "";
-      const oldEserviceName = `${
-        oldName ?? eserviceTemplate.id
-      }${instanceLabelSuffix}`;
-      const newEserviceName = `${eserviceTemplate.name}${instanceLabelSuffix}`;
+      const oldEserviceName = buildEServiceInstanceName({
+        templateName: oldName ?? eserviceTemplate.id,
+        instanceLabel: eservice.instanceLabel,
+      });
+      const newEserviceName = buildEServiceInstanceName({
+        templateName: eserviceTemplate.name,
+        instanceLabel: eservice.instanceLabel,
+      });
       return {
         userId,
         tenantId,

--- a/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameChangedToInstantiator.ts
+++ b/packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameChangedToInstantiator.ts
@@ -70,13 +70,20 @@ export async function handleEserviceTemplateNameChangedToInstantiator(
       const entityId = EServiceIdDescriptorId.parse(
         `${eservice.id}/${retrieveLatestDescriptor(eservice).id}`
       );
-      const instanceLabelSuffix: string = eservice.instanceLabel
+      /**
+       * The instance rename happens asynchronously (eservice-template-instances-updater
+       * -> catalogProcess.internalUpdateTemplateInstanceName), so `eservice.name` may still
+       * hold the old name at this point. Both names are therefore rebuilt from the template
+       * name and the instance label, following the same rule as `buildInstanceName` in
+       * catalog-process (`packages/catalog-process/src/services/catalogService.ts`).
+       */
+      const instanceLabelSuffix = eservice.instanceLabel
         ? ` - ${eservice.instanceLabel}`
         : "";
-      const oldEserviceName: string = `${
+      const oldEserviceName = `${
         oldName ?? eserviceTemplate.id
       }${instanceLabelSuffix}`;
-      const newEserviceName: string = `${eserviceTemplate.name}${instanceLabelSuffix}`;
+      const newEserviceName = `${eserviceTemplate.name}${instanceLabelSuffix}`;
       return {
         userId,
         tenantId,

--- a/packages/in-app-notification-dispatcher/test/handleEserviceTemplateNameChangedToInstantiator.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleEserviceTemplateNameChangedToInstantiator.test.ts
@@ -13,7 +13,6 @@ import {
   EServiceTemplate,
   generateId,
   missingKafkaMessageDataError,
-  NewNotification,
   TenantId,
   toEServiceTemplateV2,
   UserId,
@@ -135,14 +134,10 @@ describe("handleEserviceTemplateNameChangedToInstantiator", async () => {
       readModelService
     );
 
-    const instanceLabelSuffix: string = eservice1.instanceLabel
-      ? ` - ${eservice1.instanceLabel}`
-      : "";
-    const body: string =
-      inAppTemplates.eserviceTemplateNameChangedToInstantiator(
-        `oldName${instanceLabelSuffix}`,
-        `${eserviceTemplate.name}${instanceLabelSuffix}`
-      );
+    const body = inAppTemplates.eserviceTemplateNameChangedToInstantiator(
+      `oldName - ${eservice1.instanceLabel}`,
+      `${eserviceTemplate.name} - ${eservice1.instanceLabel}`
+    );
 
     const expectedNotifications = users.flatMap((user) => [
       {
@@ -168,14 +163,14 @@ describe("handleEserviceTemplateNameChangedToInstantiator", async () => {
   });
 
   it("should include the instance label in the old and new e-service names", async () => {
-    const oldTemplateName: string = "eservice-template-807838540-0";
-    const newTemplateName: string = "eservice-template-807838540-1";
-    const instanceLabel: string = "istanza";
+    const oldTemplateName = "eservice-template-807838540-0";
+    const newTemplateName = "eservice-template-807838540-1";
+    const instanceLabel = "istanza";
     const renamedTemplate: EServiceTemplate = {
       ...getMockEServiceTemplate(),
       name: newTemplateName,
     };
-    const producerId: TenantId = generateId<TenantId>();
+    const producerId = generateId<TenantId>();
     const instance: EService = {
       ...getMockEService(
         generateId<EServiceId>(),
@@ -186,25 +181,62 @@ describe("handleEserviceTemplateNameChangedToInstantiator", async () => {
       name: `${oldTemplateName} - ${instanceLabel}`,
       instanceLabel,
     };
-    const users: Array<{ userId: UserId; tenantId: TenantId }> = [
-      { userId: generateId<UserId>(), tenantId: producerId },
-    ];
+    const users = [{ userId: generateId<UserId>(), tenantId: producerId }];
     mockGetNotificationRecipients.mockResolvedValue(users);
     readModelService.getEServicesByTemplateId = vi
       .fn()
       .mockResolvedValue([instance]);
 
-    const notifications: NewNotification[] =
-      await handleEserviceTemplateNameChangedToInstantiator(
-        toEServiceTemplateV2(renamedTemplate),
-        oldTemplateName,
-        logger,
-        readModelService
-      );
+    const notifications = await handleEserviceTemplateNameChangedToInstantiator(
+      toEServiceTemplateV2(renamedTemplate),
+      oldTemplateName,
+      logger,
+      readModelService
+    );
 
-    const expectedBody: string =
+    const expectedBody =
       `Ti informiamo che il tuo e-service ${oldTemplateName} - ${instanceLabel} ` +
       `è stato rinominato in ${newTemplateName} - ${instanceLabel} in quanto ` +
+      "è stato modificato il template e-service da cui lo hai generato.";
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.body).toBe(expectedBody);
+  });
+
+  it("should not add any suffix when the instance has no instance label", async () => {
+    const oldTemplateName = "eservice-template-807838540-0";
+    const newTemplateName = "eservice-template-807838540-1";
+    const renamedTemplate: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      name: newTemplateName,
+    };
+    const producerId = generateId<TenantId>();
+    const instance: EService = {
+      ...getMockEService(
+        generateId<EServiceId>(),
+        producerId,
+        [getMockDescriptor(descriptorState.published)],
+        renamedTemplate.id
+      ),
+      name: oldTemplateName,
+      instanceLabel: undefined,
+    };
+    const users = [{ userId: generateId<UserId>(), tenantId: producerId }];
+    mockGetNotificationRecipients.mockResolvedValue(users);
+    readModelService.getEServicesByTemplateId = vi
+      .fn()
+      .mockResolvedValue([instance]);
+
+    const notifications = await handleEserviceTemplateNameChangedToInstantiator(
+      toEServiceTemplateV2(renamedTemplate),
+      oldTemplateName,
+      logger,
+      readModelService
+    );
+
+    const expectedBody =
+      `Ti informiamo che il tuo e-service ${oldTemplateName} ` +
+      `è stato rinominato in ${newTemplateName} in quanto ` +
       "è stato modificato il template e-service da cui lo hai generato.";
 
     expect(notifications).toHaveLength(1);

--- a/packages/in-app-notification-dispatcher/test/handleEserviceTemplateNameChangedToInstantiator.test.ts
+++ b/packages/in-app-notification-dispatcher/test/handleEserviceTemplateNameChangedToInstantiator.test.ts
@@ -8,11 +8,15 @@ import {
 } from "pagopa-interop-commons-test";
 import {
   descriptorState,
+  EService,
   EServiceId,
+  EServiceTemplate,
   generateId,
   missingKafkaMessageDataError,
+  NewNotification,
   TenantId,
   toEServiceTemplateV2,
+  UserId,
 } from "pagopa-interop-models";
 import {
   getNotificationRecipients,
@@ -131,10 +135,14 @@ describe("handleEserviceTemplateNameChangedToInstantiator", async () => {
       readModelService
     );
 
-    const body = inAppTemplates.eserviceTemplateNameChangedToInstantiator(
-      eserviceTemplate,
-      "oldName"
-    );
+    const instanceLabelSuffix: string = eservice1.instanceLabel
+      ? ` - ${eservice1.instanceLabel}`
+      : "";
+    const body: string =
+      inAppTemplates.eserviceTemplateNameChangedToInstantiator(
+        `oldName${instanceLabelSuffix}`,
+        `${eserviceTemplate.name}${instanceLabelSuffix}`
+      );
 
     const expectedNotifications = users.flatMap((user) => [
       {
@@ -157,5 +165,49 @@ describe("handleEserviceTemplateNameChangedToInstantiator", async () => {
     expect(notifications).toEqual(
       expect.arrayContaining(expectedNotifications)
     );
+  });
+
+  it("should include the instance label in the old and new e-service names", async () => {
+    const oldTemplateName: string = "eservice-template-807838540-0";
+    const newTemplateName: string = "eservice-template-807838540-1";
+    const instanceLabel: string = "istanza";
+    const renamedTemplate: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      name: newTemplateName,
+    };
+    const producerId: TenantId = generateId<TenantId>();
+    const instance: EService = {
+      ...getMockEService(
+        generateId<EServiceId>(),
+        producerId,
+        [getMockDescriptor(descriptorState.published)],
+        renamedTemplate.id
+      ),
+      name: `${oldTemplateName} - ${instanceLabel}`,
+      instanceLabel,
+    };
+    const users: Array<{ userId: UserId; tenantId: TenantId }> = [
+      { userId: generateId<UserId>(), tenantId: producerId },
+    ];
+    mockGetNotificationRecipients.mockResolvedValue(users);
+    readModelService.getEServicesByTemplateId = vi
+      .fn()
+      .mockResolvedValue([instance]);
+
+    const notifications: NewNotification[] =
+      await handleEserviceTemplateNameChangedToInstantiator(
+        toEServiceTemplateV2(renamedTemplate),
+        oldTemplateName,
+        logger,
+        readModelService
+      );
+
+    const expectedBody: string =
+      `Ti informiamo che il tuo e-service ${oldTemplateName} - ${instanceLabel} ` +
+      `è stato rinominato in ${newTemplateName} - ${instanceLabel} in quanto ` +
+      "è stato modificato il template e-service da cui lo hai generato.";
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.body).toBe(expectedBody);
   });
 });

--- a/packages/models/src/eservice/eserviceInstanceName.ts
+++ b/packages/models/src/eservice/eserviceInstanceName.ts
@@ -1,0 +1,37 @@
+export const ESERVICE_INSTANCE_NAME_SEPARATOR = " - ";
+
+/**
+ * Normalizes the instance label: empty spaces are removed and an empty string
+ * is treated as undefined.
+ * - instanceLabel: maxLength 12
+ */
+export const parseEServiceInstanceLabel = (
+  instanceLabel: string | undefined
+): string | undefined => {
+  const trimmedInstanceLabel = instanceLabel?.trim();
+  return trimmedInstanceLabel && trimmedInstanceLabel.length > 0
+    ? trimmedInstanceLabel
+    : undefined;
+};
+
+/**
+ * Builds the instance name from the template name and optional instance label.
+ * - templateName: maxLength 45
+ * - separator: 3 characters
+ * - instanceLabel: maxLength 12
+ * - eservice name (result): maxLength 60
+ *
+ * The instance label is normalized with `parseEServiceInstanceLabel`.
+ */
+export const buildEServiceInstanceName = ({
+  templateName,
+  instanceLabel,
+}: {
+  templateName: string;
+  instanceLabel: string | undefined;
+}): string => {
+  const parsedInstanceLabel = parseEServiceInstanceLabel(instanceLabel);
+  return parsedInstanceLabel
+    ? `${templateName}${ESERVICE_INSTANCE_NAME_SEPARATOR}${parsedInstanceLabel}`
+    : templateName;
+};

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -23,6 +23,7 @@ export * from "./email/emailNotificationMessagePayload.js";
 
 export * from "./eservice/eservice.js";
 export * from "./eservice/eserviceEvents.js";
+export * from "./eservice/eserviceInstanceName.js";
 export * from "./eservice/protobufConverterFromV1.js";
 export * from "./eservice/protobufConverterFromV2.js";
 export * from "./eservice/protobufConverterToV2.js";

--- a/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
+++ b/packages/notification-commons/src/templates/inApp/inAppTemplates.ts
@@ -1,5 +1,5 @@
 import { dateAtRomeZone } from "pagopa-interop-commons";
-import { EService, EServiceTemplate } from "pagopa-interop-models";
+import { EService } from "pagopa-interop-models";
 import { match } from "ts-pattern";
 
 export type DelegationApprovedRejectedToDelegatorEventType =
@@ -282,14 +282,10 @@ export const inAppTemplates = {
   ): string =>
     `L'ente ${creatorName} ha pubblicato una nuova versione ${eserviceTemplateVersion} del template "${eserviceTemplateName}".`,
   eserviceTemplateNameChangedToInstantiator: (
-    eserviceTemplate: EServiceTemplate,
-    oldName: string | undefined
+    oldEserviceName: string,
+    newEserviceName: string
   ): string =>
-    `Ti informiamo che il tuo e-service ${
-      oldName ?? eserviceTemplate.id
-    } è stato rinominato in ${
-      eserviceTemplate.name
-    } in quanto è stato modificato il template e-service da cui lo hai generato.`,
+    `Ti informiamo che il tuo e-service ${oldEserviceName} è stato rinominato in ${newEserviceName} in quanto è stato modificato il template e-service da cui lo hai generato.`,
   eserviceTemplateStatusChangedToInstantiator: (
     eserviceTemplateName: string,
     creatorName: string


### PR DESCRIPTION
## Jira Issue
[PIN-10729](https://pagopa.atlassian.net/browse/PIN-10729)

## Context
- An e-service instance name is derived from its template as `<templateName> - <instanceLabel>`, but the rule was hand-written in four independent places: if one drifts from the others, notifications announce e-service names that do not exist in the catalog, and the name conflict check on rename stops matching the name the catalog actually stores. No test would catch it.
- This branch is stacked on `bugfix/PIN-10610_include-instance-label-in-notification` (PR #3663) and contains its three commits: it must be merged after PIN-10610.

## Services Affected
- models
- catalog-process
- eservice-template-process
- in-app-notification-dispatcher
- email-notification-dispatcher

## Key Changes
- `packages/models/src/eservice/eserviceInstanceName.ts`: new, exports `ESERVICE_INSTANCE_NAME_SEPARATOR`, `parseEServiceInstanceLabel` and `buildEServiceInstanceName`.
- `packages/models/src/index.ts`: exports the new module.
- `packages/catalog-process/src/services/catalogService.ts`: private `buildInstanceName` removed, its four call sites now use the shared helper.
- `packages/eservice-template-process/src/services/readModelServiceSQL.ts`: `hasInstanceNameConflicts` interpolates the separator constant instead of the `' - '` literal.
- `packages/in-app-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameChangedToInstantiator.ts`: builds both names through the helper, and therefore normalizes the instance label the same way catalog-process already did.
- `packages/email-notification-dispatcher/src/handlers/eserviceTemplates/handleEserviceTemplateNameUpdated.ts`: same name composition for the email notification.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [x] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)


[PIN-10729]: https://pagopa.atlassian.net/browse/PIN-10729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ