### PR TITLE
fix(PIN-10741): increase template version ref url fields length domains-analytics-db

### DIFF
--- a/docker/domains-analytics-db/domains-init.sql
+++ b/docker/domains-analytics-db/domains-init.sql
@@ -78,8 +78,8 @@ CREATE TABLE domains.eservice_descriptor_template_version_ref (
   descriptor_id VARCHAR(36) NOT NULL REFERENCES domains.eservice_descriptor (id),
   contact_name VARCHAR(2048),
   contact_email VARCHAR(2048),
-  contact_url VARCHAR(2048),
-  terms_and_conditions_url VARCHAR(2048),
+  contact_url VARCHAR(65535),
+  terms_and_conditions_url VARCHAR(65535),
   deleted BOOLEAN,
   PRIMARY KEY (eservice_template_version_id, descriptor_id),
   FOREIGN KEY (eservice_id) REFERENCES domains.eservice (id)


### PR DESCRIPTION
## Jira Issue
[PIN-10741](https://pagopa.atlassian.net/browse/PIN-10741)

## Context/Why
- `contact_url` and `terms_and_conditions_url` in `domains-init.sql` can exceed the current `VARCHAR(2048)` limit.
- This cause db writes to fail with `value too long for type character varying(2048)`.

## Services Impacted
- domains-analytics-db

## Key Changes
- Increase `contact_url` and `terms_and_conditions_url` length to `VARCHAR(65535)`.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [x] Service labels applied

[PIN-10741]: https://pagopa.atlassian.net/browse/PIN-10741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ