### PR TITLE
fix: tolerate an existing S3 key when storing a signed document (PIN-9842)

### DIFF
--- a/packages/commons-test/package.json
+++ b/packages/commons-test/package.json
@@ -19,6 +19,7 @@
     "@anatine/zod-mock": "catalog:",
     "@aws-sdk/client-dynamodb": "catalog:",
     "@aws-sdk/client-kms": "catalog:",
+    "@aws-sdk/client-s3": "catalog:",
     "@aws-sdk/client-sesv2": "catalog:",
     "@aws-sdk/util-dynamodb": "catalog:",
     "@faker-js/faker": "catalog:",

--- a/packages/commons-test/test/fileManagerResumeOrStoreBytes.test.ts
+++ b/packages/commons-test/test/fileManagerResumeOrStoreBytes.test.ts
@@ -1,0 +1,138 @@
+import {
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  S3ServiceException,
+} from "@aws-sdk/client-s3";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  FileManagerConfig,
+  LoggerConfig,
+  genericLogger,
+  initFileManager,
+} from "pagopa-interop-commons";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const s3Mock = mockClient(S3Client);
+
+const config: FileManagerConfig & LoggerConfig = {
+  s3CustomServer: false,
+  logLevel: "info",
+};
+
+const s3File = {
+  bucket: "test-bucket",
+  path: "test/path",
+  name: "document_signed.pdf",
+  content: Buffer.from("content"),
+};
+
+const expectedKey = `${s3File.path}/${s3File.name}`;
+
+function s3Error(name: string, httpStatusCode: number): S3ServiceException {
+  return new S3ServiceException({
+    name,
+    message: name,
+    $fault: "client",
+    $metadata: { httpStatusCode },
+  });
+}
+
+const notFound = (): S3ServiceException => s3Error("NotFound", 404);
+const conflict = (): S3ServiceException => s3Error("Conflict", 409);
+
+describe("resumeOrStoreBytes", () => {
+  beforeEach(() => {
+    s3Mock.reset();
+  });
+
+  it("should resume the existing file without storing it again", async () => {
+    s3Mock.on(HeadObjectCommand).resolves({});
+
+    const fileManager = initFileManager(config);
+    const key = await fileManager.resumeOrStoreBytes(s3File, genericLogger);
+
+    expect(key).toBe(expectedKey);
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+  });
+
+  it("should store the file when it does not exist yet", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(notFound());
+    s3Mock.on(PutObjectCommand).resolves({});
+
+    const fileManager = initFileManager(config);
+    const key = await fileManager.resumeOrStoreBytes(s3File, genericLogger);
+
+    expect(key).toBe(expectedKey);
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+  });
+
+  it("should resume the file when the store fails and the file exists", async () => {
+    s3Mock.on(HeadObjectCommand).rejectsOnce(notFound()).resolves({});
+    s3Mock.on(PutObjectCommand).rejects(conflict());
+
+    const fileManager = initFileManager(config);
+    const key = await fileManager.resumeOrStoreBytes(s3File, genericLogger);
+
+    expect(key).toBe(expectedKey);
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+    // The first head check misses the file, the second one finds it.
+    expect(s3Mock.commandCalls(HeadObjectCommand)).toHaveLength(2);
+  });
+
+  it("should fail with the store error when the file does not exist", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(notFound());
+    s3Mock.on(PutObjectCommand).rejects(s3Error("AccessDenied", 403));
+
+    const fileManager = initFileManager(config);
+
+    await expect(
+      fileManager.resumeOrStoreBytes(s3File, genericLogger)
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        code: "fileManagerStoreBytesError",
+        detail: expect.stringContaining("AccessDenied"),
+      })
+    );
+    expect(s3Mock.commandCalls(HeadObjectCommand)).toHaveLength(2);
+  });
+
+  it("should fail with the store error when the check after the store also fails", async () => {
+    s3Mock.on(HeadObjectCommand).rejectsOnce(notFound()).rejects(conflict());
+    s3Mock.on(PutObjectCommand).rejects(s3Error("AccessDenied", 403));
+
+    const fileManager = initFileManager(config);
+
+    await expect(
+      fileManager.resumeOrStoreBytes(s3File, genericLogger)
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: "fileManagerStoreBytesError" })
+    );
+  });
+
+  it("should fail when the head check fails for a reason other than a missing file", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(s3Error("AccessDenied", 403));
+
+    const fileManager = initFileManager(config);
+
+    await expect(
+      fileManager.resumeOrStoreBytes(s3File, genericLogger)
+    ).rejects.toThrowError(
+      expect.objectContaining({ code: "fileManagerResumeFileError" })
+    );
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+  });
+
+  it("should build the key with the resource id when it is provided", async () => {
+    s3Mock.on(HeadObjectCommand).rejects(notFound());
+    s3Mock.on(PutObjectCommand).resolves({});
+
+    const fileManager = initFileManager(config);
+    const key = await fileManager.resumeOrStoreBytes(
+      { ...s3File, resourceId: "resource-id" },
+      genericLogger
+    );
+
+    expect(key).toBe(`${s3File.path}/resource-id/${s3File.name}`);
+  });
+});

--- a/packages/commons/src/file-manager/fileManager.ts
+++ b/packages/commons/src/file-manager/fileManager.ts
@@ -121,6 +121,27 @@ export function initFileManager(
     }
   };
 
+  const fileExists = async (
+    bucket: string,
+    key: string,
+    logger: Logger
+  ): Promise<boolean> => {
+    try {
+      await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+      return true;
+    } catch (error) {
+      if (error instanceof S3ServiceException && error.name === "NotFound") {
+        return false;
+      }
+      // The caller is already handling a store failure, so this check must not
+      // replace it with a less accurate error.
+      logger.warn(
+        `Error checking file s3://${bucket}/${key} after a store failure: ${error}`
+      );
+      return false;
+    }
+  };
+
   const storeBytesFn = async (
     s3File: {
       bucket: string;
@@ -260,7 +281,22 @@ export function initFileManager(
           throw fileManagerResumeFileError(key, s3File.bucket, error);
         }
       }
-      return storeBytesFn(s3File, logger);
+
+      try {
+        return await storeBytesFn(s3File, logger);
+      } catch (storeError) {
+        // The head check above can miss a file that a concurrent writer stores
+        // immediately after, and an immutable bucket rejects the overwrite. An
+        // existing key is the result this function asks for, so it is a
+        // success, as in the head check above.
+        if (await fileExists(s3File.bucket, key, logger)) {
+          logger.warn(
+            `File exists after a failed store, resuming s3://${s3File.bucket}/${key}. Store error: ${storeError}`
+          );
+          return key;
+        }
+        throw storeError;
+      }
     },
     generateGetPresignedUrl: async (
       bucketName: string,

--- a/packages/purpose-template-process/src/model/domain/errors.ts
+++ b/packages/purpose-template-process/src/model/domain/errors.ts
@@ -412,7 +412,7 @@ export function purposeTemplateRiskAnalysisTemplateSignedDocumentNotFound(
   purposeTemplateRiskAnalysisForm: RiskAnalysisFormTemplateId
 ): ApiError<ErrorCodes> {
   return new ApiError({
-    detail: `No signed document found for Risk Analysis Template Form ${purposeTemplateRiskAnalysisForm}`,
+    detail: `No signed document found for Risk Analysis Template Form ${purposeTemplateRiskAnalysisForm}. The signature is asynchronous: the document can still be in progress`,
     code: "purposeTemplateRiskAnalysisTemplateSignedDocumentNotFound",
     title: "Risk Analysis Template Signed Document Not Found",
   });

--- a/packages/signed-objects-persister/package.json
+++ b/packages/signed-objects-persister/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "catalog:",
-    "@aws-sdk/client-s3": "catalog:",
     "@aws-sdk/client-sqs": "catalog:",
     "date-fns": "catalog:",
     "pagopa-interop-api-clients": "workspace:*",

--- a/packages/signed-objects-persister/src/handlers/sqsMessageHandler.ts
+++ b/packages/signed-objects-persister/src/handlers/sqsMessageHandler.ts
@@ -1,4 +1,3 @@
-import { S3ServiceException } from "@aws-sdk/client-s3";
 import { Message } from "@aws-sdk/client-sqs";
 import {
   DocumentSignatureReference,
@@ -102,33 +101,12 @@ async function processMessage(
       signature.fileName
     );
 
-    // immutable s3Key with 409 handling for specific documentTypes
-    const s3Key: string = await (async (): Promise<string> => {
-      try {
-        return await fileManager.resumeOrStoreBytes(
-          { bucket, path: filePath, name: fileName, content: fileContent },
-          logger
-        );
-      } catch (error) {
-        const isConflict =
-          error instanceof S3ServiceException &&
-          (error.$metadata?.httpStatusCode === 409 ||
-            error.name === "Conflict");
-
-        const allowConflictWarning =
-          signatureFileKind === "RISK_ANALYSIS_DOCUMENT" ||
-          signatureFileKind === "RISK_ANALYSIS_TEMPLATE_DOCUMENT" ||
-          signatureFileKind === "AGREEMENT_CONTRACT";
-
-        if (isConflict && allowConflictWarning) {
-          logger.warn(
-            `Conflict (409) uploading s3://${bucket}/${path}/${fileName} — file already exists, continuing`
-          );
-          return `${path}/${fileName}`;
-        }
-        throw error;
-      }
-    })();
+    // resumeOrStoreBytes tolerates an already existing key, so a re-delivered
+    // message reuses the stored file instead of failing on an immutable bucket.
+    const s3Key: string = await fileManager.resumeOrStoreBytes(
+      { bucket, path: filePath, name: fileName, content: fileContent },
+      logger
+    );
 
     logger.info(`File successfully saved in S3 with key: ${s3Key}`);
 

--- a/packages/signed-objects-persister/test/sqsMessageHandlerStoreFailure.test.ts
+++ b/packages/signed-objects-persister/test/sqsMessageHandlerStoreFailure.test.ts
@@ -1,11 +1,13 @@
-import { S3ServiceException } from "@aws-sdk/client-s3";
 import { Message } from "@aws-sdk/client-sqs";
 import {
   FileManager,
+  FileManagerError,
+  fileManagerStoreBytesError,
   RefreshableInteropToken,
   SafeStorageService,
 } from "pagopa-interop-commons";
 import { SignatureServiceBuilder } from "pagopa-interop-commons";
+import { InternalError } from "pagopa-interop-models";
 import { describe, it, expect, vi, Mock, beforeEach } from "vitest";
 
 import { sqsMessageHandler } from "../src/handlers/sqsMessageHandler.js";
@@ -35,12 +37,12 @@ const mockSafeStorageService: SafeStorageService = {
   downloadFileContent: vi.fn(),
 };
 
-describe("sqsMessageHandler - S3 409 Conflict", () => {
+describe("sqsMessageHandler - S3 store failure", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should handle S3 409 Conflict gracefully for RISK_ANALYSIS_DOCUMENT", async () => {
+  it("should retry the message when the file manager fails to store the signed file", async () => {
     const sqsMessageBody = {
       version: "0",
       id: "6e902b1c-7f55-4074-a036-749e75551f33",
@@ -51,7 +53,7 @@ describe("sqsMessageHandler - S3 409 Conflict", () => {
       region: "eu-central-1",
       resources: ["arn:aws:s3:::some-bucket"],
       detail: {
-        key: "conflict-file.pdf",
+        key: "document.pdf",
         versionId: "12345",
         documentType: "INTEROP_LEGAL_FACTS",
         documentStatus: "SAVED",
@@ -77,18 +79,15 @@ describe("sqsMessageHandler - S3 409 Conflict", () => {
       mockFileContent
     );
 
-    // Simula S3 409 Conflict
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const conflictError = new S3ServiceException({} as any);
-    // eslint-disable-next-line functional/immutable-data
-    conflictError.$metadata = { httpStatusCode: 409 };
-    // eslint-disable-next-line functional/immutable-data
-    conflictError.name = "Conflict";
+    // The file manager wraps every S3 failure into a FileManagerError.
     (mockFileManager.resumeOrStoreBytes as Mock).mockRejectedValueOnce(
-      conflictError
+      fileManagerStoreBytesError(
+        "path/to/document_signed.pdf",
+        "signed-documents-bucket",
+        new Error("AccessDenied")
+      )
     );
 
-    // Mock of signature read
     (mockDbService.readSignatureReferenceById as Mock).mockResolvedValueOnce({
       id: sqsMessageBody.id,
       key: sqsMessageBody.detail.key,
@@ -98,36 +97,25 @@ describe("sqsMessageHandler - S3 409 Conflict", () => {
       subObjectId: "sub-object-id",
       streamId: "stream-id",
       correlationId: "corr-id",
-      fileName: "conflict-file.pdf",
+      fileName: "document.pdf",
       path: "path/to",
     });
 
-    (mockDbService.deleteSignatureReference as Mock).mockResolvedValueOnce(
-      void 0
-    );
-
-    // Mock metadata function
-    vi.mock("../src/utils/metadata/riskAnalysis.js", () => ({
-      addPurposeRiskAnalysisSignedDocument: vi
-        .fn()
-        .mockResolvedValue(undefined),
-    }));
-
-    await sqsMessageHandler(
+    const error = await sqsMessageHandler(
       sqsMessagePayload,
       mockFileManager as FileManager,
       mockDbService,
       mockSafeStorageService,
       mockRefreshableToken
-    );
+    ).catch((e) => e);
 
-    // Check that resumeOrStoreBytes has been called
-    expect(mockFileManager.resumeOrStoreBytes).toHaveBeenCalled();
+    expect(error).toBeInstanceOf(FileManagerError);
+    // A FileManagerError is an InternalError, so the SQS runner keeps the
+    // message and retries it instead of stopping the consumer.
+    expect(error).toBeInstanceOf(InternalError);
 
-    // Verify that the signature was deleted despite the 409
-    expect(mockDbService.deleteSignatureReference).toHaveBeenCalledWith(
-      sqsMessageBody.detail.key,
-      expect.any(Object)
-    );
+    // The signature reference stays in place, so a later delivery can complete
+    // the flow.
+    expect(mockDbService.deleteSignatureReference).not.toHaveBeenCalled();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2061,6 +2061,9 @@ importers:
       '@aws-sdk/client-kms':
         specifier: 'catalog:'
         version: 3.840.0
+      '@aws-sdk/client-s3':
+        specifier: 'catalog:'
+        version: 3.842.0
       '@aws-sdk/client-sesv2':
         specifier: 'catalog:'
         version: 3.840.0
@@ -6250,9 +6253,6 @@ importers:
       '@aws-sdk/client-dynamodb':
         specifier: 'catalog:'
         version: 3.840.0
-      '@aws-sdk/client-s3':
-        specifier: 'catalog:'
-        version: 3.842.0
       '@aws-sdk/client-sqs':
         specifier: 'catalog:'
         version: 3.840.0


### PR DESCRIPTION
## What

Makes `resumeOrStoreBytes` tolerant of an S3 key that already exists, and removes the conflict branch in `signed-objects-persister`, which could never run. Also states in the error detail that a signed risk analysis template document can still be in progress.

## Problem

`sqsMessageHandler` had a branch that caught an S3 conflict (409) and continued with the existing file. That branch could never run.

`resumeOrStoreBytes` wraps every AWS failure into `FileManagerError`, both for the head check and for the put. `FileManagerError` extends `InternalError`. The handler tested `error instanceof S3ServiceException`, so the test was always false.

Result on a real conflict:

1. The handler throws the `FileManagerError`.
2. The shared SQS runner sees an `InternalError`, logs it and keeps the message (`packages/commons/src/sqs/index.ts:172-181`).
3. The message returns after the visibility timeout and fails the same way. The queue `interop-safe-storage-completed-tasks-<env>` has no DLQ, so the loop is silent.
4. The signed document metadata is never sent to the process service.
5. `GET /purposeTemplates/{id}/riskAnalysisDocument/signed` returns 404 (error `015-0025`) for that document. The same applies to the purpose and agreement signed documents.

The dead branch had a second defect. It interpolated the `path` module, imported at the top of the file, instead of the `filePath` variable. The value of the module in a template string is `[object Object]`. If the branch could run, it stored `[object Object]/<fileName>` as the S3 key in the read model, and every later download of that document failed.

Introduced in `df7d99633` (PR #2545, 06/11/2025).

## Changes

**Conflict tolerance moves into `commons`.** In `resumeOrStoreBytes`, if the store fails, the head check runs again. If the object exists, the function returns the key that `buildS3Key` produces, and logs the store error. This covers two cases:

- the first head check misses a file that a concurrent writer stores immediately after;
- an immutable bucket rejects the overwrite.

The behaviour of the function does not change in any other case. If the second head check fails, the original store error goes up, so a store failure is never replaced by a less accurate error.

The new behaviour is the same one that the head check before the store already applies: an existing key is a success and the content is not compared. For this reason the removal of the file kind allow list in the handler does not add a risk of a silent overwrite. A key that two different files share is already resumed by the first head check.

Every consumer of the file manager gets the behaviour, so the branch in `sqsMessageHandler` is removed.

**Error detail.** `purposeTemplateRiskAnalysisTemplateSignedDocumentNotFound` now says that the signature is asynchronous and that the document can still be in progress. The frontend can show a message about a document in preparation instead of a generic failure. The error code, the title and the 404 status do not change, so the API contract stays the same.

## Tests

`sqsMessageHandler409.test.ts` rejected with a raw `S3ServiceException` that the real file manager never throws, and it did not assert the S3 key that the handler sends downstream. It gave confidence in code that could not run, and it hid the wrong variable. It becomes `sqsMessageHandlerStoreFailure.test.ts`, which rejects with a real `FileManagerError` and asserts the retry contract: the handler propagates an `InternalError` and keeps the signature reference, so a later delivery can complete the flow.

`resumeOrStoreBytes` had no test. New unit tests in `commons-test` use `aws-sdk-client-mock` for seven cases:

- resume an existing file, without a store;
- store a file that does not exist;
- resume after a failed store, when the file exists;
- fail with the store error when the file does not exist;
- fail with the store error when the check after the store also fails;
- fail when the first head check fails for a reason other than a missing file;
- build the key with the resource id.

`@aws-sdk/client-s3` is added to the `commons-test` dev dependencies, because the package did not declare it.

## Notes

This is a candidate cause of PIN-9842, but not a confirmed one. The 404 in QA has three possible causes with the same symptom:

1. the missing signature reference race, fixed by #3497;
2. this conflict path;
3. the signer or SafeStorage never produced the file.

The QA template needs a check on the DynamoDB signature reference table and on the persister logs to tell them apart. A template that is already without a signed document does not heal on its own, because the SQS message is past retention and there is no reprocess job.

The DLQ on `interop-safe-storage-completed-tasks-<env>` is still missing. It stays the recommended backstop, because a permanent failure of this kind is otherwise silent.
