### PR TITLE
refactor: clarify certifier scoped certified attributes endpoint (PIN-10765)

### DIFF
--- a/packages/api-clients/open-api/bffApi.yml
+++ b/packages/api-clients/open-api/bffApi.yml
@@ -4643,8 +4643,11 @@ paths:
     get:
       tags:
         - tenants
-      summary: Gets the certified attributes of the requester
-      description: Retrieve the certified attributes
+      summary: Gets the certified attributes assigned by the requester as certifier
+      description: >-
+        Retrieves the certified attributes assigned by the requester tenant
+        acting as certifier, paired with the tenants they are assigned to.
+        It does not return the attributes assigned to the requester tenant.
       operationId: getRequesterCertifiedAttributes
       parameters:
         - in: query

--- a/packages/api-clients/open-api/tenantApi.yml
+++ b/packages/api-clients/open-api/tenantApi.yml
@@ -533,8 +533,10 @@ paths:
     get:
       tags:
         - tenant
-      operationId: getCertifiedAttributes
-      description: Retrieve the certified attributes
+      operationId: getCertifiedAttributesByCertifier
+      description: >-
+        Retrieves the certified attributes assigned by the requester tenant
+        acting as certifier, paired with the tenants they are assigned to.
       responses:
         "200":
           description: Certified Attributes retrieved

--- a/packages/backend-for-frontend/src/services/tenantService.ts
+++ b/packages/backend-for-frontend/src/services/tenantService.ts
@@ -229,7 +229,7 @@ export function tenantServiceBuilder(
         `Getting requester certified attributes with limit ${limit}, offset ${offset}`
       );
       const { results, totalCount } =
-        await tenantProcessClient.tenant.getCertifiedAttributes({
+        await tenantProcessClient.tenant.getCertifiedAttributesByCertifier({
           queries: {
             offset,
             limit,

--- a/packages/tenant-process/src/routers/TenantRouter.ts
+++ b/packages/tenant-process/src/routers/TenantRouter.ts
@@ -28,7 +28,7 @@ import {
   updateTenantVerifiedAttributeErrorMapper,
   selfcareUpsertTenantErrorMapper,
   addCertifiedAttributeErrorMapper,
-  getCertifiedAttributesErrorMapper,
+  getCertifiedAttributesByCertifierErrorMapper,
   revokeCertifiedAttributeErrorMapper,
   maintenanceTenantDeletedErrorMapper,
   maintenanceTenantPromotedToCertifierErrorMapper,
@@ -266,7 +266,7 @@ const tenantsRouter = (
 
         const { offset, limit } = req.query;
         const { results, totalCount } =
-          await tenantService.getCertifiedAttributes(
+          await tenantService.getCertifiedAttributesByCertifier(
             {
               offset,
               limit,
@@ -283,7 +283,7 @@ const tenantsRouter = (
       } catch (error) {
         const errorRes = makeApiProblem(
           error,
-          getCertifiedAttributesErrorMapper,
+          getCertifiedAttributesByCertifierErrorMapper,
           ctx
         );
         return res.status(errorRes.status).send(errorRes);

--- a/packages/tenant-process/src/services/readModelServiceSQL.ts
+++ b/packages/tenant-process/src/services/readModelServiceSQL.ts
@@ -406,7 +406,7 @@ export function readModelServiceBuilderSQL(
       return agreementWithMetadata?.data;
     },
 
-    async getCertifiedAttributes({
+    async getCertifiedAttributesByCertifier({
       certifierId,
       offset,
       limit,

--- a/packages/tenant-process/src/services/tenantService.ts
+++ b/packages/tenant-process/src/services/tenantService.ts
@@ -1798,7 +1798,7 @@ export function tenantServiceBuilder(
         return { version: event.newVersion };
       }
     },
-    async getCertifiedAttributes(
+    async getCertifiedAttributesByCertifier(
       {
         offset,
         limit,
@@ -1818,7 +1818,7 @@ export function tenantServiceBuilder(
 
       const certifierId = retrieveCertifierId(tenant.data);
 
-      return await readModelService.getCertifiedAttributes({
+      return await readModelService.getCertifiedAttributesByCertifier({
         certifierId,
         offset,
         limit,

--- a/packages/tenant-process/src/utilities/errorMappers.ts
+++ b/packages/tenant-process/src/utilities/errorMappers.ts
@@ -134,7 +134,7 @@ export const revokeDeclaredAttributeErrorMapper = (
     .with("attributeNotFound", () => HTTP_STATUS_BAD_REQUEST)
     .otherwise(() => HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
-export const getCertifiedAttributesErrorMapper = (
+export const getCertifiedAttributesByCertifierErrorMapper = (
   error: ApiError<ErrorCodes>
 ): number =>
   match(error.code)

--- a/packages/tenant-process/test/api/getCertifiedAttributesByCertifier.test.ts
+++ b/packages/tenant-process/test/api/getCertifiedAttributesByCertifier.test.ts
@@ -73,7 +73,7 @@ describe("API GET /tenants/attributes/certified test", () => {
   });
 
   beforeEach(() => {
-    tenantService.getCertifiedAttributes = vi
+    tenantService.getCertifiedAttributesByCertifier = vi
       .fn()
       .mockResolvedValue(mockResponse);
   });
@@ -119,7 +119,9 @@ describe("API GET /tenants/attributes/certified test", () => {
   ])(
     "Should return $expectedStatus for $error.code",
     async ({ error, expectedStatus }) => {
-      tenantService.getCertifiedAttributes = vi.fn().mockRejectedValue(error);
+      tenantService.getCertifiedAttributesByCertifier = vi
+        .fn()
+        .mockRejectedValue(error);
       const token = generateToken(authRole.ADMIN_ROLE);
       const res = await makeRequest(token);
       expect(res.status).toBe(expectedStatus);

--- a/packages/tenant-process/test/integration/getCertifiedAttributesByCertifier.test.ts
+++ b/packages/tenant-process/test/integration/getCertifiedAttributesByCertifier.test.ts
@@ -24,7 +24,7 @@ import {
   tenantService,
 } from "../integrationUtils.js";
 
-describe("getCertifiedAttributes", () => {
+describe("getCertifiedAttributesByCertifier", () => {
   it("should get standard and discrete certified attributes", async () => {
     const certifierId: string = "test";
     const tenantCertifier: Tenant = {
@@ -60,7 +60,7 @@ describe("getCertifiedAttributes", () => {
       attributes: [tenantCertifiedAttribute, tenantCertifiedDiscreteAttribute],
     });
 
-    const result = await tenantService.getCertifiedAttributes(
+    const result = await tenantService.getCertifiedAttributesByCertifier(
       { offset: 0, limit: 50 },
       getMockContext({ authData: getMockAuthData(tenantCertifier.id) })
     );
@@ -123,11 +123,11 @@ describe("getCertifiedAttributes", () => {
       attributes: [tenantCertifiedAttribute, tenantCertifiedDiscreteAttribute],
     });
 
-    const firstPage = await tenantService.getCertifiedAttributes(
+    const firstPage = await tenantService.getCertifiedAttributesByCertifier(
       { offset: 0, limit: 1 },
       getMockContext({ authData: getMockAuthData(tenantCertifier.id) })
     );
-    const secondPage = await tenantService.getCertifiedAttributes(
+    const secondPage = await tenantService.getCertifiedAttributesByCertifier(
       { offset: 1, limit: 1 },
       getMockContext({ authData: getMockAuthData(tenantCertifier.id) })
     );
@@ -199,7 +199,7 @@ describe("getCertifiedAttributes", () => {
     await addOneTenant(tenantCertifier);
     await addOneTenant(tenantWithCertifiedAttributes);
 
-    const result = await tenantService.getCertifiedAttributes(
+    const result = await tenantService.getCertifiedAttributesByCertifier(
       {
         offset: 0,
         limit: 50,
@@ -269,7 +269,7 @@ describe("getCertifiedAttributes", () => {
     await addOneTenant(tenantCertifier);
     await addOneTenant(tenantWithCertifiedAttributes);
 
-    const result = await tenantService.getCertifiedAttributes(
+    const result = await tenantService.getCertifiedAttributesByCertifier(
       {
         offset: 0,
         limit: 50,
@@ -328,8 +328,8 @@ describe("getCertifiedAttributes", () => {
 
     await addOneTenant(tenantWithCertifiedAttributes);
 
-    void expect(
-      tenantService.getCertifiedAttributes(
+    await expect(
+      tenantService.getCertifiedAttributesByCertifier(
         {
           offset: 0,
           limit: 50,
@@ -380,8 +380,8 @@ describe("getCertifiedAttributes", () => {
     await addOneTenant(tenantNotCertifier);
     await addOneTenant(tenantWithCertifiedAttributes);
 
-    void expect(
-      tenantService.getCertifiedAttributes(
+    await expect(
+      tenantService.getCertifiedAttributesByCertifier(
         {
           offset: 0,
           limit: 50,


### PR DESCRIPTION
## Jira Issue
[PIN-10765](https://pagopa.atlassian.net/browse/PIN-10765)

## Context
- `GET /tenants/attributes/certified` returns the certified attributes assigned by the requester acting as certifier, but its OpenAPI summary reads "Gets the certified attributes of the requester", which is naturally read as the attributes owned by the requester tenant.
- The ambiguity leads to misunderstanding and errors. A ticket was opened because of this ambiguity.

## Services Affected
- api-clients
- tenant-process
- backend-for-frontend

## Key Changes
- `packages/api-clients/open-api/bffApi.yml`: summary and description now state that the endpoint returns the attributes assigned by the requester acting as certifier, and that it does not return the attributes assigned to the requester tenant. The operationId is left unchanged because it is part of the frontend contract.
- `packages/api-clients/open-api/tenantApi.yml`: same description, and `operationId` renamed from `getCertifiedAttributes` to `getCertifiedAttributesByCertifier`.
- `packages/tenant-process/src/services/tenantService.ts`: service method renamed to `getCertifiedAttributesByCertifier`.
- `packages/tenant-process/src/services/readModelServiceSQL.ts`: read model method renamed to `getCertifiedAttributesByCertifier`, aligned with the existing `getOneCertifiedAttributeByCertifier`.
- `packages/tenant-process/src/utilities/errorMappers.ts`: mapper renamed to `getCertifiedAttributesByCertifierErrorMapper`.
- `packages/tenant-process/src/routers/TenantRouter.ts`: import and call sites updated. Route path, query parameters, response schema and status codes are unchanged.
- `packages/backend-for-frontend/src/services/tenantService.ts`: call to the generated tenant process client updated to the new alias.
- `packages/tenant-process/test/api/getCertifiedAttributesByCertifier.test.ts`: file and references renamed.
- `packages/tenant-process/test/integration/getCertifiedAttributesByCertifier.test.ts`: file and references renamed, and the two `expect(...).rejects` assertions are now awaited.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [x] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [x] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)


[PIN-10765]: https://pagopa.atlassian.net/browse/PIN-10765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ