### PR TITLE
feature: Update endpoint for discrete certified attributes (PIN-10735)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -7645,6 +7645,124 @@ paths:
                 type: integer
                 format: int32
               description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+    put:
+      tags:
+        - tenants
+      operationId: updateCertifiedDiscreteAttribute
+      description: Update the value of a certified discrete attribute for a Tenant by the requester Tenant
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateCertifiedDiscreteTenantAttributeSeed"
+        required: true
+      responses:
+        "204":
+          description: Updated Tenant
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "404":
+          description: Tenant Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "409":
+          description: Attribute already revoked for the Tenant
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            "X-Rate-Limit-Limit":
+              schema:
+                type: integer
+                format: int32
+              description: Max allowed requests within time interval
+            "X-Rate-Limit-Remaining":
+              schema:
+                type: integer
+                format: int32
+              description: Remaining requests within time interval
+            "X-Rate-Limit-Interval":
+              schema:
+                type: integer
+                format: int32
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
   "/tenants/{tenantId}/attributes/verified/{attributeId}":
     parameters:
       - name: tenantId
@@ -17106,6 +17224,17 @@ components:
           maximum: 1000000000
       required:
         - id
+        - certifiedDiscreteValue
+    UpdateCertifiedDiscreteTenantAttributeSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        certifiedDiscreteValue:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+      required:
         - certifiedDiscreteValue
     DelegationKind:
       type: string

--- a/packages/api-clients/open-api/tenantApi.yml
+++ b/packages/api-clients/open-api/tenantApi.yml
@@ -1002,7 +1002,52 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          $ref: "#/components/responses/Conflict"
+          description: Attribute already revoked for the Tenant
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+    put:
+      tags:
+        - tenantAttribute
+      operationId: updateCertifiedDiscreteAttributeById
+      description: Update the value of an assigned certified discrete attribute for a Tenant by the requester Tenant
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateCertifiedDiscreteTenantAttributeSeed"
+        required: true
+      responses:
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "200":
+          description: Updated Tenant
+          headers:
+            X-Metadata-Version:
+              $ref: "#/components/headers/MetadataVersionHeader"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tenant"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Tenant Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Attribute already revoked for the Tenant
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /maintenance/tenants/{tenantId}:
     parameters:
       - $ref: "#/components/parameters/CorrelationIdHeader"
@@ -1310,6 +1355,17 @@ components:
           maximum: 1000000000
       required:
         - id
+        - certifiedDiscreteValue
+    UpdateCertifiedDiscreteTenantAttributeSeed:
+      type: object
+      additionalProperties: false
+      properties:
+        certifiedDiscreteValue:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 1000000000
+      required:
         - certifiedDiscreteValue
     TenantUnitType:
       type: string

--- a/packages/backend-for-frontend/src/routers/tenantRouter.ts
+++ b/packages/backend-for-frontend/src/routers/tenantRouter.ts
@@ -309,6 +309,35 @@ const tenantRouter = (
         }
       }
     )
+    .put(
+      "/tenants/:tenantId/attributes/certifiedDiscrete/:attributeId",
+      async (req, res) => {
+        const ctx = fromBffAppContext(req.ctx, req.headers);
+
+        try {
+          const tenantId = unsafeBrandId<TenantId>(req.params.tenantId);
+          const attributeId = unsafeBrandId<AttributeId>(
+            req.params.attributeId
+          );
+          await tenantService.updateCertifiedDiscreteAttribute(
+            tenantId,
+            attributeId,
+            req.body,
+            ctx
+          );
+
+          return res.status(204).send();
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            emptyErrorMapper,
+            ctx,
+            `Error updating certified discrete attribute ${req.params.attributeId} for tenant ${req.params.tenantId}`
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
     .post(
       "/tenants/:tenantId/attributes/verified/:attributeId",
       async (req, res) => {

--- a/packages/backend-for-frontend/src/services/tenantService.ts
+++ b/packages/backend-for-frontend/src/services/tenantService.ts
@@ -444,6 +444,23 @@ export function tenantServiceBuilder(
         }
       );
     },
+    async updateCertifiedDiscreteAttribute(
+      tenantId: TenantId,
+      attributeId: AttributeId,
+      seed: bffApi.UpdateCertifiedDiscreteTenantAttributeSeed,
+      { logger, headers }: WithLogger<BffAppContext>
+    ): Promise<void> {
+      logger.info(
+        `Updating certified discrete attribute ${attributeId} for tenant ${tenantId}`
+      );
+      await tenantProcessClient.tenantAttribute.updateCertifiedDiscreteAttributeById(
+        seed,
+        {
+          params: { tenantId, attributeId },
+          headers,
+        }
+      );
+    },
     async revokeVerifiedAttribute(
       tenantId: TenantId,
       attributeId: AttributeId,

--- a/packages/backend-for-frontend/test/api/tenantRouter/updateCertifiedDiscreteAttribute.test.ts
+++ b/packages/backend-for-frontend/test/api/tenantRouter/updateCertifiedDiscreteAttribute.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { bffApi } from "pagopa-interop-api-clients";
+import { authRole } from "pagopa-interop-commons";
+import { generateToken } from "pagopa-interop-commons-test";
+import { AttributeId, TenantId, generateId } from "pagopa-interop-models";
+import request from "supertest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { appBasePath } from "../../../src/config/appBasePath.js";
+import { api, clients } from "../../vitest.api.setup.js";
+
+describe("API PUT /tenants/:tenantId/attributes/certifiedDiscrete/:attributeId test", () => {
+  const updateSeed: bffApi.UpdateCertifiedDiscreteTenantAttributeSeed = {
+    certifiedDiscreteValue: 100,
+  };
+
+  beforeEach(() => {
+    clients.tenantProcessClient.tenantAttribute.updateCertifiedDiscreteAttributeById =
+      vi.fn().mockResolvedValue(undefined);
+  });
+
+  const makeRequest = async (
+    token: string,
+    tenantId: TenantId = generateId(),
+    attributeId: AttributeId = generateId(),
+    body: bffApi.UpdateCertifiedDiscreteTenantAttributeSeed = updateSeed
+  ) =>
+    request(api)
+      .put(
+        `${appBasePath}/tenants/${tenantId}/attributes/certifiedDiscrete/${attributeId}`
+      )
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send(body);
+
+  it("Should return 204 for user with role Admin", async () => {
+    const token = generateToken(authRole.ADMIN_ROLE);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(204);
+  });
+
+  it.each([
+    { tenantId: "invalid" as TenantId },
+    { attributeId: "invalid" as AttributeId },
+    { body: {} },
+    { body: { certifiedDiscreteValue: 0 } },
+    { body: { certifiedDiscreteValue: "invalid" } },
+    { body: { ...updateSeed, extraField: 1 } },
+  ])(
+    "Should return 400 if passed invalid data: %s",
+    async ({ tenantId, attributeId, body }) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        tenantId,
+        attributeId,
+        body as bffApi.UpdateCertifiedDiscreteTenantAttributeSeed
+      );
+      expect(res.status).toBe(400);
+    }
+  );
+});

--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -1071,6 +1071,40 @@ const tenantsRouter = (
         }
       }
     )
+    .put(
+      "/tenants/:tenantId/attributes/certifiedDiscrete/:attributeId",
+      async (req, res) => {
+        const ctx = fromAppContext(req.ctx);
+
+        try {
+          validateAuthorization(ctx, [ADMIN_ROLE, M2M_ROLE, M2M_ADMIN_ROLE]);
+
+          const { tenantId, attributeId } = req.params;
+          const { data: tenant, metadata } =
+            await tenantService.updateCertifiedDiscreteAttributeById(
+              {
+                tenantId: unsafeBrandId(tenantId),
+                attributeId: unsafeBrandId(attributeId),
+                tenantAttributeSeed: req.body,
+              },
+              ctx
+            );
+
+          setMetadataVersionHeader(res, metadata);
+
+          return res
+            .status(200)
+            .send(tenantApi.Tenant.parse(toApiTenant(tenant)));
+        } catch (error) {
+          const errorRes = makeApiProblem(
+            error,
+            revokeCertifiedAttributeErrorMapper,
+            ctx
+          );
+          return res.status(errorRes.status).send(errorRes);
+        }
+      }
+    )
     .delete(
       "/tenants/:tenantId/attributes/certifiedDiscrete/:attributeId",
       async (req, res) => {

--- a/packages/tenant-process/src/services/tenantService.ts
+++ b/packages/tenant-process/src/services/tenantService.ts
@@ -229,6 +229,31 @@ async function retrieveAgreement(
   return agreement;
 }
 
+type CertifiedDiscreteTenantAttribute = Extract<
+  TenantAttribute,
+  { type: typeof tenantAttributeType.CERTIFIED_DISCRETE }
+>;
+
+function isCertifiedDiscreteTenantAttribute(
+  attr: TenantAttribute,
+  attributeId: AttributeId
+): attr is CertifiedDiscreteTenantAttribute {
+  return (
+    attr.type === tenantAttributeType.CERTIFIED_DISCRETE &&
+    attr.id === attributeId
+  );
+}
+
+function isActiveCertifiedDiscreteTenantAttribute(
+  attr: TenantAttribute,
+  attributeId: AttributeId
+): attr is CertifiedDiscreteTenantAttribute {
+  return (
+    isCertifiedDiscreteTenantAttribute(attr, attributeId) &&
+    !attr.revocationTimestamp
+  );
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function tenantServiceBuilder(
   dbInstance: DB,
@@ -667,14 +692,8 @@ export function tenantServiceBuilder(
       const targetTenant = await retrieveTenant(tenantId, readModelService);
 
       const existingCertifiedDiscrete = targetTenant.data.attributes.find(
-        (
-          attr
-        ): attr is Extract<
-          TenantAttribute,
-          { type: typeof tenantAttributeType.CERTIFIED_DISCRETE }
-        > =>
-          attr.type === tenantAttributeType.CERTIFIED_DISCRETE &&
-          attr.id === attribute.id
+        (attr): attr is CertifiedDiscreteTenantAttribute =>
+          isCertifiedDiscreteTenantAttribute(attr, attribute.id)
       );
 
       const now = new Date();
@@ -1018,14 +1037,8 @@ export function tenantServiceBuilder(
       const targetTenant = await retrieveTenant(tenantId, readModelService);
 
       const certifiedTenantAttribute = targetTenant.data.attributes.find(
-        (
-          attr
-        ): attr is Extract<
-          TenantAttribute,
-          { type: typeof tenantAttributeType.CERTIFIED_DISCRETE }
-        > =>
-          attr.type === tenantAttributeType.CERTIFIED_DISCRETE &&
-          attr.id === attributeId
+        (attr): attr is CertifiedDiscreteTenantAttribute =>
+          isCertifiedDiscreteTenantAttribute(attr, attributeId)
       );
 
       if (!certifiedTenantAttribute) {
@@ -1092,6 +1105,143 @@ export function tenantServiceBuilder(
 
       return {
         data: tenantWithRevokedAttribute,
+        metadata: { version: newVersion },
+      };
+    },
+
+    async updateCertifiedDiscreteAttributeById(
+      {
+        tenantId,
+        attributeId,
+        tenantAttributeSeed,
+      }: {
+        tenantId: TenantId;
+        attributeId: AttributeId;
+        tenantAttributeSeed: tenantApi.UpdateCertifiedDiscreteTenantAttributeSeed;
+      },
+      {
+        authData,
+        correlationId,
+        logger,
+      }: WithLogger<AppContext<UIAuthData | M2MAuthData | M2MAdminAuthData>>
+    ): Promise<WithMetadata<Tenant>> {
+      const newValue = tenantAttributeSeed.certifiedDiscreteValue;
+
+      logger.info(
+        `Update certified discrete attribute ${attributeId} to value ${newValue} for tenant ${tenantId}`
+      );
+
+      const requesterTenant = await retrieveTenant(
+        authData.organizationId,
+        readModelService
+      );
+
+      const certifierId = retrieveCertifierId(requesterTenant.data);
+
+      const attribute = await retrieveAttribute(attributeId, readModelService);
+
+      if (attribute.kind !== attributeKind.certifiedDiscrete) {
+        throw attributeNotFound(attribute.id);
+      }
+
+      if (!attribute.origin || attribute.origin !== certifierId) {
+        throw attributeDoesNotBelongToCertifier(
+          attribute.id,
+          authData.organizationId,
+          tenantId
+        );
+      }
+
+      const targetTenant = await retrieveTenant(tenantId, readModelService);
+
+      const certifiedTenantAttribute = targetTenant.data.attributes.find(
+        (attr): attr is CertifiedDiscreteTenantAttribute =>
+          isCertifiedDiscreteTenantAttribute(attr, attributeId)
+      );
+
+      if (!certifiedTenantAttribute) {
+        throw attributeNotFound(attributeId);
+      }
+
+      if (certifiedTenantAttribute.revocationTimestamp) {
+        throw attributeAlreadyRevoked(
+          tenantId,
+          authData.organizationId,
+          attributeId
+        );
+      }
+
+      const previousValue = certifiedTenantAttribute.discreteValue;
+
+      if (previousValue === newValue) {
+        return {
+          data: targetTenant.data,
+          metadata: { version: targetTenant.metadata.version },
+        };
+      }
+
+      const updatedAttributes = targetTenant.data.attributes.map((a) =>
+        a.id === attributeId &&
+        a.type === tenantAttributeType.CERTIFIED_DISCRETE
+          ? { ...a, discreteValue: newValue }
+          : a
+      );
+
+      const tenantWithUpdatedAttribute: Tenant = {
+        ...targetTenant.data,
+        attributes: updatedAttributes,
+        updatedAt: new Date(),
+      };
+
+      const tenantCertifiedDiscreteAttributeUpdatedEvent =
+        toCreateEventTenantCertifiedDiscreteAttributeUpdated(
+          targetTenant.metadata.version,
+          tenantWithUpdatedAttribute,
+          attributeId,
+          previousValue,
+          newValue,
+          correlationId
+        );
+
+      const tenantKind = await getTenantKindLoadingCertifiedAttributes(
+        readModelService,
+        tenantWithUpdatedAttribute.attributes,
+        tenantWithUpdatedAttribute.externalId,
+        tenantWithUpdatedAttribute.selfcareInstitutionType
+      );
+
+      if (tenantWithUpdatedAttribute.kind !== tenantKind) {
+        const updatedTenant = {
+          ...tenantWithUpdatedAttribute,
+          kind: tenantKind,
+        };
+
+        const tenantKindUpdatedEvent = toCreateEventTenantKindUpdated(
+          targetTenant.metadata.version + 1,
+          targetTenant.data.kind,
+          updatedTenant,
+          correlationId
+        );
+
+        const createdEvents = await repository.createEvents([
+          tenantCertifiedDiscreteAttributeUpdatedEvent,
+          tenantKindUpdatedEvent,
+        ]);
+
+        return {
+          data: updatedTenant,
+          metadata: {
+            version: createdEvents.latestNewVersions.get(updatedTenant.id) ?? 0,
+          },
+        };
+      }
+
+      const { newVersion } = await repository.createEvent(
+        tenantCertifiedDiscreteAttributeUpdatedEvent
+      );
+
+      return {
+        data: tenantWithUpdatedAttribute,
         metadata: { version: newVersion },
       };
     },
@@ -1738,11 +1888,8 @@ export function tenantServiceBuilder(
         readModelService,
       });
 
-      const certifiedAttribute = tenantToModify.data.attributes.find(
-        (attr): boolean =>
-          attr.type === tenantAttributeType.CERTIFIED_DISCRETE &&
-          attr.id === attributeToRevoke.id &&
-          !attr.revocationTimestamp
+      const certifiedAttribute = tenantToModify.data.attributes.find((attr) =>
+        isActiveCertifiedDiscreteTenantAttribute(attr, attributeToRevoke.id)
       );
 
       if (!certifiedAttribute) {

--- a/packages/tenant-process/test/api/updateCertifiedDiscreteAttributeById.test.ts
+++ b/packages/tenant-process/test/api/updateCertifiedDiscreteAttributeById.test.ts
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { tenantApi } from "pagopa-interop-api-clients";
+import { AuthRole, authRole } from "pagopa-interop-commons";
+import {
+  generateToken,
+  getMockTenant,
+  getMockWithMetadata,
+} from "pagopa-interop-commons-test";
+import {
+  AttributeId,
+  generateId,
+  Tenant,
+  TenantId,
+} from "pagopa-interop-models";
+import request from "supertest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { toApiTenant } from "../../src/model/domain/apiConverter.js";
+import {
+  attributeAlreadyRevoked,
+  attributeDoesNotBelongToCertifier,
+  attributeNotFound,
+  tenantIsNotACertifier,
+  tenantNotFound,
+} from "../../src/model/domain/errors.js";
+import { api, tenantService } from "../vitest.api.setup.js";
+
+describe("API PUT /tenants/{tenantId}/attributes/certifiedDiscrete/{attributeId} test", () => {
+  const updateSeed: tenantApi.UpdateCertifiedDiscreteTenantAttributeSeed = {
+    certifiedDiscreteValue: 100,
+  };
+
+  const tenant: Tenant = getMockTenant();
+
+  const serviceResponse = getMockWithMetadata(tenant);
+  const apiResponse = tenantApi.Tenant.parse(toApiTenant(tenant));
+
+  beforeEach(() => {
+    tenantService.updateCertifiedDiscreteAttributeById = vi
+      .fn()
+      .mockResolvedValue(serviceResponse);
+  });
+
+  const authorizedRoles: AuthRole[] = [
+    authRole.ADMIN_ROLE,
+    authRole.M2M_ROLE,
+    authRole.M2M_ADMIN_ROLE,
+  ];
+
+  const makeRequest = async (
+    token: string,
+    tenantId: TenantId = tenant.id,
+    attributeId: AttributeId = generateId(),
+    body: tenantApi.UpdateCertifiedDiscreteTenantAttributeSeed = updateSeed
+  ) =>
+    request(api)
+      .put(`/tenants/${tenantId}/attributes/certifiedDiscrete/${attributeId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Correlation-Id", generateId())
+      .send(body);
+
+  it.each(authorizedRoles)(
+    "Should return 200 for user with role %s",
+    async (role) => {
+      const token = generateToken(role);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(apiResponse);
+      expect(res.headers["x-metadata-version"]).toBe(
+        serviceResponse.metadata.version.toString()
+      );
+    }
+  );
+
+  it.each(
+    Object.values(authRole).filter((role) => !authorizedRoles.includes(role))
+  )("Should return 403 for user with role %s", async (role) => {
+    const token = generateToken(role);
+    const res = await makeRequest(token);
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { error: tenantNotFound(tenant.id), expectedStatus: 404 },
+    { error: attributeNotFound(generateId()), expectedStatus: 404 },
+    {
+      error: attributeDoesNotBelongToCertifier(
+        generateId(),
+        generateId(),
+        tenant.id
+      ),
+      expectedStatus: 403,
+    },
+    { error: tenantIsNotACertifier(generateId()), expectedStatus: 403 },
+    {
+      error: attributeAlreadyRevoked(generateId(), generateId(), generateId()),
+      expectedStatus: 409,
+    },
+  ])(
+    "Should return $expectedStatus for $error.code",
+    async ({ error, expectedStatus }) => {
+      tenantService.updateCertifiedDiscreteAttributeById = vi
+        .fn()
+        .mockRejectedValue(error);
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(token);
+      expect(res.status).toBe(expectedStatus);
+    }
+  );
+
+  it.each([
+    { tenantId: "invalid" as TenantId },
+    { attributeId: "invalid" as AttributeId },
+    { body: {} },
+    { body: { certifiedDiscreteValue: 0 } },
+    { body: { certifiedDiscreteValue: "invalid" } },
+    { body: { ...updateSeed, extraField: 1 } },
+  ])(
+    "Should return 400 if passed invalid data: %s",
+    async ({ tenantId, attributeId, body }) => {
+      const token = generateToken(authRole.ADMIN_ROLE);
+      const res = await makeRequest(
+        token,
+        tenantId,
+        attributeId,
+        body as tenantApi.UpdateCertifiedDiscreteTenantAttributeSeed
+      );
+      expect(res.status).toBe(400);
+    }
+  );
+});


### PR DESCRIPTION
## Context
This PR introduces the ability to update the value of a discrete certified attribute. To support this, a new update endpoint has been added to the BFF, and the request is propagated to the tenant-process.

## Services Affected
- `backend-for-frontend`
- `tenant-process`

## Key Changes
- **Attribute update (BFF):** Added the new endpoint `PUT /backend-for-frontend/tenants/:tenantId/attributes/certifiedDiscrete/:attributeId` with payload `{ "value": number }`.
- **Process propagation:** Implemented the propagation of the update request to the `tenant-process` endpoint `PUT /tenants/:tenantId/attributes/certifiedDiscrete/:attributeId`.

## Traceability Checklist
- [X] Branch name contain the Jira key
- [X] PR title is compliant with the standard
- [X] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [x] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated