### PR TITLE
PIN-10754 Fixed deeplink in handleEserviceArchivingScheduledReminderInApp

### DIFF
--- a/packages/in-app-scheduled-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingScheduledReminderInApp.ts
+++ b/packages/in-app-scheduled-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingScheduledReminderInApp.ts
@@ -1,14 +1,13 @@
 import { Logger } from "pagopa-interop-commons";
 import {
   EService,
-  EServiceIdDescriptorId,
+  EServiceId,
   NewNotification,
   TenantId,
 } from "pagopa-interop-models";
 import {
   getNotificationRecipients,
   inAppTemplates,
-  retrieveLatestDescriptor,
 } from "pagopa-interop-notification-commons";
 import {
   ScheduledNotificationRow,
@@ -52,10 +51,7 @@ export async function handleEserviceArchivingScheduledReminderInApp(
     Math.min(...archivableOns.map((d) => d.getTime()))
   );
 
-  const latestDescriptor = retrieveLatestDescriptor(eservice);
-  const entityId = EServiceIdDescriptorId.parse(
-    `${eservice.id}/${latestDescriptor.id}`
-  );
+  const entityId = eservice.id;
 
   const producerNotifications = await buildProducerNotifications({
     eservice,
@@ -79,7 +75,7 @@ export async function handleEserviceArchivingScheduledReminderInApp(
 type BuilderParams = {
   eservice: EService;
   archivableOn: Date;
-  entityId: EServiceIdDescriptorId;
+  entityId: EServiceId;
   readModelService: ReadModelServiceSQL;
   log: Logger;
 };

--- a/packages/in-app-scheduled-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingScheduledReminderInApp.ts
+++ b/packages/in-app-scheduled-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingScheduledReminderInApp.ts
@@ -1,13 +1,14 @@
 import { Logger } from "pagopa-interop-commons";
 import {
   EService,
-  EServiceId,
+  EServiceIdDescriptorId,
   NewNotification,
   TenantId,
 } from "pagopa-interop-models";
 import {
   getNotificationRecipients,
   inAppTemplates,
+  retrieveLatestDescriptor,
 } from "pagopa-interop-notification-commons";
 import {
   ScheduledNotificationRow,
@@ -51,10 +52,15 @@ export async function handleEserviceArchivingScheduledReminderInApp(
     Math.min(...archivableOns.map((d) => d.getTime()))
   );
 
+  const latestDescriptor = retrieveLatestDescriptor(eservice);
+  const entityId = EServiceIdDescriptorId.parse(
+    `${eservice.id}/${latestDescriptor.id}`
+  );
+
   const producerNotifications = await buildProducerNotifications({
     eservice,
     archivableOn,
-    entityId: eserviceId,
+    entityId,
     readModelService,
     log,
   });
@@ -62,7 +68,7 @@ export async function handleEserviceArchivingScheduledReminderInApp(
   const consumerNotifications = await buildConsumerNotifications({
     eservice,
     archivableOn,
-    entityId: eserviceId,
+    entityId,
     readModelService,
     log,
   });
@@ -73,7 +79,7 @@ export async function handleEserviceArchivingScheduledReminderInApp(
 type BuilderParams = {
   eservice: EService;
   archivableOn: Date;
-  entityId: EServiceId;
+  entityId: EServiceIdDescriptorId;
   readModelService: ReadModelServiceSQL;
   log: Logger;
 };

--- a/packages/scheduled-in-app-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingScheduledReminderInApp.ts
+++ b/packages/scheduled-in-app-notification-dispatcher/src/handlers/eservices/handleEserviceArchivingScheduledReminderInApp.ts
@@ -1,13 +1,14 @@
 import { Logger } from "pagopa-interop-commons";
 import {
   EService,
-  EServiceId,
+  EServiceIdDescriptorId,
   NewNotification,
   TenantId,
 } from "pagopa-interop-models";
 import {
   getNotificationRecipients,
   inAppTemplates,
+  retrieveLatestDescriptor,
 } from "pagopa-interop-notification-commons";
 import {
   ScheduledNotificationRow,
@@ -51,10 +52,15 @@ export async function handleEserviceArchivingScheduledReminderInApp(
     Math.min(...archivableOns.map((d) => d.getTime()))
   );
 
+  const latestDescriptor = retrieveLatestDescriptor(eservice);
+  const entityId = EServiceIdDescriptorId.parse(
+    `${eservice.id}/${latestDescriptor.id}`
+  );
+
   const producerNotifications = await buildProducerNotifications({
     eservice,
     archivableOn,
-    entityId: eserviceId,
+    entityId,
     readModelService,
     log,
   });
@@ -62,7 +68,7 @@ export async function handleEserviceArchivingScheduledReminderInApp(
   const consumerNotifications = await buildConsumerNotifications({
     eservice,
     archivableOn,
-    entityId: eserviceId,
+    entityId,
     readModelService,
     log,
   });
@@ -73,7 +79,7 @@ export async function handleEserviceArchivingScheduledReminderInApp(
 type BuilderParams = {
   eservice: EService;
   archivableOn: Date;
-  entityId: EServiceId;
+  entityId: EServiceIdDescriptorId;
   readModelService: ReadModelServiceSQL;
   log: Logger;
 };

--- a/packages/scheduled-in-app-notification-dispatcher/test/unit/handleEserviceArchivingScheduledReminderInApp.test.ts
+++ b/packages/scheduled-in-app-notification-dispatcher/test/unit/handleEserviceArchivingScheduledReminderInApp.test.ts
@@ -129,7 +129,10 @@ describe("handleEserviceArchivingScheduledReminderInApp", () => {
     "notifies producer + all consumers across all eservice-scope descriptors with copy that does NOT cite a specific version (gracePeriodDays: %d)",
     async (gracePeriodDaysValue: GracePeriodDays) => {
       const descriptorA = makeDescriptor({}, gracePeriodDaysValue);
-      const descriptorB = makeDescriptor({}, gracePeriodDaysValue);
+      const descriptorB = makeDescriptor(
+        { version: "2" },
+        gracePeriodDaysValue
+      );
       const eservice = makeEservice({
         descriptors: [descriptorA, descriptorB],
       });
@@ -195,7 +198,7 @@ describe("handleEserviceArchivingScheduledReminderInApp", () => {
         (n) => n.notificationType === "eserviceStateChangedToConsumer"
       );
       expect(producer?.userId).toBe(producerUserId);
-      expect(producer?.entityId).toBe(eservice.id);
+      expect(producer?.entityId).toBe(`${eservice.id}/${descriptorB.id}`);
       expect(producer?.body).toContain("sarà archiviato");
       expect(producer?.body).not.toMatch(/versione\s+\d/);
       expect(consumers).toHaveLength(2);


### PR DESCRIPTION
## Issue
- [PIN-10754](https://pagopa.atlassian.net/browse/PIN-10754)

## Context
The in-app reminder notification that warns a producer about the upcoming archiving date of an entire e-service showed the correct copy, but its deep link pointed to a Not Found page. The `entityId` sent with the notification was the bare `eserviceId`, while the expected deep link format is `/erogazione/e-service/:eserviceId/:descriptorId` (same convention already used by the other archiving-related handlers, e.g. `handleEserviceArchivingToConsumer`, `handleEserviceDescriptorArchivingScheduledReminderInApp`).

This PR fixes `handleEserviceArchivingScheduledReminderInApp` to build the `entityId` as an `EServiceIdDescriptorId` (`eserviceId/descriptorId`), retrieving the e-service's latest descriptor via `retrieveLatestDescriptor`, so the "Visualizza" button now links to the correct e-service/descriptor page.

## Scope
- scheduled-in-app-notification-dispatcher

## Traceability Checklist
- [X] PR title compliant (type(scope): description (KEY))
- [X] Service labels applied

[PIN-10754]: https://pagopa.atlassian.net/browse/PIN-10754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ