### PR TITLE
fix(PIN-10750): align client key relationship migration staging domains

### DIFF
--- a/packages/domains-analytics-writer/src/repository/client/clientKey.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/clientKey.repository.ts
@@ -59,7 +59,7 @@ export function clientKeyRepository(conn: DBConnection) {
         await t.none(
           generateStagingDeleteQuery(
             tableName,
-            ["clientId", "kid", "userId"],
+            ["clientId", "kid"],
             keyRelationshipTableName
           )
         );
@@ -76,7 +76,7 @@ export function clientKeyRepository(conn: DBConnection) {
           ClientKeyUserMigrationSchema,
           schemaName,
           tableName,
-          ["clientId", "kid", "userId"],
+          ["clientId", "kid"],
           keyRelationshipTableName
         );
         await t.none(mergeQuery);

--- a/packages/domains-analytics-writer/src/repository/client/clientKey.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/client/clientKey.repository.ts
@@ -39,7 +39,7 @@ export function clientKeyRepository(conn: DBConnection) {
   const tableName = ClientDbTable.client_key;
   const keyRelationshipTableName =
     ClientDbTablePartialTable.key_relationship_migrated;
-  const stagingTableName = `${tableName}_${config.mergeTableSuffix}`;
+  const stagingTableName = `${keyRelationshipTableName}_${config.mergeTableSuffix}`;
 
   return {
     ...base,
@@ -76,12 +76,23 @@ export function clientKeyRepository(conn: DBConnection) {
           ClientKeyUserMigrationSchema,
           schemaName,
           tableName,
-          ["clientId", "kid", "userId"]
+          ["clientId", "kid", "userId"],
+          keyRelationshipTableName
         );
         await t.none(mergeQuery);
       } catch (error: unknown) {
         throw genericInternalError(
           `Error merging staging table ${stagingTableName} into ${schemaName}.${tableName}: ${error}`
+        );
+      }
+    },
+
+    async cleanKeyUserMigration(): Promise<void> {
+      try {
+        await conn.none(`TRUNCATE TABLE ${stagingTableName};`);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error cleaning staging table ${stagingTableName}: ${error}`
         );
       }
     },

--- a/packages/domains-analytics-writer/src/service/authorizationService.ts
+++ b/packages/domains-analytics-writer/src/service/authorizationService.ts
@@ -353,7 +353,7 @@ export function authorizationServiceBuilder(db: DBContext) {
         `Staging data merged into target tables for ClientKeyUserMigration`
       );
 
-      await clientKeyRepo.clean();
+      await clientKeyRepo.cleanKeyUserMigration();
 
       genericLogger.info(`Staging table cleaned for ClientKeyUserMigration`);
     },

--- a/packages/domains-analytics-writer/test/authorizationService.test.ts
+++ b/packages/domains-analytics-writer/test/authorizationService.test.ts
@@ -12,6 +12,7 @@ import {
   generateId,
   PurposeId,
   Key,
+  KeyRelationshipToUserMigratedV1,
   AuthorizationEventEnvelopeV2,
   toClientV2,
   ClientV2,
@@ -300,6 +301,47 @@ describe("Authorization messages consumers - handleAuthorizationMessageV1", () =
       }
     );
     expect(purpose).toBeUndefined();
+  });
+
+  it("KeyRelationshipToUserMigrated: updates client key user relationship", async () => {
+    const userId: UserId = generateId<UserId>();
+    const key: Key = { ...getMockKey(), userId: "" as UserId };
+
+    const client = toClientV1({
+      ...mockClient,
+      users: [userId],
+      keys: [key],
+    });
+
+    const payloadAdd: ClientAddedV1 = { client };
+    const payloadMigration: KeyRelationshipToUserMigratedV1 = {
+      clientId: client.id,
+      keyId: key.kid,
+      userId,
+    };
+
+    const addMsg: AuthorizationEventEnvelopeV1 = {
+      ...mockMessage,
+      type: "ClientAdded",
+      data: payloadAdd,
+    };
+
+    const migrationMsg: AuthorizationEventEnvelopeV1 = {
+      ...mockMessage,
+      version: 2,
+      type: "KeyRelationshipToUserMigrated",
+      data: payloadMigration,
+    };
+
+    await handleAuthorizationMessageV1([addMsg, migrationMsg], dbContext);
+
+    const storedKey = await getOneFromDb(dbContext, ClientDbTable.client_key, {
+      clientId: client.id,
+      kid: key.kid,
+    });
+
+    expect(storedKey?.userId).toBe(userId);
+    expect(storedKey?.metadataVersion).toBe(2);
   });
 
   it("ClientAdded: should throw error when client is missing", async () => {

--- a/packages/domains-analytics-writer/test/authorizationService.test.ts
+++ b/packages/domains-analytics-writer/test/authorizationService.test.ts
@@ -8,10 +8,12 @@ import {
   ClientAddedV1,
   AuthorizationEventEnvelopeV1,
   ClientV1,
+  KeysAddedV1,
   UserId,
   generateId,
   PurposeId,
   Key,
+  toKeyV1,
   KeyRelationshipToUserMigratedV1,
   AuthorizationEventEnvelopeV2,
   toClientV2,
@@ -47,6 +49,7 @@ import {
   getOneFromDb,
   clientTables,
   producerKeychainTables,
+  getMockRsaKey,
 } from "./utils.js";
 
 describe("Authorization messages consumers - handleAuthorizationMessageV1", () => {
@@ -305,15 +308,25 @@ describe("Authorization messages consumers - handleAuthorizationMessageV1", () =
 
   it("KeyRelationshipToUserMigrated: updates client key user relationship", async () => {
     const userId: UserId = generateId<UserId>();
-    const key: Key = { ...getMockKey(), userId: "" as UserId };
+    const previousUserId: UserId = generateId<UserId>();
+    const key: Key = getMockRsaKey(previousUserId);
 
     const client = toClientV1({
       ...mockClient,
-      users: [userId],
-      keys: [key],
+      users: [previousUserId, userId],
+      keys: [],
     });
 
     const payloadAdd: ClientAddedV1 = { client };
+    const payloadKeysAdded: KeysAddedV1 = {
+      clientId: client.id,
+      keys: [
+        {
+          keyId: key.kid,
+          value: toKeyV1(key),
+        },
+      ],
+    };
     const payloadMigration: KeyRelationshipToUserMigratedV1 = {
       clientId: client.id,
       keyId: key.kid,
@@ -326,14 +339,24 @@ describe("Authorization messages consumers - handleAuthorizationMessageV1", () =
       data: payloadAdd,
     };
 
-    const migrationMsg: AuthorizationEventEnvelopeV1 = {
+    const keysAddedMsg: AuthorizationEventEnvelopeV1 = {
       ...mockMessage,
       version: 2,
+      type: "KeysAdded",
+      data: payloadKeysAdded,
+    };
+
+    const migrationMsg: AuthorizationEventEnvelopeV1 = {
+      ...mockMessage,
+      version: 3,
       type: "KeyRelationshipToUserMigrated",
       data: payloadMigration,
     };
 
-    await handleAuthorizationMessageV1([addMsg, migrationMsg], dbContext);
+    await handleAuthorizationMessageV1(
+      [addMsg, keysAddedMsg, migrationMsg],
+      dbContext
+    );
 
     const storedKey = await getOneFromDb(dbContext, ClientDbTable.client_key, {
       clientId: client.id,
@@ -341,7 +364,7 @@ describe("Authorization messages consumers - handleAuthorizationMessageV1", () =
     });
 
     expect(storedKey?.userId).toBe(userId);
-    expect(storedKey?.metadataVersion).toBe(2);
+    expect(storedKey?.metadataVersion).toBe(3);
   });
 
   it("ClientAdded: should throw error when client is missing", async () => {

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -1,8 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import camelcaseKeys from "camelcase-keys";
+import crypto from "crypto";
 import { genericLogger } from "pagopa-interop-commons";
-import { setupTestContainersVitest } from "pagopa-interop-commons-test";
+import {
+  getMockKey,
+  setupTestContainersVitest,
+} from "pagopa-interop-commons-test";
+import { Key, UserId } from "pagopa-interop-models";
 import { inject } from "vitest";
 import { z } from "zod";
 
@@ -38,7 +43,7 @@ const { analyticsPostgresDB } = await setupTestContainersVitest(
   undefined,
   undefined,
   undefined,
-  inject("analyticsSQLConfig")
+  inject("analyticsSQLConfig"),
 );
 const connection = await analyticsPostgresDB.connect();
 
@@ -237,18 +242,18 @@ await retryConnection(
     await setupDbService.setupPartialStagingTables(partialTables);
     await setupDbService.setupStagingDeletingTables(setupStagingDeletingTables);
   },
-  genericLogger
+  genericLogger,
 );
 
 export async function resetTargetTables(
-  tables: DomainDbTable[]
+  tables: DomainDbTable[],
 ): Promise<void> {
   await dbContext.conn.none(`TRUNCATE TABLE ${tables.join(",")} CASCADE;`);
 }
 
 export async function getTablesByName(
   db: DBConnection,
-  tables: string[]
+  tables: string[],
 ): Promise<Array<{ tablename: string }>> {
   const query = `
       SELECT tablename
@@ -262,7 +267,7 @@ export async function getTablesByName(
 export async function getOneFromDb<T extends DomainDbTable>(
   db: DBContext,
   tableName: T,
-  where: Partial<z.infer<DomainDbTableSchemas[T]>>
+  where: Partial<z.infer<DomainDbTableSchemas[T]>>,
 ): Promise<z.infer<DomainDbTableSchemas[T]> | undefined> {
   const snakeCaseMapper = getColumnNameMapper(tableName);
 
@@ -274,7 +279,7 @@ export async function getOneFromDb<T extends DomainDbTable>(
 
   const row = await db.conn.oneOrNone(
     `SELECT * FROM ${config.dbSchemaName}.${tableName} WHERE ${clause}`,
-    values
+    values,
   );
 
   return row ? camelcaseKeys(row) : undefined;
@@ -283,7 +288,7 @@ export async function getOneFromDb<T extends DomainDbTable>(
 export async function getManyFromDb<T extends DomainDbTable>(
   db: DBContext,
   tableName: T,
-  where: Partial<z.infer<DomainDbTableSchemas[T]>>
+  where: Partial<z.infer<DomainDbTableSchemas[T]>>,
 ): Promise<Array<z.infer<DomainDbTableSchemas[T]>>> {
   const snakeCaseMapper = getColumnNameMapper(tableName);
 
@@ -295,8 +300,19 @@ export async function getManyFromDb<T extends DomainDbTable>(
 
   const rows = await db.conn.any(
     `SELECT * FROM ${config.dbSchemaName}.${tableName} WHERE ${clause}`,
-    values
+    values,
   );
 
   return rows.map((row) => camelcaseKeys(row));
 }
+
+export const getMockRsaKey = (userId: UserId): Key => {
+  const publicKey = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+  }).publicKey;
+  const encodedPem = Buffer.from(
+    publicKey.export({ type: "pkcs1", format: "pem" }),
+  ).toString("base64url");
+
+  return { ...getMockKey(), encodedPem, userId };
+};

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -43,7 +43,7 @@ const { analyticsPostgresDB } = await setupTestContainersVitest(
   undefined,
   undefined,
   undefined,
-  inject("analyticsSQLConfig"),
+  inject("analyticsSQLConfig")
 );
 const connection = await analyticsPostgresDB.connect();
 
@@ -242,18 +242,18 @@ await retryConnection(
     await setupDbService.setupPartialStagingTables(partialTables);
     await setupDbService.setupStagingDeletingTables(setupStagingDeletingTables);
   },
-  genericLogger,
+  genericLogger
 );
 
 export async function resetTargetTables(
-  tables: DomainDbTable[],
+  tables: DomainDbTable[]
 ): Promise<void> {
   await dbContext.conn.none(`TRUNCATE TABLE ${tables.join(",")} CASCADE;`);
 }
 
 export async function getTablesByName(
   db: DBConnection,
-  tables: string[],
+  tables: string[]
 ): Promise<Array<{ tablename: string }>> {
   const query = `
       SELECT tablename
@@ -267,7 +267,7 @@ export async function getTablesByName(
 export async function getOneFromDb<T extends DomainDbTable>(
   db: DBContext,
   tableName: T,
-  where: Partial<z.infer<DomainDbTableSchemas[T]>>,
+  where: Partial<z.infer<DomainDbTableSchemas[T]>>
 ): Promise<z.infer<DomainDbTableSchemas[T]> | undefined> {
   const snakeCaseMapper = getColumnNameMapper(tableName);
 
@@ -279,7 +279,7 @@ export async function getOneFromDb<T extends DomainDbTable>(
 
   const row = await db.conn.oneOrNone(
     `SELECT * FROM ${config.dbSchemaName}.${tableName} WHERE ${clause}`,
-    values,
+    values
   );
 
   return row ? camelcaseKeys(row) : undefined;
@@ -288,7 +288,7 @@ export async function getOneFromDb<T extends DomainDbTable>(
 export async function getManyFromDb<T extends DomainDbTable>(
   db: DBContext,
   tableName: T,
-  where: Partial<z.infer<DomainDbTableSchemas[T]>>,
+  where: Partial<z.infer<DomainDbTableSchemas[T]>>
 ): Promise<Array<z.infer<DomainDbTableSchemas[T]>>> {
   const snakeCaseMapper = getColumnNameMapper(tableName);
 
@@ -300,7 +300,7 @@ export async function getManyFromDb<T extends DomainDbTable>(
 
   const rows = await db.conn.any(
     `SELECT * FROM ${config.dbSchemaName}.${tableName} WHERE ${clause}`,
-    values,
+    values
   );
 
   return rows.map((row) => camelcaseKeys(row));
@@ -311,7 +311,7 @@ export const getMockRsaKey = (userId: UserId): Key => {
     modulusLength: 2048,
   }).publicKey;
   const encodedPem = Buffer.from(
-    publicKey.export({ type: "pkcs1", format: "pem" }),
+    publicKey.export({ type: "pkcs1", format: "pem" })
   ).toString("base64url");
 
   return { ...getMockKey(), encodedPem, userId };


### PR DESCRIPTION
## Jira Issue
[PIN-10750](https://pagopa.atlassian.net/browse/PIN-10750)

## Context/Why
- Fix V1 `KeyRelationshipToUserMigrated` handling in `domains-analytics-writer`
- The flow inserted data into `key_relationship_migrated_<suffix>`, but merged from `client_key_<suffix>`
- Align insert, merge and cleanup on the same partial staging table
- The partial merge is incorrectly matching on `clientId + kid + userId` instead of `clientId + kid`

## Services Impacted
- domains-analytics-writer

## Key Changes
- Use `key_relationship_migrated_<suffix>` as source table for `ClientKeyUserMigration` merge
- Add dedicated cleanup for the partial staging table
- Add a test for `KeyRelationshipToUserMigrated`
- The merge key has been corrected to `clientId + kid`, aligned with the `client_key` primary key

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [x] Service labels applied
- [x] API and integration tests updated

[PIN-10750]: https://pagopa.atlassian.net/browse/PIN-10750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ