### PR TITLE
PIN-10734 Fix async template instance descriptor inheritance

### DIFF
--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -924,6 +924,29 @@ function createNextDescriptor(
   };
 }
 
+async function cloneDocumentForNewDescriptor(
+  document: Document,
+  fileManager: FileManager,
+  logger: Logger
+): Promise<Document> {
+  const clonedDocumentId = generateId<EServiceDocumentId>();
+  const clonedDocumentPath = await fileManager.copy(
+    config.s3Bucket,
+    document.path,
+    config.eserviceDocumentsPath,
+    clonedDocumentId,
+    document.name,
+    logger
+  );
+
+  return {
+    ...document,
+    id: clonedDocumentId,
+    path: clonedDocumentPath,
+    uploadDate: new Date(),
+  };
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function catalogServiceBuilder(
   dbInstance: DB,
@@ -3928,19 +3951,39 @@ export function catalogServiceBuilder(
         })
       );
 
-      const newDescriptor: Descriptor = createNextDescriptor(eservice.data, {
-        description: lastVersion.description,
-        voucherLifespan: lastVersion.voucherLifespan,
-        audience: [],
-        dailyCallsPerConsumer:
-          lastVersion.dailyCallsPerConsumer ?? DEFAULT_DAILY_CALLS_PER_CONSUMER,
-        dailyCallsTotal:
-          lastVersion.dailyCallsTotal ?? DEFAULT_DAILY_CALLS_TOTAL,
-        agreementApprovalPolicy: lastVersion.agreementApprovalPolicy,
-        attributes: lastVersion.attributes,
-        docs,
-        templateVersionId: lastVersion.id,
-      });
+      const asyncExchangeEnabled =
+        isFeatureFlagEnabled(config, "featureFlagAsyncExchange") &&
+        eservice.data.asyncExchange === true;
+
+      const clonedAsyncExchangeCallbackInterface =
+        asyncExchangeEnabled && lastVersion.asyncExchangeCallbackInterface
+          ? await cloneDocumentForNewDescriptor(
+              lastVersion.asyncExchangeCallbackInterface,
+              fileManager,
+              logger
+            )
+          : undefined;
+
+      const newDescriptor: Descriptor = {
+        ...createNextDescriptor(eservice.data, {
+          description: lastVersion.description,
+          voucherLifespan: lastVersion.voucherLifespan,
+          audience: [],
+          dailyCallsPerConsumer:
+            lastVersion.dailyCallsPerConsumer ??
+            DEFAULT_DAILY_CALLS_PER_CONSUMER,
+          dailyCallsTotal:
+            lastVersion.dailyCallsTotal ?? DEFAULT_DAILY_CALLS_TOTAL,
+          agreementApprovalPolicy: lastVersion.agreementApprovalPolicy,
+          attributes: lastVersion.attributes,
+          docs,
+          templateVersionId: lastVersion.id,
+          asyncExchangeProperties: asyncExchangeEnabled
+            ? lastVersion.asyncExchangeProperties
+            : undefined,
+        }),
+        asyncExchangeCallbackInterface: clonedAsyncExchangeCallbackInterface,
+      };
 
       const upgradedEService: EService = {
         ...eservice.data,
@@ -4285,6 +4328,27 @@ export function catalogServiceBuilder(
 
       assertConsistentDailyCalls(eserviceInstanceDescriptorSeed);
 
+      const asyncExchangeEnabled =
+        isFeatureFlagEnabled(config, "featureFlagAsyncExchange") &&
+        eservice.data.asyncExchange === true;
+
+      const asyncExchangeProperties =
+        asyncExchangeEnabled && templateVersion.asyncExchangeProperties
+          ? {
+              ...templateVersion.asyncExchangeProperties,
+              responseTime:
+                latestDescriptor.asyncExchangeProperties?.responseTime ??
+                templateVersion.asyncExchangeProperties.responseTime,
+              resourceAvailableTime:
+                latestDescriptor.asyncExchangeProperties
+                  ?.resourceAvailableTime ??
+                templateVersion.asyncExchangeProperties.resourceAvailableTime,
+              maxResultSet:
+                latestDescriptor.asyncExchangeProperties?.maxResultSet ??
+                templateVersion.asyncExchangeProperties.maxResultSet,
+            }
+          : undefined;
+
       const newDescriptor: Descriptor = createNextDescriptor(eservice.data, {
         description: templateVersion.description,
         voucherLifespan: templateVersion.voucherLifespan,
@@ -4299,6 +4363,7 @@ export function catalogServiceBuilder(
         docs: [],
         attributes: templateVersion.attributes,
         templateVersionId: templateVersion.id,
+        asyncExchangeProperties,
       });
 
       const eserviceVersion = eservice.metadata.version;
@@ -4315,17 +4380,33 @@ export function catalogServiceBuilder(
         ctx.correlationId
       );
 
-      const { updatedDescriptor, events } = await templateVersion.docs.reduce(
+      const documentsToClone = [
+        ...templateVersion.docs.map((document) => ({
+          document,
+          kind: "DOCUMENT" as const,
+        })),
+        ...(asyncExchangeEnabled &&
+        templateVersion.asyncExchangeCallbackInterface
+          ? [
+              {
+                document: templateVersion.asyncExchangeCallbackInterface,
+                kind: "ASYNC_EXCHANGE_CALLBACK_INTERFACE" as const,
+              },
+            ]
+          : []),
+      ];
+
+      const { updatedDescriptor, events } = await documentsToClone.reduce(
         async (accPromise, doc, index) => {
           const acc = await accPromise;
 
           const clonedDocumentId = generateId<EServiceDocumentId>();
           const clonedDocumentPath = await fileManager.copy(
             config.s3Bucket,
-            doc.path,
+            doc.document.path,
             config.eserviceDocumentsPath,
             clonedDocumentId,
-            doc.name,
+            doc.document.name,
             ctx.logger
           );
 
@@ -4335,12 +4416,12 @@ export function catalogServiceBuilder(
               acc.updatedDescriptor.id,
               {
                 documentId: clonedDocumentId,
-                kind: "DOCUMENT",
-                prettyName: doc.prettyName,
+                kind: doc.kind,
+                prettyName: doc.document.prettyName,
                 filePath: clonedDocumentPath,
-                fileName: doc.name,
-                contentType: doc.contentType,
-                checksum: doc.checksum,
+                fileName: doc.document.name,
+                contentType: doc.document.contentType,
+                checksum: doc.document.checksum,
                 serverUrls: [],
               },
               ctx

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -924,7 +924,7 @@ function createNextDescriptor(
   };
 }
 
-async function cloneDocument(
+async function cloneDocumentWithNewId(
   document: Document,
   fileManager: FileManager,
   logger: Logger
@@ -2215,12 +2215,16 @@ export function catalogServiceBuilder(
       const descriptor = retrieveDescriptor(descriptorId, eservice);
 
       const clonedInterfaceDocument = descriptor.interface
-        ? await cloneDocument(descriptor.interface, fileManager, logger)
+        ? await cloneDocumentWithNewId(
+            descriptor.interface,
+            fileManager,
+            logger
+          )
         : undefined;
 
       const clonedAsyncExchangeCallbackInterfaceDocument =
         descriptor.asyncExchangeCallbackInterface
-          ? await cloneDocument(
+          ? await cloneDocumentWithNewId(
               descriptor.asyncExchangeCallbackInterface,
               fileManager,
               logger
@@ -2228,7 +2232,9 @@ export function catalogServiceBuilder(
           : undefined;
 
       const clonedDocuments = await Promise.all(
-        descriptor.docs.map((doc) => cloneDocument(doc, fileManager, logger))
+        descriptor.docs.map((doc) =>
+          cloneDocumentWithNewId(doc, fileManager, logger)
+        )
       );
 
       const clonedEservice: EService = {
@@ -3864,7 +3870,9 @@ export function catalogServiceBuilder(
       }
 
       const docs = await Promise.all(
-        lastVersion.docs.map((doc) => cloneDocument(doc, fileManager, logger))
+        lastVersion.docs.map((doc) =>
+          cloneDocumentWithNewId(doc, fileManager, logger)
+        )
       );
 
       const asyncExchangeEnabled =
@@ -3873,7 +3881,7 @@ export function catalogServiceBuilder(
 
       const clonedAsyncExchangeCallbackInterface =
         asyncExchangeEnabled && lastVersion.asyncExchangeCallbackInterface
-          ? await cloneDocument(
+          ? await cloneDocumentWithNewId(
               lastVersion.asyncExchangeCallbackInterface,
               fileManager,
               logger
@@ -4267,7 +4275,7 @@ export function catalogServiceBuilder(
 
       const clonedAsyncExchangeCallbackInterface =
         asyncExchangeEnabled && templateVersion.asyncExchangeCallbackInterface
-          ? await cloneDocument(
+          ? await cloneDocumentWithNewId(
               templateVersion.asyncExchangeCallbackInterface,
               fileManager,
               ctx.logger

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -4265,22 +4265,34 @@ export function catalogServiceBuilder(
             }
           : undefined;
 
-      const newDescriptor: Descriptor = createNextDescriptor(eservice.data, {
-        description: templateVersion.description,
-        voucherLifespan: templateVersion.voucherLifespan,
-        audience: eserviceInstanceDescriptorSeed.audience,
-        dailyCallsPerConsumer:
-          eserviceInstanceDescriptorSeed.dailyCallsPerConsumer,
-        dailyCallsTotal: eserviceInstanceDescriptorSeed.dailyCallsTotal,
-        agreementApprovalPolicy:
-          agreementApprovalPolicySeed ??
-          templateVersion.agreementApprovalPolicy ??
-          agreementApprovalPolicy.automatic,
-        docs: [],
-        attributes: templateVersion.attributes,
-        templateVersionId: templateVersion.id,
-        asyncExchangeProperties,
-      });
+      const clonedAsyncExchangeCallbackInterface =
+        asyncExchangeEnabled && templateVersion.asyncExchangeCallbackInterface
+          ? await cloneDocument(
+              templateVersion.asyncExchangeCallbackInterface,
+              fileManager,
+              ctx.logger
+            )
+          : undefined;
+
+      const newDescriptor: Descriptor = {
+        ...createNextDescriptor(eservice.data, {
+          description: templateVersion.description,
+          voucherLifespan: templateVersion.voucherLifespan,
+          audience: eserviceInstanceDescriptorSeed.audience,
+          dailyCallsPerConsumer:
+            eserviceInstanceDescriptorSeed.dailyCallsPerConsumer,
+          dailyCallsTotal: eserviceInstanceDescriptorSeed.dailyCallsTotal,
+          agreementApprovalPolicy:
+            agreementApprovalPolicySeed ??
+            templateVersion.agreementApprovalPolicy ??
+            agreementApprovalPolicy.automatic,
+          docs: [],
+          attributes: templateVersion.attributes,
+          templateVersionId: templateVersion.id,
+          asyncExchangeProperties,
+        }),
+        asyncExchangeCallbackInterface: clonedAsyncExchangeCallbackInterface,
+      };
 
       const eserviceVersion = eservice.metadata.version;
 
@@ -4296,33 +4308,17 @@ export function catalogServiceBuilder(
         ctx.correlationId
       );
 
-      const documentsToClone = [
-        ...templateVersion.docs.map((document) => ({
-          document,
-          kind: "DOCUMENT" as const,
-        })),
-        ...(asyncExchangeEnabled &&
-        templateVersion.asyncExchangeCallbackInterface
-          ? [
-              {
-                document: templateVersion.asyncExchangeCallbackInterface,
-                kind: "ASYNC_EXCHANGE_CALLBACK_INTERFACE" as const,
-              },
-            ]
-          : []),
-      ];
-
-      const { updatedDescriptor, events } = await documentsToClone.reduce(
+      const { updatedDescriptor, events } = await templateVersion.docs.reduce(
         async (accPromise, doc, index) => {
           const acc = await accPromise;
 
           const clonedDocumentId = generateId<EServiceDocumentId>();
           const clonedDocumentPath = await fileManager.copy(
             config.s3Bucket,
-            doc.document.path,
+            doc.path,
             config.eserviceDocumentsPath,
             clonedDocumentId,
-            doc.document.name,
+            doc.name,
             ctx.logger
           );
 
@@ -4332,12 +4328,12 @@ export function catalogServiceBuilder(
               acc.updatedDescriptor.id,
               {
                 documentId: clonedDocumentId,
-                kind: doc.kind,
-                prettyName: doc.document.prettyName,
+                kind: "DOCUMENT",
+                prettyName: doc.prettyName,
                 filePath: clonedDocumentPath,
-                fileName: doc.document.name,
-                contentType: doc.document.contentType,
-                checksum: doc.document.checksum,
+                fileName: doc.name,
+                contentType: doc.contentType,
+                checksum: doc.checksum,
                 serverUrls: [],
               },
               ctx

--- a/packages/catalog-process/src/services/catalogService.ts
+++ b/packages/catalog-process/src/services/catalogService.ts
@@ -924,7 +924,7 @@ function createNextDescriptor(
   };
 }
 
-async function cloneDocumentForNewDescriptor(
+async function cloneDocument(
   document: Document,
   fileManager: FileManager,
   logger: Logger
@@ -2214,83 +2214,21 @@ export function catalogServiceBuilder(
 
       const descriptor = retrieveDescriptor(descriptorId, eservice);
 
-      const clonedInterfaceId = generateId<EServiceDocumentId>();
-      const clonedInterfacePath =
-        descriptor.interface !== undefined
-          ? await fileManager.copy(
-              config.s3Bucket,
-              descriptor.interface.path,
-              config.eserviceDocumentsPath,
-              clonedInterfaceId,
-              descriptor.interface.name,
+      const clonedInterfaceDocument = descriptor.interface
+        ? await cloneDocument(descriptor.interface, fileManager, logger)
+        : undefined;
+
+      const clonedAsyncExchangeCallbackInterfaceDocument =
+        descriptor.asyncExchangeCallbackInterface
+          ? await cloneDocument(
+              descriptor.asyncExchangeCallbackInterface,
+              fileManager,
               logger
             )
-          : undefined;
-
-      const clonedInterfaceDocument: Document | undefined =
-        descriptor.interface !== undefined && clonedInterfacePath !== undefined
-          ? {
-              id: clonedInterfaceId,
-              name: descriptor.interface.name,
-              contentType: descriptor.interface.contentType,
-              prettyName: descriptor.interface.prettyName,
-              path: clonedInterfacePath,
-              checksum: descriptor.interface.checksum,
-              uploadDate: new Date(),
-            }
-          : undefined;
-
-      const clonedAsyncExchangeCallbackInterfaceId =
-        generateId<EServiceDocumentId>();
-      const clonedAsyncExchangeCallbackInterfacePath =
-        descriptor.asyncExchangeCallbackInterface !== undefined
-          ? await fileManager.copy(
-              config.s3Bucket,
-              descriptor.asyncExchangeCallbackInterface.path,
-              config.eserviceDocumentsPath,
-              clonedAsyncExchangeCallbackInterfaceId,
-              descriptor.asyncExchangeCallbackInterface.name,
-              logger
-            )
-          : undefined;
-
-      const clonedAsyncExchangeCallbackInterfaceDocument: Document | undefined =
-        descriptor.asyncExchangeCallbackInterface !== undefined &&
-        clonedAsyncExchangeCallbackInterfacePath !== undefined
-          ? {
-              id: clonedAsyncExchangeCallbackInterfaceId,
-              name: descriptor.asyncExchangeCallbackInterface.name,
-              contentType:
-                descriptor.asyncExchangeCallbackInterface.contentType,
-              prettyName: descriptor.asyncExchangeCallbackInterface.prettyName,
-              path: clonedAsyncExchangeCallbackInterfacePath,
-              checksum: descriptor.asyncExchangeCallbackInterface.checksum,
-              uploadDate: new Date(),
-            }
           : undefined;
 
       const clonedDocuments = await Promise.all(
-        descriptor.docs.map(async (doc: Document) => {
-          const clonedDocumentId = generateId<EServiceDocumentId>();
-          const clonedDocumentPath = await fileManager.copy(
-            config.s3Bucket,
-            doc.path,
-            config.eserviceDocumentsPath,
-            clonedDocumentId,
-            doc.name,
-            logger
-          );
-          const clonedDocument: Document = {
-            id: clonedDocumentId,
-            name: doc.name,
-            contentType: doc.contentType,
-            prettyName: doc.prettyName,
-            path: clonedDocumentPath,
-            checksum: doc.checksum,
-            uploadDate: new Date(),
-          };
-          return clonedDocument;
-        })
+        descriptor.docs.map((doc) => cloneDocument(doc, fileManager, logger))
       );
 
       const clonedEservice: EService = {
@@ -3926,29 +3864,7 @@ export function catalogServiceBuilder(
       }
 
       const docs = await Promise.all(
-        // eslint-disable-next-line sonarjs/no-identical-functions
-        lastVersion.docs.map(async (doc) => {
-          const clonedDocumentId = generateId<EServiceDocumentId>();
-          const clonedDocumentPath = await fileManager.copy(
-            config.s3Bucket,
-            doc.path,
-            config.eserviceDocumentsPath,
-            clonedDocumentId,
-            doc.name,
-            logger
-          );
-          const clonedDocument: Document = {
-            id: clonedDocumentId,
-            name: doc.name,
-            contentType: doc.contentType,
-            prettyName: doc.prettyName,
-            path: clonedDocumentPath,
-            checksum: doc.checksum,
-            uploadDate: new Date(),
-          };
-
-          return clonedDocument;
-        })
+        lastVersion.docs.map((doc) => cloneDocument(doc, fileManager, logger))
       );
 
       const asyncExchangeEnabled =
@@ -3957,7 +3873,7 @@ export function catalogServiceBuilder(
 
       const clonedAsyncExchangeCallbackInterface =
         asyncExchangeEnabled && lastVersion.asyncExchangeCallbackInterface
-          ? await cloneDocumentForNewDescriptor(
+          ? await cloneDocument(
               lastVersion.asyncExchangeCallbackInterface,
               fileManager,
               logger

--- a/packages/catalog-process/test/integration/createTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/createTemplateInstanceDescriptor.test.ts
@@ -160,6 +160,7 @@ describe("create descriptor", async () => {
     const templateVersion: EServiceTemplateVersion = {
       ...getMockEServiceTemplateVersion(),
       state: eserviceTemplateVersionState.published,
+      docs: [],
       asyncExchangeProperties: {
         responseTime: 300,
         resourceAvailableTime: 600,
@@ -248,9 +249,16 @@ describe("create descriptor", async () => {
 
     const writtenEvent = await readLastEserviceEvent(eservice.id);
     expect(writtenEvent).toMatchObject({
-      type: "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded",
+      type: "EServiceDescriptorAdded",
       event_version: 2,
     });
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorAddedV2,
+      payload: writtenEvent.data,
+    });
+    expect(
+      writtenPayload.eservice?.descriptors[1].asyncExchangeCallbackInterface
+    ).toBeDefined();
   });
 
   it("should write on event-store for the creation of a descriptor of a instance e-service (delegate)", async () => {

--- a/packages/catalog-process/test/integration/createTemplateInstanceDescriptor.test.ts
+++ b/packages/catalog-process/test/integration/createTemplateInstanceDescriptor.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { catalogApi } from "pagopa-interop-api-clients";
+import { genericLogger } from "pagopa-interop-commons";
 import {
   decodeProtobufPayload,
   getMockContext,
@@ -24,9 +25,13 @@ import {
   EServiceTemplateVersion,
   EServiceTemplate,
   eserviceTemplateVersionState,
+  Document,
+  EServiceDocumentId,
+  generateId,
 } from "pagopa-interop-models";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
+import { config } from "../../src/config/config.js";
 import {
   draftDescriptorAlreadyExists,
   eServiceNotFound,
@@ -37,6 +42,7 @@ import {
   addOneEService,
   addOneEServiceTemplate,
   catalogService,
+  fileManager,
   readLastEserviceEvent,
 } from "../integrationUtils.js";
 
@@ -137,6 +143,113 @@ describe("create descriptor", async () => {
         ...eservice,
         descriptors: [prevDescriptor, returnedDescriptor],
       }),
+    });
+  });
+
+  it("should inherit async exchange fields and callback when creating a new descriptor for a template instance", async () => {
+    vi.spyOn(fileManager, "copy");
+
+    const callbackDocumentId = generateId<EServiceDocumentId>();
+    const callbackDocument: Document = {
+      ...getMockDocument(),
+      id: callbackDocumentId,
+      name: "callback.yaml",
+      prettyName: "Callback interface",
+      path: `${config.eserviceDocumentsPath}/${callbackDocumentId}/callback.yaml`,
+    };
+    const templateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      state: eserviceTemplateVersionState.published,
+      asyncExchangeProperties: {
+        responseTime: 300,
+        resourceAvailableTime: 600,
+        confirmation: true,
+        bulk: false,
+        maxResultSet: 100,
+      },
+      asyncExchangeCallbackInterface: callbackDocument,
+    };
+    const template: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      versions: [templateVersion],
+      asyncExchange: true,
+    };
+    const previousDescriptor: Descriptor = {
+      ...getMockDescriptor(),
+      version: "1",
+      state: descriptorState.published,
+      templateVersionRef: {
+        id: templateVersion.id,
+      },
+      asyncExchangeProperties: {
+        responseTime: 900,
+        resourceAvailableTime: 1200,
+        confirmation: false,
+        bulk: true,
+        maxResultSet: 200,
+      },
+    };
+    const eservice: EService = {
+      ...getMockEService(),
+      descriptors: [previousDescriptor],
+      templateId: template.id,
+      asyncExchange: true,
+    };
+
+    await addOneEServiceTemplate(template);
+    await addOneEService(eservice);
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.eserviceDocumentsPath,
+        resourceId: callbackDocument.id,
+        name: callbackDocument.name,
+        content: Buffer.from("callback-content"),
+      },
+      genericLogger
+    );
+
+    const returnedDescriptor =
+      await catalogService.createTemplateInstanceDescriptor(
+        eservice.id,
+        {
+          audience: [],
+          dailyCallsPerConsumer: 60,
+          dailyCallsTotal: 600,
+        },
+        getMockContext({ authData: getMockAuthData(eservice.producerId) })
+      );
+
+    expect(returnedDescriptor.asyncExchangeProperties).toEqual({
+      responseTime: 900,
+      resourceAvailableTime: 1200,
+      confirmation: true,
+      bulk: false,
+      maxResultSet: 200,
+    });
+    expect(returnedDescriptor.asyncExchangeCallbackInterface).toMatchObject({
+      name: callbackDocument.name,
+      prettyName: callbackDocument.prettyName,
+      contentType: callbackDocument.contentType,
+      checksum: callbackDocument.checksum,
+    });
+    expect(returnedDescriptor.asyncExchangeCallbackInterface?.id).not.toBe(
+      callbackDocument.id
+    );
+
+    expect(fileManager.copy).toHaveBeenCalledWith(
+      config.s3Bucket,
+      callbackDocument.path,
+      config.eserviceDocumentsPath,
+      returnedDescriptor.asyncExchangeCallbackInterface?.id,
+      callbackDocument.name,
+      genericLogger
+    );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    expect(writtenEvent).toMatchObject({
+      type: "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded",
+      event_version: 2,
     });
   });
 

--- a/packages/catalog-process/test/integration/upgradeEserviceTemplateInstance.test.ts
+++ b/packages/catalog-process/test/integration/upgradeEserviceTemplateInstance.test.ts
@@ -240,6 +240,111 @@ describe("upgrade eservice template instance", () => {
       await fileManager.listFiles(config.s3Bucket, genericLogger)
     ).toContain(expectedDocument2.path);
   });
+
+  it("should inherit async exchange fields and callback when upgrading a template instance", async () => {
+    vi.spyOn(fileManager, "copy");
+
+    const callbackDocumentId = generateId<EServiceDocumentId>();
+    const callbackDocument: Document = {
+      ...getMockDocument(),
+      id: callbackDocumentId,
+      name: "callback.yaml",
+      prettyName: "Callback interface",
+      path: `${config.eserviceDocumentsPath}/${callbackDocumentId}/callback.yaml`,
+    };
+    const firstTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      version: 1,
+      state: descriptorState.deprecated,
+    };
+    const secondTemplateVersion: EServiceTemplateVersion = {
+      ...getMockEServiceTemplateVersion(),
+      version: 2,
+      state: descriptorState.published,
+      asyncExchangeProperties: {
+        responseTime: 300,
+        resourceAvailableTime: 600,
+        confirmation: true,
+        bulk: false,
+        maxResultSet: 100,
+      },
+      asyncExchangeCallbackInterface: callbackDocument,
+    };
+    const template: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      versions: [firstTemplateVersion, secondTemplateVersion],
+      asyncExchange: true,
+    };
+    const eservice: EService = {
+      ...mockEService,
+      templateId: template.id,
+      asyncExchange: true,
+      descriptors: [
+        {
+          ...mockDescriptor,
+          templateVersionRef: { id: firstTemplateVersion.id },
+          version: "1",
+          state: descriptorState.published,
+          asyncExchangeProperties: {
+            responseTime: 900,
+            resourceAvailableTime: 1200,
+            confirmation: false,
+            bulk: true,
+            maxResultSet: 200,
+          },
+        },
+      ],
+    };
+
+    await addOneEServiceTemplate(template);
+    await addOneEService(eservice);
+    await fileManager.storeBytes(
+      {
+        bucket: config.s3Bucket,
+        path: config.eserviceDocumentsPath,
+        resourceId: callbackDocument.id,
+        name: callbackDocument.name,
+        content: Buffer.from("callback-content"),
+      },
+      genericLogger
+    );
+
+    const returnedDescriptor = await catalogService.upgradeEServiceInstance(
+      eservice.id,
+      getMockContext({ authData: getMockAuthData(eservice.producerId) })
+    );
+
+    expect(returnedDescriptor.asyncExchangeProperties).toEqual(
+      secondTemplateVersion.asyncExchangeProperties
+    );
+    expect(returnedDescriptor.asyncExchangeCallbackInterface).toMatchObject({
+      name: callbackDocument.name,
+      prettyName: callbackDocument.prettyName,
+      contentType: callbackDocument.contentType,
+      checksum: callbackDocument.checksum,
+    });
+    expect(returnedDescriptor.asyncExchangeCallbackInterface?.id).not.toBe(
+      callbackDocument.id
+    );
+    expect(fileManager.copy).toHaveBeenCalledWith(
+      config.s3Bucket,
+      callbackDocument.path,
+      config.eserviceDocumentsPath,
+      returnedDescriptor.asyncExchangeCallbackInterface?.id,
+      callbackDocument.name,
+      genericLogger
+    );
+
+    const writtenEvent = await readLastEserviceEvent(eservice.id);
+    const writtenPayload = decodeProtobufPayload({
+      messageType: EServiceDescriptorAddedV2,
+      payload: writtenEvent.data,
+    });
+    expect(
+      writtenPayload.eservice?.descriptors[1].asyncExchangeCallbackInterface
+    ).toBeDefined();
+  });
+
   it("should write on event-store for the upgrading of a eservice template instance, and clone the template version docs (producer delegate)", async () => {
     vi.spyOn(fileManager, "copy");
 


### PR DESCRIPTION
## Summary

- inherit asynchronous exchange properties when creating a new descriptor for an e-service template instance
- preserve instance-editable values while restoring template-owned `confirmation` and `bulk` values
- clone the asynchronous callback interface for both same-template descriptor creation and template-version upgrades
- add integration coverage for both flows

## Root cause

The template-instance descriptor creation paths populated standard descriptor fields and documents but omitted `asyncExchangeProperties` and `asyncExchangeCallbackInterface`. The resulting draft could not be published because the callback and required asynchronous exchange settings were missing, while template instances are not allowed to replace template-owned fields.

## Behavior

When creating another descriptor from the same template version:

- `responseTime`, `resourceAvailableTime`, and `maxResultSet` are preserved from the previous instance descriptor
- `confirmation` and `bulk` are inherited from the template version
- the callback interface is cloned with a new document ID and the dedicated callback-interface event is emitted

When upgrading an instance to a newer template version:

- asynchronous exchange properties are initialized from the new template version
- the new template callback interface is cloned into the draft descriptor
- instance-editable fields remain configurable through the existing draft update endpoint

## Validation

- `pnpm run build` in `packages/catalog-process`
- `pnpm run check` in `packages/catalog-process`
- ESLint on the changed service and integration tests
- targeted integration tests: 29 passed

Jira: [PIN-10734](https://pagopa.atlassian.net/browse/PIN-10734)


[PIN-10734]: https://pagopa.atlassian.net/browse/PIN-10734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ