### PR TITLE
fix: Feature flag check for discrete certified attributes (PIN-10763)

### DIFF
--- a/packages/backend-for-frontend/src/services/attributeService.ts
+++ b/packages/backend-for-frontend/src/services/attributeService.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 import { attributeRegistryApi, bffApi } from "pagopa-interop-api-clients";
-import { getAllFromPaginated, WithLogger } from "pagopa-interop-commons";
+import {
+  assertFeatureFlagEnabled,
+  getAllFromPaginated,
+  WithLogger,
+} from "pagopa-interop-commons";
 
 import {
   toApiCertifiedAttributeProcessSeed,
@@ -9,6 +13,7 @@ import {
   toCompactAttribute,
 } from "../api/attributeApiConverter.js";
 import { PagoPAInteropBeClients } from "../clients/clientsProvider.js";
+import { config } from "../config/config.js";
 import { BffAppContext } from "../utilities/context.js";
 
 export async function getAllBulkAttributes(
@@ -50,6 +55,8 @@ export function attributeServiceBuilder(
       seed: bffApi.AttributeSeed,
       { logger, headers }: WithLogger<BffAppContext>
     ): Promise<bffApi.Attribute> {
+      assertFeatureFlagEnabled(config, "featureFlagAttributeCertifiedDiscrete");
+
       logger.info(
         `Creating certified discrete attribute with name ${seed.name}`
       );

--- a/packages/backend-for-frontend/test/api/attributeRouter/createCertifiedDiscreteAttribute.test.ts
+++ b/packages/backend-for-frontend/test/api/attributeRouter/createCertifiedDiscreteAttribute.test.ts
@@ -7,6 +7,7 @@ import request from "supertest";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { appBasePath } from "../../../src/config/appBasePath.js";
+import { config } from "../../../src/config/config.js";
 import {
   getMockBffApiAttribute,
   getMockBffApiAttributeSeed,
@@ -18,6 +19,7 @@ describe("API POST /certifiedDiscreteAttributes", () => {
   const mockAttribute = getMockBffApiAttribute("CERTIFIED_DISCRETE");
 
   beforeEach(() => {
+    config.featureFlagAttributeCertifiedDiscrete = true;
     clients.attributeProcessClient.createCertifiedDiscreteAttribute = vi
       .fn()
       .mockResolvedValue(mockAttribute);
@@ -49,5 +51,17 @@ describe("API POST /certifiedDiscreteAttributes", () => {
     const token = generateToken(authRole.ADMIN_ROLE);
     const res = await makeRequest(token, body as bffApi.AttributeSeed);
     expect(res.status).toBe(400);
+  });
+
+  it("Should return 501 when feature flag is disabled", async () => {
+    config.featureFlagAttributeCertifiedDiscrete = false;
+
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token);
+
+    expect(res.status).toBe(501);
+    expect(
+      clients.attributeProcessClient.createCertifiedDiscreteAttribute
+    ).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Context
This PR addresses a bug where discrete certified attributes could be created even when the corresponding Feature Flag (FF) was set to `false`. The endpoint `POST /certifiedDiscreteAttributes` was missing the necessary feature flag validation. 

## Services Affected
- `backend-for-frontend`

## Key Changes
- **Feature Flag validation:** Added an assertion to the `POST /backend-for-frontend/certifiedDiscreteAttributes` endpoint to check the feature flag status.
- **Error handling:** Configured the endpoint to correctly return a `501 Not Implemented` error when the feature flag is disabled, rather than proceeding with the creation.

## Traceability Checklist(PIN-10763)
- [X] PR title is compliant with the standard
- [X] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated