### PR TITLE
fix(PIN-9430): add reviewer staging table on startup domains-analytics-writer

### DIFF
--- a/packages/domains-analytics-writer/src/index.ts
+++ b/packages/domains-analytics-writer/src/index.ts
@@ -77,6 +77,7 @@ await retryConnection(
       PurposeDbTable.purpose_risk_analysis_form,
       PurposeDbTable.purpose_risk_analysis_answer,
       PurposeDbTable.purpose_version_signed_document,
+      PurposeDbTable.purpose_risk_analysis_reviewer,
       ClientDbTable.client,
       ClientDbTable.client_purpose,
       ClientDbTable.client_user,


### PR DESCRIPTION
## Jira Issue
[PIN-9430](https://pagopa.atlassian.net/browse/PIN-9430)

## Context/Why
- Align startup staging table setup with the existing `purpose_risk_analysis_reviewer` flow.

## Services Impacted
- domains-analytics-writer

## Key Changes
- Add missing table `purpose_risk_analysis_reviewer` to startup staging tables.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [x] Service labels applied

[PIN-9430]: https://pagopa.atlassian.net/browse/PIN-9430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ