### PR TITLE
feat(PIN-10751): add purpose template e-service template version link to domains analytics

### DIFF
--- a/docker/domains-analytics-db/domains-init.sql
+++ b/docker/domains-analytics-db/domains-init.sql
@@ -767,6 +767,16 @@ CREATE TABLE IF NOT EXISTS domains.purpose_template_eservice_descriptor (
   PRIMARY KEY (purpose_template_id, eservice_id)
 );
 
+CREATE TABLE IF NOT EXISTS domains.purpose_template_eservice_template_version_purpose_template (
+  metadata_version INTEGER NOT NULL,
+  purpose_template_id VARCHAR(36) NOT NULL REFERENCES domains.purpose_template (id),
+  eservice_template_id VARCHAR(36) NOT NULL,
+  eservice_template_version_id VARCHAR(36) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  deleted BOOLEAN,
+  PRIMARY KEY (purpose_template_id, eservice_template_id)
+);
+
 CREATE TABLE IF NOT EXISTS domains.purpose_template_risk_analysis_form (
   id VARCHAR(36),
   purpose_template_id VARCHAR(36) NOT NULL REFERENCES domains.purpose_template (id),

--- a/docker/domains-analytics-db/domains-init.sql
+++ b/docker/domains-analytics-db/domains-init.sql
@@ -767,7 +767,7 @@ CREATE TABLE IF NOT EXISTS domains.purpose_template_eservice_descriptor (
   PRIMARY KEY (purpose_template_id, eservice_id)
 );
 
-CREATE TABLE IF NOT EXISTS domains.purpose_template_eservice_template_version_purpose_template (
+CREATE TABLE IF NOT EXISTS domains.purpose_template_eservice_template_version (
   metadata_version INTEGER NOT NULL,
   purpose_template_id VARCHAR(36) NOT NULL REFERENCES domains.purpose_template (id),
   eservice_template_id VARCHAR(36) NOT NULL,

--- a/packages/domains-analytics-writer/src/handlers/purpose-template/consumerServiceV2.ts
+++ b/packages/domains-analytics-writer/src/handlers/purpose-template/consumerServiceV2.ts
@@ -2,13 +2,16 @@
 /* eslint-disable functional/immutable-data */
 /* eslint-disable sonarjs/cognitive-complexity */
 import {
+  PurposeTemplateEserviceTemplateVersionSchema,
   PurposeTemplateItemsSchema,
   PurposeTemplateEServiceDescriptorSchema,
 } from "pagopa-interop-kpi-models";
 import {
+  bigIntToDate,
   PurposeTemplateEventEnvelope,
   fromPurposeTemplateV2,
   missingKafkaMessageDataError,
+  unsafeBrandId,
 } from "pagopa-interop-models";
 import { splitPurposeTemplateIntoObjectsSQL } from "pagopa-interop-readmodel";
 import { match, P } from "ts-pattern";
@@ -17,6 +20,7 @@ import { z } from "zod";
 import { DBContext } from "../../db/db.js";
 import { PurposeTemplateDeletingSchema } from "../../model/purposeTemplate/purposeTemplate.js";
 import { PurposeTemplateEServiceDescriptorDeletingSchema } from "../../model/purposeTemplate/purposeTemplateEserviceDescriptor.js";
+import { PurposeTemplateEserviceTemplateVersionDeletingSchema } from "../../model/purposeTemplate/purposeTemplateEserviceTemplateVersion.js";
 import { purposeTemplateServiceBuilder } from "../../service/purposeTemplateService.js";
 
 export async function handlePurposeTemplateMessageV2(
@@ -30,6 +34,10 @@ export async function handlePurposeTemplateMessageV2(
   const upsertPurposeTemplateEserviceDescriptorBatch: PurposeTemplateEServiceDescriptorSchema[] =
     [];
   const deletePurposeTemplateEserviceDescriptorBatch: PurposeTemplateEServiceDescriptorDeletingSchema[] =
+    [];
+  const upsertPurposeTemplateEserviceTemplateVersionBatch: PurposeTemplateEserviceTemplateVersionSchema[] =
+    [];
+  const deletePurposeTemplateEserviceTemplateVersionBatch: PurposeTemplateEserviceTemplateVersionDeletingSchema[] =
     [];
 
   for (const message of messages) {
@@ -127,10 +135,51 @@ export async function handlePurposeTemplateMessageV2(
           >)
         );
       })
+      .with({ type: "PurposeTemplateEServiceTemplateLinked" }, async (msg) => {
+        if (!msg.data.purposeTemplate) {
+          throw missingKafkaMessageDataError("purposeTemplate", msg.type);
+        }
+        if (!msg.data.eserviceTemplate) {
+          throw missingKafkaMessageDataError("eserviceTemplate", msg.type);
+        }
+
+        upsertPurposeTemplateEserviceTemplateVersionBatch.push(
+          PurposeTemplateEserviceTemplateVersionSchema.parse({
+            purposeTemplateId: unsafeBrandId(msg.data.purposeTemplate.id),
+            eserviceTemplateId: unsafeBrandId(msg.data.eserviceTemplate.id),
+            eserviceTemplateVersionId: unsafeBrandId(
+              msg.data.eserviceTemplateVersionId
+            ),
+            createdAt: bigIntToDate(msg.data.createdAt).toISOString(),
+            metadataVersion: msg.version,
+          } satisfies z.input<
+            typeof PurposeTemplateEserviceTemplateVersionSchema
+          >)
+        );
+      })
       .with(
-        { type: "PurposeTemplateEServiceTemplateLinked" },
         { type: "PurposeTemplateEServiceTemplateUnlinked" },
-        () => Promise.resolve()
+        async (msg) => {
+          if (!msg.data.purposeTemplate) {
+            throw missingKafkaMessageDataError("purposeTemplate", msg.type);
+          }
+          if (!msg.data.eserviceTemplate) {
+            throw missingKafkaMessageDataError("eserviceTemplate", msg.type);
+          }
+
+          deletePurposeTemplateEserviceTemplateVersionBatch.push(
+            PurposeTemplateEserviceTemplateVersionDeletingSchema.parse({
+              purposeTemplateId: unsafeBrandId(msg.data.purposeTemplate.id),
+              eserviceTemplateId: unsafeBrandId(msg.data.eserviceTemplate.id),
+              eserviceTemplateVersionId: unsafeBrandId(
+                msg.data.eserviceTemplateVersionId
+              ),
+              deleted: true,
+            } satisfies z.input<
+              typeof PurposeTemplateEserviceTemplateVersionDeletingSchema
+            >)
+          );
+        }
       )
       .exhaustive();
   }
@@ -160,6 +209,20 @@ export async function handlePurposeTemplateMessageV2(
     await purposeTemplateService.deleteBatchTemplateEServiceDescriptor(
       dbContext,
       deletePurposeTemplateEserviceDescriptorBatch
+    );
+  }
+
+  if (upsertPurposeTemplateEserviceTemplateVersionBatch.length > 0) {
+    await purposeTemplateService.upsertBatchPurposeTemplateEServiceTemplateVersion(
+      dbContext,
+      upsertPurposeTemplateEserviceTemplateVersionBatch
+    );
+  }
+
+  if (deletePurposeTemplateEserviceTemplateVersionBatch.length > 0) {
+    await purposeTemplateService.deleteBatchPurposeTemplateEServiceTemplateVersion(
+      dbContext,
+      deletePurposeTemplateEserviceTemplateVersionBatch
     );
   }
 }

--- a/packages/domains-analytics-writer/src/index.ts
+++ b/packages/domains-analytics-writer/src/index.ts
@@ -167,7 +167,7 @@ await retryConnection(
         columns: ["purposeTemplateId", "eserviceId", "descriptorId"],
       },
       {
-        name: DeletingDbTable.purpose_template_eservice_template_version_purpose_template_deleting_table,
+        name: DeletingDbTable.purpose_template_eservice_template_version_deleting_table,
         columns: [
           "purposeTemplateId",
           "eserviceTemplateId",

--- a/packages/domains-analytics-writer/src/index.ts
+++ b/packages/domains-analytics-writer/src/index.ts
@@ -166,6 +166,14 @@ await retryConnection(
         name: DeletingDbTable.purpose_template_eservice_descriptor_deleting_table,
         columns: ["purposeTemplateId", "eserviceId", "descriptorId"],
       },
+      {
+        name: DeletingDbTable.purpose_template_eservice_template_version_purpose_template_deleting_table,
+        columns: [
+          "purposeTemplateId",
+          "eserviceTemplateId",
+          "eserviceTemplateVersionId",
+        ],
+      },
     ]);
   },
   logger({ serviceName: config.serviceName })

--- a/packages/domains-analytics-writer/src/model/db/deleting.ts
+++ b/packages/domains-analytics-writer/src/model/db/deleting.ts
@@ -53,7 +53,7 @@ export const DeletingDbTableConfig = {
   purpose_template_deleting_table: PurposeTemplateDeletingSchema,
   purpose_template_eservice_descriptor_deleting_table:
     PurposeTemplateEServiceDescriptorDeletingSchema,
-  purpose_template_eservice_template_version_purpose_template_deleting_table:
+  purpose_template_eservice_template_version_deleting_table:
     PurposeTemplateEserviceTemplateVersionDeletingSchema,
 } as const;
 export type DeletingDbTableConfig = typeof DeletingDbTableConfig;
@@ -76,7 +76,7 @@ export const DeletingDbTableReadModel = {
   purpose_template_deleting_table: purposeTemplateInReadmodelPurposeTemplate,
   purpose_template_eservice_descriptor_deleting_table:
     purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate,
-  purpose_template_eservice_template_version_purpose_template_deleting_table:
+  purpose_template_eservice_template_version_deleting_table:
     purposeTemplateEserviceTemplateVersionInReadmodelPurposeTemplate,
 } as const;
 export type DeletingDbTableReadModel = typeof DeletingDbTableReadModel;
@@ -84,7 +84,7 @@ export type DeletingDbTableReadModel = typeof DeletingDbTableReadModel;
 export type DeletingDbTable = keyof DeletingDbTableConfig;
 
 export const DeletingDbTable = Object.fromEntries(
-  Object.keys(DeletingDbTableConfig).map((k) => [k, k])
+  Object.keys(DeletingDbTableConfig).map((k) => [k, k]),
 ) as { [K in DeletingDbTable]: K };
 
 export type DeletingDbTableConfigMap = {

--- a/packages/domains-analytics-writer/src/model/db/deleting.ts
+++ b/packages/domains-analytics-writer/src/model/db/deleting.ts
@@ -14,6 +14,7 @@ import {
   producerKeychainInReadmodelProducerKeychain,
   purposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate,
+  eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate as purposeTemplateEserviceTemplateVersionInReadmodelPurposeTemplate,
 } from "pagopa-interop-readmodel-models";
 import { z } from "zod";
 
@@ -30,6 +31,7 @@ import { EserviceTemplateDeletingSchema } from "../eserviceTemplate/eserviceTemp
 import { PurposeDeletingSchema } from "../purpose/purpose.js";
 import { PurposeTemplateDeletingSchema } from "../purposeTemplate/purposeTemplate.js";
 import { PurposeTemplateEServiceDescriptorDeletingSchema } from "../purposeTemplate/purposeTemplateEserviceDescriptor.js";
+import { PurposeTemplateEserviceTemplateVersionDeletingSchema } from "../purposeTemplate/purposeTemplateEserviceTemplateVersion.js";
 import { TenantDeletingSchema } from "../tenant/tenant.js";
 import { TenantMailDeletingSchema } from "../tenant/tenantMail.js";
 
@@ -51,6 +53,8 @@ export const DeletingDbTableConfig = {
   purpose_template_deleting_table: PurposeTemplateDeletingSchema,
   purpose_template_eservice_descriptor_deleting_table:
     PurposeTemplateEServiceDescriptorDeletingSchema,
+  purpose_template_eservice_template_version_purpose_template_deleting_table:
+    PurposeTemplateEserviceTemplateVersionDeletingSchema,
 } as const;
 export type DeletingDbTableConfig = typeof DeletingDbTableConfig;
 
@@ -72,6 +76,8 @@ export const DeletingDbTableReadModel = {
   purpose_template_deleting_table: purposeTemplateInReadmodelPurposeTemplate,
   purpose_template_eservice_descriptor_deleting_table:
     purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate,
+  purpose_template_eservice_template_version_purpose_template_deleting_table:
+    purposeTemplateEserviceTemplateVersionInReadmodelPurposeTemplate,
 } as const;
 export type DeletingDbTableReadModel = typeof DeletingDbTableReadModel;
 

--- a/packages/domains-analytics-writer/src/model/db/deleting.ts
+++ b/packages/domains-analytics-writer/src/model/db/deleting.ts
@@ -84,7 +84,7 @@ export type DeletingDbTableReadModel = typeof DeletingDbTableReadModel;
 export type DeletingDbTable = keyof DeletingDbTableConfig;
 
 export const DeletingDbTable = Object.fromEntries(
-  Object.keys(DeletingDbTableConfig).map((k) => [k, k]),
+  Object.keys(DeletingDbTableConfig).map((k) => [k, k])
 ) as { [K in DeletingDbTable]: K };
 
 export type DeletingDbTableConfigMap = {

--- a/packages/domains-analytics-writer/src/model/db/purposeTemplate.ts
+++ b/packages/domains-analytics-writer/src/model/db/purposeTemplate.ts
@@ -4,6 +4,7 @@ import {
   PurposeTemplateRiskAnalysisAnswerSchema,
   PurposeTemplateRiskAnalysisAnswerAnnotationSchema,
   PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema,
+  PurposeTemplateEserviceTemplateVersionSchema,
   PurposeTemplateEServiceDescriptorSchema,
 } from "pagopa-interop-kpi-models";
 
@@ -17,6 +18,8 @@ export const PurposeTemplateDbTableConfig = {
     PurposeTemplateRiskAnalysisAnswerAnnotationSchema,
   purpose_template_risk_analysis_answer_annotation_document:
     PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema,
+  purpose_template_eservice_template_version_purpose_template:
+    PurposeTemplateEserviceTemplateVersionSchema,
 } as const;
 export type PurposeTemplateDbTableConfig = typeof PurposeTemplateDbTableConfig;
 export type PurposeTemplateDbTable = keyof typeof PurposeTemplateDbTableConfig;

--- a/packages/domains-analytics-writer/src/model/db/purposeTemplate.ts
+++ b/packages/domains-analytics-writer/src/model/db/purposeTemplate.ts
@@ -18,12 +18,12 @@ export const PurposeTemplateDbTableConfig = {
     PurposeTemplateRiskAnalysisAnswerAnnotationSchema,
   purpose_template_risk_analysis_answer_annotation_document:
     PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema,
-  purpose_template_eservice_template_version_purpose_template:
+  purpose_template_eservice_template_version:
     PurposeTemplateEserviceTemplateVersionSchema,
 } as const;
 export type PurposeTemplateDbTableConfig = typeof PurposeTemplateDbTableConfig;
 export type PurposeTemplateDbTable = keyof typeof PurposeTemplateDbTableConfig;
 
 export const PurposeTemplateDbTable = Object.fromEntries(
-  Object.keys(PurposeTemplateDbTableConfig).map((k) => [k, k])
+  Object.keys(PurposeTemplateDbTableConfig).map((k) => [k, k]),
 ) as { [K in PurposeTemplateDbTable]: K };

--- a/packages/domains-analytics-writer/src/model/db/purposeTemplate.ts
+++ b/packages/domains-analytics-writer/src/model/db/purposeTemplate.ts
@@ -25,5 +25,5 @@ export type PurposeTemplateDbTableConfig = typeof PurposeTemplateDbTableConfig;
 export type PurposeTemplateDbTable = keyof typeof PurposeTemplateDbTableConfig;
 
 export const PurposeTemplateDbTable = Object.fromEntries(
-  Object.keys(PurposeTemplateDbTableConfig).map((k) => [k, k]),
+  Object.keys(PurposeTemplateDbTableConfig).map((k) => [k, k])
 ) as { [K in PurposeTemplateDbTable]: K };

--- a/packages/domains-analytics-writer/src/model/purposeTemplate/purposeTemplateEserviceTemplateVersion.ts
+++ b/packages/domains-analytics-writer/src/model/purposeTemplate/purposeTemplateEserviceTemplateVersion.ts
@@ -1,0 +1,13 @@
+import { PurposeTemplateEserviceTemplateVersionSchema } from "pagopa-interop-kpi-models";
+import { z } from "zod";
+
+export const PurposeTemplateEserviceTemplateVersionDeletingSchema =
+  PurposeTemplateEserviceTemplateVersionSchema.pick({
+    purposeTemplateId: true,
+    eserviceTemplateId: true,
+    eserviceTemplateVersionId: true,
+    deleted: true,
+  });
+export type PurposeTemplateEserviceTemplateVersionDeletingSchema = z.infer<
+  typeof PurposeTemplateEserviceTemplateVersionDeletingSchema
+>;

--- a/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateEserviceTemplateVersion.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateEserviceTemplateVersion.repository.ts
@@ -14,12 +14,12 @@ export const purposeTemplateEserviceTemplateVersionRepository = (
 ) =>
   createRepository(conn, {
     tableName:
-      PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
+      PurposeTemplateDbTable.purpose_template_eservice_template_version,
     schema: PurposeTemplateEserviceTemplateVersionSchema,
     keyColumns: ["purposeTemplateId", "eserviceTemplateId"],
     deleting: {
       deletingTableName:
-        DeletingDbTable.purpose_template_eservice_template_version_purpose_template_deleting_table,
+        DeletingDbTable.purpose_template_eservice_template_version_deleting_table,
       deletingSchema: PurposeTemplateEserviceTemplateVersionDeletingSchema,
       deletingKeyColumns: [
         "purposeTemplateId",

--- a/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateEserviceTemplateVersion.repository.ts
+++ b/packages/domains-analytics-writer/src/repository/purposeTemplate/purposeTemplateEserviceTemplateVersion.repository.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { PurposeTemplateEserviceTemplateVersionSchema } from "pagopa-interop-kpi-models";
+
+import { DBConnection } from "../../db/db.js";
+import {
+  DeletingDbTable,
+  PurposeTemplateDbTable,
+} from "../../model/db/index.js";
+import { PurposeTemplateEserviceTemplateVersionDeletingSchema } from "../../model/purposeTemplate/purposeTemplateEserviceTemplateVersion.js";
+import { createRepository } from "../createRepository.js";
+
+export const purposeTemplateEserviceTemplateVersionRepository = (
+  conn: DBConnection
+) =>
+  createRepository(conn, {
+    tableName:
+      PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
+    schema: PurposeTemplateEserviceTemplateVersionSchema,
+    keyColumns: ["purposeTemplateId", "eserviceTemplateId"],
+    deleting: {
+      deletingTableName:
+        DeletingDbTable.purpose_template_eservice_template_version_purpose_template_deleting_table,
+      deletingSchema: PurposeTemplateEserviceTemplateVersionDeletingSchema,
+      deletingKeyColumns: [
+        "purposeTemplateId",
+        "eserviceTemplateId",
+        "eserviceTemplateVersionId",
+      ],
+      useIdAsSourceDeleteKey: false,
+      physicalDelete: false,
+    },
+  });

--- a/packages/domains-analytics-writer/src/service/purposeTemplateService.ts
+++ b/packages/domains-analytics-writer/src/service/purposeTemplateService.ts
@@ -3,6 +3,7 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import { genericLogger } from "pagopa-interop-commons";
 import {
+  PurposeTemplateEserviceTemplateVersionSchema,
   PurposeTemplateItemsSchema,
   PurposeTemplateEServiceDescriptorSchema,
 } from "pagopa-interop-kpi-models";
@@ -12,8 +13,10 @@ import { DBContext } from "../db/db.js";
 import { DeletingDbTable, PurposeTemplateDbTable } from "../model/db/index.js";
 import { PurposeTemplateDeletingSchema } from "../model/purposeTemplate/purposeTemplate.js";
 import { PurposeTemplateEServiceDescriptorDeletingSchema } from "../model/purposeTemplate/purposeTemplateEserviceDescriptor.js";
+import { PurposeTemplateEserviceTemplateVersionDeletingSchema } from "../model/purposeTemplate/purposeTemplateEserviceTemplateVersion.js";
 import { purposeTemplateRepository } from "../repository/purposeTemplate/purposeTemplate.repository.js";
 import { purposeTemplateEServiceDescriptorRepository } from "../repository/purposeTemplate/purposeTemplateEServiceDescriptor.repository.js";
+import { purposeTemplateEserviceTemplateVersionRepository } from "../repository/purposeTemplate/purposeTemplateEserviceTemplateVersion.repository.js";
 import { purposeTemplateRiskAnalysisAnswerRepository } from "../repository/purposeTemplate/purposeTemplateRiskAnalysisAnswer.repository.js";
 import { purposeTemplateRiskAnalysisAnswerAnnotationRepository } from "../repository/purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotation.repository.js";
 import { purposeTemplateRiskAnalysisAnswerAnnotationDocumentRepository } from "../repository/purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotationDocument.repository.js";
@@ -35,6 +38,8 @@ export function purposeTemplateServiceBuilder(db: DBContext) {
     purposeTemplateRiskAnalysisAnswerAnnotationDocumentRepository(db.conn);
   const templateEserviceDescriptorRepo =
     purposeTemplateEServiceDescriptorRepository(db.conn);
+  const purposeTemplateEserviceTemplateVersionRepo =
+    purposeTemplateEserviceTemplateVersionRepository(db.conn);
 
   return {
     async upsertBatchPurposeTemplate(
@@ -192,6 +197,7 @@ export function purposeTemplateServiceBuilder(db: DBContext) {
             PurposeTemplateDbTable.purpose_template_risk_analysis_answer,
             PurposeTemplateDbTable.purpose_template_risk_analysis_form,
             PurposeTemplateDbTable.purpose_template_eservice_descriptor,
+            PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
           ],
           DeletingDbTable.purpose_template_deleting_table
         );
@@ -232,6 +238,74 @@ export function purposeTemplateServiceBuilder(db: DBContext) {
       await templateEserviceDescriptorRepo.cleanDeleting();
       genericLogger.info(
         `Staging deletion table cleaned for purpose template eservice descriptor`
+      );
+    },
+
+    async upsertBatchPurposeTemplateEServiceTemplateVersion(
+      dbContext: DBContext,
+      items: PurposeTemplateEserviceTemplateVersionSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        for (const batch of batchMessages(
+          items,
+          config.dbMessagesToInsertPerBatch
+        )) {
+          await purposeTemplateEserviceTemplateVersionRepo.insert(
+            t,
+            dbContext.pgp,
+            batch
+          );
+          genericLogger.info(
+            `Staging data inserted for purpose template eservice template version batch: ${batch
+              .map((r) => r.purposeTemplateId)
+              .join(", ")}`
+          );
+        }
+
+        await purposeTemplateEserviceTemplateVersionRepo.merge(t);
+      });
+
+      genericLogger.info(
+        `Staging data merged into target tables for purpose template eservice template version`
+      );
+
+      await purposeTemplateEserviceTemplateVersionRepo.clean();
+      genericLogger.info(
+        `Staging table cleaned for purpose template eservice template version`
+      );
+    },
+
+    async deleteBatchPurposeTemplateEServiceTemplateVersion(
+      dbContext: DBContext,
+      records: PurposeTemplateEserviceTemplateVersionDeletingSchema[]
+    ) {
+      await dbContext.conn.tx(async (t) => {
+        for (const batch of batchMessages(
+          records,
+          config.dbMessagesToInsertPerBatch
+        )) {
+          await purposeTemplateEserviceTemplateVersionRepo.insertDeleting(
+            t,
+            dbContext.pgp,
+            batch
+          );
+          genericLogger.info(
+            `Staging deletion inserted for purpose template eservice template version batch: ${batch
+              .map((r) => JSON.stringify(r))
+              .join(", ")}`
+          );
+        }
+
+        await purposeTemplateEserviceTemplateVersionRepo.mergeDeleting(t);
+      });
+
+      genericLogger.info(
+        `Staging deletion merged into target tables for purpose template eservice template version`
+      );
+
+      await purposeTemplateEserviceTemplateVersionRepo.cleanDeleting();
+      genericLogger.info(
+        `Staging deletion table cleaned for purpose template eservice template version`
       );
     },
   };

--- a/packages/domains-analytics-writer/src/service/purposeTemplateService.ts
+++ b/packages/domains-analytics-writer/src/service/purposeTemplateService.ts
@@ -197,7 +197,7 @@ export function purposeTemplateServiceBuilder(db: DBContext) {
             PurposeTemplateDbTable.purpose_template_risk_analysis_answer,
             PurposeTemplateDbTable.purpose_template_risk_analysis_form,
             PurposeTemplateDbTable.purpose_template_eservice_descriptor,
-            PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
+            PurposeTemplateDbTable.purpose_template_eservice_template_version,
           ],
           DeletingDbTable.purpose_template_deleting_table
         );

--- a/packages/domains-analytics-writer/test/purposeTemplateService.test.ts
+++ b/packages/domains-analytics-writer/test/purposeTemplateService.test.ts
@@ -5,10 +5,13 @@
 import {
   getMockDescriptor,
   getMockEService,
+  getMockEServiceTemplate,
+  getMockEServiceTemplateVersion,
   getMockPurposeTemplate,
 } from "pagopa-interop-commons-test";
 import {
   EService,
+  EServiceTemplate,
   missingKafkaMessageDataError,
   PurposeTemplate,
   PurposeTemplateAddedV2,
@@ -16,12 +19,15 @@ import {
   PurposeTemplateDraftDeletedV2,
   PurposeTemplateDraftUpdatedV2,
   PurposeTemplateEServiceLinkedV2,
+  PurposeTemplateEServiceTemplateLinkedV2,
+  PurposeTemplateEServiceTemplateUnlinkedV2,
   PurposeTemplateEServiceUnlinkedV2,
   PurposeTemplateEventEnvelope,
   PurposeTemplatePublishedV2,
   purposeTemplateState,
   PurposeTemplateSuspendedV2,
   PurposeTemplateUnsuspendedV2,
+  toEServiceTemplateV2,
   toEServiceV2,
   toPurposeTemplateV2,
 } from "pagopa-interop-models";
@@ -660,5 +666,144 @@ describe("Purpose template messages consumers - handlePurposeTemplateMessageV2",
       purposeTemplate.id
     );
     expect(retrievedPurposeTemplateEServiceDescriptors?.deleted).toBe(true);
+  });
+
+  it("PurposeTemplateEServiceTemplateLinked: insert purpose template linked EService template version", async () => {
+    const eserviceTemplateVersion = getMockEServiceTemplateVersion();
+    const eserviceTemplate: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      versions: [eserviceTemplateVersion],
+    };
+
+    const messagePurposeTemplateAdded: PurposeTemplateEventEnvelope = {
+      sequence_num: 1,
+      stream_id: purposeTemplate.id,
+      version: 0,
+      type: "PurposeTemplateAdded",
+      event_version: 2,
+      data: {
+        purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+      },
+      log_date: new Date(),
+    };
+
+    const payloadPurposeTemplateEServiceTemplateLinked: PurposeTemplateEServiceTemplateLinkedV2 =
+      {
+        purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+        eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+        eserviceTemplateVersionId: eserviceTemplateVersion.id,
+        createdAt: BigInt(Date.now()),
+      };
+    const messagePurposeTemplateEServiceTemplateLinked: PurposeTemplateEventEnvelope =
+      {
+        sequence_num: 1,
+        stream_id: purposeTemplate.id,
+        version: 1,
+        type: "PurposeTemplateEServiceTemplateLinked",
+        event_version: 2,
+        data: payloadPurposeTemplateEServiceTemplateLinked,
+        log_date: new Date(),
+      };
+
+    await handlePurposeTemplateMessageV2(
+      [
+        messagePurposeTemplateAdded,
+        messagePurposeTemplateEServiceTemplateLinked,
+      ],
+      dbContext
+    );
+
+    const retrievedPurposeTemplateEServiceTemplateVersion = await getOneFromDb(
+      dbContext,
+      PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
+      {
+        purposeTemplateId: purposeTemplate.id,
+      }
+    );
+
+    expect(
+      retrievedPurposeTemplateEServiceTemplateVersion?.purposeTemplateId
+    ).toBe(purposeTemplate.id);
+    expect(
+      retrievedPurposeTemplateEServiceTemplateVersion?.eserviceTemplateId
+    ).toBe(eserviceTemplate.id);
+    expect(
+      retrievedPurposeTemplateEServiceTemplateVersion?.eserviceTemplateVersionId
+    ).toBe(eserviceTemplateVersion.id);
+  });
+
+  it("PurposeTemplateEServiceTemplateUnlinked: marks a purpose template linked EService template version as deleted", async () => {
+    const eserviceTemplateVersion = getMockEServiceTemplateVersion();
+    const eserviceTemplate: EServiceTemplate = {
+      ...getMockEServiceTemplate(),
+      versions: [eserviceTemplateVersion],
+    };
+
+    const messagePurposeTemplateAdded: PurposeTemplateEventEnvelope = {
+      sequence_num: 1,
+      stream_id: purposeTemplate.id,
+      version: 0,
+      type: "PurposeTemplateAdded",
+      event_version: 2,
+      data: {
+        purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+      },
+      log_date: new Date(),
+    };
+
+    const messagePurposeTemplateEServiceTemplateLinked: PurposeTemplateEventEnvelope =
+      {
+        sequence_num: 1,
+        stream_id: purposeTemplate.id,
+        version: 1,
+        type: "PurposeTemplateEServiceTemplateLinked",
+        event_version: 2,
+        data: {
+          purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+          eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+          eserviceTemplateVersionId: eserviceTemplateVersion.id,
+          createdAt: BigInt(Date.now()),
+        } satisfies PurposeTemplateEServiceTemplateLinkedV2,
+        log_date: new Date(),
+      };
+
+    const payloadPurposeTemplateEServiceTemplateUnlinked: PurposeTemplateEServiceTemplateUnlinkedV2 =
+      {
+        purposeTemplate: toPurposeTemplateV2(purposeTemplate),
+        eserviceTemplate: toEServiceTemplateV2(eserviceTemplate),
+        eserviceTemplateVersionId: eserviceTemplateVersion.id,
+      };
+    const messagePurposeTemplateEServiceTemplateUnlinked: PurposeTemplateEventEnvelope =
+      {
+        sequence_num: 1,
+        stream_id: purposeTemplate.id,
+        version: 2,
+        type: "PurposeTemplateEServiceTemplateUnlinked",
+        event_version: 2,
+        data: payloadPurposeTemplateEServiceTemplateUnlinked,
+        log_date: new Date(),
+      };
+
+    await handlePurposeTemplateMessageV2(
+      [
+        messagePurposeTemplateAdded,
+        messagePurposeTemplateEServiceTemplateLinked,
+        messagePurposeTemplateEServiceTemplateUnlinked,
+      ],
+      dbContext
+    );
+
+    const retrievedPurposeTemplateEServiceTemplateVersion = await getOneFromDb(
+      dbContext,
+      PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
+      {
+        purposeTemplateId: purposeTemplate.id,
+      }
+    );
+
+    expect(
+      retrievedPurposeTemplateEServiceTemplateVersion?.purposeTemplateId
+    ).toBe(purposeTemplate.id);
+    expect(retrievedPurposeTemplateEServiceTemplateVersion?.deleted).toBe(true);
   });
 });

--- a/packages/domains-analytics-writer/test/purposeTemplateService.test.ts
+++ b/packages/domains-analytics-writer/test/purposeTemplateService.test.ts
@@ -715,7 +715,7 @@ describe("Purpose template messages consumers - handlePurposeTemplateMessageV2",
 
     const retrievedPurposeTemplateEServiceTemplateVersion = await getOneFromDb(
       dbContext,
-      PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
+      PurposeTemplateDbTable.purpose_template_eservice_template_version,
       {
         purposeTemplateId: purposeTemplate.id,
       }
@@ -795,7 +795,7 @@ describe("Purpose template messages consumers - handlePurposeTemplateMessageV2",
 
     const retrievedPurposeTemplateEServiceTemplateVersion = await getOneFromDb(
       dbContext,
-      PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
+      PurposeTemplateDbTable.purpose_template_eservice_template_version,
       {
         purposeTemplateId: purposeTemplate.id,
       }

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -136,6 +136,7 @@ export const producerKeychainTables: ProducerKeychainDbTable[] = [
 export const purposeTemplateTables: PurposeTemplateDbTable[] = [
   PurposeTemplateDbTable.purpose_template,
   PurposeTemplateDbTable.purpose_template_eservice_descriptor,
+  PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
   PurposeTemplateDbTable.purpose_template_risk_analysis_answer,
   PurposeTemplateDbTable.purpose_template_risk_analysis_answer_annotation,
   PurposeTemplateDbTable.purpose_template_risk_analysis_answer_annotation_document,
@@ -164,6 +165,7 @@ export const deletingTables: DeletingDbTable[] = [
   DeletingDbTable.eservice_template_deleting_table,
   DeletingDbTable.purpose_template_deleting_table,
   DeletingDbTable.purpose_template_eservice_descriptor_deleting_table,
+  DeletingDbTable.purpose_template_eservice_template_version_purpose_template_deleting_table,
 ];
 
 export const domainTables: DomainDbTable[] = [
@@ -224,6 +226,14 @@ export const setupStagingDeletingTables: DeletingDbTableConfigMap[] = [
   {
     name: DeletingDbTable.purpose_template_eservice_descriptor_deleting_table,
     columns: ["purposeTemplateId", "eserviceId", "descriptorId"],
+  },
+  {
+    name: DeletingDbTable.purpose_template_eservice_template_version_purpose_template_deleting_table,
+    columns: [
+      "purposeTemplateId",
+      "eserviceTemplateId",
+      "eserviceTemplateVersionId",
+    ],
   },
 ];
 

--- a/packages/domains-analytics-writer/test/utils.ts
+++ b/packages/domains-analytics-writer/test/utils.ts
@@ -136,7 +136,7 @@ export const producerKeychainTables: ProducerKeychainDbTable[] = [
 export const purposeTemplateTables: PurposeTemplateDbTable[] = [
   PurposeTemplateDbTable.purpose_template,
   PurposeTemplateDbTable.purpose_template_eservice_descriptor,
-  PurposeTemplateDbTable.purpose_template_eservice_template_version_purpose_template,
+  PurposeTemplateDbTable.purpose_template_eservice_template_version,
   PurposeTemplateDbTable.purpose_template_risk_analysis_answer,
   PurposeTemplateDbTable.purpose_template_risk_analysis_answer_annotation,
   PurposeTemplateDbTable.purpose_template_risk_analysis_answer_annotation_document,
@@ -165,7 +165,7 @@ export const deletingTables: DeletingDbTable[] = [
   DeletingDbTable.eservice_template_deleting_table,
   DeletingDbTable.purpose_template_deleting_table,
   DeletingDbTable.purpose_template_eservice_descriptor_deleting_table,
-  DeletingDbTable.purpose_template_eservice_template_version_purpose_template_deleting_table,
+  DeletingDbTable.purpose_template_eservice_template_version_deleting_table,
 ];
 
 export const domainTables: DomainDbTable[] = [
@@ -228,7 +228,7 @@ export const setupStagingDeletingTables: DeletingDbTableConfigMap[] = [
     columns: ["purposeTemplateId", "eserviceId", "descriptorId"],
   },
   {
-    name: DeletingDbTable.purpose_template_eservice_template_version_purpose_template_deleting_table,
+    name: DeletingDbTable.purpose_template_eservice_template_version_deleting_table,
     columns: [
       "purposeTemplateId",
       "eserviceTemplateId",

--- a/packages/kpi-models/src/db/purposeTemplate.ts
+++ b/packages/kpi-models/src/db/purposeTemplate.ts
@@ -26,7 +26,7 @@ export const PurposeTemplateDbTableConfig = {
     PurposeTemplateRiskAnalysisAnswerAnnotationSchema,
   purpose_template_risk_analysis_answer_annotation_document:
     PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema,
-  purpose_template_eservice_template_version_purpose_template:
+  purpose_template_eservice_template_version:
     PurposeTemplateEserviceTemplateVersionSchema,
 } as const;
 export type PurposeTemplateDbTableConfig = typeof PurposeTemplateDbTableConfig;
@@ -43,7 +43,7 @@ export const PurposeTemplateDbTableReadModel = {
     purposeTemplateRiskAnalysisAnswerAnnotationInReadmodelPurposeTemplate,
   purpose_template_risk_analysis_answer_annotation_document:
     purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate,
-  purpose_template_eservice_template_version_purpose_template:
+  purpose_template_eservice_template_version:
     purposeTemplateEserviceTemplateVersionInReadmodelPurposeTemplate,
 } as const;
 export type PurposeTemplateDbTableReadModel =
@@ -52,5 +52,5 @@ export type PurposeTemplateDbTableReadModel =
 export type PurposeTemplateDbTable = keyof typeof PurposeTemplateDbTableConfig;
 
 export const PurposeTemplateDbTable = Object.fromEntries(
-  Object.keys(PurposeTemplateDbTableConfig).map((k) => [k, k])
+  Object.keys(PurposeTemplateDbTableConfig).map((k) => [k, k]),
 ) as { [K in PurposeTemplateDbTable]: K };

--- a/packages/kpi-models/src/db/purposeTemplate.ts
+++ b/packages/kpi-models/src/db/purposeTemplate.ts
@@ -1,4 +1,5 @@
 import {
+  eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate as purposeTemplateEserviceTemplateVersionInReadmodelPurposeTemplate,
   purposeTemplateInReadmodelPurposeTemplate,
   purposeTemplateEserviceDescriptorInReadmodelPurposeTemplate,
   purposeTemplateRiskAnalysisFormInReadmodelPurposeTemplate,
@@ -9,6 +10,7 @@ import {
 
 import { PurposeTemplateSchema } from "../purposeTemplate/purposeTemplate.js";
 import { PurposeTemplateEServiceDescriptorSchema } from "../purposeTemplate/purposeTemplateEserviceDescriptor.js";
+import { PurposeTemplateEserviceTemplateVersionSchema } from "../purposeTemplate/purposeTemplateEserviceTemplateVersion.js";
 import { PurposeTemplateRiskAnalysisAnswerSchema } from "../purposeTemplate/purposeTemplateRiskAnalysisAnswer.js";
 import { PurposeTemplateRiskAnalysisAnswerAnnotationSchema } from "../purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotation.js";
 import { PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema } from "../purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotationDocument.js";
@@ -24,6 +26,8 @@ export const PurposeTemplateDbTableConfig = {
     PurposeTemplateRiskAnalysisAnswerAnnotationSchema,
   purpose_template_risk_analysis_answer_annotation_document:
     PurposeTemplateRiskAnalysisAnswerAnnotationDocumentSchema,
+  purpose_template_eservice_template_version_purpose_template:
+    PurposeTemplateEserviceTemplateVersionSchema,
 } as const;
 export type PurposeTemplateDbTableConfig = typeof PurposeTemplateDbTableConfig;
 
@@ -39,6 +43,8 @@ export const PurposeTemplateDbTableReadModel = {
     purposeTemplateRiskAnalysisAnswerAnnotationInReadmodelPurposeTemplate,
   purpose_template_risk_analysis_answer_annotation_document:
     purposeTemplateRiskAnalysisAnswerAnnotationDocumentInReadmodelPurposeTemplate,
+  purpose_template_eservice_template_version_purpose_template:
+    purposeTemplateEserviceTemplateVersionInReadmodelPurposeTemplate,
 } as const;
 export type PurposeTemplateDbTableReadModel =
   typeof PurposeTemplateDbTableReadModel;

--- a/packages/kpi-models/src/index.ts
+++ b/packages/kpi-models/src/index.ts
@@ -66,6 +66,7 @@ export * from "./purposeTemplate/purposeTemplateRiskAnalysisForm.js";
 export * from "./purposeTemplate/purposeTemplateRiskAnalysisAnswer.js";
 export * from "./purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotation.js";
 export * from "./purposeTemplate/purposeTemplateRiskAnalysisAnswerAnnotationDocument.js";
+export * from "./purposeTemplate/purposeTemplateEserviceTemplateVersion.js";
 
 // Tenant models
 export * from "./tenant/tenant.js";

--- a/packages/kpi-models/src/purposeTemplate/purposeTemplateEserviceTemplateVersion.ts
+++ b/packages/kpi-models/src/purposeTemplate/purposeTemplateEserviceTemplateVersion.ts
@@ -1,0 +1,12 @@
+import { createSelectSchema } from "drizzle-zod";
+import { eserviceTemplateVersionPurposeTemplateInReadmodelPurposeTemplate as purposeTemplateEserviceTemplateVersionInReadmodelPurposeTemplate } from "pagopa-interop-readmodel-models";
+import { z } from "zod";
+
+export const PurposeTemplateEserviceTemplateVersionSchema = createSelectSchema(
+  purposeTemplateEserviceTemplateVersionInReadmodelPurposeTemplate
+).extend({
+  deleted: z.boolean().default(false).optional(),
+});
+export type PurposeTemplateEserviceTemplateVersionSchema = z.infer<
+  typeof PurposeTemplateEserviceTemplateVersionSchema
+>;


### PR DESCRIPTION
## Jira Issue
[PIN-10751](https://pagopa.atlassian.net/browse/PIN-10751) 
(Related: [PIN-8621](https://pagopa.atlassian.net/browse/PIN-8621))

## Context/Why
- Add KPI/domains support for purpose template links to e-service template versions
- Align domains analytics schema with the readmodel table used by the new link/unlink events

## Services Impacted
- domains-analytics-writer
- kpi-models

## Key Changes
- Add domains table `purpose_template_eservice_template_version_purpose_template`
- Add KPI model/schema and repository mapping for the new link table
- Handle `PurposeTemplateEServiceTemplateLinked` and `PurposeTemplateEServiceTemplateUnlinked` events
- Add tests for insert and logical delete of e-service template version links

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard
- [x] Service labels applied
- [x] API and integration tests updated


[PIN-10751]: https://pagopa.atlassian.net/browse/PIN-10751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-8621]: https://pagopa.atlassian.net/browse/PIN-8621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ