### PR TITLE
PIN-5601 disabling turbo telemetry

### DIFF
--- a/.github/workflows/pr-app-validation.yaml
+++ b/.github/workflows/pr-app-validation.yaml
@@ -9,6 +9,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  TURBO_TELEMETRY_DISABLED: "1"
+
 jobs:
   lint-openapi:
     name: Lint Open Api specification

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ You should see the event being processed by the consumer and the read model bein
 
 You can verify this by using PgAdmin, which is being started alongside the consumer and is available at http://localhost:8082. That can be used to inspect the event store.
 
+## Turborepo telemetry
+
+Turborepo collects anonymous usage [telemetry](https://turborepo.com/docs/telemetry) by default.
+
+In CI it is disabled via the `TURBO_TELEMETRY_DISABLED=1` environment variable.
+
+To disable it for your local machine, run once:
+
+```
+pnpm turbo telemetry disable
+```
+
 ## Licensing
 
 This project is licensed under the terms of the **European Union Public Licence version 1.2 (EUPL-1.2)**.


### PR DESCRIPTION
[PIN-5601](https://pagopa.atlassian.net/browse/PIN-5601)

This pull request adds documentation and configuration to disable Turborepo telemetry, both in CI and locally. The main changes include updating the workflow environment variables and providing instructions in the `README.md`.

**Turborepo telemetry configuration:**

* [`.github/workflows/pr-app-validation.yaml`](diffhunk://#diff-7ef0fc26ae70608bf4300e55decbc65d18dcda2342bf7b9a19532de73b1907baR12-R14): Sets the `TURBO_TELEMETRY_DISABLED` environment variable to `"1"` to disable telemetry during CI runs.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R64-R75): Adds a section explaining Turborepo telemetry, how it is disabled in CI, and instructions for disabling it locally.

[PIN-5601]: https://pagopa.atlassian.net/browse/PIN-5601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ